### PR TITLE
Add deal name to accelerator details search table

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/search/table/ProjectAcceleratorDetailsTable.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/table/ProjectAcceleratorDetailsTable.kt
@@ -34,6 +34,7 @@ class ProjectAcceleratorDetailsTable(tables: SearchTables) : SearchTable() {
             bigDecimalField("carbonCapacity", CARBON_CAPACITY),
             bigDecimalField("confirmedReforestableLand", CONFIRMED_REFORESTABLE_LAND),
             textField("dealDescription", DEAL_DESCRIPTION),
+            textField("dealName", DEAL_NAME),
             nonLocalizableEnumField("dealStage", DEAL_STAGE_ID),
             textField("dropboxFolderPath", DROPBOX_FOLDER_PATH),
             textField("failureRisk", FAILURE_RISK),

--- a/src/main/resources/i18n/Messages_en.properties
+++ b/src/main/resources/i18n/Messages_en.properties
@@ -818,6 +818,7 @@ search.projectAcceleratorDetails.applicationReforestableLand=Application refores
 search.projectAcceleratorDetails.carbonCapacity=Carbon capacity (tons CO2/hectare)
 search.projectAcceleratorDetails.confirmedReforestableLand=Confirmed reforestable land (hectares)
 search.projectAcceleratorDetails.dealDescription=Deal description
+search.projectAcceleratorDetails.dealName=Deal name
 search.projectAcceleratorDetails.dealStage=Deal stage
 search.projectAcceleratorDetails.dropboxFolderPath=Dropbox folder path
 search.projectAcceleratorDetails.failureRisk=Failure risk

--- a/src/main/resources/i18n/Messages_es.properties
+++ b/src/main/resources/i18n/Messages_es.properties
@@ -1449,6 +1449,8 @@ search.projectAcceleratorDetails.carbonCapacity=Capacidad de carbono (toneladas 
 search.projectAcceleratorDetails.confirmedReforestableLand=Suelo reforestable confirmado (hectáreas)
 # 4e2b2b08
 search.projectAcceleratorDetails.dealDescription=Descripción de acuerdo
+# 4f3f0bed
+search.projectAcceleratorDetails.dealName=Nombre del acuerdo
 # 3cad07c0
 search.projectAcceleratorDetails.dealStage=Etapa de acuerdo
 # 25fa242f

--- a/src/main/resources/i18n/Messages_fr.properties
+++ b/src/main/resources/i18n/Messages_fr.properties
@@ -1449,6 +1449,8 @@ search.projectAcceleratorDetails.carbonCapacity=Capacité de carbone (tonnes de 
 search.projectAcceleratorDetails.confirmedReforestableLand=Terres reforestables confirmées (hectares)
 # 4e2b2b08
 search.projectAcceleratorDetails.dealDescription=Description de l''opportunité
+# 4f3f0bed
+search.projectAcceleratorDetails.dealName=Nom de l''accord
 # 3cad07c0
 search.projectAcceleratorDetails.dealStage=Stade d''implémentation
 # 25fa242f


### PR DESCRIPTION
The matrix view has a `Deal Name` column that has been incorrectly displaying the project name. In order to get the deal name in the FE, add it as a field in the `ProjectAcceleratorDetails` table.