### PR TITLE
Remove mobile app background upload workaround

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -124,7 +124,6 @@ dependencies {
   implementation("jakarta.inject:jakarta.inject-api:2.0.1")
   implementation("jakarta.ws.rs:jakarta.ws.rs-api:4.0.0")
   implementation("net.coobird:thumbnailator:0.4.21")
-  implementation("org.apache.commons:commons-fileupload2-jakarta-servlet6:2.0.0-M4")
   implementation("org.apache.tika:tika-core:3.2.3")
   implementation("org.bouncycastle:bcpkix-jdk18on:1.83")
   implementation("org.commonmark:commonmark:0.27.1")

--- a/src/main/kotlin/com/terraformation/backend/api/Extensions.kt
+++ b/src/main/kotlin/com/terraformation/backend/api/Extensions.kt
@@ -3,7 +3,6 @@ package com.terraformation.backend.api
 import com.terraformation.backend.file.SizedInputStream
 import jakarta.ws.rs.NotSupportedException
 import java.io.ByteArrayOutputStream
-import org.apache.commons.fileupload2.core.FileItemInput
 import org.apache.tika.mime.MimeTypes
 import org.geotools.api.feature.simple.SimpleFeature
 import org.geotools.geojson.feature.FeatureJSON
@@ -49,7 +48,7 @@ private fun getPlainContentType(plainContentType: String?, allowedTypes: Set<Med
     val contentType =
         try {
           MediaType.parseMediaType(plainContentType)
-        } catch (e: InvalidMediaTypeException) {
+        } catch (_: InvalidMediaTypeException) {
           null
         }
 
@@ -81,17 +80,6 @@ fun MultipartFile.getPlainContentType(allowedTypes: Set<MediaType>): String {
 }
 
 /**
- * Returns the content type of an uploaded file, minus any extended information. For example, if the
- * client-supplied content type is, "text/plain;charset=UTF-8", returns "text/plain".
- *
- * @param allowedTypes Only accept content types from this set; throw NotSupportedException for
- *   types that aren't listed.
- */
-fun FileItemInput.getPlainContentType(allowedTypes: Set<MediaType>): String {
-  return getPlainContentType(getPlainContentType(contentType), allowedTypes)
-}
-
-/**
  * Returns the filename of an uploaded file. If the client supplied a filename, returns it as-is.
  * Otherwise, constructs a filename based on a default base name and an appropriate extension for
  * the content type, if any.
@@ -100,22 +88,6 @@ fun MultipartFile.getFilename(defaultBaseName: String = "upload"): String {
   return originalFilename?.ifEmpty { null }
       ?: run {
         val contentType = getPlainContentType() ?: MediaType.APPLICATION_OCTET_STREAM_VALUE
-        val extension =
-            MimeTypes.getDefaultMimeTypes().getRegisteredMimeType(contentType)?.extension ?: ""
-        defaultBaseName + extension
-      }
-}
-
-/**
- * Returns the filename of an uploaded file. If the client supplied a filename, returns it as-is.
- * Otherwise, constructs a filename based on a default base name and an appropriate extension for
- * the content type, if any.
- */
-fun FileItemInput.getFilename(defaultBaseName: String = "upload"): String {
-  return name?.ifEmpty { null }
-      ?: run {
-        val contentType =
-            getPlainContentType(contentType) ?: MediaType.APPLICATION_OCTET_STREAM_VALUE
         val extension =
             MimeTypes.getDefaultMimeTypes().getRegisteredMimeType(contentType)?.extension ?: ""
         defaultBaseName + extension

--- a/src/main/kotlin/com/terraformation/backend/auth/RequestResponseLoggingFilter.kt
+++ b/src/main/kotlin/com/terraformation/backend/auth/RequestResponseLoggingFilter.kt
@@ -46,7 +46,6 @@ class RequestResponseLoggingFilter(
       listOf(
           MediaType.APPLICATION_FORM_URLENCODED,
           MediaType.APPLICATION_JSON,
-          MediaType.APPLICATION_OCTET_STREAM,
           MediaType.MULTIPART_FORM_DATA,
       )
 

--- a/src/main/kotlin/com/terraformation/backend/tracking/api/ObservationsController.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/api/ObservationsController.kt
@@ -1,8 +1,6 @@
 package com.terraformation.backend.tracking.api
 
 import com.fasterxml.jackson.annotation.JsonInclude
-import com.fasterxml.jackson.databind.ObjectMapper
-import com.fasterxml.jackson.module.kotlin.readValue
 import com.terraformation.backend.api.ApiResponse200
 import com.terraformation.backend.api.ApiResponse200Photo
 import com.terraformation.backend.api.ApiResponse404
@@ -66,18 +64,14 @@ import io.swagger.v3.oas.annotations.media.ArraySchema
 import io.swagger.v3.oas.annotations.media.Content
 import io.swagger.v3.oas.annotations.media.Schema
 import io.swagger.v3.oas.annotations.responses.ApiResponse
-import jakarta.servlet.http.HttpServletRequest
-import jakarta.servlet.http.HttpServletRequestWrapper
 import jakarta.validation.Valid
 import jakarta.ws.rs.BadRequestException
 import java.math.BigDecimal
 import java.time.Instant
 import java.time.LocalDate
 import java.time.format.DateTimeFormatter
-import org.apache.commons.fileupload2.jakarta.servlet6.JakartaServletFileUpload
 import org.locationtech.jts.geom.Geometry
 import org.locationtech.jts.geom.Point
-import org.springframework.boot.autoconfigure.web.servlet.MultipartProperties
 import org.springframework.core.io.InputStreamResource
 import org.springframework.http.MediaType
 import org.springframework.http.ResponseEntity
@@ -101,8 +95,6 @@ import org.springframework.web.multipart.MultipartFile
 class ObservationsController(
     private val biomassStore: BiomassStore,
     private val messages: Messages,
-    private val multipartProperties: MultipartProperties,
-    private val objectMapper: ObjectMapper,
     private val observationService: ObservationService,
     private val observationStore: ObservationStore,
     private val observationResultsStore: ObservationResultsStore,
@@ -599,89 +591,6 @@ class ObservationsController(
             type = payload.type ?: ObservationMediaType.Plot,
         )
     return UploadPlotMediaResponsePayload(fileId)
-  }
-
-  @Operation(
-      summary = "Adds a photo/video of a monitoring plot after an observation is complete.",
-      description =
-          "This is a workaround for a limitation of background uploads on the mobile app.",
-  )
-  @PostMapping(
-      "/{observationId}/plots/{plotId}/otherMedia",
-      consumes = [MediaType.APPLICATION_OCTET_STREAM_VALUE],
-  )
-  fun uploadOtherPlotMediaOctetStream(
-      @PathVariable observationId: ObservationId,
-      @PathVariable plotId: MonitoringPlotId,
-      request: HttpServletRequest,
-  ): UploadPlotMediaResponsePayload {
-    val boundary =
-        request.getHeader("X-Multipart-Boundary")?.ifBlank { null }
-            ?: throw BadRequestException("No X-Multipart-Boundary header found")
-    val fakeContentType = "${MediaType.MULTIPART_FORM_DATA_VALUE}; boundary=$boundary"
-    val wrappedRequest =
-        object : HttpServletRequestWrapper(request) {
-          override fun getContentType() = fakeContentType
-
-          override fun getHeader(name: String) =
-              if (name.equals("Content-Type", ignoreCase = true)) {
-                fakeContentType
-              } else {
-                super.getHeader(name)
-              }
-        }
-
-    val fileUpload = JakartaServletFileUpload()
-    val items = fileUpload.getItemIterator(wrappedRequest)
-    var payload: UploadPlotMediaRequestPayload? = null
-    var response: UploadPlotMediaResponsePayload? = null
-
-    while (items.hasNext()) {
-      val item = items.next()
-
-      when (item.fieldName) {
-        "payload" -> {
-          payload =
-              objectMapper.readValue<UploadPlotMediaRequestPayload>(item.inputStream.readAllBytes())
-        }
-        "file" -> {
-          if (payload == null) {
-            throw BadRequestException(
-                "JSON payload must come before file in background upload request body"
-            )
-          }
-          val contentType = item.getPlainContentType(SUPPORTED_MEDIA_TYPES)
-          val filename = item.getFilename()
-          val contentLength =
-              item.headers.getHeader("Content-Length")?.toLong()
-                  ?: throw BadRequestException("File must include Content-Length header")
-
-          if (contentLength > multipartProperties.maxFileSize.toBytes()) {
-            throw BadRequestException("File exceeds maximum size")
-          }
-
-          val fileId =
-              observationService.storeMediaFile(
-                  observationId = observationId,
-                  monitoringPlotId = plotId,
-                  position = payload.position,
-                  data = item.inputStream,
-                  metadata = FileMetadata.of(contentType, filename, contentLength),
-                  caption = payload.caption,
-                  isOriginal = false,
-                  type = payload.type ?: ObservationMediaType.Plot,
-              )
-
-          response = UploadPlotMediaResponsePayload(fileId)
-        }
-        else ->
-            throw BadRequestException(
-                "Unrecognized item in mobile background upload form submission: ${item.fieldName}"
-            )
-      }
-    }
-
-    return response ?: throw BadRequestException("No uploaded file found in request")
   }
 
   @ApiResponse409("The plot is already claimed by someone else.")

--- a/src/test/kotlin/com/terraformation/backend/api/ApiExtensionsTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/api/ApiExtensionsTest.kt
@@ -1,9 +1,6 @@
 package com.terraformation.backend.api
 
-import io.mockk.every
-import io.mockk.mockk
 import jakarta.ws.rs.NotSupportedException
-import org.apache.commons.fileupload2.core.FileItemInput
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.Nested
@@ -99,87 +96,6 @@ class ApiExtensionsTest {
       val file = mockMultipartFile(originalFilename = null, contentType = null)
       assertEquals("upload.bin", file.getFilename())
     }
-  }
-
-  @Nested
-  inner class FileItemInputGetPlainContentType {
-    @Test
-    fun `returns content type if it matches allowed types`() {
-      val fileItem = mockFileItemInput(contentType = "text/plain;charset=UTF-8")
-      val allowedTypes = setOf(MediaType.TEXT_PLAIN, MediaType.APPLICATION_JSON)
-
-      assertEquals("text/plain", fileItem.getPlainContentType(allowedTypes))
-    }
-
-    @Test
-    fun `returns content type if wildcard matches allowed types`() {
-      val fileItem = mockFileItemInput(contentType = "image/png")
-      val allowedTypes = setOf(MediaType.parseMediaType("image/*"))
-
-      assertEquals("image/png", fileItem.getPlainContentType(allowedTypes))
-    }
-
-    @Test
-    fun `throws NotSupportedException if content type not in allowed types`() {
-      val fileItem = mockFileItemInput(contentType = "application/octet-stream")
-      val allowedTypes = setOf(MediaType.TEXT_PLAIN, MediaType.APPLICATION_JSON)
-
-      assertThrows<NotSupportedException> { fileItem.getPlainContentType(allowedTypes) }
-    }
-
-    @Test
-    fun `throws NotSupportedException if content type is null`() {
-      val fileItem = mockFileItemInput(contentType = null)
-      val allowedTypes = setOf(MediaType.TEXT_PLAIN)
-
-      assertThrows<NotSupportedException> { fileItem.getPlainContentType(allowedTypes) }
-    }
-
-    @Test
-    fun `throws NotSupportedException if content type is invalid`() {
-      val fileItem = mockFileItemInput(contentType = "invalid-content-type")
-      val allowedTypes = setOf(MediaType.TEXT_PLAIN)
-
-      assertThrows<NotSupportedException> { fileItem.getPlainContentType(allowedTypes) }
-    }
-  }
-
-  @Nested
-  inner class FileItemInputGetFilename {
-    @Test
-    fun `returns name when present`() {
-      val fileItem = mockFileItemInput(originalFilename = "document.pdf")
-      assertEquals("document.pdf", fileItem.getFilename())
-    }
-
-    @Test
-    fun `constructs filename when name is missing`() {
-      val fileItem = mockFileItemInput(originalFilename = null, contentType = "application/json")
-      assertEquals("data.json", fileItem.getFilename("data"))
-    }
-
-    @Test
-    fun `constructs filename with no extension when content type is unknown`() {
-      val fileItem =
-          mockFileItemInput(originalFilename = null, contentType = "application/x-unknown")
-      assertEquals("upload", fileItem.getFilename())
-    }
-
-    @Test
-    fun `constructs filename with octet-stream when content type is null`() {
-      val fileItem = mockFileItemInput(originalFilename = null, contentType = null)
-      assertEquals("upload.bin", fileItem.getFilename())
-    }
-  }
-
-  fun mockFileItemInput(
-      originalFilename: String? = "test.bin",
-      contentType: String? = "image/png",
-  ): FileItemInput {
-    val item = mockk<FileItemInput>()
-    every { item.contentType } returns contentType
-    every { item.name } returns originalFilename
-    return item
   }
 
   fun mockMultipartFile(


### PR DESCRIPTION
This partially reverts commit d60ebf6a, which added an alternate endpoint for
video uploads. We were able to get the mobile app to submit multipart/form-data
requests in the background, so the workaround isn't needed.

This change retains the test suite and minor code cleanup from commit d60ebf6a.