### PR TITLE
Accept observation video parameters as form fields

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/tracking/api/ObservationsController.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/api/ObservationsController.kt
@@ -574,7 +574,10 @@ class ObservationsController(
       @PathVariable observationId: ObservationId,
       @PathVariable plotId: MonitoringPlotId,
       @RequestPart("file") file: MultipartFile,
-      @RequestPart("payload") payload: UploadPlotMediaRequestPayload,
+      @RequestPart("payload") payload: UploadPlotMediaRequestPayload?,
+      @RequestParam caption: String?,
+      @RequestParam position: ObservationPlotPosition?,
+      @RequestParam type: ObservationMediaType?,
   ): UploadPlotMediaResponsePayload {
     val contentType = file.getPlainContentType(SUPPORTED_MEDIA_TYPES)
     val filename = file.getFilename("photo")
@@ -583,12 +586,12 @@ class ObservationsController(
         observationService.storeMediaFile(
             observationId = observationId,
             monitoringPlotId = plotId,
-            position = payload.position,
+            position = payload?.position ?: position,
             data = file.inputStream,
             metadata = FileMetadata.of(contentType, filename, file.size),
-            caption = payload.caption,
+            caption = payload?.caption ?: caption,
             isOriginal = false,
-            type = payload.type ?: ObservationMediaType.Plot,
+            type = payload?.type ?: type ?: ObservationMediaType.Plot,
         )
     return UploadPlotMediaResponsePayload(fileId)
   }


### PR DESCRIPTION
For mobile app background uploads, it turns out to be challenging to send a
request that has both a JSON payload and a file. Change the upload endpoint
to accept upload parameters as either a JSON payload (the existing behavior)
or as individual form fields called `caption`, `position`, and `type`. The
values from the JSON payload will take precedence if both the payload and
the form fields are present.