### PR TITLE
Added fetch report targets endpoints

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/accelerator/api/ProjectReportsController.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/api/ProjectReportsController.kt
@@ -10,8 +10,11 @@ import com.terraformation.backend.accelerator.model.ReportMetricEntryModel
 import com.terraformation.backend.accelerator.model.ReportModel
 import com.terraformation.backend.accelerator.model.ReportPhotoModel
 import com.terraformation.backend.accelerator.model.ReportProjectMetricModel
+import com.terraformation.backend.accelerator.model.ReportProjectMetricTargetModel
 import com.terraformation.backend.accelerator.model.ReportStandardMetricModel
+import com.terraformation.backend.accelerator.model.ReportStandardMetricTargetModel
 import com.terraformation.backend.accelerator.model.ReportSystemMetricModel
+import com.terraformation.backend.accelerator.model.ReportSystemMetricTargetModel
 import com.terraformation.backend.api.AcceleratorEndpoint
 import com.terraformation.backend.api.ApiResponse200
 import com.terraformation.backend.api.ApiResponse200Photo
@@ -485,6 +488,42 @@ class ProjectReportsController(
     )
     return SimpleSuccessResponsePayload()
   }
+
+  @ApiResponse200
+  @GetMapping("/projectMetricTargets")
+  @Operation(summary = "Get all project metric targets for a project.")
+  fun getProjectMetricTargets(
+      @PathVariable projectId: ProjectId
+  ): GetProjectMetricTargetsResponsePayload {
+    val targets = reportStore.fetchReportProjectMetricTargets(projectId)
+    return GetProjectMetricTargetsResponsePayload(
+        targets.map { ReportProjectMetricTargetPayload(it) }
+    )
+  }
+
+  @ApiResponse200
+  @GetMapping("/standardMetricTargets")
+  @Operation(summary = "Get all standard metric targets for a project.")
+  fun getStandardMetricTargets(
+      @PathVariable projectId: ProjectId
+  ): GetStandardMetricTargetsResponsePayload {
+    val targets = reportStore.fetchReportStandardMetricTargets(projectId)
+    return GetStandardMetricTargetsResponsePayload(
+        targets.map { ReportStandardMetricTargetPayload(it) }
+    )
+  }
+
+  @ApiResponse200
+  @GetMapping("/systemMetricTargets")
+  @Operation(summary = "Get all system metric targets for a project.")
+  fun getSystemMetricTargets(
+      @PathVariable projectId: ProjectId
+  ): GetSystemMetricTargetsResponsePayload {
+    val targets = reportStore.fetchReportSystemMetricTargets(projectId)
+    return GetSystemMetricTargetsResponsePayload(
+        targets.map { ReportSystemMetricTargetPayload(it) }
+    )
+  }
 }
 
 data class ExistingAcceleratorReportConfigPayload(
@@ -849,3 +888,57 @@ data class UpdateProjectMetricRequestPayload(@field:Valid val metric: ExistingPr
 data class UpdateAcceleratorReportPhotoRequestPayload(val caption: String?)
 
 data class UploadAcceleratorReportPhotoResponsePayload(val fileId: FileId) : SuccessResponsePayload
+
+data class ReportProjectMetricTargetPayload(
+    val metricId: ProjectMetricId,
+    val target: Number?,
+    val year: Number,
+) {
+  constructor(
+      model: ReportProjectMetricTargetModel
+  ) : this(
+      metricId = model.metricId,
+      target = model.target,
+      year = model.year,
+  )
+}
+
+data class ReportStandardMetricTargetPayload(
+    val metricId: StandardMetricId,
+    val target: Number?,
+    val year: Number,
+) {
+  constructor(
+      model: ReportStandardMetricTargetModel
+  ) : this(
+      metricId = model.metricId,
+      target = model.target,
+      year = model.year,
+  )
+}
+
+data class ReportSystemMetricTargetPayload(
+    val metric: SystemMetric,
+    val target: Number?,
+    val year: Number,
+) {
+  constructor(
+      model: ReportSystemMetricTargetModel
+  ) : this(
+      metric = model.metric,
+      target = model.target,
+      year = model.year,
+  )
+}
+
+data class GetProjectMetricTargetsResponsePayload(
+    val targets: List<ReportProjectMetricTargetPayload>
+) : SuccessResponsePayload
+
+data class GetStandardMetricTargetsResponsePayload(
+    val targets: List<ReportStandardMetricTargetPayload>
+) : SuccessResponsePayload
+
+data class GetSystemMetricTargetsResponsePayload(
+    val targets: List<ReportSystemMetricTargetPayload>
+) : SuccessResponsePayload

--- a/src/main/kotlin/com/terraformation/backend/accelerator/db/ReportStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/db/ReportStore.kt
@@ -11,8 +11,11 @@ import com.terraformation.backend.accelerator.model.ReportMetricEntryModel
 import com.terraformation.backend.accelerator.model.ReportModel
 import com.terraformation.backend.accelerator.model.ReportPhotoModel
 import com.terraformation.backend.accelerator.model.ReportProjectMetricModel
+import com.terraformation.backend.accelerator.model.ReportProjectMetricTargetModel
 import com.terraformation.backend.accelerator.model.ReportStandardMetricModel
+import com.terraformation.backend.accelerator.model.ReportStandardMetricTargetModel
 import com.terraformation.backend.accelerator.model.ReportSystemMetricModel
+import com.terraformation.backend.accelerator.model.ReportSystemMetricTargetModel
 import com.terraformation.backend.auth.currentUser
 import com.terraformation.backend.customer.model.SimpleUserModel
 import com.terraformation.backend.customer.model.SystemUser
@@ -173,6 +176,59 @@ class ReportStore(
               null
             }
           }
+    }
+  }
+
+  fun fetchReportProjectMetricTargets(projectId: ProjectId): List<ReportProjectMetricTargetModel> {
+    requirePermissions { readProjectReports(projectId) }
+
+    return with(REPORT_PROJECT_METRIC_TARGETS) {
+      dslContext
+          .select(
+              PROJECT_METRIC_ID,
+              TARGET,
+              YEAR,
+          )
+          .from(this)
+          .where(PROJECT_ID.eq(projectId))
+          .orderBy(YEAR, PROJECT_METRIC_ID)
+          .fetch { ReportProjectMetricTargetModel.of(it) }
+    }
+  }
+
+  fun fetchReportStandardMetricTargets(
+      projectId: ProjectId
+  ): List<ReportStandardMetricTargetModel> {
+    requirePermissions { readProjectReports(projectId) }
+
+    return with(REPORT_STANDARD_METRIC_TARGETS) {
+      dslContext
+          .select(
+              STANDARD_METRIC_ID,
+              TARGET,
+              YEAR,
+          )
+          .from(this)
+          .where(PROJECT_ID.eq(projectId))
+          .orderBy(YEAR, STANDARD_METRIC_ID)
+          .fetch { ReportStandardMetricTargetModel.of(it) }
+    }
+  }
+
+  fun fetchReportSystemMetricTargets(projectId: ProjectId): List<ReportSystemMetricTargetModel> {
+    requirePermissions { readProjectReports(projectId) }
+
+    return with(REPORT_SYSTEM_METRIC_TARGETS) {
+      dslContext
+          .select(
+              SYSTEM_METRIC_ID,
+              TARGET,
+              YEAR,
+          )
+          .from(this)
+          .where(PROJECT_ID.eq(projectId))
+          .orderBy(YEAR, SYSTEM_METRIC_ID)
+          .fetch { ReportSystemMetricTargetModel.of(it) }
     }
   }
 

--- a/src/main/kotlin/com/terraformation/backend/accelerator/model/ReportMetricTargetModel.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/model/ReportMetricTargetModel.kt
@@ -1,0 +1,65 @@
+package com.terraformation.backend.accelerator.model
+
+import com.terraformation.backend.db.accelerator.ProjectMetricId
+import com.terraformation.backend.db.accelerator.StandardMetricId
+import com.terraformation.backend.db.accelerator.SystemMetric
+import com.terraformation.backend.db.accelerator.tables.references.REPORT_PROJECT_METRIC_TARGETS
+import org.jooq.Record
+
+data class ReportProjectMetricTargetModel(
+    val metricId: ProjectMetricId,
+    val target: Number?,
+    val year: Number,
+) {
+  companion object {
+    fun of(record: Record): ReportProjectMetricTargetModel {
+      return with(REPORT_PROJECT_METRIC_TARGETS) {
+        ReportProjectMetricTargetModel(
+            metricId = record[PROJECT_METRIC_ID]!!,
+            target = record[TARGET],
+            year = record[YEAR]!!,
+        )
+      }
+    }
+  }
+}
+
+data class ReportStandardMetricTargetModel(
+    val metricId: StandardMetricId,
+    val target: Number?,
+    val year: Number,
+) {
+  companion object {
+    fun of(record: Record): ReportStandardMetricTargetModel {
+      return with(
+          com.terraformation.backend.db.accelerator.tables.references.REPORT_STANDARD_METRIC_TARGETS
+      ) {
+        ReportStandardMetricTargetModel(
+            metricId = record[STANDARD_METRIC_ID]!!,
+            target = record[TARGET],
+            year = record[YEAR]!!,
+        )
+      }
+    }
+  }
+}
+
+data class ReportSystemMetricTargetModel(
+    val metric: SystemMetric,
+    val target: Number?,
+    val year: Number,
+) {
+  companion object {
+    fun of(record: Record): ReportSystemMetricTargetModel {
+      return with(
+          com.terraformation.backend.db.accelerator.tables.references.REPORT_SYSTEM_METRIC_TARGETS
+      ) {
+        ReportSystemMetricTargetModel(
+            metric = record[SYSTEM_METRIC_ID]!!,
+            target = record[TARGET],
+            year = record[YEAR]!!,
+        )
+      }
+    }
+  }
+}

--- a/src/test/kotlin/com/terraformation/backend/accelerator/db/ReportStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/db/ReportStoreTest.kt
@@ -14,9 +14,12 @@ import com.terraformation.backend.accelerator.model.ReportMetricEntryModel
 import com.terraformation.backend.accelerator.model.ReportModel
 import com.terraformation.backend.accelerator.model.ReportPhotoModel
 import com.terraformation.backend.accelerator.model.ReportProjectMetricModel
+import com.terraformation.backend.accelerator.model.ReportProjectMetricTargetModel
 import com.terraformation.backend.accelerator.model.ReportStandardMetricModel
+import com.terraformation.backend.accelerator.model.ReportStandardMetricTargetModel
 import com.terraformation.backend.accelerator.model.ReportSystemMetricEntryModel
 import com.terraformation.backend.accelerator.model.ReportSystemMetricModel
+import com.terraformation.backend.accelerator.model.ReportSystemMetricTargetModel
 import com.terraformation.backend.accelerator.model.StandardMetricModel
 import com.terraformation.backend.assertSetEquals
 import com.terraformation.backend.auth.currentUser
@@ -5637,6 +5640,175 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
             target = 500,
         )
       }
+    }
+  }
+
+  @Nested
+  inner class FetchReportProjectMetricTargets {
+    @Test
+    fun `requires permission to read project reports`() {
+      deleteUserGlobalRole(role = GlobalRole.AcceleratorAdmin)
+      deleteOrganizationUser()
+      insertOrganizationUser(role = Role.Contributor)
+
+      assertThrows<AccessDeniedException> { store.fetchReportProjectMetricTargets(projectId) }
+    }
+
+    @Test
+    fun `returns all project metric targets for a project`() {
+      val projectMetricId1 =
+          insertProjectMetric(
+              component = MetricComponent.ProjectObjectives,
+              description = "Test metric 1",
+              name = "Test Metric 1",
+              reference = "1.0",
+              type = MetricType.Activity,
+          )
+      val projectMetricId2 =
+          insertProjectMetric(
+              component = MetricComponent.ProjectObjectives,
+              description = "Test metric 2",
+              name = "Test Metric 2",
+              reference = "2.0",
+              type = MetricType.Activity,
+          )
+
+      insertProjectMetricTarget(
+          projectId = projectId,
+          projectMetricId = projectMetricId1,
+          year = 2024,
+          target = 100,
+      )
+      insertProjectMetricTarget(
+          projectId = projectId,
+          projectMetricId = projectMetricId2,
+          year = 2024,
+          target = 200,
+      )
+      insertProjectMetricTarget(
+          projectId = projectId,
+          projectMetricId = projectMetricId1,
+          year = 2025,
+          target = 150,
+      )
+
+      val targets = store.fetchReportProjectMetricTargets(projectId)
+
+      assertEquals(
+          listOf(
+              ReportProjectMetricTargetModel(projectMetricId1, 100, 2024),
+              ReportProjectMetricTargetModel(projectMetricId2, 200, 2024),
+              ReportProjectMetricTargetModel(projectMetricId1, 150, 2025),
+          ),
+          targets,
+      )
+    }
+  }
+
+  @Nested
+  inner class FetchReportStandardMetricTargets {
+    @Test
+    fun `requires permission to read project reports`() {
+      deleteUserGlobalRole(role = GlobalRole.AcceleratorAdmin)
+      deleteOrganizationUser()
+      insertOrganizationUser(role = Role.Contributor)
+
+      assertThrows<AccessDeniedException> { store.fetchReportStandardMetricTargets(projectId) }
+    }
+
+    @Test
+    fun `returns all standard metric targets for a project`() {
+      val standardMetricId1 =
+          insertStandardMetric(
+              component = MetricComponent.Climate,
+              description = "Test metric 1",
+              name = "Test Metric 1",
+              reference = "1.0",
+              type = MetricType.Activity,
+          )
+      val standardMetricId2 =
+          insertStandardMetric(
+              component = MetricComponent.Climate,
+              description = "Test metric 2",
+              name = "Test Metric 2",
+              reference = "2.0",
+              type = MetricType.Activity,
+          )
+
+      insertStandardMetricTarget(
+          projectId = projectId,
+          standardMetricId = standardMetricId1,
+          year = 2024,
+          target = 300,
+      )
+      insertStandardMetricTarget(
+          projectId = projectId,
+          standardMetricId = standardMetricId2,
+          year = 2024,
+          target = 400,
+      )
+      insertStandardMetricTarget(
+          projectId = projectId,
+          standardMetricId = standardMetricId1,
+          year = 2025,
+          target = 350,
+      )
+
+      val targets = store.fetchReportStandardMetricTargets(projectId)
+
+      assertEquals(
+          listOf(
+              ReportStandardMetricTargetModel(standardMetricId1, 300, 2024),
+              ReportStandardMetricTargetModel(standardMetricId2, 400, 2024),
+              ReportStandardMetricTargetModel(standardMetricId1, 350, 2025),
+          ),
+          targets,
+      )
+    }
+  }
+
+  @Nested
+  inner class FetchReportSystemMetricTargets {
+    @Test
+    fun `requires permission to read project reports`() {
+      deleteUserGlobalRole(role = GlobalRole.AcceleratorAdmin)
+      deleteOrganizationUser()
+      insertOrganizationUser(role = Role.Contributor)
+
+      assertThrows<AccessDeniedException> { store.fetchReportSystemMetricTargets(projectId) }
+    }
+
+    @Test
+    fun `returns all system metric targets for a project`() {
+      insertSystemMetricTarget(
+          projectId = projectId,
+          metric = SystemMetric.TreesPlanted,
+          year = 2024,
+          target = 500,
+      )
+      insertSystemMetricTarget(
+          projectId = projectId,
+          metric = SystemMetric.SeedsCollected,
+          year = 2024,
+          target = 1000,
+      )
+      insertSystemMetricTarget(
+          projectId = projectId,
+          metric = SystemMetric.TreesPlanted,
+          year = 2025,
+          target = 600,
+      )
+
+      val targets = store.fetchReportSystemMetricTargets(projectId)
+
+      assertEquals(
+          listOf(
+              ReportSystemMetricTargetModel(SystemMetric.SeedsCollected, 1000, 2024),
+              ReportSystemMetricTargetModel(SystemMetric.TreesPlanted, 500, 2024),
+              ReportSystemMetricTargetModel(SystemMetric.TreesPlanted, 600, 2025),
+          ),
+          targets,
+      )
     }
   }
 }


### PR DESCRIPTION
This will allow us to read report targets for the target tables without having to fetch all of our reports.