### PR TITLE
SW-7931 SW-7945 Add phase to project accelerator details endpoints

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/accelerator/api/ProjectAcceleratorDetailsController.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/api/ProjectAcceleratorDetailsController.kt
@@ -88,7 +88,6 @@ data class ProjectAcceleratorDetailsPayload(
     val clickUpLink: URI?,
     val cohortId: CohortId?,
     val cohortName: String?,
-    val cohortPhase: CohortPhase?,
     val confirmedReforestableLand: BigDecimal?,
     val countryAlpha3: String?,
     val countryCode: String?,
@@ -112,6 +111,7 @@ data class ProjectAcceleratorDetailsPayload(
     val numCommunities: Int?,
     val numNativeSpecies: Int?,
     val perHectareBudget: BigDecimal?,
+    val phase: CohortPhase?,
     val pipeline: Pipeline?,
     val plantingSitesCql: String?,
     val projectArea: BigDecimal?,
@@ -141,7 +141,6 @@ data class ProjectAcceleratorDetailsPayload(
       clickUpLink = model.clickUpLink,
       cohortId = model.cohortId,
       cohortName = model.cohortName,
-      cohortPhase = model.cohortPhase,
       confirmedReforestableLand = model.confirmedReforestableLand,
       countryAlpha3 = model.countryAlpha3,
       countryCode = model.countryCode,
@@ -165,6 +164,7 @@ data class ProjectAcceleratorDetailsPayload(
       numCommunities = model.numCommunities,
       numNativeSpecies = model.numNativeSpecies,
       perHectareBudget = model.perHectareBudget,
+      phase = model.phase,
       pipeline = model.pipeline,
       plantingSitesCql = model.plantingSitesCql,
       projectArea = model.projectArea,
@@ -183,6 +183,10 @@ data class ProjectAcceleratorDetailsPayload(
       verraLink = model.verraLink,
       whatNeedsToBeTrue = model.whatNeedsToBeTrue,
   )
+
+  @Deprecated("Use phase instead.")
+  val cohortPhase: CohortPhase? // for backwards compatibility in response payloads
+    get() = phase
 }
 
 data class MetricProgressPayload(
@@ -243,6 +247,7 @@ data class UpdateProjectAcceleratorDetailsRequestPayload(
     val numCommunities: Int?,
     val numNativeSpecies: Int?,
     val perHectareBudget: BigDecimal?,
+    val phase: CohortPhase?,
     val pipeline: Pipeline?,
     val projectArea: BigDecimal? = null,
     val riskTrackerLink: URI? = null,
@@ -285,6 +290,7 @@ data class UpdateProjectAcceleratorDetailsRequestPayload(
           numNativeSpecies = numNativeSpecies,
           perHectareBudget = perHectareBudget,
           pipeline = pipeline,
+          phase = phase,
           projectArea = projectArea,
           riskTrackerLink = riskTrackerLink,
           sdgList = sdgList.orEmpty(),

--- a/src/main/kotlin/com/terraformation/backend/accelerator/db/ProjectAcceleratorDetailsStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/db/ProjectAcceleratorDetailsStore.kt
@@ -92,6 +92,10 @@ class ProjectAcceleratorDetailsStore(
     val existing = fetchOneById(projectId, variableValues)
     val updated = applyFunc(existing)
 
+    require(updated.phase == null || updated.fileNaming != null) {
+      "File Naming is required if phase is selected"
+    }
+
     val dropboxFolderPath: String?
     val googleFolderUrl: URI?
 
@@ -168,6 +172,14 @@ class ProjectAcceleratorDetailsStore(
             .set(MODIFIED_BY, currentUser().userId)
             .set(MODIFIED_TIME, clock.instant())
             .where(ID.eq(projectId))
+            .execute()
+      }
+
+      if (existing.phase != updated.phase) {
+        dslContext
+            .update(COHORTS)
+            .set(COHORTS.PHASE_ID, updated.phase)
+            .where(COHORTS.ID.eq(existing.cohortId))
             .execute()
       }
 

--- a/src/main/kotlin/com/terraformation/backend/accelerator/db/ProjectAcceleratorDetailsStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/db/ProjectAcceleratorDetailsStore.kt
@@ -12,6 +12,7 @@ import com.terraformation.backend.db.accelerator.CohortId
 import com.terraformation.backend.db.accelerator.CohortPhase
 import com.terraformation.backend.db.accelerator.SystemMetric
 import com.terraformation.backend.db.accelerator.tables.references.COHORTS
+import com.terraformation.backend.db.accelerator.tables.references.COHORT_MODULES
 import com.terraformation.backend.db.accelerator.tables.references.PROJECT_ACCELERATOR_DETAILS
 import com.terraformation.backend.db.default_schema.ProjectId
 import com.terraformation.backend.db.default_schema.tables.records.ProjectLandUseModelTypesRecord
@@ -285,6 +286,10 @@ class ProjectAcceleratorDetailsStore(
         val projectsInCohort =
             dslContext.fetchCount(PROJECTS, PROJECTS.COHORT_ID.eq(existingCohortId))
         if (projectsInCohort == 0) {
+          dslContext
+              .deleteFrom(COHORT_MODULES)
+              .where(COHORT_MODULES.COHORT_ID.eq(existingCohortId))
+              .execute()
           dslContext.deleteFrom(COHORTS).where(COHORTS.ID.eq(existingCohortId)).execute()
         }
       } else {

--- a/src/main/kotlin/com/terraformation/backend/accelerator/db/ProjectAcceleratorDetailsStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/db/ProjectAcceleratorDetailsStore.kt
@@ -92,8 +92,13 @@ class ProjectAcceleratorDetailsStore(
     val existing = fetchOneById(projectId, variableValues)
     val updated = applyFunc(existing)
 
-    require(updated.phase == null || updated.fileNaming != null) {
-      "File Naming is required if phase is selected"
+    require(
+        updated.phase == null ||
+            (updated.fileNaming != null &&
+                updated.dropboxFolderPath != null &&
+                updated.googleFolderUrl != null)
+    ) {
+      "If phase is selected, file naming, dropbox folder path, and Google folder URL must be set."
     }
 
     val dropboxFolderPath: String?

--- a/src/main/kotlin/com/terraformation/backend/accelerator/model/ProjectAcceleratorDetailsModel.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/model/ProjectAcceleratorDetailsModel.kt
@@ -29,7 +29,6 @@ data class ProjectAcceleratorDetailsModel(
     val clickUpLink: URI? = null,
     val cohortId: CohortId? = null,
     val cohortName: String? = null,
-    val cohortPhase: CohortPhase? = null,
     val confirmedReforestableLand: BigDecimal? = null,
     val countryAlpha3: String? = null,
     val countryCode: String? = null,
@@ -53,6 +52,7 @@ data class ProjectAcceleratorDetailsModel(
     val numCommunities: Int? = null,
     val numNativeSpecies: Int? = null,
     val perHectareBudget: BigDecimal? = null,
+    val phase: CohortPhase? = null,
     val pipeline: Pipeline? = null,
     val plantingSitesCql: String? = null,
     val projectArea: BigDecimal? = null,
@@ -88,7 +88,6 @@ data class ProjectAcceleratorDetailsModel(
             clickUpLink = variableValues.clickUpLink,
             cohortId = record[COHORTS.ID],
             cohortName = record[COHORTS.NAME],
-            cohortPhase = record[COHORTS.PHASE_ID],
             confirmedReforestableLand = variableValues.confirmedReforestableLand,
             countryAlpha3 = variableValues.countryAlpha3,
             countryCode = variableValues.countryCode,
@@ -112,6 +111,7 @@ data class ProjectAcceleratorDetailsModel(
             numCommunities = record[NUM_COMMUNITIES],
             numNativeSpecies = variableValues.numNativeSpecies,
             perHectareBudget = variableValues.perHectareBudget,
+            phase = record[COHORTS.PHASE_ID],
             pipeline = record[PIPELINE_ID],
             plantingSitesCql = record[PLANTING_SITES_CQL],
             projectArea = variableValues.projectArea,
@@ -173,4 +173,8 @@ data class ProjectAcceleratorDetailsModel(
           verraLink = verraLink,
           whatNeedsToBeTrue = whatNeedsToBeTrue,
       )
+
+  @Deprecated("Use phase instead.")
+  val cohortPhase: CohortPhase?
+    get() = phase
 }

--- a/src/test/kotlin/com/terraformation/backend/accelerator/db/ProjectAcceleratorDetailsStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/db/ProjectAcceleratorDetailsStoreTest.kt
@@ -17,6 +17,7 @@ import com.terraformation.backend.db.accelerator.SystemMetric
 import com.terraformation.backend.db.accelerator.tables.records.CohortsRecord
 import com.terraformation.backend.db.accelerator.tables.records.ProjectAcceleratorDetailsRecord
 import com.terraformation.backend.db.accelerator.tables.references.COHORTS
+import com.terraformation.backend.db.accelerator.tables.references.COHORT_MODULES
 import com.terraformation.backend.db.default_schema.LandUseModelType
 import com.terraformation.backend.db.default_schema.Region
 import com.terraformation.backend.db.default_schema.tables.references.PROJECTS
@@ -636,8 +637,10 @@ class ProjectAcceleratorDetailsStoreTest : DatabaseTest(), RunsAsUser {
     }
 
     @Test
-    fun `clears cohort and deletes it when phase is set to null and no other projects use it`() {
+    fun `clears cohort and deletes it with modules when phase is set to null and no other projects use it`() {
       insertCohort(name = "Test Cohort", phase = CohortPhase.Phase0DueDiligence)
+      insertModule()
+      insertCohortModule()
       val projectId = insertProject(cohortId = inserted.cohortId)
 
       val existingValues =
@@ -658,6 +661,7 @@ class ProjectAcceleratorDetailsStoreTest : DatabaseTest(), RunsAsUser {
       assertNull(project?.cohortId, "Project should have cohort_id cleared")
 
       assertTableEmpty(COHORTS)
+      assertTableEmpty(COHORT_MODULES)
     }
 
     @Test


### PR DESCRIPTION
Replace `cohortPhase` with `phase` in GET project accelerator details endpoints. Add `cohortPhase` as deprecated getter for `phase` for backwards compatibility.

Add `phase` to PUT endpoint to update cohort phase for now. Add requirement that document properties are non-null if phase is non-null (per [PRD](https://terraformation.atlassian.net/wiki/spaces/PM/pages/2038464515/PRD+Removing+Cohorts+from+Terraware#Project-Data-(Updates))).