### PR TITLE
Expose individual SfM steps in admin UI

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/admin/AdminSplatsController.kt
+++ b/src/main/kotlin/com/terraformation/backend/admin/AdminSplatsController.kt
@@ -38,6 +38,7 @@ class AdminSplatsController(
       @RequestParam fileId: FileId,
       @RequestParam abortAfter: String?,
       @RequestParam dataFactor: Int?,
+      @RequestParam featureMatcherSubcommand: String?,
       @RequestParam fps: Int?,
       @RequestParam keepPercent: Double?,
       @RequestParam mapper: String?,
@@ -53,7 +54,8 @@ class AdminSplatsController(
     try {
       val stepArgs =
           listOfNotNull(
-                  dataFactor?.let { "gsplat" to listOf("--data-factor", "$dataFactor") },
+                  dataFactor?.let { "gsplat" to listOf("--data_factor", "$dataFactor") },
+                  featureMatcherSubcommand?.let { "feature-matcher" to listOf("--subcommand", it) },
                   fps?.let { "extract" to listOf("--fps", "$fps") },
                   keepPercent?.let {
                     if (keepPercent < 100.0) {
@@ -62,7 +64,7 @@ class AdminSplatsController(
                       "filter-blurry" to listOf("--no-filter-blurry")
                     }
                   },
-                  mapper?.ifBlank { null }?.let { "sfm" to listOf("--mapper", mapper) },
+                  mapper?.ifBlank { null }?.let { "mapper" to listOf("--mapper", mapper) },
                   maxSize?.let { "extract" to listOf("--max-size", "$maxSize") },
                   maxSteps?.let { "gsplat" to listOf("--max_steps", "$maxSteps") },
                   ssimLambda?.let { "gsplat" to listOf("--ssim_lambda", "$ssimLambda") },

--- a/src/main/resources/templates/admin/splats.html
+++ b/src/main/resources/templates/admin/splats.html
@@ -97,9 +97,44 @@
         <tr><td colspan="4"><hr/></td></tr>
 
         <tbody>
+        <tr>
+            <td>feature-extractor</td>
+            <td>Other Args</td>
+            <td><input type="text" name="stepArgs[feature-extractor]"/></td>
+            <td>
+                Additional space-separated arguments to pass to colmap feature_extractor.
+            </td>
+        </tr>
+        </tbody>
+
+        <tr><td colspan="4"><hr/></td></tr>
+
+        <tbody>
             <tr>
-                <td rowspan="2">sfm</td>
-                <td>Mapper</td>
+                <td rowspan="2">feature-matcher</td>
+                <td>Subcommand</td>
+                <td>
+                    <input type="text" name="featureMatcherSubcommand" placeholder="sequential_matcher"/>
+                </td>
+                <td>
+                    Which colmap subcommand to use for feature matching.
+                </td>
+            </tr>
+            <tr>
+                <td>Other Args</td>
+                <td><input type="text" name="stepArgs[feature-matcher]"/></td>
+                <td>
+                    Additional space-separated arguments to pass to colmap.
+                </td>
+            </tr>
+        </tbody>
+
+        <tr><td colspan="4"><hr/></td></tr>
+
+        <tbody>
+            <tr>
+                <td rowspan="2">mapper</td>
+                <td>Command</td>
                 <td>
                     <select name="mapper">
                         <option value="colmap">COLMAP</option>
@@ -111,9 +146,22 @@
             </tr>
             <tr>
                 <td>Other Args</td>
-                <td><input type="text" name="stepArgs[sfm]"/></td>
+                <td><input type="text" name="stepArgs[mapper]"/></td>
                 <td>
-                    Additional space-separated arguments to pass to splat.py sfm.
+                    Additional space-separated arguments to pass to the colmap or glomap.
+                </td>
+            </tr>
+        </tbody>
+
+        <tr><td colspan="4"><hr/></td></tr>
+
+        <tbody>
+            <tr>
+                <td>model-converter</td>
+                <td>Other Args</td>
+                <td><input type="text" name="stepArgs[model-converter]"/></td>
+                <td>
+                    Additional space-separated arguments to pass to colmap model_converter.
                 </td>
             </tr>
         </tbody>


### PR DESCRIPTION
Now that the SfM steps are individually configurable on the splatter side, update
the admin UI to allow people to pass command-line arguments to them.