### PR TITLE
SW-7936 Add projectModules sublist as placeholder for FE work

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/search/table/ModulesTable.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/table/ModulesTable.kt
@@ -29,6 +29,10 @@ class ModulesTable(tables: SearchTables) : SearchTable() {
           ),
           deliverables.asMultiValueSublist("deliverables", MODULES.ID.eq(DELIVERABLES.MODULE_ID)),
           events.asMultiValueSublist("events", MODULES.ID.eq(EVENTS.MODULE_ID)),
+          cohortModules.asMultiValueSublist(
+              "projectModules",
+              MODULES.ID.eq(COHORT_MODULES.MODULE_ID),
+          ),
       )
     }
   }


### PR DESCRIPTION
In order to change over the Modules list `Cohorts` column to `Projects`, we first need a `projectModules` property on the `ModulesTable`. Until we have an actual `project_modules` table, make this point to `cohort_modules` so that we can update the FE to use this sublist. 