### PR TITLE
SW-8055 Remove unused accelerator organization searches

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/accelerator/api/AcceleratorOrganizationsController.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/api/AcceleratorOrganizationsController.kt
@@ -15,13 +15,11 @@ import com.terraformation.backend.db.default_schema.OrganizationId
 import com.terraformation.backend.db.default_schema.ProjectId
 import com.terraformation.backend.db.default_schema.UserId
 import io.swagger.v3.oas.annotations.Operation
-import io.swagger.v3.oas.annotations.Parameter
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PutMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
-import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
 
 @AcceleratorEndpoint
@@ -35,32 +33,9 @@ class AcceleratorOrganizationsController(
   @GetMapping
   @Operation(
       summary = "Lists accelerator related organizations and their projects.",
-      description =
-          "By default, only lists tagged organizations that have projects that have not been " +
-              "assigned to participants yet.",
   )
-  fun listAcceleratorOrganizations(
-      @Parameter(
-          description = "Whether to also include projects that have been assigned to participants."
-      )
-      @RequestParam
-      includeParticipants: Boolean?,
-      @Parameter(
-          description = "Whether to load all organizations with a project with an application."
-      )
-      @RequestParam
-      hasProjectApplication: Boolean?,
-  ): ListAcceleratorOrganizationsResponsePayload {
-    val organizations =
-        if (includeParticipants == true && hasProjectApplication == true) {
-          acceleratorOrganizationStore.findAll()
-        } else if (includeParticipants == true) {
-          acceleratorOrganizationStore.findAllWithAcceleratorTag()
-        } else if (hasProjectApplication == true) {
-          acceleratorOrganizationStore.findAllWithProjectApplication()
-        } else {
-          acceleratorOrganizationStore.fetchWithUnassignedProjects()
-        }
+  fun listAcceleratorOrganizations(): ListAcceleratorOrganizationsResponsePayload {
+    val organizations = acceleratorOrganizationStore.findAll()
 
     return ListAcceleratorOrganizationsResponsePayload(
         organizations.map { (organization, projects) ->

--- a/src/main/kotlin/com/terraformation/backend/accelerator/db/AcceleratorOrganizationStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/db/AcceleratorOrganizationStore.kt
@@ -1,80 +1,32 @@
 package com.terraformation.backend.accelerator.db
 
 import com.terraformation.backend.customer.model.ExistingProjectModel
-import com.terraformation.backend.customer.model.InternalTagIds
 import com.terraformation.backend.customer.model.OrganizationModel
 import com.terraformation.backend.customer.model.ProjectModel
 import com.terraformation.backend.customer.model.requirePermissions
 import com.terraformation.backend.db.accelerator.tables.references.APPLICATIONS
 import com.terraformation.backend.db.default_schema.tables.references.ORGANIZATIONS
-import com.terraformation.backend.db.default_schema.tables.references.ORGANIZATION_INTERNAL_TAGS
 import com.terraformation.backend.db.default_schema.tables.references.PROJECTS
 import jakarta.inject.Named
-import org.jooq.Condition
 import org.jooq.DSLContext
 import org.jooq.impl.DSL
+import org.jooq.impl.DSL.multiset
+import org.jooq.impl.DSL.selectFrom
 
 @Named
 class AcceleratorOrganizationStore(private val dslContext: DSLContext) {
   /**
-   * Returns all the projects in organizations with the Accelerator internal tag that have not been
-   * assigned to cohorts yet.
-   */
-  fun fetchWithUnassignedProjects(): Map<OrganizationModel, List<ExistingProjectModel>> {
-    requirePermissions { readInternalTags() }
-
-    val hasParticipantProject =
-        DSL.exists(
-            DSL.selectOne()
-                .from(PROJECTS)
-                .where(PROJECTS.ORGANIZATION_ID.eq(ORGANIZATIONS.ID))
-                .and(PROJECTS.COHORT_ID.isNull)
-        )
-
-    val isUnassigned = PROJECTS.COHORT_ID.isNull
-
-    return fetchWithProjects(
-        listOf(hasAcceleratorTagCondition, hasParticipantProject),
-        listOf(isUnassigned),
-    )
-  }
-
-  /**
-   * Returns all the projects in organizations with either the Accelerator internal tag or those
-   * that have an application
+   * Returns all the projects in organizations that have projects in the accelerator or with an
+   * accelerator application.
    */
   fun findAll(): Map<OrganizationModel, List<ExistingProjectModel>> {
     requirePermissions { readInternalTags() }
     requirePermissions { readAllAcceleratorDetails() }
 
-    return fetchWithProjects(listOf(hasAcceleratorTagCondition.or(hasProjectApplicationCondition)))
-  }
-
-  /** Returns all the projects in organizations with the Accelerator internal tag. */
-  fun findAllWithAcceleratorTag(): Map<OrganizationModel, List<ExistingProjectModel>> {
-    requirePermissions { readInternalTags() }
-
-    return fetchWithProjects(listOf(hasAcceleratorTagCondition))
-  }
-
-  fun findAllWithProjectApplication(): Map<OrganizationModel, List<ExistingProjectModel>> {
-    requirePermissions { readAllAcceleratorDetails() }
-
-    return fetchWithProjects(listOf(hasProjectApplicationCondition))
-  }
-
-  private fun fetchWithProjects(
-      orgConditions: List<Condition>,
-      projectConditions: List<Condition> = emptyList(),
-  ): Map<OrganizationModel, List<ExistingProjectModel>> {
-    if (orgConditions.isEmpty()) {
-      return emptyMap()
-    }
-
     val projectsMultiset =
-        DSL.multiset(
-                DSL.selectFrom(PROJECTS)
-                    .where(projectConditions + PROJECTS.ORGANIZATION_ID.eq(ORGANIZATIONS.ID))
+        multiset(
+                selectFrom(PROJECTS)
+                    .where(PROJECTS.ORGANIZATION_ID.eq(ORGANIZATIONS.ID))
                     .orderBy(PROJECTS.NAME)
             )
             .convertFrom { result -> result.map { ProjectModel.of(it) } }
@@ -82,26 +34,18 @@ class AcceleratorOrganizationStore(private val dslContext: DSLContext) {
     return dslContext
         .select(ORGANIZATIONS.asterisk(), projectsMultiset)
         .from(ORGANIZATIONS)
-        .where(orgConditions)
+        .where(
+            DSL.exists(
+                DSL.selectOne()
+                    .from(PROJECTS)
+                    .leftJoin(APPLICATIONS)
+                    .on(PROJECTS.ID.eq(APPLICATIONS.PROJECT_ID))
+                    .where(PROJECTS.PHASE_ID.isNotNull.or(APPLICATIONS.PROJECT_ID.isNotNull))
+                    .and(PROJECTS.ORGANIZATION_ID.eq(ORGANIZATIONS.ID))
+            )
+        )
         .orderBy(ORGANIZATIONS.NAME)
         .fetch { OrganizationModel(it) to it[projectsMultiset] }
         .toMap()
   }
-
-  private val hasAcceleratorTagCondition =
-      DSL.exists(
-          DSL.selectOne()
-              .from(ORGANIZATION_INTERNAL_TAGS)
-              .where(ORGANIZATION_INTERNAL_TAGS.ORGANIZATION_ID.eq(ORGANIZATIONS.ID))
-              .and(ORGANIZATION_INTERNAL_TAGS.INTERNAL_TAG_ID.eq(InternalTagIds.Accelerator))
-      )
-
-  private val hasProjectApplicationCondition =
-      DSL.exists(
-          DSL.selectOne()
-              .from(APPLICATIONS)
-              .join(PROJECTS)
-              .on(PROJECTS.ID.eq(APPLICATIONS.PROJECT_ID))
-              .where(PROJECTS.ORGANIZATION_ID.eq(ORGANIZATIONS.ID))
-      )
 }

--- a/src/main/kotlin/com/terraformation/backend/customer/model/ProjectModel.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/ProjectModel.kt
@@ -1,6 +1,7 @@
 package com.terraformation.backend.customer.model
 
 import com.terraformation.backend.db.accelerator.CohortId
+import com.terraformation.backend.db.accelerator.CohortPhase
 import com.terraformation.backend.db.default_schema.OrganizationId
 import com.terraformation.backend.db.default_schema.ProjectId
 import com.terraformation.backend.db.default_schema.UserId
@@ -20,6 +21,7 @@ data class ProjectModel<ID : ProjectId?>(
     val modifiedTime: Instant? = null,
     val name: String,
     val organizationId: OrganizationId,
+    val phase: CohortPhase? = null,
 ) {
   companion object {
     fun of(row: ProjectsRow): ExistingProjectModel {
@@ -34,6 +36,7 @@ data class ProjectModel<ID : ProjectId?>(
           row.modifiedTime,
           row.name!!,
           row.organizationId!!,
+          row.phaseId,
       )
     }
 
@@ -49,6 +52,7 @@ data class ProjectModel<ID : ProjectId?>(
           modifiedTime = record[PROJECTS.MODIFIED_TIME]!!,
           name = record[PROJECTS.NAME]!!,
           organizationId = record[PROJECTS.ORGANIZATION_ID]!!,
+          phase = record[PROJECTS.PHASE_ID],
       )
     }
   }

--- a/src/test/kotlin/com/terraformation/backend/accelerator/db/AcceleratorOrganizationStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/db/AcceleratorOrganizationStoreTest.kt
@@ -6,14 +6,13 @@ import com.terraformation.backend.customer.model.InternalTagIds
 import com.terraformation.backend.customer.model.OrganizationModel
 import com.terraformation.backend.customer.model.TerrawareUser
 import com.terraformation.backend.db.DatabaseTest
+import com.terraformation.backend.db.accelerator.CohortPhase
 import com.terraformation.backend.db.default_schema.GlobalRole
 import java.time.Instant
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.assertThrows
-import org.springframework.security.access.AccessDeniedException
 
 class AcceleratorOrganizationStoreTest : DatabaseTest(), RunsAsDatabaseUser {
   override lateinit var user: TerrawareUser
@@ -28,268 +27,15 @@ class AcceleratorOrganizationStoreTest : DatabaseTest(), RunsAsDatabaseUser {
   }
 
   @Nested
-  inner class FetchWithUnassignedProjects {
-    @Test
-    fun `only returns unassigned projects in Accelerator tagged organizations`() {
-      val acceleratorOrgId1 = insertOrganization()
-      val acceleratorOrgId2 = insertOrganization()
-      val nonAcceleratorOrgId = insertOrganization()
-      val untaggedOrgId = insertOrganization()
-      val cohortId = insertCohort()
-      val currentUserId = user.userId
-
-      insertOrganizationInternalTag(acceleratorOrgId1, InternalTagIds.Accelerator)
-      insertOrganizationInternalTag(acceleratorOrgId2, InternalTagIds.Accelerator)
-      insertOrganizationInternalTag(nonAcceleratorOrgId, InternalTagIds.Internal)
-
-      insertProject(organizationId = nonAcceleratorOrgId)
-      insertProject(organizationId = untaggedOrgId)
-      insertProject(organizationId = acceleratorOrgId1, cohortId = cohortId)
-      val unassignedProjectId1 = insertProject(organizationId = acceleratorOrgId1, name = "A")
-      val unassignedProjectId2 = insertProject(organizationId = acceleratorOrgId2, name = "C")
-      val unassignedProjectId3 = insertProject(organizationId = acceleratorOrgId2, name = "B")
-
-      assertEquals(
-          mapOf(
-              OrganizationModel(
-                  createdTime = Instant.EPOCH,
-                  id = acceleratorOrgId1,
-                  name = "Organization 1",
-                  totalUsers = 0,
-              ) to
-                  listOf(
-                      ExistingProjectModel(
-                          createdBy = currentUserId,
-                          createdTime = Instant.EPOCH,
-                          id = unassignedProjectId1,
-                          modifiedBy = currentUserId,
-                          modifiedTime = Instant.EPOCH,
-                          name = "A",
-                          organizationId = acceleratorOrgId1,
-                      ),
-                  ),
-              OrganizationModel(
-                  createdTime = Instant.EPOCH,
-                  id = acceleratorOrgId2,
-                  name = "Organization 2",
-                  totalUsers = 0,
-              ) to
-                  listOf(
-                      ExistingProjectModel(
-                          createdBy = currentUserId,
-                          createdTime = Instant.EPOCH,
-                          id = unassignedProjectId3,
-                          modifiedBy = currentUserId,
-                          modifiedTime = Instant.EPOCH,
-                          name = "B",
-                          organizationId = acceleratorOrgId2,
-                      ),
-                      ExistingProjectModel(
-                          createdBy = currentUserId,
-                          createdTime = Instant.EPOCH,
-                          id = unassignedProjectId2,
-                          modifiedBy = currentUserId,
-                          modifiedTime = Instant.EPOCH,
-                          name = "C",
-                          organizationId = acceleratorOrgId2,
-                      ),
-                  ),
-          ),
-          store.fetchWithUnassignedProjects(),
-      )
-    }
-
-    @Test
-    fun `throws exception if no permission to read internal tags`() {
-      deleteUserGlobalRole(role = GlobalRole.ReadOnly)
-
-      assertThrows<AccessDeniedException> { store.fetchWithUnassignedProjects() }
-    }
-  }
-
-  @Nested
-  inner class FindAllWithAcceleratorTag {
-    @Test
-    fun `returns both assigned and unassigned projects in Accelerator tagged organizations`() {
-      val acceleratorOrgId1 = insertOrganization()
-      val acceleratorOrgId2 = insertOrganization()
-      val acceleratorOrgIdWithoutProjects = insertOrganization()
-      val nonAcceleratorOrgId = insertOrganization()
-      val untaggedOrgId = insertOrganization()
-      val cohortId = insertCohort()
-      val currentUserId = user.userId
-
-      insertOrganizationInternalTag(acceleratorOrgId1, InternalTagIds.Accelerator)
-      insertOrganizationInternalTag(acceleratorOrgId2, InternalTagIds.Accelerator)
-      insertOrganizationInternalTag(acceleratorOrgIdWithoutProjects, InternalTagIds.Accelerator)
-      insertOrganizationInternalTag(nonAcceleratorOrgId, InternalTagIds.Internal)
-
-      insertProject(organizationId = nonAcceleratorOrgId)
-      insertProject(organizationId = untaggedOrgId)
-      val assignedProjectId =
-          insertProject(
-              organizationId = acceleratorOrgId1,
-              name = "D",
-              cohortId = cohortId,
-          )
-      val unassignedProjectId1 = insertProject(organizationId = acceleratorOrgId1, name = "A")
-      val unassignedProjectId2 = insertProject(organizationId = acceleratorOrgId2, name = "C")
-
-      assertEquals(
-          mapOf(
-              OrganizationModel(
-                  createdTime = Instant.EPOCH,
-                  id = acceleratorOrgId1,
-                  name = "Organization 1",
-                  totalUsers = 0,
-              ) to
-                  listOf(
-                      ExistingProjectModel(
-                          createdBy = currentUserId,
-                          createdTime = Instant.EPOCH,
-                          id = unassignedProjectId1,
-                          modifiedBy = currentUserId,
-                          modifiedTime = Instant.EPOCH,
-                          name = "A",
-                          organizationId = acceleratorOrgId1,
-                      ),
-                      ExistingProjectModel(
-                          cohortId = cohortId,
-                          createdBy = currentUserId,
-                          createdTime = Instant.EPOCH,
-                          id = assignedProjectId,
-                          modifiedBy = currentUserId,
-                          modifiedTime = Instant.EPOCH,
-                          name = "D",
-                          organizationId = acceleratorOrgId1,
-                      ),
-                  ),
-              OrganizationModel(
-                  createdTime = Instant.EPOCH,
-                  id = acceleratorOrgId2,
-                  name = "Organization 2",
-                  totalUsers = 0,
-              ) to
-                  listOf(
-                      ExistingProjectModel(
-                          createdBy = currentUserId,
-                          createdTime = Instant.EPOCH,
-                          id = unassignedProjectId2,
-                          modifiedBy = currentUserId,
-                          modifiedTime = Instant.EPOCH,
-                          name = "C",
-                          organizationId = acceleratorOrgId2,
-                      ),
-                  ),
-              OrganizationModel(
-                  createdTime = Instant.EPOCH,
-                  id = acceleratorOrgIdWithoutProjects,
-                  name = "Organization 3",
-                  totalUsers = 0,
-              ) to emptyList(),
-          ),
-          store.findAllWithAcceleratorTag(),
-      )
-    }
-
-    @Test
-    fun `throws exception if no permission to read internal tags`() {
-      deleteUserGlobalRole(role = GlobalRole.ReadOnly)
-
-      assertThrows<AccessDeniedException> { store.fetchWithUnassignedProjects() }
-    }
-  }
-
-  @Nested
-  inner class FindAllWithProjectApplication {
-    @Test
-    fun `returns all organizations with a project that has an application`() {
-      val projectApplicationOrg1Id = insertOrganization(name = "ProjectApplicationOrg1")
-      val projectApplicationOrg1ProjectId = insertProject(organizationId = projectApplicationOrg1Id)
-      insertApplication(
-          internalName = "Org1ProjectApplication",
-          projectId = projectApplicationOrg1ProjectId,
-      )
-
-      val projectApplicationOrg2Id = insertOrganization(name = "ProjectApplicationOrg2")
-      val projectApplicationOrg2ProjectId = insertProject(organizationId = projectApplicationOrg2Id)
-      insertApplication(
-          internalName = "Org2ProjectApplication",
-          projectId = projectApplicationOrg2ProjectId,
-      )
-
-      val otherOrgIdWithoutProjectApplication =
-          insertOrganization(name = "OtherOrgWithoutProjectApplication")
-      insertProject(organizationId = otherOrgIdWithoutProjectApplication)
-
-      insertOrganization(name = "OtherOrgWithoutProjects")
-
-      val currentUserId = user.userId
-
-      assertEquals(
-          mapOf(
-              OrganizationModel(
-                  createdTime = Instant.EPOCH,
-                  id = projectApplicationOrg1Id,
-                  name = "ProjectApplicationOrg1",
-                  totalUsers = 0,
-              ) to
-                  listOf(
-                      ExistingProjectModel(
-                          createdBy = currentUserId,
-                          createdTime = Instant.EPOCH,
-                          id = projectApplicationOrg1ProjectId,
-                          modifiedBy = currentUserId,
-                          modifiedTime = Instant.EPOCH,
-                          name = "Project 1",
-                          organizationId = projectApplicationOrg1Id,
-                      ),
-                  ),
-              OrganizationModel(
-                  createdTime = Instant.EPOCH,
-                  id = projectApplicationOrg2Id,
-                  name = "ProjectApplicationOrg2",
-                  totalUsers = 0,
-              ) to
-                  listOf(
-                      ExistingProjectModel(
-                          createdBy = currentUserId,
-                          createdTime = Instant.EPOCH,
-                          id = projectApplicationOrg2ProjectId,
-                          modifiedBy = currentUserId,
-                          modifiedTime = Instant.EPOCH,
-                          name = "Project 2",
-                          organizationId = projectApplicationOrg2Id,
-                      ),
-                  ),
-          ),
-          store.findAllWithProjectApplication(),
-      )
-    }
-
-    @Test
-    fun `throws exception if no permission to read all accelerator details (read only and higher)`() {
-      deleteUserGlobalRole(role = GlobalRole.ReadOnly)
-
-      assertThrows<AccessDeniedException> { store.findAllWithProjectApplication() }
-    }
-  }
-
-  @Nested
   inner class FindAll {
     @Test
-    fun `finds projects with applications, plus assigned and unassigned projects under orgs with tag`() {
+    fun `finds projects with applications, plus assigned and unassigned projects under orgs with projects in phases`() {
       val acceleratorOrgId1 = insertOrganization()
-      val acceleratorOrgId2 = insertOrganization()
-      val acceleratorOrgIdWithoutProjects = insertOrganization()
       val nonAcceleratorOrgId = insertOrganization()
       val untaggedOrgId = insertOrganization()
       val cohortId = insertCohort()
       val currentUserId = user.userId
 
-      insertOrganizationInternalTag(acceleratorOrgId1, InternalTagIds.Accelerator)
-      insertOrganizationInternalTag(acceleratorOrgId2, InternalTagIds.Accelerator)
-      insertOrganizationInternalTag(acceleratorOrgIdWithoutProjects, InternalTagIds.Accelerator)
       insertOrganizationInternalTag(nonAcceleratorOrgId, InternalTagIds.Internal)
 
       insertProject(organizationId = nonAcceleratorOrgId)
@@ -299,9 +45,9 @@ class AcceleratorOrganizationStoreTest : DatabaseTest(), RunsAsDatabaseUser {
               organizationId = acceleratorOrgId1,
               name = "D",
               cohortId = cohortId,
+              phase = CohortPhase.Phase0DueDiligence,
           )
       val unassignedProjectId1 = insertProject(organizationId = acceleratorOrgId1, name = "A")
-      val unassignedProjectId2 = insertProject(organizationId = acceleratorOrgId2, name = "C")
 
       val projectApplicationOrg1Id = insertOrganization(name = "ProjectApplicationOrg1")
       val projectApplicationOrg1ProjectId = insertProject(organizationId = projectApplicationOrg1Id)
@@ -350,31 +96,9 @@ class AcceleratorOrganizationStoreTest : DatabaseTest(), RunsAsDatabaseUser {
                           modifiedTime = Instant.EPOCH,
                           name = "D",
                           organizationId = acceleratorOrgId1,
+                          phase = CohortPhase.Phase0DueDiligence,
                       ),
                   ),
-              OrganizationModel(
-                  createdTime = Instant.EPOCH,
-                  id = acceleratorOrgId2,
-                  name = "Organization 2",
-                  totalUsers = 0,
-              ) to
-                  listOf(
-                      ExistingProjectModel(
-                          createdBy = currentUserId,
-                          createdTime = Instant.EPOCH,
-                          id = unassignedProjectId2,
-                          modifiedBy = currentUserId,
-                          modifiedTime = Instant.EPOCH,
-                          name = "C",
-                          organizationId = acceleratorOrgId2,
-                      ),
-                  ),
-              OrganizationModel(
-                  createdTime = Instant.EPOCH,
-                  id = acceleratorOrgIdWithoutProjects,
-                  name = "Organization 3",
-                  totalUsers = 0,
-              ) to emptyList(),
               OrganizationModel(
                   createdTime = Instant.EPOCH,
                   id = projectApplicationOrg1Id,


### PR DESCRIPTION
The web app no longer needs to search for organizations with the Accelerator
internal tag, so remove that ability from the accelerator organizations
endpoint and change the implementation to only return organizations that have
projects with phases or applications.