### PR TITLE
SW-8059 Read phase from project, not cohort

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/accelerator/AcceleratorProjectService.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/AcceleratorProjectService.kt
@@ -47,9 +47,9 @@ class AcceleratorProjectService(
         .select(
             COHORTS.ID,
             COHORTS.NAME,
-            COHORTS.PHASE_ID,
             PROJECTS.ID,
             PROJECTS.NAME,
+            PROJECTS.PHASE_ID,
             decisionsMultiset,
         )
         .from(PROJECTS)

--- a/src/main/kotlin/com/terraformation/backend/accelerator/VoteService.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/VoteService.kt
@@ -9,6 +9,7 @@ import com.terraformation.backend.customer.model.SystemUser
 import jakarta.inject.Named
 import org.jooq.DSLContext
 import org.springframework.context.event.EventListener
+import org.springframework.core.annotation.Order
 
 @Named
 class VoteService(
@@ -23,6 +24,7 @@ class VoteService(
   }
 
   @EventListener
+  @Order(ProjectPhaseService.EVENT_LISTENER_ORDER + 10)
   fun on(event: CohortPhaseUpdatedEvent) {
     systemUser.run {
       val cohort = cohortStore.fetchOneById(event.cohortId, CohortDepth.Project)

--- a/src/main/kotlin/com/terraformation/backend/accelerator/db/ProjectAcceleratorDetailsStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/db/ProjectAcceleratorDetailsStore.kt
@@ -64,10 +64,10 @@ class ProjectAcceleratorDetailsStore(
     return dslContext
         .select(
             PROJECT_ACCELERATOR_DETAILS.asterisk(),
-            PROJECTS.ID,
             COHORTS.ID,
             COHORTS.NAME,
-            COHORTS.PHASE_ID,
+            PROJECTS.ID,
+            PROJECTS.PHASE_ID,
             projectProgressMultiset,
         )
         .from(PROJECTS)

--- a/src/main/kotlin/com/terraformation/backend/accelerator/db/ProjectCohortFetcher.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/db/ProjectCohortFetcher.kt
@@ -17,7 +17,7 @@ class ProjectCohortFetcher(private val dslContext: DSLContext) {
     requirePermissions { readProject(projectId) }
 
     return dslContext
-        .select(COHORTS.ID, COHORTS.PHASE_ID, APPLICATIONS.APPLICATION_STATUS_ID)
+        .select(COHORTS.ID, PROJECTS.PHASE_ID, APPLICATIONS.APPLICATION_STATUS_ID)
         .from(PROJECTS)
         .leftJoin(COHORTS)
         .on(PROJECTS.COHORT_ID.eq(COHORTS.ID))

--- a/src/main/kotlin/com/terraformation/backend/accelerator/model/AcceleratorProjectModel.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/model/AcceleratorProjectModel.kt
@@ -26,7 +26,7 @@ data class AcceleratorProjectModel(
       return AcceleratorProjectModel(
           cohortId = record[COHORTS.ID]!!,
           cohortName = record[COHORTS.NAME]!!,
-          phase = record[COHORTS.PHASE_ID]!!,
+          phase = record[PROJECTS.PHASE_ID]!!,
           projectId = record[PROJECTS.ID]!!,
           projectName = record[PROJECTS.NAME]!!,
           voteDecisions = record[decisionsField] ?: emptyMap(),

--- a/src/main/kotlin/com/terraformation/backend/accelerator/model/ProjectAcceleratorDetailsModel.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/model/ProjectAcceleratorDetailsModel.kt
@@ -111,7 +111,7 @@ data class ProjectAcceleratorDetailsModel(
             numCommunities = record[NUM_COMMUNITIES],
             numNativeSpecies = variableValues.numNativeSpecies,
             perHectareBudget = variableValues.perHectareBudget,
-            phase = record[COHORTS.PHASE_ID],
+            phase = record[PROJECTS.PHASE_ID],
             pipeline = record[PIPELINE_ID],
             plantingSitesCql = record[PLANTING_SITES_CQL],
             projectArea = variableValues.projectArea,
@@ -173,8 +173,4 @@ data class ProjectAcceleratorDetailsModel(
           verraLink = verraLink,
           whatNeedsToBeTrue = whatNeedsToBeTrue,
       )
-
-  @Deprecated("Use phase instead.")
-  val cohortPhase: CohortPhase?
-    get() = phase
 }

--- a/src/test/kotlin/com/terraformation/backend/accelerator/AcceleratorProjectServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/AcceleratorProjectServiceTest.kt
@@ -27,7 +27,11 @@ class AcceleratorProjectServiceTest : DatabaseTest(), RunsAsDatabaseUser {
     insertOrganization()
     insertOrganizationInternalTag(tagId = InternalTagIds.Accelerator)
     insertCohort(phase = CohortPhase.Phase1FeasibilityStudy)
-    insertProject(cohortId = inserted.cohortId, countryCode = "KE")
+    insertProject(
+        cohortId = inserted.cohortId,
+        countryCode = "KE",
+        phase = CohortPhase.Phase1FeasibilityStudy,
+    )
     insertVoteDecision(
         projectId = inserted.projectId,
         phase = CohortPhase.Phase0DueDiligence,
@@ -49,12 +53,11 @@ class AcceleratorProjectServiceTest : DatabaseTest(), RunsAsDatabaseUser {
 
   @Test
   fun `fetches one by Id, or throws not found exception`() {
-    val phase = cohortsDao.fetchOneById(inserted.cohortId)!!.phaseId!!
     assertEquals(
         AcceleratorProjectModel(
             cohortId = inserted.cohortId,
             cohortName = cohortsDao.fetchOneById(inserted.cohortId)!!.name!!,
-            phase = phase,
+            phase = CohortPhase.Phase1FeasibilityStudy,
             projectId = inserted.projectId,
             projectName = projectsDao.fetchOneById(inserted.projectId)!!.name!!,
             voteDecisions =
@@ -72,13 +75,12 @@ class AcceleratorProjectServiceTest : DatabaseTest(), RunsAsDatabaseUser {
 
   @Test
   fun `returns accelerator projects`() {
-    val phase = cohortsDao.fetchOneById(inserted.cohortId)!!.phaseId!!
     assertEquals(
         listOf(
             AcceleratorProjectModel(
                 cohortId = inserted.cohortId,
                 cohortName = cohortsDao.fetchOneById(inserted.cohortId)!!.name!!,
-                phase = phase,
+                phase = CohortPhase.Phase1FeasibilityStudy,
                 projectId = inserted.projectId,
                 projectName = projectsDao.fetchOneById(inserted.projectId)!!.name!!,
                 voteDecisions =

--- a/src/test/kotlin/com/terraformation/backend/accelerator/VoteServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/VoteServiceTest.kt
@@ -56,7 +56,7 @@ class VoteServiceTest : DatabaseTest(), RunsAsDatabaseUser {
     @Test
     fun `inserts voters`() {
       val cohortId1 = insertCohort()
-      val projectId1 = insertProject(cohortId = cohortId1)
+      val projectId1 = insertProject(cohortId = cohortId1, phase = CohortPhase.Phase0DueDiligence)
 
       // Should leave these alone
       insertProject(cohortId = cohortId1)
@@ -85,8 +85,8 @@ class VoteServiceTest : DatabaseTest(), RunsAsDatabaseUser {
     fun `inserts voters`() {
       val phase = CohortPhase.Phase1FeasibilityStudy
       val cohortId1 = insertCohort(phase = phase)
-      val projectId1 = insertProject(cohortId = cohortId1)
-      val projectId2 = insertProject(cohortId = cohortId1)
+      val projectId1 = insertProject(cohortId = cohortId1, phase = phase)
+      val projectId2 = insertProject(cohortId = cohortId1, phase = phase)
 
       // Should leave these alone
       val otherCohortId = insertCohort()

--- a/src/test/kotlin/com/terraformation/backend/accelerator/db/ProjectAcceleratorDetailsStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/db/ProjectAcceleratorDetailsStoreTest.kt
@@ -60,7 +60,8 @@ class ProjectAcceleratorDetailsStoreTest : DatabaseTest(), RunsAsUser {
     @Test
     fun `returns all details fields`() {
       insertCohort(name = "Cohort name", phase = CohortPhase.Phase0DueDiligence)
-      val projectId = insertProject(cohortId = inserted.cohortId)
+      val projectId =
+          insertProject(cohortId = inserted.cohortId, phase = CohortPhase.Phase0DueDiligence)
       insertProjectLandUseModelType(landUseModelType = LandUseModelType.Agroforestry)
       insertProjectLandUseModelType(landUseModelType = LandUseModelType.Mangroves)
 
@@ -662,7 +663,8 @@ class ProjectAcceleratorDetailsStoreTest : DatabaseTest(), RunsAsUser {
       insertCohort(name = "Test Cohort", phase = CohortPhase.Phase0DueDiligence)
       insertModule()
       insertCohortModule()
-      val projectId = insertProject(cohortId = inserted.cohortId)
+      val projectId =
+          insertProject(cohortId = inserted.cohortId, phase = CohortPhase.Phase0DueDiligence)
 
       val existingValues =
           ProjectAcceleratorVariableValuesModel(
@@ -689,8 +691,18 @@ class ProjectAcceleratorDetailsStoreTest : DatabaseTest(), RunsAsUser {
     @Test
     fun `clears cohort but keeps it when phase is set to null and other projects use it`() {
       insertCohort(name = "Shared Cohort", phase = CohortPhase.Phase0DueDiligence)
-      val projectId1 = insertProject(name = "Project 1", cohortId = inserted.cohortId)
-      val projectId2 = insertProject(name = "Project 2", cohortId = inserted.cohortId)
+      val projectId1 =
+          insertProject(
+              name = "Project 1",
+              cohortId = inserted.cohortId,
+              phase = CohortPhase.Phase0DueDiligence,
+          )
+      val projectId2 =
+          insertProject(
+              name = "Project 2",
+              cohortId = inserted.cohortId,
+              phase = CohortPhase.Phase0DueDiligence,
+          )
 
       val existingValues =
           ProjectAcceleratorVariableValuesModel(

--- a/src/test/kotlin/com/terraformation/backend/accelerator/db/ProjectCohortFetcherTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/db/ProjectCohortFetcherTest.kt
@@ -36,7 +36,7 @@ class ProjectCohortFetcherTest : DatabaseTest(), RunsAsUser {
     @Test
     fun `fetches project's cohort data`() {
       val cohortId = insertCohort()
-      val projectId = insertProject(cohortId = cohortId)
+      val projectId = insertProject(cohortId = cohortId, phase = CohortPhase.Phase0DueDiligence)
 
       val expected =
           ProjectCohortData(cohortId = cohortId, cohortPhase = CohortPhase.Phase0DueDiligence)
@@ -48,7 +48,7 @@ class ProjectCohortFetcherTest : DatabaseTest(), RunsAsUser {
     @Test
     fun `uses cohort data even if project has an application`() {
       val cohortId = insertCohort()
-      val projectId = insertProject(cohortId = cohortId)
+      val projectId = insertProject(cohortId = cohortId, phase = CohortPhase.Phase0DueDiligence)
       insertApplication()
 
       val expected =

--- a/src/test/kotlin/com/terraformation/backend/accelerator/db/ProjectScoreStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/db/ProjectScoreStoreTest.kt
@@ -156,7 +156,8 @@ class ProjectScoreStoreTest : DatabaseTest(), RunsAsUser {
   inner class UpdateScores {
     @Test
     fun `creates scores that do not exist`() {
-      val projectId = insertProject(cohortId = inserted.cohortId)
+      val projectId =
+          insertProject(cohortId = inserted.cohortId, phase = CohortPhase.Phase0DueDiligence)
 
       clock.instant = Instant.ofEpochSecond(123)
 
@@ -198,7 +199,8 @@ class ProjectScoreStoreTest : DatabaseTest(), RunsAsUser {
 
     @Test
     fun `updates scores that already exist`() {
-      val projectId = insertProject(cohortId = inserted.cohortId)
+      val projectId =
+          insertProject(cohortId = inserted.cohortId, phase = CohortPhase.Phase0DueDiligence)
 
       insertProjectScore(phase = CohortPhase.Phase0DueDiligence, category = ScoreCategory.Legal)
       insertProjectScore(
@@ -276,7 +278,8 @@ class ProjectScoreStoreTest : DatabaseTest(), RunsAsUser {
 
     @Test
     fun `throws exception if updating scores for a different phase than the current one`() {
-      val projectId = insertProject(cohortId = inserted.cohortId)
+      val projectId =
+          insertProject(cohortId = inserted.cohortId, phase = CohortPhase.Phase0DueDiligence)
 
       assertThrows<ProjectNotInCohortPhaseException> {
         store.updateScores(

--- a/src/test/kotlin/com/terraformation/backend/accelerator/db/VoteStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/db/VoteStoreTest.kt
@@ -210,9 +210,9 @@ class VoteStoreTest : DatabaseTest(), RunsAsUser {
 
     @Test
     fun `fetches vote decisions by phase`() {
-      val projectId = insertProject(cohortId = inserted.cohortId)
       val phase0: CohortPhase = CohortPhase.Phase0DueDiligence
       val phase1: CohortPhase = CohortPhase.Phase1FeasibilityStudy
+      val projectId = insertProject(cohortId = inserted.cohortId, phase = phase1)
 
       insertVoteDecision(projectId, phase0, VoteOption.Yes, clock.instant)
       insertVoteDecision(projectId, phase1, VoteOption.No, clock.instant)
@@ -230,8 +230,8 @@ class VoteStoreTest : DatabaseTest(), RunsAsUser {
   inner class Delete {
     @Test
     fun `delete only vote`() {
-      val projectId = insertProject(cohortId = inserted.cohortId)
       val phase: CohortPhase = CohortPhase.Phase1FeasibilityStudy
+      val projectId = insertProject(cohortId = inserted.cohortId, phase = phase)
 
       val newUser = insertUser()
       val vote = VoteOption.No
@@ -245,8 +245,8 @@ class VoteStoreTest : DatabaseTest(), RunsAsUser {
 
     @Test
     fun `delete one vote from multiple voters`() {
-      val projectId = insertProject(cohortId = inserted.cohortId)
       val phase: CohortPhase = CohortPhase.Phase1FeasibilityStudy
+      val projectId = insertProject(cohortId = inserted.cohortId, phase = phase)
       clock.instant = Instant.EPOCH.plusSeconds(500)
 
       val user1 = insertUser()
@@ -293,9 +293,9 @@ class VoteStoreTest : DatabaseTest(), RunsAsUser {
 
     @Test
     fun `delete one phase of votes from multiple phases`() {
-      val projectId = insertProject(cohortId = inserted.cohortId)
       val phase0: CohortPhase = CohortPhase.Phase0DueDiligence
       val phase1: CohortPhase = CohortPhase.Phase1FeasibilityStudy
+      val projectId = insertProject(cohortId = inserted.cohortId, phase = phase1)
       clock.instant = Instant.EPOCH.plusSeconds(500)
 
       val user1 = insertUser()
@@ -369,9 +369,9 @@ class VoteStoreTest : DatabaseTest(), RunsAsUser {
     }
 
     @Test
-    fun `throws exception on delete if no permission to update votes `() {
-      val projectId = insertProject(cohortId = inserted.cohortId)
+    fun `throws exception on delete if no permission to update votes`() {
       val phase: CohortPhase = CohortPhase.Phase1FeasibilityStudy
+      val projectId = insertProject(cohortId = inserted.cohortId, phase = phase)
       val newUser = insertUser()
       val vote = VoteOption.No
       insertVote(projectId, phase, newUser, vote)
@@ -382,7 +382,7 @@ class VoteStoreTest : DatabaseTest(), RunsAsUser {
     }
 
     @Test
-    fun `throws exception on delete if project not in cohort `() {
+    fun `throws exception on delete if project not in phase`() {
       val projectId = insertProject()
       val phase: CohortPhase = CohortPhase.Phase1FeasibilityStudy
       val newUser = insertUser()
@@ -393,9 +393,10 @@ class VoteStoreTest : DatabaseTest(), RunsAsUser {
     }
 
     @Test
-    fun `throws exception on delete for wrong phase `() {
-      val projectId = insertProject(cohortId = inserted.cohortId)
+    fun `throws exception on delete for wrong phase`() {
       val phase: CohortPhase = CohortPhase.Phase0DueDiligence
+      val projectId =
+          insertProject(cohortId = inserted.cohortId, phase = CohortPhase.Phase1FeasibilityStudy)
       val newUser = insertUser()
       val vote = VoteOption.No
       insertVote(projectId, phase, newUser, vote)
@@ -405,8 +406,8 @@ class VoteStoreTest : DatabaseTest(), RunsAsUser {
 
     @Test
     fun `computes vote decision on deleting one vote from many`() {
-      val projectId = insertProject(cohortId = inserted.cohortId)
       val phase: CohortPhase = CohortPhase.Phase1FeasibilityStudy
+      val projectId = insertProject(cohortId = inserted.cohortId, phase = phase)
 
       val user1 = insertUser()
       val user2 = insertUser()
@@ -426,8 +427,8 @@ class VoteStoreTest : DatabaseTest(), RunsAsUser {
 
     @Test
     fun `computes vote decision on deleting only vote`() {
-      val projectId = insertProject(cohortId = inserted.cohortId)
       val phase: CohortPhase = CohortPhase.Phase1FeasibilityStudy
+      val projectId = insertProject(cohortId = inserted.cohortId, phase = phase)
 
       val newUser = insertUser()
       val vote = VoteOption.No
@@ -447,10 +448,10 @@ class VoteStoreTest : DatabaseTest(), RunsAsUser {
   inner class Upsert {
     @Test
     fun `creates blank vote for self`() {
-      val projectId = insertProject(cohortId = inserted.cohortId)
+      val phase: CohortPhase = CohortPhase.Phase1FeasibilityStudy
+      val projectId = insertProject(cohortId = inserted.cohortId, phase = phase)
 
       clock.instant = Instant.EPOCH.plusSeconds(500)
-      val phase: CohortPhase = CohortPhase.Phase1FeasibilityStudy
       store.upsert(projectId, phase, user.userId, null, null)
 
       assertTableEquals(
@@ -470,11 +471,11 @@ class VoteStoreTest : DatabaseTest(), RunsAsUser {
 
     @Test
     fun `creates blank vote for other user`() {
-      val projectId = insertProject(cohortId = inserted.cohortId)
+      val phase: CohortPhase = CohortPhase.Phase1FeasibilityStudy
+      val projectId = insertProject(cohortId = inserted.cohortId, phase = phase)
       val otherUser = insertUser()
 
       clock.instant = Instant.EPOCH.plusSeconds(500)
-      val phase: CohortPhase = CohortPhase.Phase1FeasibilityStudy
       store.upsert(projectId, phase, otherUser, null, null)
 
       assertTableEquals(
@@ -494,11 +495,11 @@ class VoteStoreTest : DatabaseTest(), RunsAsUser {
 
     @Test
     fun `creates conditional vote for other user`() {
-      val projectId = insertProject(cohortId = inserted.cohortId)
+      val phase: CohortPhase = CohortPhase.Phase1FeasibilityStudy
+      val projectId = insertProject(cohortId = inserted.cohortId, phase = phase)
       val otherUser = insertUser()
 
       clock.instant = Instant.EPOCH.plusSeconds(500)
-      val phase: CohortPhase = CohortPhase.Phase1FeasibilityStudy
       val voteOption: VoteOption = VoteOption.Conditional
       val conditionalInfo = "Reason why the vote is a maybe"
       store.upsert(projectId, phase, otherUser, voteOption, conditionalInfo)
@@ -520,8 +521,8 @@ class VoteStoreTest : DatabaseTest(), RunsAsUser {
 
     @Test
     fun `update only voter selection`() {
-      val projectId = insertProject(cohortId = inserted.cohortId)
       val phase: CohortPhase = CohortPhase.Phase1FeasibilityStudy
+      val projectId = insertProject(cohortId = inserted.cohortId, phase = phase)
 
       val newUser = insertUser()
       val vote = VoteOption.No
@@ -552,8 +553,8 @@ class VoteStoreTest : DatabaseTest(), RunsAsUser {
 
     @Test
     fun `update voter selection with multiple voters`() {
-      val projectId = insertProject(cohortId = inserted.cohortId)
       val phase: CohortPhase = CohortPhase.Phase1FeasibilityStudy
+      val projectId = insertProject(cohortId = inserted.cohortId, phase = phase)
 
       val createdTime = Instant.EPOCH.plusSeconds(500)
 
@@ -617,9 +618,9 @@ class VoteStoreTest : DatabaseTest(), RunsAsUser {
 
     @Test
     fun `update voter selection for multiple phases`() {
-      val projectId = insertProject(cohortId = inserted.cohortId)
       val phase0: CohortPhase = CohortPhase.Phase0DueDiligence
       val phase1: CohortPhase = CohortPhase.Phase1FeasibilityStudy
+      val projectId = insertProject(cohortId = inserted.cohortId, phase = phase1)
 
       val createdTime = Instant.EPOCH.plusSeconds(500)
 
@@ -666,9 +667,9 @@ class VoteStoreTest : DatabaseTest(), RunsAsUser {
 
     @Test
     fun `update voter selection for multiple projects`() {
-      val project1 = insertProject(cohortId = inserted.cohortId)
-      val project2 = insertProject(cohortId = inserted.cohortId)
       val phase: CohortPhase = CohortPhase.Phase1FeasibilityStudy
+      val project1 = insertProject(cohortId = inserted.cohortId, phase = phase)
+      val project2 = insertProject(cohortId = inserted.cohortId, phase = phase)
 
       val createdTime = Instant.EPOCH.plusSeconds(500)
 
@@ -715,8 +716,8 @@ class VoteStoreTest : DatabaseTest(), RunsAsUser {
 
     @Test
     fun `throws exception on upsert if no permission to update votes`() {
-      val projectId = insertProject(cohortId = inserted.cohortId)
       val phase: CohortPhase = CohortPhase.Phase1FeasibilityStudy
+      val projectId = insertProject(cohortId = inserted.cohortId, phase = phase)
       val newUser = insertUser()
       val vote = VoteOption.No
       insertVote(projectId, phase, newUser, vote)
@@ -727,7 +728,7 @@ class VoteStoreTest : DatabaseTest(), RunsAsUser {
     }
 
     @Test
-    fun `throws exception on upsert if project not in cohort`() {
+    fun `throws exception on upsert if project not in phase`() {
       val projectId = insertProject()
       val phase: CohortPhase = CohortPhase.Phase1FeasibilityStudy
       val newUser = insertUser()
@@ -741,7 +742,8 @@ class VoteStoreTest : DatabaseTest(), RunsAsUser {
 
     @Test
     fun `throws exception on upsert if project in wrong phase`() {
-      val projectId = insertProject(cohortId = inserted.cohortId)
+      val projectId =
+          insertProject(cohortId = inserted.cohortId, phase = CohortPhase.Phase1FeasibilityStudy)
       val phase: CohortPhase = CohortPhase.Phase0DueDiligence
       val newUser = insertUser()
       val vote = VoteOption.No
@@ -754,8 +756,8 @@ class VoteStoreTest : DatabaseTest(), RunsAsUser {
 
     @Test
     fun `computes vote decision on creating one vote`() {
-      val projectId = insertProject(cohortId = inserted.cohortId)
       val phase: CohortPhase = CohortPhase.Phase1FeasibilityStudy
+      val projectId = insertProject(cohortId = inserted.cohortId, phase = phase)
       clock.instant = Instant.EPOCH.plusSeconds(500)
 
       val newUser = insertUser()
@@ -768,8 +770,8 @@ class VoteStoreTest : DatabaseTest(), RunsAsUser {
 
     @Test
     fun `computes vote decision on creating one null vote`() {
-      val projectId = insertProject(cohortId = inserted.cohortId)
       val phase: CohortPhase = CohortPhase.Phase1FeasibilityStudy
+      val projectId = insertProject(cohortId = inserted.cohortId, phase = phase)
       clock.instant = Instant.EPOCH.plusSeconds(500)
 
       val newUser = insertUser()
@@ -781,8 +783,8 @@ class VoteStoreTest : DatabaseTest(), RunsAsUser {
 
     @Test
     fun `computes vote decision on updating one vote`() {
-      val projectId = insertProject(cohortId = inserted.cohortId)
       val phase: CohortPhase = CohortPhase.Phase1FeasibilityStudy
+      val projectId = insertProject(cohortId = inserted.cohortId, phase = phase)
       clock.instant = Instant.EPOCH.plusSeconds(500)
 
       val newUser = insertUser()
@@ -799,8 +801,8 @@ class VoteStoreTest : DatabaseTest(), RunsAsUser {
 
     @Test
     fun `computes vote decision on upserting to a tie`() {
-      val projectId = insertProject(cohortId = inserted.cohortId)
       val phase: CohortPhase = CohortPhase.Phase1FeasibilityStudy
+      val projectId = insertProject(cohortId = inserted.cohortId, phase = phase)
       clock.instant = Instant.EPOCH.plusSeconds(500)
 
       val user1 = insertUser()
@@ -819,8 +821,8 @@ class VoteStoreTest : DatabaseTest(), RunsAsUser {
 
     @Test
     fun `computes vote decision on updating to no vote`() {
-      val projectId = insertProject(cohortId = inserted.cohortId)
       val phase: CohortPhase = CohortPhase.Phase1FeasibilityStudy
+      val projectId = insertProject(cohortId = inserted.cohortId, phase = phase)
       clock.instant = Instant.EPOCH.plusSeconds(500)
 
       val user1 = insertUser()


### PR DESCRIPTION
Update all the places where we were determining a project's phase by reading the
cohort to instead refer to the project's phase.

The cohort's phase is still accessed by code that directly deals with cohorts,
e.g., the "fetch the details of a cohort" code path.