### PR TITLE
SW-8060 Remove cohort deliverable due dates

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/accelerator/db/DeliverableDueDateStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/db/DeliverableDueDateStore.kt
@@ -7,7 +7,6 @@ import com.terraformation.backend.db.accelerator.DeliverableId
 import com.terraformation.backend.db.accelerator.ModuleId
 import com.terraformation.backend.db.accelerator.tables.references.COHORT_MODULES
 import com.terraformation.backend.db.accelerator.tables.references.DELIVERABLES
-import com.terraformation.backend.db.accelerator.tables.references.DELIVERABLE_COHORT_DUE_DATES
 import com.terraformation.backend.db.accelerator.tables.references.DELIVERABLE_PROJECT_DUE_DATES
 import com.terraformation.backend.db.default_schema.ProjectId
 import jakarta.inject.Named
@@ -55,44 +54,21 @@ class DeliverableDueDateStore(
             COHORT_MODULES.END_DATE,
             COHORT_MODULES.MODULE_ID,
             DELIVERABLES.ID,
-            DELIVERABLE_COHORT_DUE_DATES.DUE_DATE,
             projectDueDatesMultiset,
         )
         .from(COHORT_MODULES)
         .join(DELIVERABLES)
         .on(DELIVERABLES.MODULE_ID.eq(COHORT_MODULES.MODULE_ID))
-        .leftJoin(DELIVERABLE_COHORT_DUE_DATES)
-        .on(DELIVERABLE_COHORT_DUE_DATES.DELIVERABLE_ID.eq(DELIVERABLES.ID))
         .where(conditions)
         .fetch { record ->
           DeliverableDueDateModel(
               cohortId = record[COHORT_MODULES.COHORT_ID]!!,
               deliverableId = record[DELIVERABLES.ID]!!,
               moduleId = record[COHORT_MODULES.MODULE_ID]!!,
-              cohortDueDate = record[DELIVERABLE_COHORT_DUE_DATES.DUE_DATE],
               moduleDueDate = record[COHORT_MODULES.END_DATE]!!,
               projectDueDates = record[projectDueDatesMultiset],
           )
         }
-  }
-
-  fun upsertDeliverableCohortDueDate(
-      deliverableId: DeliverableId,
-      cohortId: CohortId,
-      dueDate: LocalDate,
-  ) {
-    requirePermissions { manageDeliverables() }
-
-    with(DELIVERABLE_COHORT_DUE_DATES) {
-      dslContext
-          .insertInto(this)
-          .set(DELIVERABLE_ID, deliverableId)
-          .set(COHORT_ID, cohortId)
-          .set(DUE_DATE, dueDate)
-          .onDuplicateKeyUpdate()
-          .set(DUE_DATE, dueDate)
-          .execute()
-    }
   }
 
   fun upsertDeliverableProjectDueDate(
@@ -110,21 +86,6 @@ class DeliverableDueDateStore(
           .set(DUE_DATE, dueDate)
           .onDuplicateKeyUpdate()
           .set(DUE_DATE, dueDate)
-          .execute()
-    }
-  }
-
-  fun deleteDeliverableCohortDueDate(
-      deliverableId: DeliverableId,
-      cohortId: CohortId,
-  ) {
-    requirePermissions { manageDeliverables() }
-
-    with(DELIVERABLE_COHORT_DUE_DATES) {
-      dslContext
-          .deleteFrom(this)
-          .where(DELIVERABLE_ID.eq(deliverableId))
-          .and(COHORT_ID.eq(cohortId))
           .execute()
     }
   }

--- a/src/main/kotlin/com/terraformation/backend/accelerator/db/DeliverableStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/db/DeliverableStore.kt
@@ -12,7 +12,6 @@ import com.terraformation.backend.db.accelerator.SubmissionStatus
 import com.terraformation.backend.db.accelerator.tables.references.COHORTS
 import com.terraformation.backend.db.accelerator.tables.references.COHORT_MODULES
 import com.terraformation.backend.db.accelerator.tables.references.DELIVERABLES
-import com.terraformation.backend.db.accelerator.tables.references.DELIVERABLE_COHORT_DUE_DATES
 import com.terraformation.backend.db.accelerator.tables.references.DELIVERABLE_DOCUMENTS
 import com.terraformation.backend.db.accelerator.tables.references.DELIVERABLE_PROJECT_DUE_DATES
 import com.terraformation.backend.db.accelerator.tables.references.MODULES
@@ -111,12 +110,7 @@ class DeliverableStore(
             )
             .convertFrom { result -> result.map { SubmissionDocumentModel.of(it) } }
 
-    val dueDateField =
-        DSL.coalesce(
-            DELIVERABLE_PROJECT_DUE_DATES.DUE_DATE,
-            DELIVERABLE_COHORT_DUE_DATES.DUE_DATE,
-            COHORT_MODULES.END_DATE,
-        )
+    val dueDateField = DSL.coalesce(DELIVERABLE_PROJECT_DUE_DATES.DUE_DATE, COHORT_MODULES.END_DATE)
 
     val deliverableIdField = DELIVERABLES.ID.`as`("deliverable_id")
     val projectIdField = PROJECTS.ID.`as`("project_id")
@@ -192,9 +186,6 @@ class DeliverableStore(
               .leftJoin(SUBMISSIONS)
               .on(DELIVERABLES.ID.eq(SUBMISSIONS.DELIVERABLE_ID))
               .and(PROJECTS.ID.eq(SUBMISSIONS.PROJECT_ID))
-              .leftJoin(DELIVERABLE_COHORT_DUE_DATES)
-              .on(DELIVERABLE_COHORT_DUE_DATES.DELIVERABLE_ID.eq(DELIVERABLES.ID))
-              .and(DELIVERABLE_COHORT_DUE_DATES.COHORT_ID.eq(COHORT_MODULES.COHORT_ID))
               .leftJoin(DELIVERABLE_PROJECT_DUE_DATES)
               .on(DELIVERABLE_PROJECT_DUE_DATES.DELIVERABLE_ID.eq(DELIVERABLES.ID))
               .and(DELIVERABLE_PROJECT_DUE_DATES.PROJECT_ID.eq(PROJECTS.ID))
@@ -222,9 +213,6 @@ class DeliverableStore(
               .leftJoin(SUBMISSIONS)
               .on(DELIVERABLES.ID.eq(SUBMISSIONS.DELIVERABLE_ID))
               .and(PROJECTS.ID.eq(SUBMISSIONS.PROJECT_ID))
-              .leftJoin(DELIVERABLE_COHORT_DUE_DATES)
-              .on(DELIVERABLE_COHORT_DUE_DATES.DELIVERABLE_ID.eq(DELIVERABLES.ID))
-              .and(DELIVERABLE_COHORT_DUE_DATES.COHORT_ID.eq(COHORT_MODULES.COHORT_ID))
               .leftJoin(DELIVERABLE_PROJECT_DUE_DATES)
               .on(DELIVERABLE_PROJECT_DUE_DATES.DELIVERABLE_ID.eq(DELIVERABLES.ID))
               .and(DELIVERABLE_PROJECT_DUE_DATES.PROJECT_ID.eq(PROJECTS.ID))

--- a/src/main/kotlin/com/terraformation/backend/accelerator/model/DeliverableDueDateModel.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/model/DeliverableDueDateModel.kt
@@ -11,7 +11,6 @@ data class DeliverableDueDateModel(
     val cohortId: CohortId,
     val deliverableId: DeliverableId,
     val moduleId: ModuleId,
-    val cohortDueDate: LocalDate? = null,
     val moduleDueDate: LocalDate,
     val projectDueDates: Map<ProjectId, LocalDate>,
 )

--- a/src/main/kotlin/com/terraformation/backend/admin/AdminCohortsController.kt
+++ b/src/main/kotlin/com/terraformation/backend/admin/AdminCohortsController.kt
@@ -165,7 +165,7 @@ class AdminCohortsController(
       @PathVariable cohortId: CohortId,
       @PathVariable deliverableId: DeliverableId,
       @RequestParam operation: String,
-      @RequestParam projectId: ProjectId?,
+      @RequestParam projectId: ProjectId,
       @RequestParam dueDate: LocalDate?,
       redirectAttributes: RedirectAttributes,
   ): String {
@@ -178,15 +178,11 @@ class AdminCohortsController(
         }
 
         try {
-          if (projectId != null) {
-            deliverableDueDateStore.upsertDeliverableProjectDueDate(
-                deliverableId,
-                projectId,
-                dueDate,
-            )
-          } else {
-            deliverableDueDateStore.upsertDeliverableCohortDueDate(deliverableId, cohortId, dueDate)
-          }
+          deliverableDueDateStore.upsertDeliverableProjectDueDate(
+              deliverableId,
+              projectId,
+              dueDate,
+          )
         } catch (e: Exception) {
           log.warn("Upsert deliverable due date failed", e)
           redirectAttributes.failureMessage = "Error updating deliverable due date: ${e.message}"
@@ -196,11 +192,7 @@ class AdminCohortsController(
       }
       "remove" -> {
         try {
-          if (projectId != null) {
-            deliverableDueDateStore.deleteDeliverableProjectDueDate(deliverableId, projectId)
-          } else {
-            deliverableDueDateStore.deleteDeliverableCohortDueDate(deliverableId, cohortId)
-          }
+          deliverableDueDateStore.deleteDeliverableProjectDueDate(deliverableId, projectId)
         } catch (e: Exception) {
           log.warn("Delete deliverable due date failed", e)
           redirectAttributes.failureMessage = "Error deleting deliverable due date: ${e.message}"

--- a/src/main/resources/db/migration/0400/V448__DropDeliverableCohortDueDates.sql
+++ b/src/main/resources/db/migration/0400/V448__DropDeliverableCohortDueDates.sql
@@ -1,0 +1,35 @@
+-- Previous version was in V438
+CREATE OR REPLACE VIEW accelerator.project_deliverables AS
+SELECT deliverables.id as deliverable_id,
+       deliverables.deliverable_category_id,
+       deliverables.deliverable_type_id,
+       deliverables.position,
+       deliverables.name,
+       deliverables.description_html,
+       deliverables.is_required,
+       deliverables.is_sensitive,
+       deliverables.module_id,
+       COALESCE(project_due_dates.due_date, cohort_modules.end_date) as due_date,
+       projects.id as project_id,
+       submissions.id as submission_id,
+       submissions.submission_status_id,
+       submissions.feedback as submission_feedback
+FROM accelerator.deliverables deliverables
+         JOIN accelerator.modules modules ON deliverables.module_id = modules.id
+         JOIN accelerator.cohort_modules cohort_modules ON modules.id = cohort_modules.module_id
+         JOIN accelerator.cohorts cohorts ON cohorts.id = cohort_modules.cohort_id
+         JOIN projects ON projects.cohort_id = cohorts.id
+         LEFT JOIN accelerator.submissions submissions
+                   ON submissions.project_id = projects.id
+                       AND submissions.deliverable_id = deliverables.id
+         LEFT JOIN accelerator.deliverable_project_due_dates project_due_dates
+                   ON project_due_dates.project_id = projects.id
+                       AND project_due_dates.deliverable_id = deliverables.id;
+
+INSERT INTO accelerator.deliverable_project_due_dates (deliverable_id, project_id, due_date)
+SELECT dcdd.deliverable_id, p.id, dcdd.due_date
+FROM accelerator.deliverable_cohort_due_dates dcdd
+JOIN projects p ON dcdd.cohort_id = p.cohort_id
+ON CONFLICT DO NOTHING;
+
+DROP TABLE accelerator.deliverable_cohort_due_dates;

--- a/src/main/resources/db/migration/R__Comments.sql
+++ b/src/main/resources/db/migration/R__Comments.sql
@@ -623,8 +623,6 @@ COMMENT ON TABLE accelerator.default_voters IS 'Users to automatically be assign
 COMMENT ON TABLE accelerator.deliverable_categories IS '(Enum) High-level groups for organizing deliverables.';
 COMMENT ON COLUMN accelerator.deliverable_categories.internal_interest_id IS 'Internal interest enum that the deliverable category corresponds to.';
 
-COMMENT ON TABLE accelerator.deliverable_cohort_due_dates IS 'Deliverable due dates overrides for cohorts. Can be overridden at the project level.';
-
 COMMENT ON TABLE accelerator.deliverable_documents IS 'Information about expected deliverables of type Document that isn''t relevant for other deliverable types.';
 
 COMMENT ON TABLE accelerator.deliverable_project_due_dates IS 'Deliverable due dates overrides for projects.';

--- a/src/main/resources/templates/admin/cohortDeliverable.html
+++ b/src/main/resources/templates/admin/cohortDeliverable.html
@@ -25,38 +25,8 @@
 <p> Deliverable due dates are project-specific, and follows the following order: </p>
 <ol>
     <li>The project due date, if set. </li>
-    <li>The cohort due date, if set. </li>
     <li>The module end date for the cohort. </li>
 </ol>
-
-<h3>Cohort Due Date </h3>
-
-<p th:text="|Current override: ${dueDates.cohortDueDate}|"></p>
-<form method="POST"
-      th:action="|/admin/cohorts/${cohort.id}/deliverables/${deliverable.id}|">
-    <input type="date"
-           name="dueDate"
-           required
-           th:disabled="${!canManageDeliverables}"
-           th:value="${dueDates.cohortDueDate}" />
-    <input type="hidden" name="operation" value="upsert" />
-    <input type="submit"
-           th:if="${dueDates.cohortDueDate != null}"
-           th:disabled="${!canManageDeliverables}"
-           value="Update" />
-    <input type="submit"
-           th:if="${dueDates.cohortDueDate == null}"
-           th:disabled="${!canManageDeliverables}"
-           value="Add" />
-</form>
-<form method="POST"
-      th:action="|/admin/cohorts/${cohort.id}/deliverables/${deliverable.id}|">
-    <input type="hidden" name="operation" value="remove" />
-    <input type="submit"
-           th:if="${dueDates.cohortDueDate != null}"
-           th:disabled="${!canManageDeliverables}"
-           value="Remove" />
-</form>
 
 <h3>Project Due Dates </h3>
 

--- a/src/test/kotlin/com/terraformation/backend/accelerator/ProjectDeliverableSearchTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/ProjectDeliverableSearchTest.kt
@@ -258,7 +258,7 @@ class ProjectDeliverableSearchTest : DatabaseTest(), RunsAsUser {
   }
 
   @Test
-  fun `returns deliverable due date according to cohort or project overrides`() {
+  fun `returns deliverable due date according to project overrides`() {
     val projectId = insertProject(cohortId = inserted.cohortId)
     val deliverableId = insertDeliverable(moduleId = inserted.moduleId)
 
@@ -273,18 +273,6 @@ class ProjectDeliverableSearchTest : DatabaseTest(), RunsAsUser {
         ),
         searchService.search(prefix, fields, mapOf(prefix to NoConditionNode())),
         "Search project deliverables with module end date",
-    )
-
-    val cohortDueDate = moduleEndDate.plusDays(5)
-    insertDeliverableCohortDueDate(deliverableId, inserted.cohortId, cohortDueDate)
-    assertJsonEquals(
-        SearchResults(
-            listOf(
-                mapOf("id" to "$deliverableId", "dueDate" to "$cohortDueDate"),
-            )
-        ),
-        searchService.search(prefix, fields, mapOf(prefix to NoConditionNode())),
-        "Search project deliverables with cohort due date override",
     )
 
     val projectDueDate = moduleEndDate.plusDays(5)

--- a/src/test/kotlin/com/terraformation/backend/accelerator/db/DeliverableStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/db/DeliverableStoreTest.kt
@@ -591,7 +591,6 @@ class DeliverableStoreTest : DatabaseTest(), RunsAsUser {
       insertOrganization()
 
       val projectWithProjectDueDate = insertProject(cohortId = cohortWithDueDate)
-      val projectWithCohortDueDate = insertProject(cohortId = cohortWithDueDate)
       val projectWithDefaultDueDate = insertProject(cohortId = cohortWithoutDueDate)
 
       val cohortModuleEndDate = LocalDate.of(2024, 1, 2)
@@ -610,10 +609,8 @@ class DeliverableStoreTest : DatabaseTest(), RunsAsUser {
           endDate = cohortModuleEndDate,
       )
 
-      val cohortDueDate = LocalDate.of(2024, 2, 1)
       val projectDueDate = LocalDate.of(2024, 3, 1)
 
-      insertDeliverableCohortDueDate(deliverableId, cohortWithDueDate, cohortDueDate)
       insertDeliverableProjectDueDate(deliverableId, projectWithProjectDueDate, projectDueDate)
 
       assertEquals(
@@ -626,18 +623,6 @@ class DeliverableStoreTest : DatabaseTest(), RunsAsUser {
               .firstOrNull()
               ?.dueDate,
           "Deliverable for project with project due date",
-      )
-
-      assertEquals(
-          cohortDueDate,
-          store
-              .fetchDeliverableSubmissions(
-                  projectId = projectWithCohortDueDate,
-                  deliverableId = deliverableId,
-              )
-              .firstOrNull()
-              ?.dueDate,
-          "Deliverable for project with cohort due date and no project due date",
       )
 
       assertEquals(

--- a/src/test/kotlin/com/terraformation/backend/db/DatabaseBackedTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/db/DatabaseBackedTest.kt
@@ -60,7 +60,6 @@ import com.terraformation.backend.db.accelerator.tables.daos.ApplicationsDao
 import com.terraformation.backend.db.accelerator.tables.daos.CohortModulesDao
 import com.terraformation.backend.db.accelerator.tables.daos.CohortsDao
 import com.terraformation.backend.db.accelerator.tables.daos.DefaultVotersDao
-import com.terraformation.backend.db.accelerator.tables.daos.DeliverableCohortDueDatesDao
 import com.terraformation.backend.db.accelerator.tables.daos.DeliverableDocumentsDao
 import com.terraformation.backend.db.accelerator.tables.daos.DeliverableProjectDueDatesDao
 import com.terraformation.backend.db.accelerator.tables.daos.DeliverableVariablesDao
@@ -99,7 +98,6 @@ import com.terraformation.backend.db.accelerator.tables.pojos.ApplicationsRow
 import com.terraformation.backend.db.accelerator.tables.pojos.CohortModulesRow
 import com.terraformation.backend.db.accelerator.tables.pojos.CohortsRow
 import com.terraformation.backend.db.accelerator.tables.pojos.DefaultVotersRow
-import com.terraformation.backend.db.accelerator.tables.pojos.DeliverableCohortDueDatesRow
 import com.terraformation.backend.db.accelerator.tables.pojos.DeliverableDocumentsRow
 import com.terraformation.backend.db.accelerator.tables.pojos.DeliverableProjectDueDatesRow
 import com.terraformation.backend.db.accelerator.tables.pojos.DeliverableVariablesRow
@@ -636,7 +634,6 @@ abstract class DatabaseBackedTest {
   protected val countriesDao: CountriesDao by lazyDao()
   protected val countrySubdivisionsDao: CountrySubdivisionsDao by lazyDao()
   protected val defaultVotersDao: DefaultVotersDao by lazyDao()
-  protected val deliverableCohortDueDatesDao: DeliverableCohortDueDatesDao by lazyDao()
   protected val deliverableDocumentsDao: DeliverableDocumentsDao by lazyDao()
   protected val deliverableProjectDueDatesDao: DeliverableProjectDueDatesDao by lazyDao()
   protected val deliverablesDao: DeliverablesDao by lazyDao()
@@ -1228,21 +1225,6 @@ abstract class DatabaseBackedTest {
     deliverablesDao.insert(row)
 
     return row.id!!.also { inserted.deliverableIds.add(it) }
-  }
-
-  protected fun insertDeliverableCohortDueDate(
-      deliverableId: DeliverableId = inserted.deliverableId,
-      cohortId: CohortId = inserted.cohortId,
-      dueDate: LocalDate,
-  ) {
-    val row =
-        DeliverableCohortDueDatesRow(
-            cohortId = cohortId,
-            deliverableId = deliverableId,
-            dueDate = dueDate,
-        )
-
-    deliverableCohortDueDatesDao.insert(row)
   }
 
   protected fun insertDeliverableDocument(

--- a/src/test/kotlin/com/terraformation/backend/db/SchemaDocsGenerator.kt
+++ b/src/test/kotlin/com/terraformation/backend/db/SchemaDocsGenerator.kt
@@ -148,7 +148,6 @@ class SchemaDocsGenerator : DatabaseTest() {
                   "deal_stages" to setOf(ALL, ACCELERATOR),
                   "default_voters" to setOf(ALL, ACCELERATOR),
                   "deliverable_categories" to setOf(ALL, ACCELERATOR),
-                  "deliverable_cohort_due_dates" to setOf(ALL, ACCELERATOR),
                   "deliverable_documents" to setOf(ALL, ACCELERATOR),
                   "deliverable_project_due_dates" to setOf(ALL, ACCELERATOR),
                   "deliverable_types" to setOf(ALL, ACCELERATOR),


### PR DESCRIPTION
We currently allow overriding deliverable due dates on a per-project and
per-cohort basis. Remove the per-cohort override, moving all existing cohort-level
due dates to the cohorts' projects.