### PR TITLE
Remove override for fullyAuthenticated spring security config, use default

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/auth/SecurityConfig.kt
+++ b/src/main/kotlin/com/terraformation/backend/auth/SecurityConfig.kt
@@ -9,7 +9,6 @@ import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
-import org.springframework.security.authorization.AuthenticatedAuthorizationManager
 import org.springframework.security.config.annotation.web.builders.HttpSecurity
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity
 import org.springframework.security.config.annotation.web.invoke
@@ -19,7 +18,6 @@ import org.springframework.security.oauth2.client.oidc.web.logout.OidcClientInit
 import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository
 import org.springframework.security.oauth2.server.resource.web.authentication.BearerTokenAuthenticationFilter
 import org.springframework.security.web.SecurityFilterChain
-import org.springframework.security.web.access.intercept.RequestAuthorizationContext
 import org.springframework.security.web.authentication.HttpStatusEntryPoint
 import org.springframework.security.web.header.writers.StaticHeadersWriter
 import org.springframework.security.web.util.matcher.MediaTypeRequestMatcher
@@ -63,10 +61,6 @@ class SecurityConfig(
       http: HttpSecurity,
       clientRegistrationRepository: ClientRegistrationRepository,
   ): SecurityFilterChain {
-    // https://github.com/spring-projects/spring-security/issues/16162
-    val fullyAuthenticated =
-        AuthenticatedAuthorizationManager.fullyAuthenticated<RequestAuthorizationContext>()
-
     http {
       cors {}
       csrf { disable() }


### PR DESCRIPTION
`fullyAuthenticated` was missing from the spring security `authorizeHttpRequests` dsl, as pointed out in [this issue](https://github.com/spring-projects/spring-security/issues/16162). It was then fixed in version 6.5.0 (https://github.com/spring-projects/spring-security/pull/16190). 

Use the default `fullyAuthenticated` access instead of the manual one.