### PR TITLE
SW-8060 Track project/module relationships

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/accelerator/ProjectPhaseService.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/ProjectPhaseService.kt
@@ -4,9 +4,12 @@ import com.terraformation.backend.accelerator.event.CohortPhaseUpdatedEvent
 import com.terraformation.backend.accelerator.event.CohortProjectAddedEvent
 import com.terraformation.backend.accelerator.event.CohortProjectRemovedEvent
 import com.terraformation.backend.db.accelerator.tables.references.COHORTS
+import com.terraformation.backend.db.accelerator.tables.references.COHORT_MODULES
+import com.terraformation.backend.db.accelerator.tables.references.PROJECT_MODULES
 import com.terraformation.backend.db.default_schema.tables.references.PROJECTS
 import jakarta.inject.Named
 import org.jooq.DSLContext
+import org.jooq.impl.DSL
 import org.springframework.context.event.EventListener
 import org.springframework.core.annotation.Order
 
@@ -24,6 +27,24 @@ class ProjectPhaseService(private val dslContext: DSLContext) {
     with(PROJECTS) {
       dslContext.update(PROJECTS).set(PHASE_ID, phase).where(ID.eq(event.projectId)).execute()
     }
+
+    with(PROJECT_MODULES) {
+      dslContext
+          .insertInto(PROJECT_MODULES, PROJECT_ID, MODULE_ID, START_DATE, END_DATE, TITLE)
+          .select(
+              DSL.select(
+                      DSL.value(event.projectId),
+                      COHORT_MODULES.MODULE_ID,
+                      COHORT_MODULES.START_DATE,
+                      COHORT_MODULES.END_DATE,
+                      COHORT_MODULES.TITLE,
+                  )
+                  .from(COHORT_MODULES)
+                  .where(COHORT_MODULES.COHORT_ID.eq(event.cohortId))
+          )
+          .onConflictDoNothing()
+          .execute()
+    }
   }
 
   @EventListener
@@ -31,6 +52,20 @@ class ProjectPhaseService(private val dslContext: DSLContext) {
   fun on(event: CohortProjectRemovedEvent) {
     with(PROJECTS) {
       dslContext.update(PROJECTS).setNull(PHASE_ID).where(ID.eq(event.projectId)).execute()
+    }
+
+    with(PROJECT_MODULES) {
+      dslContext
+          .deleteFrom(PROJECT_MODULES)
+          .where(PROJECT_ID.eq(event.projectId))
+          .and(
+              MODULE_ID.`in`(
+                  DSL.select(COHORT_MODULES.MODULE_ID)
+                      .from(COHORT_MODULES)
+                      .where(COHORT_MODULES.COHORT_ID.eq(event.cohortId))
+              )
+          )
+          .execute()
     }
   }
 

--- a/src/main/resources/db/migration/0450/V451__ProjectModules.sql
+++ b/src/main/resources/db/migration/0450/V451__ProjectModules.sql
@@ -1,0 +1,17 @@
+CREATE TABLE accelerator.project_modules (
+    project_id BIGINT NOT NULL REFERENCES projects ON DELETE CASCADE,
+    module_id BIGINT NOT NULL REFERENCES accelerator.modules ON DELETE CASCADE,
+    start_date DATE NOT NULL,
+    end_date DATE NOT NULL,
+    title TEXT NOT NULL,
+
+    PRIMARY KEY (project_id, module_id),
+    CONSTRAINT dates_start_before_end CHECK (start_date <= end_date)
+);
+
+CREATE INDEX ON accelerator.project_modules (module_id);
+
+INSERT INTO accelerator.project_modules (project_id, module_id, start_date, end_date, title)
+SELECT p.id, cm.module_id, cm.start_date, cm.end_date, cm.title
+FROM accelerator.cohort_modules cm
+JOIN projects p ON cm.cohort_id = p.cohort_id;

--- a/src/main/resources/db/migration/R__Comments.sql
+++ b/src/main/resources/db/migration/R__Comments.sql
@@ -668,6 +668,9 @@ COMMENT ON VIEW accelerator.project_deliverables IS 'Deliverable information for
 
 COMMENT ON TABLE accelerator.project_metrics IS 'Metrics specific to one project to report on.';
 
+COMMENT ON TABLE accelerator.project_modules IS 'Which modules are assigned to which projects.';
+COMMENT ON COLUMN accelerator.project_modules.title IS 'The title for the module for the project. For example "Module 3A" for Module 3A: Title';
+
 COMMENT ON TABLE accelerator.project_overall_scores IS 'Overall scores assigned to project by scorers.';
 
 COMMENT ON TABLE accelerator.project_report_configs IS 'Configurations for accelerator project reports, including reporting dates and reporting frequencies.';

--- a/src/main/resources/db/migration/R__Comments.sql
+++ b/src/main/resources/db/migration/R__Comments.sql
@@ -612,7 +612,7 @@ COMMENT ON TABLE accelerator.applications IS 'Information about projects that ar
 COMMENT ON TABLE accelerator.cohorts IS 'Accelerator cohort details.';
 
 COMMENT ON TABLE accelerator.cohort_modules IS 'Which modules are assigned to which cohorts.';
-COMMENT ON COLUMN accelerator.cohort_modules.title IS 'The title for the module for the cohort. For example "Module 3A" for Module 3A: Title';
+COMMENT ON COLUMN accelerator.cohort_modules.title IS 'The title for the module for the cohort. This is shown above the module name in the module timeline.';
 
 COMMENT ON TABLE accelerator.cohort_phases IS '(Enum) Available cohort phases';
 
@@ -669,7 +669,7 @@ COMMENT ON VIEW accelerator.project_deliverables IS 'Deliverable information for
 COMMENT ON TABLE accelerator.project_metrics IS 'Metrics specific to one project to report on.';
 
 COMMENT ON TABLE accelerator.project_modules IS 'Which modules are assigned to which projects.';
-COMMENT ON COLUMN accelerator.project_modules.title IS 'The title for the module for the project. For example "Module 3A" for Module 3A: Title';
+COMMENT ON COLUMN accelerator.project_modules.title IS 'The title for the module for the project. This is shown above the module name in the module timeline.';
 
 COMMENT ON TABLE accelerator.project_overall_scores IS 'Overall scores assigned to project by scorers.';
 

--- a/src/test/kotlin/com/terraformation/backend/accelerator/ProjectPhaseServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/ProjectPhaseServiceTest.kt
@@ -7,7 +7,10 @@ import com.terraformation.backend.accelerator.event.CohortProjectRemovedEvent
 import com.terraformation.backend.customer.model.TerrawareUser
 import com.terraformation.backend.db.DatabaseTest
 import com.terraformation.backend.db.accelerator.CohortPhase
+import com.terraformation.backend.db.accelerator.tables.records.ProjectModulesRecord
+import com.terraformation.backend.db.accelerator.tables.references.PROJECT_MODULES
 import com.terraformation.backend.db.default_schema.tables.references.PROJECTS
+import java.time.LocalDate
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
@@ -44,6 +47,56 @@ class ProjectPhaseServiceTest : DatabaseTest(), RunsAsDatabaseUser {
 
       assertTableEquals(expected)
     }
+
+    @Test
+    fun `populates project modules based on cohort modules`() {
+      val cohortId = insertCohort()
+      val projectId = insertProject(cohortId = cohortId)
+      val moduleId1 = insertModule()
+      insertCohortModule(
+          startDate = LocalDate.of(2026, 1, 1),
+          endDate = LocalDate.of(2026, 1, 2),
+          title = "Module 1",
+      )
+      insertProjectModule(
+          startDate = LocalDate.of(2026, 1, 3),
+          endDate = LocalDate.of(2026, 1, 4),
+          title = "Module 1 (Project)",
+      )
+      val moduleId2 = insertModule()
+      insertCohortModule(
+          startDate = LocalDate.of(2026, 1, 5),
+          endDate = LocalDate.of(2026, 1, 6),
+          title = "Module 2",
+      )
+
+      insertCohort()
+      insertModule()
+      insertCohortModule()
+
+      service.on(CohortProjectAddedEvent(user.userId, cohortId, projectId))
+
+      assertTableEquals(
+          setOf(
+              // Existing association with module 1 should remain untouched
+              ProjectModulesRecord(
+                  projectId,
+                  moduleId1,
+                  LocalDate.of(2026, 1, 3),
+                  LocalDate.of(2026, 1, 4),
+                  "Module 1 (Project)",
+              ),
+              // New record should be inserted from cohort modules
+              ProjectModulesRecord(
+                  projectId,
+                  moduleId2,
+                  LocalDate.of(2026, 1, 5),
+                  LocalDate.of(2026, 1, 6),
+                  "Module 2",
+              ),
+          )
+      )
+    }
   }
 
   @Nested
@@ -61,6 +114,46 @@ class ProjectPhaseServiceTest : DatabaseTest(), RunsAsDatabaseUser {
               record.phaseId = null
             }
           }
+
+      service.on(CohortProjectRemovedEvent(cohortId, projectId, user.userId))
+
+      assertTableEquals(expected)
+    }
+
+    @Test
+    fun `removes project modules based on cohort modules`() {
+      insertCohort()
+      insertModule()
+      insertCohortModule()
+      insertProject()
+      insertProjectModule()
+
+      val expected = dslContext.fetch(PROJECT_MODULES)
+
+      val cohortId = insertCohort()
+      val projectId = insertProject(cohortId = cohortId)
+      insertModule()
+      insertCohortModule(
+          startDate = LocalDate.of(2026, 1, 1),
+          endDate = LocalDate.of(2026, 1, 2),
+          title = "Module 1",
+      )
+      insertProjectModule(
+          startDate = LocalDate.of(2026, 1, 3),
+          endDate = LocalDate.of(2026, 1, 4),
+          title = "Module 1 (Project)",
+      )
+      insertModule()
+      insertCohortModule(
+          startDate = LocalDate.of(2026, 1, 5),
+          endDate = LocalDate.of(2026, 1, 6),
+          title = "Module 2",
+      )
+      insertProjectModule(
+          startDate = LocalDate.of(2026, 1, 5),
+          endDate = LocalDate.of(2026, 1, 6),
+          title = "Module 2",
+      )
 
       service.on(CohortProjectRemovedEvent(cohortId, projectId, user.userId))
 

--- a/src/test/kotlin/com/terraformation/backend/accelerator/db/CohortModuleStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/db/CohortModuleStoreTest.kt
@@ -6,8 +6,10 @@ import com.terraformation.backend.customer.model.TerrawareUser
 import com.terraformation.backend.db.DatabaseTest
 import com.terraformation.backend.db.ProjectNotFoundException
 import com.terraformation.backend.db.accelerator.CohortPhase
-import com.terraformation.backend.db.accelerator.tables.pojos.CohortModulesRow
+import com.terraformation.backend.db.accelerator.tables.records.CohortModulesRecord
+import com.terraformation.backend.db.accelerator.tables.records.ProjectModulesRecord
 import com.terraformation.backend.db.accelerator.tables.references.COHORT_MODULES
+import com.terraformation.backend.db.accelerator.tables.references.PROJECT_MODULES
 import com.terraformation.backend.db.default_schema.GlobalRole
 import java.time.LocalDate
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -211,6 +213,7 @@ class CohortModuleStoreTest : DatabaseTest(), RunsAsDatabaseUser {
 
       insertCohort(phase = CohortPhase.Phase0DueDiligence)
       insertModule()
+      insertProject(cohortId = inserted.cohortId)
 
       store.assign(
           inserted.cohortId,
@@ -220,17 +223,24 @@ class CohortModuleStoreTest : DatabaseTest(), RunsAsDatabaseUser {
           LocalDate.of(2024, 1, 3),
       )
 
-      assertEquals(
-          listOf(
-              CohortModulesRow(
-                  cohortId = inserted.cohortId,
-                  moduleId = inserted.moduleId,
-                  title = "Module title",
-                  startDate = LocalDate.of(2024, 1, 1),
-                  endDate = LocalDate.of(2024, 1, 3),
-              )
-          ),
-          cohortModulesDao.findAll(),
+      assertTableEquals(
+          CohortModulesRecord(
+              cohortId = inserted.cohortId,
+              moduleId = inserted.moduleId,
+              title = "Module title",
+              startDate = LocalDate.of(2024, 1, 1),
+              endDate = LocalDate.of(2024, 1, 3),
+          )
+      )
+
+      assertTableEquals(
+          ProjectModulesRecord(
+              projectId = inserted.projectId,
+              moduleId = inserted.moduleId,
+              title = "Module title",
+              startDate = LocalDate.of(2024, 1, 1),
+              endDate = LocalDate.of(2024, 1, 3),
+          )
       )
     }
 
@@ -240,10 +250,15 @@ class CohortModuleStoreTest : DatabaseTest(), RunsAsDatabaseUser {
 
       insertCohort(phase = CohortPhase.Phase0DueDiligence)
       insertModule()
+      insertProject(cohortId = inserted.cohortId)
 
       insertCohortModule(
-          cohortId = inserted.cohortId,
-          moduleId = inserted.moduleId,
+          title = "Old module title",
+          startDate = LocalDate.of(2024, 1, 1),
+          endDate = LocalDate.of(2024, 1, 3),
+      )
+
+      insertProjectModule(
           title = "Old module title",
           startDate = LocalDate.of(2024, 1, 1),
           endDate = LocalDate.of(2024, 1, 3),
@@ -257,17 +272,24 @@ class CohortModuleStoreTest : DatabaseTest(), RunsAsDatabaseUser {
           LocalDate.of(2024, 2, 3),
       )
 
-      assertEquals(
-          listOf(
-              CohortModulesRow(
-                  cohortId = inserted.cohortId,
-                  moduleId = inserted.moduleId,
-                  title = "New module title",
-                  startDate = LocalDate.of(2024, 2, 1),
-                  endDate = LocalDate.of(2024, 2, 3),
-              )
-          ),
-          cohortModulesDao.findAll(),
+      assertTableEquals(
+          CohortModulesRecord(
+              cohortId = inserted.cohortId,
+              moduleId = inserted.moduleId,
+              title = "New module title",
+              startDate = LocalDate.of(2024, 2, 1),
+              endDate = LocalDate.of(2024, 2, 3),
+          )
+      )
+
+      assertTableEquals(
+          ProjectModulesRecord(
+              projectId = inserted.projectId,
+              moduleId = inserted.moduleId,
+              title = "New module title",
+              startDate = LocalDate.of(2024, 2, 1),
+              endDate = LocalDate.of(2024, 2, 3),
+          )
       )
     }
   }
@@ -328,17 +350,24 @@ class CohortModuleStoreTest : DatabaseTest(), RunsAsDatabaseUser {
           LocalDate.of(2024, 1, 3),
       )
 
-      assertEquals(
-          listOf(
-              CohortModulesRow(
-                  cohortId = inserted.cohortId,
-                  moduleId = inserted.moduleId,
-                  title = "Module title",
-                  startDate = LocalDate.of(2024, 1, 1),
-                  endDate = LocalDate.of(2024, 1, 3),
-              )
-          ),
-          cohortModulesDao.findAll(),
+      assertTableEquals(
+          CohortModulesRecord(
+              cohortId = inserted.cohortId,
+              moduleId = inserted.moduleId,
+              title = "Module title",
+              startDate = LocalDate.of(2024, 1, 1),
+              endDate = LocalDate.of(2024, 1, 3),
+          )
+      )
+
+      assertTableEquals(
+          ProjectModulesRecord(
+              projectId = inserted.projectId,
+              moduleId = inserted.moduleId,
+              title = "Module title",
+              startDate = LocalDate.of(2024, 1, 1),
+              endDate = LocalDate.of(2024, 1, 3),
+          )
       )
     }
 
@@ -351,8 +380,12 @@ class CohortModuleStoreTest : DatabaseTest(), RunsAsDatabaseUser {
       insertModule()
 
       insertCohortModule(
-          cohortId = inserted.cohortId,
-          moduleId = inserted.moduleId,
+          title = "Old module title",
+          startDate = LocalDate.of(2024, 1, 1),
+          endDate = LocalDate.of(2024, 1, 3),
+      )
+
+      insertProjectModule(
           title = "Old module title",
           startDate = LocalDate.of(2024, 1, 1),
           endDate = LocalDate.of(2024, 1, 3),
@@ -366,17 +399,24 @@ class CohortModuleStoreTest : DatabaseTest(), RunsAsDatabaseUser {
           LocalDate.of(2024, 2, 3),
       )
 
-      assertEquals(
-          listOf(
-              CohortModulesRow(
-                  cohortId = inserted.cohortId,
-                  moduleId = inserted.moduleId,
-                  title = "New module title",
-                  startDate = LocalDate.of(2024, 2, 1),
-                  endDate = LocalDate.of(2024, 2, 3),
-              )
-          ),
-          cohortModulesDao.findAll(),
+      assertTableEquals(
+          CohortModulesRecord(
+              cohortId = inserted.cohortId,
+              moduleId = inserted.moduleId,
+              title = "New module title",
+              startDate = LocalDate.of(2024, 2, 1),
+              endDate = LocalDate.of(2024, 2, 3),
+          )
+      )
+
+      assertTableEquals(
+          ProjectModulesRecord(
+              projectId = inserted.projectId,
+              moduleId = inserted.moduleId,
+              title = "New module title",
+              startDate = LocalDate.of(2024, 2, 1),
+              endDate = LocalDate.of(2024, 2, 3),
+          )
       )
     }
   }
@@ -404,10 +444,15 @@ class CohortModuleStoreTest : DatabaseTest(), RunsAsDatabaseUser {
 
       insertCohort(phase = CohortPhase.Phase0DueDiligence)
       insertModule()
+      insertProject(cohortId = inserted.cohortId)
 
       insertCohortModule(
-          cohortId = inserted.cohortId,
-          moduleId = inserted.moduleId,
+          title = "Module Title",
+          startDate = LocalDate.of(2024, 1, 1),
+          endDate = LocalDate.of(2024, 1, 3),
+      )
+
+      insertProjectModule(
           title = "Module Title",
           startDate = LocalDate.of(2024, 1, 1),
           endDate = LocalDate.of(2024, 1, 3),
@@ -416,6 +461,7 @@ class CohortModuleStoreTest : DatabaseTest(), RunsAsDatabaseUser {
       store.remove(inserted.cohortId, inserted.moduleId)
 
       assertTableEmpty(COHORT_MODULES)
+      assertTableEmpty(PROJECT_MODULES)
     }
   }
 
@@ -456,8 +502,12 @@ class CohortModuleStoreTest : DatabaseTest(), RunsAsDatabaseUser {
       insertModule()
 
       insertCohortModule(
-          cohortId = inserted.cohortId,
-          moduleId = inserted.moduleId,
+          title = "Module Title",
+          startDate = LocalDate.of(2024, 1, 1),
+          endDate = LocalDate.of(2024, 1, 3),
+      )
+
+      insertProjectModule(
           title = "Module Title",
           startDate = LocalDate.of(2024, 1, 1),
           endDate = LocalDate.of(2024, 1, 3),
@@ -466,6 +516,7 @@ class CohortModuleStoreTest : DatabaseTest(), RunsAsDatabaseUser {
       store.remove(inserted.projectId, inserted.moduleId)
 
       assertTableEmpty(COHORT_MODULES)
+      assertTableEmpty(PROJECT_MODULES)
     }
   }
 }

--- a/src/test/kotlin/com/terraformation/backend/db/DatabaseBackedTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/db/DatabaseBackedTest.kt
@@ -70,6 +70,7 @@ import com.terraformation.backend.db.accelerator.tables.daos.ModulesDao
 import com.terraformation.backend.db.accelerator.tables.daos.ParticipantProjectSpeciesDao
 import com.terraformation.backend.db.accelerator.tables.daos.ProjectAcceleratorDetailsDao
 import com.terraformation.backend.db.accelerator.tables.daos.ProjectMetricsDao
+import com.terraformation.backend.db.accelerator.tables.daos.ProjectModulesDao
 import com.terraformation.backend.db.accelerator.tables.daos.ProjectOverallScoresDao
 import com.terraformation.backend.db.accelerator.tables.daos.ProjectReportConfigsDao
 import com.terraformation.backend.db.accelerator.tables.daos.ProjectScoresDao
@@ -108,6 +109,7 @@ import com.terraformation.backend.db.accelerator.tables.pojos.ModulesRow
 import com.terraformation.backend.db.accelerator.tables.pojos.ParticipantProjectSpeciesRow
 import com.terraformation.backend.db.accelerator.tables.pojos.ProjectAcceleratorDetailsRow
 import com.terraformation.backend.db.accelerator.tables.pojos.ProjectMetricsRow
+import com.terraformation.backend.db.accelerator.tables.pojos.ProjectModulesRow
 import com.terraformation.backend.db.accelerator.tables.pojos.ProjectOverallScoresRow
 import com.terraformation.backend.db.accelerator.tables.pojos.ProjectReportConfigsRow
 import com.terraformation.backend.db.accelerator.tables.pojos.ProjectScoresRow
@@ -692,6 +694,7 @@ abstract class DatabaseBackedTest {
   protected val projectInternalUsersDao: ProjectInternalUsersDao by lazyDao()
   protected val projectLandUseModelTypesDao: ProjectLandUseModelTypesDao by lazyDao()
   protected val projectMetricsDao: ProjectMetricsDao by lazyDao()
+  protected val projectModulesDao: ProjectModulesDao by lazyDao()
   protected val projectOverallScoresDao: ProjectOverallScoresDao by lazyDao()
   protected val projectReportConfigsDao: ProjectReportConfigsDao by lazyDao()
   protected val projectReportSettingsDao: ProjectReportSettingsDao by lazyDao()
@@ -4274,6 +4277,28 @@ abstract class DatabaseBackedTest {
 
     nextCohortModuleStartDate = endDate.plusDays(1)
     cohortModulesDao.insert(row)
+  }
+
+  private var nextProjectModuleStartDate = LocalDate.EPOCH
+
+  fun insertProjectModule(
+      projectId: ProjectId = inserted.projectId,
+      moduleId: ModuleId = inserted.moduleId,
+      title: String = "Module 1",
+      startDate: LocalDate = nextProjectModuleStartDate,
+      endDate: LocalDate = startDate.plusDays(6),
+  ) {
+    val row =
+        ProjectModulesRow(
+            endDate = endDate,
+            moduleId = moduleId,
+            projectId = projectId,
+            startDate = startDate,
+            title = title,
+        )
+
+    nextProjectModuleStartDate = endDate.plusDays(1)
+    projectModulesDao.insert(row)
   }
 
   fun insertEvent(

--- a/src/test/kotlin/com/terraformation/backend/db/SchemaDocsGenerator.kt
+++ b/src/test/kotlin/com/terraformation/backend/db/SchemaDocsGenerator.kt
@@ -167,6 +167,7 @@ class SchemaDocsGenerator : DatabaseTest() {
                   "participant_project_species" to setOf(ALL, ACCELERATOR),
                   "project_accelerator_details" to setOf(ALL, ACCELERATOR),
                   "project_metrics" to setOf(ALL, ACCELERATOR),
+                  "project_modules" to setOf(ALL, Slice.ACCELERATOR),
                   "project_overall_scores" to setOf(ALL, ACCELERATOR),
                   "project_report_configs" to setOf(ALL, ACCELERATOR),
                   "project_scores" to setOf(ALL, ACCELERATOR),


### PR DESCRIPTION
Add a new `project_modules` table that is just like `cohort_modules`, but
associates modules with projects rather than with cohorts. Add code to
populate `project_modules` when modules are added and removed from cohorts,
and to copy or remove the cohort's modules when a project is added to or
removed from a cohort (note that it's not possible to do add and remove
projects from cohorts via the API at the moment.)

This is just the write path; nothing reads from the new table yet.