### PR TITLE
SW-8060 Fetch deliverables for project, not cohort

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/accelerator/api/DeliverablesController.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/api/DeliverablesController.kt
@@ -1,7 +1,6 @@
 package com.terraformation.backend.accelerator.api
 
 import com.terraformation.backend.accelerator.DeliverableService
-import com.terraformation.backend.accelerator.ProjectAcceleratorDetailsService
 import com.terraformation.backend.accelerator.SubmissionService
 import com.terraformation.backend.accelerator.db.DeliverableNotFoundException
 import com.terraformation.backend.accelerator.db.DeliverableStore
@@ -20,7 +19,6 @@ import com.terraformation.backend.api.SimpleSuccessResponsePayload
 import com.terraformation.backend.api.SuccessOrError
 import com.terraformation.backend.api.SuccessResponsePayload
 import com.terraformation.backend.api.getFilename
-import com.terraformation.backend.db.accelerator.CohortId
 import com.terraformation.backend.db.accelerator.DeliverableCategory
 import com.terraformation.backend.db.accelerator.DeliverableId
 import com.terraformation.backend.db.accelerator.DeliverableType
@@ -64,7 +62,6 @@ class DeliverablesController(
     private val deliverablesImporter: DeliverablesImporter,
     private val deliverableService: DeliverableService,
     private val deliverableStore: DeliverableStore,
-    private val projectAcceleratorDetailsService: ProjectAcceleratorDetailsService,
     private val submissionService: SubmissionService,
     private val submissionStore: SubmissionStore,
 ) {
@@ -266,8 +263,6 @@ class DeliverablesController(
 
 data class ListDeliverablesElement(
     val category: DeliverableCategory,
-    val cohortId: CohortId?,
-    val cohortName: String?,
     @Schema(description = "Optional description of the deliverable in HTML form.")
     val descriptionHtml: String?,
     val dueDate: LocalDate?,
@@ -297,8 +292,6 @@ data class ListDeliverablesElement(
       model: DeliverableSubmissionModel,
   ) : this(
       model.category,
-      model.cohortId,
-      model.cohortName,
       model.descriptionHtml,
       model.dueDate,
       model.deliverableId,

--- a/src/main/kotlin/com/terraformation/backend/accelerator/db/ApplicationStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/db/ApplicationStore.kt
@@ -267,8 +267,6 @@ class ApplicationStore(
         .fetch { record ->
           DeliverableSubmissionModel(
               category = record[DELIVERABLES.DELIVERABLE_CATEGORY_ID]!!,
-              cohortId = null,
-              cohortName = null,
               deliverableId = record[DELIVERABLES.ID]!!,
               descriptionHtml = record[DELIVERABLES.DESCRIPTION_HTML],
               documents = record[documentsMultiset],

--- a/src/main/kotlin/com/terraformation/backend/accelerator/db/DeliverableStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/db/DeliverableStore.kt
@@ -161,7 +161,7 @@ class DeliverableStore(
     val query =
         if (projectId != null && deliverableId != null) {
           // Project and deliverable both specified, so return a single result (possibly an empty
-          // submission) regardless of which cohort phase the deliverable's module is in.
+          // submission) regardless of which phase the deliverable's module is in.
           dslContext
               .select(*fieldList, dueDateField)
               .from(DELIVERABLES)
@@ -214,7 +214,7 @@ class DeliverableStore(
                   // There are "submissions" from importing project data from the old project data
                   // hub. The projects can have submissions for deliverables that would ordinarily
                   // only appear for projects in phases. Return these submissions if they exist,
-                  // even if there's no cohort in the picture.
+                  // even if the projects aren't in phases.
                   DSL.select(*fieldList, DELIVERABLE_PROJECT_DUE_DATES.DUE_DATE.`as`(dueDateField))
                       .from(SUBMISSIONS)
                       .join(DELIVERABLES)

--- a/src/main/kotlin/com/terraformation/backend/accelerator/db/DeliverableStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/db/DeliverableStore.kt
@@ -9,13 +9,12 @@ import com.terraformation.backend.db.accelerator.DeliverableCategory
 import com.terraformation.backend.db.accelerator.DeliverableId
 import com.terraformation.backend.db.accelerator.ModuleId
 import com.terraformation.backend.db.accelerator.SubmissionStatus
-import com.terraformation.backend.db.accelerator.tables.references.COHORTS
-import com.terraformation.backend.db.accelerator.tables.references.COHORT_MODULES
 import com.terraformation.backend.db.accelerator.tables.references.DELIVERABLES
 import com.terraformation.backend.db.accelerator.tables.references.DELIVERABLE_DOCUMENTS
 import com.terraformation.backend.db.accelerator.tables.references.DELIVERABLE_PROJECT_DUE_DATES
 import com.terraformation.backend.db.accelerator.tables.references.MODULES
 import com.terraformation.backend.db.accelerator.tables.references.PROJECT_ACCELERATOR_DETAILS
+import com.terraformation.backend.db.accelerator.tables.references.PROJECT_MODULES
 import com.terraformation.backend.db.accelerator.tables.references.SUBMISSIONS
 import com.terraformation.backend.db.accelerator.tables.references.SUBMISSION_DOCUMENTS
 import com.terraformation.backend.db.default_schema.OrganizationId
@@ -110,15 +109,16 @@ class DeliverableStore(
             )
             .convertFrom { result -> result.map { SubmissionDocumentModel.of(it) } }
 
-    val dueDateField = DSL.coalesce(DELIVERABLE_PROJECT_DUE_DATES.DUE_DATE, COHORT_MODULES.END_DATE)
+    val dueDateField =
+        DSL.coalesce(DELIVERABLE_PROJECT_DUE_DATES.DUE_DATE, PROJECT_MODULES.END_DATE)
 
     val deliverableIdField = DELIVERABLES.ID.`as`("deliverable_id")
     val projectIdField = PROJECTS.ID.`as`("project_id")
 
-    val nonCohortConditions =
+    val applicationCondition =
         DSL.and(
             listOfNotNull(
-                COHORT_MODULES.COHORT_ID.isNull,
+                PROJECT_MODULES.PROJECT_ID.isNull,
                 // Exclude pre-screen and application deliverables unless the caller is asking for
                 // specific deliverables.
                 if (deliverableId == null) {
@@ -142,9 +142,6 @@ class DeliverableStore(
             DELIVERABLES.IS_SENSITIVE,
             DELIVERABLES.MODULE_ID,
             MODULES.NAME,
-            COHORTS.ID,
-            COHORTS.NAME,
-            COHORT_MODULES.TITLE,
             DELIVERABLES.NAME,
             DELIVERABLES.POSITION,
             documentsMultiset,
@@ -153,6 +150,7 @@ class DeliverableStore(
             projectIdField,
             PROJECTS.NAME,
             PROJECT_ACCELERATOR_DETAILS.DEAL_NAME,
+            PROJECT_MODULES.TITLE,
             SUBMISSIONS.FEEDBACK,
             SUBMISSIONS.ID,
             SUBMISSIONS.INTERNAL_COMMENT,
@@ -163,8 +161,7 @@ class DeliverableStore(
     val query =
         if (projectId != null && deliverableId != null) {
           // Project and deliverable both specified, so return a single result (possibly an empty
-          // submission) regardless of whether or not there's a cohort and regardless of which
-          // cohort phase the deliverable's module is in.
+          // submission) regardless of which cohort phase the deliverable's module is in.
           dslContext
               .select(*fieldList, dueDateField)
               .from(DELIVERABLES)
@@ -176,11 +173,9 @@ class DeliverableStore(
               .on(PROJECTS.ID.eq(PROJECT_ACCELERATOR_DETAILS.PROJECT_ID))
               .join(ORGANIZATIONS)
               .on(PROJECTS.ORGANIZATION_ID.eq(ORGANIZATIONS.ID))
-              .leftJoin(COHORTS)
-              .on(PROJECTS.COHORT_ID.eq(COHORTS.ID))
-              .leftJoin(COHORT_MODULES)
-              .on(MODULES.ID.eq(COHORT_MODULES.MODULE_ID))
-              .and(COHORTS.ID.eq(COHORT_MODULES.COHORT_ID))
+              .leftJoin(PROJECT_MODULES)
+              .on(PROJECTS.ID.eq(PROJECT_MODULES.PROJECT_ID))
+              .and(MODULES.ID.eq(PROJECT_MODULES.MODULE_ID))
               .leftJoin(DELIVERABLE_DOCUMENTS)
               .on(DELIVERABLES.ID.eq(DELIVERABLE_DOCUMENTS.DELIVERABLE_ID))
               .leftJoin(SUBMISSIONS)
@@ -192,18 +187,16 @@ class DeliverableStore(
               .where(conditions)
         } else {
           // Return submission data (possibly empty submissions) for deliverables in modules that
-          // the project's cohort is a member of.
+          // the project is a member of.
           dslContext
               .select(*fieldList, dueDateField)
               .from(DELIVERABLES)
               .join(MODULES)
               .on(DELIVERABLES.MODULE_ID.eq(MODULES.ID))
-              .join(COHORT_MODULES)
-              .on(MODULES.ID.eq(COHORT_MODULES.MODULE_ID))
-              .join(COHORTS)
-              .on(COHORT_MODULES.COHORT_ID.eq(COHORTS.ID))
+              .join(PROJECT_MODULES)
+              .on(MODULES.ID.eq(PROJECT_MODULES.MODULE_ID))
               .join(PROJECTS)
-              .on(COHORTS.ID.eq(PROJECTS.COHORT_ID))
+              .on(PROJECT_MODULES.PROJECT_ID.eq(PROJECTS.ID))
               .leftJoin(PROJECT_ACCELERATOR_DETAILS)
               .on(PROJECTS.ID.eq(PROJECT_ACCELERATOR_DETAILS.PROJECT_ID))
               .join(ORGANIZATIONS)
@@ -219,10 +212,9 @@ class DeliverableStore(
               .where(conditions)
               .union(
                   // There are "submissions" from importing project data from the old project data
-                  // hub. The projects don't necessarily have cohorts but they can have submissions
-                  // for deliverables that would ordinarily only appear for projects in cohorts.
-                  // Return these submissions if they exist, even if there's no cohort in the
-                  // picture.
+                  // hub. The projects can have submissions for deliverables that would ordinarily
+                  // only appear for projects in phases. Return these submissions if they exist,
+                  // even if there's no cohort in the picture.
                   DSL.select(*fieldList, DELIVERABLE_PROJECT_DUE_DATES.DUE_DATE.`as`(dueDateField))
                       .from(SUBMISSIONS)
                       .join(DELIVERABLES)
@@ -235,11 +227,9 @@ class DeliverableStore(
                       .on(PROJECTS.ID.eq(PROJECT_ACCELERATOR_DETAILS.PROJECT_ID))
                       .join(ORGANIZATIONS)
                       .on(PROJECTS.ORGANIZATION_ID.eq(ORGANIZATIONS.ID))
-                      .leftJoin(COHORTS)
-                      .on(PROJECTS.COHORT_ID.eq(COHORTS.ID))
-                      .leftJoin(COHORT_MODULES)
-                      .on(COHORTS.ID.eq(COHORT_MODULES.COHORT_ID))
-                      .and(MODULES.ID.eq(COHORT_MODULES.MODULE_ID))
+                      .leftJoin(PROJECT_MODULES)
+                      .on(PROJECTS.ID.eq(PROJECT_MODULES.PROJECT_ID))
+                      .and(MODULES.ID.eq(PROJECT_MODULES.MODULE_ID))
                       .leftJoin(DELIVERABLE_PROJECT_DUE_DATES)
                       .on(DELIVERABLES.ID.eq(DELIVERABLE_PROJECT_DUE_DATES.DELIVERABLE_ID))
                       .and(PROJECTS.ID.eq(DELIVERABLE_PROJECT_DUE_DATES.PROJECT_ID))
@@ -247,7 +237,7 @@ class DeliverableStore(
                       .on(DELIVERABLES.ID.eq(DELIVERABLE_DOCUMENTS.DELIVERABLE_ID))
                       .and(DELIVERABLES.ID.eq(DELIVERABLE_PROJECT_DUE_DATES.DELIVERABLE_ID))
                       .where(conditions)
-                      .and(nonCohortConditions)
+                      .and(applicationCondition)
               )
               .orderBy(deliverableIdField, projectIdField)
         }
@@ -255,8 +245,6 @@ class DeliverableStore(
     return query.fetch { record ->
       DeliverableSubmissionModel(
           category = record[DELIVERABLES.DELIVERABLE_CATEGORY_ID]!!,
-          cohortId = record[COHORTS.ID],
-          cohortName = record[COHORTS.NAME],
           deliverableId = record[deliverableIdField]!!,
           descriptionHtml = record[DELIVERABLES.DESCRIPTION_HTML],
           documents = record[documentsMultiset],
@@ -266,7 +254,7 @@ class DeliverableStore(
           modifiedTime = record[SUBMISSIONS.MODIFIED_TIME],
           moduleId = record[DELIVERABLES.MODULE_ID]!!,
           moduleName = record[MODULES.NAME]!!,
-          moduleTitle = record[COHORT_MODULES.TITLE],
+          moduleTitle = record[PROJECT_MODULES.TITLE],
           name = record[DELIVERABLES.NAME]!!,
           organizationId = record[ORGANIZATIONS.ID]!!,
           organizationName = record[ORGANIZATIONS.NAME]!!,

--- a/src/main/kotlin/com/terraformation/backend/accelerator/model/DeliverableSubmissionModel.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/model/DeliverableSubmissionModel.kt
@@ -1,6 +1,5 @@
 package com.terraformation.backend.accelerator.model
 
-import com.terraformation.backend.db.accelerator.CohortId
 import com.terraformation.backend.db.accelerator.DeliverableCategory
 import com.terraformation.backend.db.accelerator.DeliverableId
 import com.terraformation.backend.db.accelerator.DeliverableType
@@ -18,8 +17,6 @@ import java.time.LocalDate
  */
 data class DeliverableSubmissionModel(
     val category: DeliverableCategory,
-    val cohortId: CohortId?,
-    val cohortName: String?,
     val deliverableId: DeliverableId,
     val descriptionHtml: String?,
     val documents: List<SubmissionDocumentModel>,

--- a/src/test/kotlin/com/terraformation/backend/accelerator/PreScreenBoundarySubmissionFetcherTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/PreScreenBoundarySubmissionFetcherTest.kt
@@ -55,8 +55,6 @@ class PreScreenBoundarySubmissionFetcherTest : DatabaseTest(), RunsAsUser {
     initialSubmissionModel =
         DeliverableSubmissionModel(
             category = DeliverableCategory.GIS,
-            cohortId = null,
-            cohortName = null,
             deliverableId = deliverableId,
             descriptionHtml = "Deliverable description",
             documents = emptyList(),

--- a/src/test/kotlin/com/terraformation/backend/accelerator/db/ApplicationStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/db/ApplicationStoreTest.kt
@@ -773,8 +773,6 @@ class ApplicationStoreTest : DatabaseTest(), RunsAsUser {
         val org1Project1PrescreenModel =
             DeliverableSubmissionModel(
                 category = DeliverableCategory.Compliance,
-                cohortId = null,
-                cohortName = null,
                 deliverableId = prescreenDeliverableId,
                 descriptionHtml = "Pre-screen deliverable description",
                 documents = emptyList(),

--- a/src/test/kotlin/com/terraformation/backend/email/EmailNotificationServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/email/EmailNotificationServiceTest.kt
@@ -429,8 +429,6 @@ internal class EmailNotificationServiceTest {
   private val deliverable =
       DeliverableSubmissionModel(
           category = deliverableCategory,
-          cohortId = cohort.id,
-          cohortName = cohort.name,
           deliverableId = DeliverableId(1),
           descriptionHtml = null,
           documents = emptyList(),


### PR DESCRIPTION
Stop looking at cohorts and cohort modules when fetching deliverables; instead
rely on project modules.

This removes the cohort ID and name from the deliverable submission API payload;
those properties aren't referenced by the terraware-web code any more.