### PR TITLE
SW-8060 Use project modules for species deliverables

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/accelerator/db/Exceptions.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/db/Exceptions.kt
@@ -68,8 +68,8 @@ class ProjectModuleNotFoundException(projectId: ProjectId, moduleId: ModuleId) :
 class ProjectNotInCohortException(id: ProjectId) :
     MismatchedStateException("Project $id is not assigned to any cohorts")
 
-class ProjectNotInCohortPhaseException(id: ProjectId, phase: CohortPhase) :
-    MismatchedStateException("Project $id is not currently in $phase")
+class ProjectNotInCohortPhaseException(id: ProjectId, phase: CohortPhase? = null) :
+    MismatchedStateException("Project $id is not currently in ${phase ?: "an accelerator phase"}")
 
 class ProjectVoteNotFoundException(
     projectId: ProjectId,
@@ -79,9 +79,6 @@ class ProjectVoteNotFoundException(
     EntityNotFoundException(
         "Vote not found for project $projectId, phase ${phase?.id}, user $userId"
     )
-
-class SpeciesDeliverableNotFoundException(id: ProjectId) :
-    EntityNotFoundException("Species Deliverable for project $id not found")
 
 class SubmissionDocumentNotFoundException(id: SubmissionDocumentId) :
     EntityNotFoundException("Submission document $id not found")

--- a/src/main/kotlin/com/terraformation/backend/accelerator/db/SubmissionStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/db/SubmissionStore.kt
@@ -9,9 +9,9 @@ import com.terraformation.backend.db.accelerator.DeliverableType
 import com.terraformation.backend.db.accelerator.SubmissionId
 import com.terraformation.backend.db.accelerator.SubmissionStatus
 import com.terraformation.backend.db.accelerator.tables.records.SubmissionsRecord
-import com.terraformation.backend.db.accelerator.tables.references.COHORT_MODULES
 import com.terraformation.backend.db.accelerator.tables.references.DELIVERABLES
 import com.terraformation.backend.db.accelerator.tables.references.MODULES
+import com.terraformation.backend.db.accelerator.tables.references.PROJECT_MODULES
 import com.terraformation.backend.db.accelerator.tables.references.SUBMISSIONS
 import com.terraformation.backend.db.attach
 import com.terraformation.backend.db.default_schema.ProjectId
@@ -82,19 +82,19 @@ class SubmissionStore(
             .from(DELIVERABLES)
             .join(MODULES)
             .on(DELIVERABLES.MODULE_ID.eq(MODULES.ID))
-            .join(COHORT_MODULES)
-            .on(MODULES.ID.eq(COHORT_MODULES.MODULE_ID))
+            .join(PROJECT_MODULES)
+            .on(MODULES.ID.eq(PROJECT_MODULES.MODULE_ID))
             .join(PROJECTS)
-            .on(COHORT_MODULES.COHORT_ID.eq(PROJECTS.COHORT_ID))
+            .on(PROJECT_MODULES.PROJECT_ID.eq(PROJECTS.ID))
             .leftJoin(SUBMISSIONS)
             .on(
                 DELIVERABLES.ID.eq(SUBMISSIONS.DELIVERABLE_ID),
                 PROJECTS.ID.eq(SUBMISSIONS.PROJECT_ID),
             )
-            .where(COHORT_MODULES.START_DATE.lessOrEqual(today))
+            .where(PROJECT_MODULES.START_DATE.lessOrEqual(today))
             .and(PROJECTS.ID.eq(projectId))
             .and(DELIVERABLES.DELIVERABLE_TYPE_ID.eq(DeliverableType.Species))
-            .orderBy(COHORT_MODULES.END_DATE.desc())
+            .orderBy(PROJECT_MODULES.END_DATE.desc())
             .limit(1)
             .fetchOne { ExistingSpeciesDeliverableSubmissionModel.of(it) }
 

--- a/src/test/kotlin/com/terraformation/backend/accelerator/SpeciesNotifierTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/SpeciesNotifierTest.kt
@@ -12,6 +12,7 @@ import com.terraformation.backend.accelerator.model.ExistingParticipantProjectSp
 import com.terraformation.backend.assertIsEventListener
 import com.terraformation.backend.customer.model.TerrawareUser
 import com.terraformation.backend.db.DatabaseTest
+import com.terraformation.backend.db.accelerator.CohortPhase
 import com.terraformation.backend.db.accelerator.DeliverableId
 import com.terraformation.backend.db.accelerator.DeliverableType
 import com.terraformation.backend.db.accelerator.ParticipantProjectSpeciesId
@@ -42,10 +43,9 @@ class SpeciesNotifierTest : DatabaseTest(), RunsAsUser {
   fun setUp() {
     insertOrganization()
     insertModule()
-    insertCohort()
-    insertCohortModule()
 
-    projectId = insertProject(cohortId = inserted.cohortId)
+    projectId = insertProject(phase = CohortPhase.Phase0DueDiligence)
+    insertProjectModule()
     deliverableId = insertDeliverable(deliverableTypeId = DeliverableType.Species)
 
     every { user.canReadProjectDeliverables(any()) } returns true

--- a/src/test/kotlin/com/terraformation/backend/db/DatabaseBackedTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/db/DatabaseBackedTest.kt
@@ -4279,13 +4279,13 @@ abstract class DatabaseBackedTest {
     cohortModulesDao.insert(row)
   }
 
-  private var nextProjectModuleStartDate = LocalDate.EPOCH
+  private val nextProjectModuleStartDates = mutableMapOf<ProjectId, LocalDate>()
 
   fun insertProjectModule(
       projectId: ProjectId = inserted.projectId,
       moduleId: ModuleId = inserted.moduleId,
       title: String = "Module 1",
-      startDate: LocalDate = nextProjectModuleStartDate,
+      startDate: LocalDate = nextProjectModuleStartDates.getOrPut(projectId) { LocalDate.EPOCH },
       endDate: LocalDate = startDate.plusDays(6),
   ) {
     val row =
@@ -4297,7 +4297,7 @@ abstract class DatabaseBackedTest {
             title = title,
         )
 
-    nextProjectModuleStartDate = endDate.plusDays(1)
+    nextProjectModuleStartDates[projectId] = endDate.plusDays(1)
     projectModulesDao.insert(row)
   }
 


### PR DESCRIPTION
Switch the code that deals with species deliverables to look for project modules
rather than cohort modules and to require projects to be in phases rather than
cohorts.