### PR TITLE
SW-8060 Use project modules for project deliverables

### DIFF
--- a/src/main/resources/db/migration/0450/V452__ProjectDeliverablesNoCohorts.sql
+++ b/src/main/resources/db/migration/0450/V452__ProjectDeliverablesNoCohorts.sql
@@ -1,0 +1,26 @@
+-- Previous version was in V448
+CREATE OR REPLACE VIEW accelerator.project_deliverables AS
+SELECT deliverables.id as deliverable_id,
+       deliverables.deliverable_category_id,
+       deliverables.deliverable_type_id,
+       deliverables.position,
+       deliverables.name,
+       deliverables.description_html,
+       deliverables.is_required,
+       deliverables.is_sensitive,
+       deliverables.module_id,
+       COALESCE(project_due_dates.due_date, project_modules.end_date) as due_date,
+       projects.id as project_id,
+       submissions.id as submission_id,
+       submissions.submission_status_id,
+       submissions.feedback as submission_feedback
+FROM accelerator.deliverables deliverables
+         JOIN accelerator.modules modules ON deliverables.module_id = modules.id
+         JOIN accelerator.project_modules project_modules ON modules.id = project_modules.module_id
+         JOIN projects ON project_modules.project_id = projects.id
+         LEFT JOIN accelerator.submissions submissions
+                   ON submissions.project_id = projects.id
+                       AND submissions.deliverable_id = deliverables.id
+         LEFT JOIN accelerator.deliverable_project_due_dates project_due_dates
+                   ON project_due_dates.project_id = projects.id
+                       AND project_due_dates.deliverable_id = deliverables.id;

--- a/src/test/kotlin/com/terraformation/backend/accelerator/ProjectDeliverableSearchTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/ProjectDeliverableSearchTest.kt
@@ -46,13 +46,13 @@ class ProjectDeliverableSearchTest : DatabaseTest(), RunsAsUser {
     )
     insertCohort()
     insertModule()
-    insertCohortModule(
-        inserted.cohortId,
+    projectId = insertProject(cohortId = inserted.cohortId, phase = CohortPhase.Phase0DueDiligence)
+    insertProjectModule(
+        projectId,
         inserted.moduleId,
         startDate = moduleStartDate,
         endDate = moduleEndDate,
     )
-    projectId = insertProject(cohortId = inserted.cohortId, phase = CohortPhase.Phase0DueDiligence)
 
     every { user.canReadAllAcceleratorDetails() } returns true
     every { user.organizationRoles } returns mapOf(inserted.organizationId to Role.Admin)
@@ -301,16 +301,9 @@ class ProjectDeliverableSearchTest : DatabaseTest(), RunsAsUser {
         )
     val deliverableWithoutSubmissions = insertDeliverable(moduleId = moduleId)
 
-    val otherCohort = insertCohort()
-    insertCohortModule(cohortId = otherCohort, moduleId = inserted.moduleId)
-
-    val otherOrganization = insertOrganization()
-    val otherProject =
-        insertProject(
-            cohortId = otherCohort,
-            organizationId = otherOrganization,
-            phase = CohortPhase.Phase0DueDiligence,
-        )
+    insertOrganization()
+    val otherProject = insertProject(phase = CohortPhase.Phase0DueDiligence)
+    insertProjectModule()
     insertSubmission(
         deliverableId = deliverableWithSubmission,
         projectId = otherProject,


### PR DESCRIPTION
Update the `project_deliverables` view to connect projects to deliverables via
project modules, not cohort modules.