### PR TITLE
SW-8059 List accelerator projects based on phase

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/accelerator/AcceleratorProjectService.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/AcceleratorProjectService.kt
@@ -3,7 +3,6 @@ package com.terraformation.backend.accelerator
 import com.terraformation.backend.accelerator.model.AcceleratorProjectModel
 import com.terraformation.backend.customer.model.requirePermissions
 import com.terraformation.backend.db.AcceleratorProjectNotFoundException
-import com.terraformation.backend.db.accelerator.tables.references.COHORTS
 import com.terraformation.backend.db.accelerator.tables.references.PROJECT_VOTE_DECISIONS
 import com.terraformation.backend.db.asNonNullable
 import com.terraformation.backend.db.default_schema.ProjectId
@@ -45,18 +44,15 @@ class AcceleratorProjectService(
 
     return dslContext
         .select(
-            COHORTS.ID,
-            COHORTS.NAME,
             PROJECTS.ID,
             PROJECTS.NAME,
             PROJECTS.PHASE_ID,
             decisionsMultiset,
         )
         .from(PROJECTS)
-        .join(COHORTS)
-        .on(PROJECTS.COHORT_ID.eq(COHORTS.ID))
         .where(condition)
-        .orderBy(COHORTS.ID, PROJECTS.ID)
+        .and(PROJECTS.PHASE_ID.isNotNull)
+        .orderBy(PROJECTS.ID)
         .fetch { AcceleratorProjectModel.of(it, decisionsMultiset) }
   }
 }

--- a/src/main/kotlin/com/terraformation/backend/accelerator/api/EventsController.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/api/EventsController.kt
@@ -12,7 +12,6 @@ import com.terraformation.backend.api.RequireGlobalRole
 import com.terraformation.backend.api.SimpleSuccessResponsePayload
 import com.terraformation.backend.api.SuccessResponsePayload
 import com.terraformation.backend.auth.currentUser
-import com.terraformation.backend.db.accelerator.CohortId
 import com.terraformation.backend.db.accelerator.EventId
 import com.terraformation.backend.db.accelerator.EventStatus
 import com.terraformation.backend.db.accelerator.EventType
@@ -168,16 +167,12 @@ class EventsController(
 data class ModuleEventProject(
     val projectId: ProjectId,
     val projectName: String,
-    val cohortId: CohortId,
-    val cohortName: String,
 ) {
   constructor(
       model: AcceleratorProjectModel
   ) : this(
       model.projectId,
       model.projectName,
-      model.cohortId,
-      model.cohortName,
   )
 }
 

--- a/src/main/kotlin/com/terraformation/backend/accelerator/model/AcceleratorProjectModel.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/model/AcceleratorProjectModel.kt
@@ -1,17 +1,13 @@
 package com.terraformation.backend.accelerator.model
 
-import com.terraformation.backend.db.accelerator.CohortId
 import com.terraformation.backend.db.accelerator.CohortPhase
 import com.terraformation.backend.db.accelerator.VoteOption
-import com.terraformation.backend.db.accelerator.tables.references.COHORTS
 import com.terraformation.backend.db.default_schema.ProjectId
 import com.terraformation.backend.db.default_schema.tables.references.PROJECTS
 import org.jooq.Field
 import org.jooq.Record
 
 data class AcceleratorProjectModel(
-    val cohortId: CohortId,
-    val cohortName: String,
     val phase: CohortPhase,
     val phaseName: String = phase.getDisplayName(null),
     val projectId: ProjectId,
@@ -24,8 +20,6 @@ data class AcceleratorProjectModel(
         decisionsField: Field<Map<CohortPhase, VoteOption>>,
     ): AcceleratorProjectModel {
       return AcceleratorProjectModel(
-          cohortId = record[COHORTS.ID]!!,
-          cohortName = record[COHORTS.NAME]!!,
           phase = record[PROJECTS.PHASE_ID]!!,
           projectId = record[PROJECTS.ID]!!,
           projectName = record[PROJECTS.NAME]!!,

--- a/src/test/kotlin/com/terraformation/backend/accelerator/AcceleratorProjectServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/AcceleratorProjectServiceTest.kt
@@ -24,9 +24,7 @@ class AcceleratorProjectServiceTest : DatabaseTest(), RunsAsDatabaseUser {
   @BeforeEach
   fun setUp() {
     insertOrganization()
-    insertCohort(phase = CohortPhase.Phase1FeasibilityStudy)
     insertProject(
-        cohortId = inserted.cohortId,
         countryCode = "KE",
         phase = CohortPhase.Phase1FeasibilityStudy,
     )
@@ -53,8 +51,6 @@ class AcceleratorProjectServiceTest : DatabaseTest(), RunsAsDatabaseUser {
   fun `fetches one by Id, or throws not found exception`() {
     assertEquals(
         AcceleratorProjectModel(
-            cohortId = inserted.cohortId,
-            cohortName = cohortsDao.fetchOneById(inserted.cohortId)!!.name!!,
             phase = CohortPhase.Phase1FeasibilityStudy,
             projectId = inserted.projectId,
             projectName = projectsDao.fetchOneById(inserted.projectId)!!.name!!,
@@ -76,8 +72,6 @@ class AcceleratorProjectServiceTest : DatabaseTest(), RunsAsDatabaseUser {
     assertEquals(
         listOf(
             AcceleratorProjectModel(
-                cohortId = inserted.cohortId,
-                cohortName = cohortsDao.fetchOneById(inserted.cohortId)!!.name!!,
                 phase = CohortPhase.Phase1FeasibilityStudy,
                 projectId = inserted.projectId,
                 projectName = projectsDao.fetchOneById(inserted.projectId)!!.name!!,


### PR DESCRIPTION
Change `AcceleratorProjectService` to query projects with non-null phases, rather
than projects in cohorts. Stop exposing cohort IDs in the API endpoint that lists
all accelerator projects.