### PR TITLE
SW-8061 Assign voters on project phase update

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/accelerator/VoteService.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/VoteService.kt
@@ -1,35 +1,18 @@
 package com.terraformation.backend.accelerator
 
-import com.terraformation.backend.accelerator.db.CohortStore
 import com.terraformation.backend.accelerator.db.VoteStore
-import com.terraformation.backend.accelerator.event.CohortPhaseUpdatedEvent
-import com.terraformation.backend.accelerator.event.CohortProjectAddedEvent
-import com.terraformation.backend.accelerator.model.CohortDepth
+import com.terraformation.backend.accelerator.event.ProjectPhaseUpdatedEvent
 import com.terraformation.backend.customer.model.SystemUser
 import jakarta.inject.Named
-import org.jooq.DSLContext
 import org.springframework.context.event.EventListener
-import org.springframework.core.annotation.Order
 
 @Named
 class VoteService(
-    private val cohortStore: CohortStore,
-    private val dslContext: DSLContext,
     private val systemUser: SystemUser,
     private val voteStore: VoteStore,
 ) {
   @EventListener
-  fun on(event: CohortProjectAddedEvent) {
+  fun on(event: ProjectPhaseUpdatedEvent) {
     systemUser.run { voteStore.assignVoters(event.projectId) }
-  }
-
-  @EventListener
-  @Order(ProjectPhaseService.EVENT_LISTENER_ORDER + 10)
-  fun on(event: CohortPhaseUpdatedEvent) {
-    systemUser.run {
-      val cohort = cohortStore.fetchOneById(event.cohortId, CohortDepth.Project)
-
-      dslContext.transaction { _ -> cohort.projectIds.forEach { voteStore.assignVoters(it) } }
-    }
   }
 }

--- a/src/main/kotlin/com/terraformation/backend/accelerator/db/ProjectAcceleratorDetailsStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/db/ProjectAcceleratorDetailsStore.kt
@@ -2,6 +2,7 @@ package com.terraformation.backend.accelerator.db
 
 import com.terraformation.backend.accelerator.event.CohortPhaseUpdatedEvent
 import com.terraformation.backend.accelerator.event.ParticipantProjectFileNamingUpdatedEvent
+import com.terraformation.backend.accelerator.event.ProjectPhaseUpdatedEvent
 import com.terraformation.backend.accelerator.model.MetricProgressModel
 import com.terraformation.backend.accelerator.model.ProjectAcceleratorDetailsModel
 import com.terraformation.backend.accelerator.model.ProjectAcceleratorVariableValuesModel
@@ -303,8 +304,12 @@ class ProjectAcceleratorDetailsStore(
             .where(COHORTS.ID.eq(existingCohortId))
             .execute()
 
+        // This will duplicate the work of the project event below; this event will go away when
+        // we get rid of cohorts, but the other one will still exist.
         eventPublisher.publishEvent(CohortPhaseUpdatedEvent(existingCohortId, newPhase))
       }
     }
+
+    eventPublisher.publishEvent(ProjectPhaseUpdatedEvent(projectId, newPhase))
   }
 }

--- a/src/main/kotlin/com/terraformation/backend/accelerator/event/ProjectPhaseUpdatedEvent.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/event/ProjectPhaseUpdatedEvent.kt
@@ -1,0 +1,9 @@
+package com.terraformation.backend.accelerator.event
+
+import com.terraformation.backend.db.accelerator.CohortPhase
+import com.terraformation.backend.db.default_schema.ProjectId
+
+data class ProjectPhaseUpdatedEvent(
+    val projectId: ProjectId,
+    val newPhase: CohortPhase?,
+)

--- a/src/test/kotlin/com/terraformation/backend/accelerator/VoteServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/VoteServiceTest.kt
@@ -2,12 +2,9 @@ package com.terraformation.backend.accelerator
 
 import com.terraformation.backend.RunsAsDatabaseUser
 import com.terraformation.backend.TestClock
-import com.terraformation.backend.TestEventPublisher
-import com.terraformation.backend.accelerator.db.CohortStore
 import com.terraformation.backend.accelerator.db.ProjectPhaseFetcher
 import com.terraformation.backend.accelerator.db.VoteStore
-import com.terraformation.backend.accelerator.event.CohortPhaseUpdatedEvent
-import com.terraformation.backend.accelerator.event.CohortProjectAddedEvent
+import com.terraformation.backend.accelerator.event.ProjectPhaseUpdatedEvent
 import com.terraformation.backend.assertIsEventListener
 import com.terraformation.backend.customer.model.SystemUser
 import com.terraformation.backend.customer.model.TerrawareUser
@@ -26,14 +23,11 @@ class VoteServiceTest : DatabaseTest(), RunsAsDatabaseUser {
   override lateinit var user: TerrawareUser
 
   private val clock = TestClock()
-  private val eventPublisher = TestEventPublisher()
 
   private val systemUser: SystemUser by lazy { SystemUser(usersDao) }
 
   private val service: VoteService by lazy {
     VoteService(
-        CohortStore(clock, cohortsDao, dslContext, eventPublisher),
-        dslContext,
         systemUser,
         VoteStore(clock, dslContext, ProjectPhaseFetcher(dslContext)),
     )
@@ -52,18 +46,15 @@ class VoteServiceTest : DatabaseTest(), RunsAsDatabaseUser {
   }
 
   @Nested
-  inner class CohortProjectAdded {
+  inner class ProjectPhaseUpdated {
     @Test
     fun `inserts voters`() {
-      val cohortId1 = insertCohort()
-      val projectId1 = insertProject(cohortId = cohortId1, phase = CohortPhase.Phase0DueDiligence)
+      val projectId1 = insertProject(phase = CohortPhase.Phase0DueDiligence)
 
-      // Should leave these alone
-      insertProject(cohortId = cohortId1)
-      val otherCohortId = insertCohort()
-      insertProject(cohortId = otherCohortId)
+      // Should leave this one alone
+      insertProject(phase = CohortPhase.Phase0DueDiligence)
 
-      service.on(CohortProjectAddedEvent(user.userId, cohortId1, projectId1))
+      service.on(ProjectPhaseUpdatedEvent(projectId1, CohortPhase.Phase0DueDiligence))
 
       assertTableEquals(
           setOf(
@@ -75,46 +66,7 @@ class VoteServiceTest : DatabaseTest(), RunsAsDatabaseUser {
 
     @Test
     fun `listens for event`() {
-      assertIsEventListener<CohortProjectAddedEvent>(service)
-    }
-  }
-
-  @Nested
-  inner class CohortPhaseUpdated {
-    @Test
-    fun `inserts voters`() {
-      val phase = CohortPhase.Phase1FeasibilityStudy
-      val cohortId1 = insertCohort(phase = phase)
-      val projectId1 = insertProject(cohortId = cohortId1, phase = phase)
-      val projectId2 = insertProject(cohortId = cohortId1, phase = phase)
-
-      // Should leave these alone
-      val otherCohortId = insertCohort()
-      insertProject(cohortId = otherCohortId)
-      insertVote(projectId1, user = voter1)
-
-      service.on(CohortPhaseUpdatedEvent(cohortId1, phase))
-
-      assertTableEquals(
-          setOf(
-              // First row is inserted by test, not by service
-              votesRecord(
-                  userId = voter1,
-                  projectId = projectId1,
-                  phase = CohortPhase.Phase0DueDiligence,
-                  createdBySystemUser = false,
-              ),
-              votesRecord(userId = voter1, projectId = projectId1, phase = phase),
-              votesRecord(userId = voter2, projectId = projectId1, phase = phase),
-              votesRecord(userId = voter1, projectId = projectId2, phase = phase),
-              votesRecord(userId = voter2, projectId = projectId2, phase = phase),
-          )
-      )
-    }
-
-    @Test
-    fun `listens for event`() {
-      assertIsEventListener<CohortPhaseUpdatedEvent>(service)
+      assertIsEventListener<ProjectPhaseUpdatedEvent>(service)
     }
   }
 

--- a/src/test/kotlin/com/terraformation/backend/accelerator/db/ProjectAcceleratorDetailsStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/db/ProjectAcceleratorDetailsStoreTest.kt
@@ -6,6 +6,7 @@ import com.terraformation.backend.TestEventPublisher
 import com.terraformation.backend.accelerator.ProjectPhaseService
 import com.terraformation.backend.accelerator.event.CohortPhaseUpdatedEvent
 import com.terraformation.backend.accelerator.event.ParticipantProjectFileNamingUpdatedEvent
+import com.terraformation.backend.accelerator.event.ProjectPhaseUpdatedEvent
 import com.terraformation.backend.accelerator.model.MetricProgressModel
 import com.terraformation.backend.accelerator.model.ProjectAcceleratorDetailsModel
 import com.terraformation.backend.accelerator.model.ProjectAcceleratorVariableValuesModel
@@ -576,12 +577,17 @@ class ProjectAcceleratorDetailsStoreTest : DatabaseTest(), RunsAsUser {
               modifiedTime = clock.instant,
           )
       )
+
+      eventPublisher.assertEventPublished(
+          ProjectPhaseUpdatedEvent(projectId, CohortPhase.Phase1FeasibilityStudy)
+      )
     }
 
     @Test
     fun `does not update cohort phase when project phase is unchanged`() {
       insertCohort(name = "Test Cohort", phase = CohortPhase.Phase0DueDiligence)
-      val projectId = insertProject(cohortId = inserted.cohortId)
+      val projectId =
+          insertProject(cohortId = inserted.cohortId, phase = CohortPhase.Phase0DueDiligence)
 
       val existingValues =
           ProjectAcceleratorVariableValuesModel(
@@ -609,6 +615,28 @@ class ProjectAcceleratorDetailsStoreTest : DatabaseTest(), RunsAsUser {
           ),
           "Cohort should remain unchanged",
       )
+    }
+
+    @Test
+    fun `does not publish event when project phase is unchanged`() {
+      val projectId = insertProject(phase = CohortPhase.Phase0DueDiligence)
+
+      val existingValues =
+          ProjectAcceleratorVariableValuesModel(
+              projectId = projectId,
+          )
+
+      store.update(projectId, existingValues) {
+        it.copy(
+            numCommunities = 5,
+            phase = CohortPhase.Phase0DueDiligence,
+            fileNaming = "test-naming",
+            dropboxFolderPath = "/dropbox/test",
+            googleFolderUrl = URI("https://drive.google.com/test"),
+        )
+      }
+
+      eventPublisher.assertEventNotPublished<ProjectPhaseUpdatedEvent>()
     }
 
     @Test


### PR DESCRIPTION
In preparation for removing cohorts, trigger assignment of default voters when
a project's phase is updated, not when a cohort's phase is updated or a project
is added to a cohort.

Note that with the removal of the cohorts API, there is no longer a way to
update a cohort's phase, so the removal of voter assignment on cohort phase
change won't have any user-visible effect.