### PR TITLE
SW-8059 Remove cohort info from accelerator details

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/accelerator/ProjectAcceleratorDetailsService.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/ProjectAcceleratorDetailsService.kt
@@ -3,8 +3,8 @@ package com.terraformation.backend.accelerator
 import com.terraformation.backend.accelerator.db.ProjectAcceleratorDetailsStore
 import com.terraformation.backend.accelerator.model.ProjectAcceleratorDetailsModel
 import com.terraformation.backend.accelerator.variables.AcceleratorProjectVariableValuesService
-import com.terraformation.backend.db.accelerator.tables.references.COHORTS
 import com.terraformation.backend.db.default_schema.ProjectId
+import com.terraformation.backend.db.default_schema.tables.references.PROJECTS
 import jakarta.inject.Named
 
 @Named
@@ -17,9 +17,9 @@ class ProjectAcceleratorDetailsService(
     return projectAcceleratorDetailsStore.fetchOneById(projectId, variableValues)
   }
 
-  /** Returns accelerator details for projects that are assigned to cohorts. */
+  /** Returns accelerator details for projects that are in phases. */
   fun fetchAllParticipantProjectDetails(): List<ProjectAcceleratorDetailsModel> {
-    return projectAcceleratorDetailsStore.fetch(COHORTS.ID.isNotNull()) {
+    return projectAcceleratorDetailsStore.fetch(PROJECTS.PHASE_ID.isNotNull()) {
       acceleratorProjectVariableValuesService.fetchValues(it)
     }
   }

--- a/src/main/kotlin/com/terraformation/backend/accelerator/api/ProjectAcceleratorDetailsController.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/api/ProjectAcceleratorDetailsController.kt
@@ -12,7 +12,6 @@ import com.terraformation.backend.api.ApiResponse404
 import com.terraformation.backend.api.ApiResponseSimpleSuccess
 import com.terraformation.backend.api.SimpleSuccessResponsePayload
 import com.terraformation.backend.api.SuccessResponsePayload
-import com.terraformation.backend.db.accelerator.CohortId
 import com.terraformation.backend.db.accelerator.CohortPhase
 import com.terraformation.backend.db.accelerator.DealStage
 import com.terraformation.backend.db.accelerator.Pipeline
@@ -86,8 +85,6 @@ data class ProjectAcceleratorDetailsPayload(
     val carbonCapacity: BigDecimal?,
     val carbonCertifications: Set<CarbonCertification>?,
     val clickUpLink: URI?,
-    val cohortId: CohortId?,
-    val cohortName: String?,
     val confirmedReforestableLand: BigDecimal?,
     val countryAlpha3: String?,
     val countryCode: String?,
@@ -139,8 +136,6 @@ data class ProjectAcceleratorDetailsPayload(
       carbonCapacity = model.carbonCapacity,
       carbonCertifications = model.carbonCertifications,
       clickUpLink = model.clickUpLink,
-      cohortId = model.cohortId,
-      cohortName = model.cohortName,
       confirmedReforestableLand = model.confirmedReforestableLand,
       countryAlpha3 = model.countryAlpha3,
       countryCode = model.countryCode,
@@ -183,10 +178,6 @@ data class ProjectAcceleratorDetailsPayload(
       verraLink = model.verraLink,
       whatNeedsToBeTrue = model.whatNeedsToBeTrue,
   )
-
-  @Deprecated("Use phase instead.")
-  val cohortPhase: CohortPhase? // for backwards compatibility in response payloads
-    get() = phase
 }
 
 data class MetricProgressPayload(

--- a/src/main/kotlin/com/terraformation/backend/accelerator/db/ProjectAcceleratorDetailsStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/db/ProjectAcceleratorDetailsStore.kt
@@ -10,7 +10,6 @@ import com.terraformation.backend.auth.currentUser
 import com.terraformation.backend.customer.model.requirePermissions
 import com.terraformation.backend.db.ProjectNotFoundException
 import com.terraformation.backend.db.accelerator.SystemMetric
-import com.terraformation.backend.db.accelerator.tables.references.COHORTS
 import com.terraformation.backend.db.accelerator.tables.references.PROJECT_ACCELERATOR_DETAILS
 import com.terraformation.backend.db.default_schema.ProjectId
 import com.terraformation.backend.db.default_schema.tables.records.ProjectLandUseModelTypesRecord
@@ -61,8 +60,6 @@ class ProjectAcceleratorDetailsStore(
     return dslContext
         .select(
             PROJECT_ACCELERATOR_DETAILS.asterisk(),
-            COHORTS.ID,
-            COHORTS.NAME,
             PROJECTS.ID,
             PROJECTS.PHASE_ID,
             projectProgressMultiset,
@@ -70,8 +67,6 @@ class ProjectAcceleratorDetailsStore(
         .from(PROJECTS)
         .leftJoin(PROJECT_ACCELERATOR_DETAILS)
         .on(PROJECTS.ID.eq(PROJECT_ACCELERATOR_DETAILS.PROJECT_ID))
-        .leftJoin(COHORTS)
-        .on(COHORTS.ID.eq(PROJECTS.COHORT_ID))
         .where(condition)
         .filter { filterFn(it[PROJECTS.ID]!!) }
         .map {

--- a/src/main/kotlin/com/terraformation/backend/accelerator/model/ProjectAcceleratorDetailsModel.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/model/ProjectAcceleratorDetailsModel.kt
@@ -2,11 +2,9 @@ package com.terraformation.backend.accelerator.model
 
 import com.terraformation.backend.db.accelerator.ApplicationId
 import com.terraformation.backend.db.accelerator.ApplicationStatus
-import com.terraformation.backend.db.accelerator.CohortId
 import com.terraformation.backend.db.accelerator.CohortPhase
 import com.terraformation.backend.db.accelerator.DealStage
 import com.terraformation.backend.db.accelerator.Pipeline
-import com.terraformation.backend.db.accelerator.tables.references.COHORTS
 import com.terraformation.backend.db.accelerator.tables.references.PROJECT_ACCELERATOR_DETAILS
 import com.terraformation.backend.db.default_schema.LandUseModelType
 import com.terraformation.backend.db.default_schema.ProjectId
@@ -27,8 +25,6 @@ data class ProjectAcceleratorDetailsModel(
     val carbonCapacity: BigDecimal? = null,
     val carbonCertifications: Set<CarbonCertification> = emptySet(),
     val clickUpLink: URI? = null,
-    val cohortId: CohortId? = null,
-    val cohortName: String? = null,
     val confirmedReforestableLand: BigDecimal? = null,
     val countryAlpha3: String? = null,
     val countryCode: String? = null,
@@ -86,8 +82,6 @@ data class ProjectAcceleratorDetailsModel(
             carbonCapacity = variableValues.carbonCapacity,
             carbonCertifications = variableValues.carbonCertifications,
             clickUpLink = variableValues.clickUpLink,
-            cohortId = record[COHORTS.ID],
-            cohortName = record[COHORTS.NAME],
             confirmedReforestableLand = variableValues.confirmedReforestableLand,
             countryAlpha3 = variableValues.countryAlpha3,
             countryCode = variableValues.countryCode,

--- a/src/test/kotlin/com/terraformation/backend/accelerator/db/ProjectAcceleratorDetailsStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/db/ProjectAcceleratorDetailsStoreTest.kt
@@ -52,9 +52,7 @@ class ProjectAcceleratorDetailsStoreTest : DatabaseTest(), RunsAsUser {
   inner class FetchOneById {
     @Test
     fun `returns all details fields`() {
-      insertCohort(name = "Cohort name", phase = CohortPhase.Phase0DueDiligence)
-      val projectId =
-          insertProject(cohortId = inserted.cohortId, phase = CohortPhase.Phase0DueDiligence)
+      val projectId = insertProject(phase = CohortPhase.Phase0DueDiligence)
       insertProjectLandUseModelType(landUseModelType = LandUseModelType.Agroforestry)
       insertProjectLandUseModelType(landUseModelType = LandUseModelType.Mangroves)
 
@@ -132,8 +130,6 @@ class ProjectAcceleratorDetailsStoreTest : DatabaseTest(), RunsAsUser {
               annualCarbon = detailsRow.annualCarbon,
               applicationReforestableLand = detailsRow.applicationReforestableLand,
               carbonCapacity = detailsRow.carbonCapacity,
-              cohortId = inserted.cohortId,
-              cohortName = "Cohort name",
               confirmedReforestableLand = detailsRow.confirmedReforestableLand,
               countryCode = "KE",
               dealDescription = detailsRow.dealDescription,


### PR DESCRIPTION
The web app no longer looks at the cohort ID or name in the project accelerator
details; stop including it.