### PR TITLE
SW-8059 Stop inserting cohorts in tests

### DIFF
--- a/src/test/kotlin/com/terraformation/backend/accelerator/DeliverableFilesRenamerTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/DeliverableFilesRenamerTest.kt
@@ -79,8 +79,7 @@ class DeliverableFilesRenamerTest : DatabaseTest(), RunsAsUser {
   @BeforeEach
   fun setUp() {
     insertOrganization()
-    insertCohort()
-    projectId = insertProject(cohortId = inserted.cohortId)
+    projectId = insertProject(phase = CohortPhase.Phase0DueDiligence)
     applicationId = insertApplication(internalName = "XXX_Organization")
 
     every { config.accelerator } returns

--- a/src/test/kotlin/com/terraformation/backend/accelerator/ModuleEventSearchTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/ModuleEventSearchTest.kt
@@ -39,7 +39,6 @@ class ModuleEventSearchTest : DatabaseTest(), RunsAsUser {
         organizationId = inserted.organizationId,
         role = Role.Admin,
     )
-    insertCohort()
     insertModule()
 
     every { user.canReadAllAcceleratorDetails() } returns true
@@ -149,23 +148,17 @@ class ModuleEventSearchTest : DatabaseTest(), RunsAsUser {
 
   @Test
   fun `can search for associated projects`() {
-    val project1 =
-        insertProject(cohortId = inserted.cohortId, phase = CohortPhase.Phase0DueDiligence)
-    val project2 =
-        insertProject(cohortId = inserted.cohortId, phase = CohortPhase.Phase0DueDiligence)
-    val project3 =
-        insertProject(cohortId = inserted.cohortId, phase = CohortPhase.Phase0DueDiligence)
+    val project1 = insertProject(phase = CohortPhase.Phase0DueDiligence)
+    val project2 = insertProject(phase = CohortPhase.Phase0DueDiligence)
+    val project3 = insertProject(phase = CohortPhase.Phase0DueDiligence)
     val event1 = insertEvent()
     insertEventProject(event1, project1)
     insertEventProject(event1, project2)
     insertEventProject(event1, project3)
 
-    val project4 =
-        insertProject(cohortId = inserted.cohortId, phase = CohortPhase.Phase0DueDiligence)
-    val project5 =
-        insertProject(cohortId = inserted.cohortId, phase = CohortPhase.Phase0DueDiligence)
-    val project6 =
-        insertProject(cohortId = inserted.cohortId, phase = CohortPhase.Phase0DueDiligence)
+    val project4 = insertProject(phase = CohortPhase.Phase0DueDiligence)
+    val project5 = insertProject(phase = CohortPhase.Phase0DueDiligence)
+    val project6 = insertProject(phase = CohortPhase.Phase0DueDiligence)
     val event2 = insertEvent()
     insertEventProject(event2, project4)
     insertEventProject(event2, project5)
@@ -211,10 +204,8 @@ class ModuleEventSearchTest : DatabaseTest(), RunsAsUser {
     val event3 = insertEvent()
     val hiddenEvent = insertEvent()
 
-    val project1 =
-        insertProject(cohortId = inserted.cohortId, phase = CohortPhase.Phase0DueDiligence)
-    val project2 =
-        insertProject(cohortId = inserted.cohortId, phase = CohortPhase.Phase0DueDiligence)
+    val project1 = insertProject(phase = CohortPhase.Phase0DueDiligence)
+    val project2 = insertProject(phase = CohortPhase.Phase0DueDiligence)
 
     insertEventProject(event1, project1)
     insertEventProject(event2, project1)
@@ -256,10 +247,8 @@ class ModuleEventSearchTest : DatabaseTest(), RunsAsUser {
 
   @Test
   fun `can search for events sublists using projects as prefix`() {
-    val project1 =
-        insertProject(cohortId = inserted.cohortId, phase = CohortPhase.Phase0DueDiligence)
-    val project2 =
-        insertProject(cohortId = inserted.cohortId, phase = CohortPhase.Phase0DueDiligence)
+    val project1 = insertProject(phase = CohortPhase.Phase0DueDiligence)
+    val project2 = insertProject(phase = CohortPhase.Phase0DueDiligence)
     val event1 = insertEvent()
     val event2 = insertEvent()
     val event3 = insertEvent()
@@ -302,7 +291,6 @@ class ModuleEventSearchTest : DatabaseTest(), RunsAsUser {
   fun `can only search for events for organization projects for non accelerator admins`() {
     val userProject =
         insertProject(
-            cohortId = inserted.cohortId,
             organizationId = inserted.organizationId,
             phase = CohortPhase.Phase0DueDiligence,
         )
@@ -314,10 +302,8 @@ class ModuleEventSearchTest : DatabaseTest(), RunsAsUser {
         organizationId = otherOrganization,
         role = Role.Admin,
     )
-    val otherCohort = insertCohort()
     val otherProject =
         insertProject(
-            cohortId = otherCohort,
             organizationId = otherOrganization,
             phase = CohortPhase.Phase0DueDiligence,
             createdBy = otherUser,

--- a/src/test/kotlin/com/terraformation/backend/accelerator/ModuleEventServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/ModuleEventServiceTest.kt
@@ -10,6 +10,7 @@ import com.terraformation.backend.assertIsEventListener
 import com.terraformation.backend.customer.model.SystemUser
 import com.terraformation.backend.customer.model.TerrawareUser
 import com.terraformation.backend.db.DatabaseTest
+import com.terraformation.backend.db.accelerator.CohortPhase
 import com.terraformation.backend.db.accelerator.EventId
 import com.terraformation.backend.db.accelerator.EventStatus
 import com.terraformation.backend.db.default_schema.ProjectId
@@ -55,9 +56,8 @@ class ModuleEventServiceTest : DatabaseTest(), RunsAsUser {
   fun setUp() {
     insertOrganization()
     insertModule()
-    insertCohort()
 
-    projectId = insertProject(cohortId = inserted.cohortId)
+    projectId = insertProject(phase = CohortPhase.Phase0DueDiligence)
 
     every { scheduler.schedule<ModuleEventService>(any<Instant>(), any()) } returns
         JobId(UUID.randomUUID())

--- a/src/test/kotlin/com/terraformation/backend/accelerator/ParticipantProjectSpeciesServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/ParticipantProjectSpeciesServiceTest.kt
@@ -371,10 +371,9 @@ class ParticipantProjectSpeciesServiceTest : DatabaseTest(), RunsAsUser {
   inner class UpdateStatusEvent {
     @Test
     fun `updates the status for the participant project species if species fields are edited by non-accelerator-users`() {
-      val cohortId = insertCohort()
-      val projectId1 = insertProject(cohortId = cohortId)
-      val projectId2 = insertProject(cohortId = cohortId)
-      val projectId3 = insertProject(cohortId = cohortId)
+      val projectId1 = insertProject(phase = CohortPhase.Phase0DueDiligence)
+      val projectId2 = insertProject(phase = CohortPhase.Phase0DueDiligence)
+      val projectId3 = insertProject(phase = CohortPhase.Phase0DueDiligence)
       val speciesId = insertSpecies()
 
       val participantProjectSpeciesId1 =
@@ -419,8 +418,7 @@ class ParticipantProjectSpeciesServiceTest : DatabaseTest(), RunsAsUser {
 
     @Test
     fun `does not update the status of the participant project species if the species fields are edited by accelerator-users`() {
-      val cohortId = insertCohort()
-      val projectId = insertProject(cohortId = cohortId)
+      val projectId = insertProject(phase = CohortPhase.Phase0DueDiligence)
       val speciesId = insertSpecies()
 
       insertParticipantProjectSpecies(

--- a/src/test/kotlin/com/terraformation/backend/accelerator/ProjectDeliverableSearchTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/ProjectDeliverableSearchTest.kt
@@ -44,9 +44,8 @@ class ProjectDeliverableSearchTest : DatabaseTest(), RunsAsUser {
         organizationId = inserted.organizationId,
         role = Role.Admin,
     )
-    insertCohort()
     insertModule()
-    projectId = insertProject(cohortId = inserted.cohortId, phase = CohortPhase.Phase0DueDiligence)
+    projectId = insertProject(phase = CohortPhase.Phase0DueDiligence)
     insertProjectModule(
         projectId,
         inserted.moduleId,
@@ -187,8 +186,7 @@ class ProjectDeliverableSearchTest : DatabaseTest(), RunsAsUser {
             submissionStatus = SubmissionStatus.Approved,
         )
 
-    val hiddenProject =
-        insertProject(cohortId = inserted.cohortId, phase = CohortPhase.Phase0DueDiligence)
+    val hiddenProject = insertProject(phase = CohortPhase.Phase0DueDiligence)
     insertSubmission(
         deliverableId = deliverableWithSubmission,
         projectId = hiddenProject,

--- a/src/test/kotlin/com/terraformation/backend/accelerator/SpeciesSubmissionUpdaterTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/SpeciesSubmissionUpdaterTest.kt
@@ -9,6 +9,7 @@ import com.terraformation.backend.accelerator.model.ExistingParticipantProjectSp
 import com.terraformation.backend.auth.currentUser
 import com.terraformation.backend.customer.model.TerrawareUser
 import com.terraformation.backend.db.DatabaseTest
+import com.terraformation.backend.db.accelerator.CohortPhase
 import com.terraformation.backend.db.accelerator.DeliverableType
 import com.terraformation.backend.db.accelerator.SubmissionStatus
 import com.terraformation.backend.db.accelerator.tables.pojos.SubmissionsRow
@@ -46,8 +47,7 @@ class SpeciesSubmissionUpdaterTest : DatabaseTest(), RunsAsUser {
   inner class ResetSubmission {
     @Test
     fun `resets the submission status if it exists and is currently 'Approved'`() {
-      val cohortId = insertCohort()
-      val projectId = insertProject(cohortId = cohortId)
+      val projectId = insertProject(phase = CohortPhase.Phase0DueDiligence)
       val speciesId = insertSpecies()
       val moduleId = insertModule()
       val deliverableId =
@@ -100,8 +100,7 @@ class SpeciesSubmissionUpdaterTest : DatabaseTest(), RunsAsUser {
 
     @Test
     fun `does nothing if the submission status is not 'Approved'`() {
-      val cohortId = insertCohort()
-      val projectId = insertProject(cohortId = cohortId)
+      val projectId = insertProject(phase = CohortPhase.Phase0DueDiligence)
       val speciesId = insertSpecies()
       val moduleId = insertModule()
       val deliverableId =

--- a/src/test/kotlin/com/terraformation/backend/accelerator/api/ParticipantProjectSpeciesControllerTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/api/ParticipantProjectSpeciesControllerTest.kt
@@ -18,10 +18,9 @@ class ParticipantProjectSpeciesControllerTest : ControllerIntegrationTest() {
     @Test
     fun `can add species to approved species list`() {
       insertModule(phase = CohortPhase.Phase1FeasibilityStudy)
-      val cohortId = insertCohort()
       insertOrganization()
       insertOrganizationUser(role = Role.Owner)
-      val projectId = insertProject(cohortId = cohortId, phase = CohortPhase.Phase0DueDiligence)
+      val projectId = insertProject(phase = CohortPhase.Phase0DueDiligence)
       val speciesId = insertSpecies()
       insertProjectModule()
       insertDeliverable(

--- a/src/test/kotlin/com/terraformation/backend/accelerator/db/AcceleratorOrganizationStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/db/AcceleratorOrganizationStoreTest.kt
@@ -33,7 +33,6 @@ class AcceleratorOrganizationStoreTest : DatabaseTest(), RunsAsDatabaseUser {
       val acceleratorOrgId1 = insertOrganization()
       val nonAcceleratorOrgId = insertOrganization()
       val untaggedOrgId = insertOrganization()
-      val cohortId = insertCohort()
       val currentUserId = user.userId
 
       insertOrganizationInternalTag(nonAcceleratorOrgId, InternalTagIds.Internal)
@@ -44,7 +43,6 @@ class AcceleratorOrganizationStoreTest : DatabaseTest(), RunsAsDatabaseUser {
           insertProject(
               organizationId = acceleratorOrgId1,
               name = "D",
-              cohortId = cohortId,
               phase = CohortPhase.Phase0DueDiligence,
           )
       val unassignedProjectId1 = insertProject(organizationId = acceleratorOrgId1, name = "A")

--- a/src/test/kotlin/com/terraformation/backend/accelerator/db/DeliverableStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/db/DeliverableStoreTest.kt
@@ -472,8 +472,7 @@ class DeliverableStoreTest : DatabaseTest(), RunsAsUser {
     @Test
     fun `returns application submissions for participant projects if deliverable ID is specified`() {
       val organizationId = insertOrganization()
-      val cohortId = insertCohort(name = "Cohort Name")
-      val projectId = insertProject(cohortId = cohortId)
+      val projectId = insertProject(phase = CohortPhase.Phase0DueDiligence)
       val moduleId = insertModule(phase = CohortPhase.PreScreen)
       val deliverableId = insertDeliverable()
       val submissionId = insertSubmission(submissionStatus = SubmissionStatus.Approved)

--- a/src/test/kotlin/com/terraformation/backend/accelerator/db/ProjectPhaseFetcherTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/db/ProjectPhaseFetcherTest.kt
@@ -81,8 +81,7 @@ class ProjectPhaseFetcherTest : DatabaseTest(), RunsAsUser {
 
     @Test
     fun `throws exception if no permission to read project`() {
-      val cohortId = insertCohort()
-      val projectId = insertProject(cohortId = cohortId)
+      val projectId = insertProject(phase = CohortPhase.Phase0DueDiligence)
 
       every { user.canReadProject(projectId) } returns false
 

--- a/src/test/kotlin/com/terraformation/backend/accelerator/db/ProjectScoreStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/db/ProjectScoreStoreTest.kt
@@ -30,7 +30,6 @@ class ProjectScoreStoreTest : DatabaseTest(), RunsAsUser {
   @BeforeEach
   fun setUp() {
     insertOrganization()
-    insertCohort(phase = CohortPhase.Phase0DueDiligence)
 
     every { user.canReadProject(any()) } returns true
     every { user.canReadProjectScores(any()) } returns true
@@ -45,7 +44,7 @@ class ProjectScoreStoreTest : DatabaseTest(), RunsAsUser {
       val time2 = Instant.ofEpochSecond(2)
       val time3 = Instant.ofEpochSecond(3)
 
-      val projectId = insertProject(cohortId = inserted.cohortId)
+      val projectId = insertProject(phase = CohortPhase.Phase0DueDiligence)
 
       insertProjectScore(
           phase = CohortPhase.Phase0DueDiligence,
@@ -89,7 +88,7 @@ class ProjectScoreStoreTest : DatabaseTest(), RunsAsUser {
       val time3 = Instant.ofEpochSecond(3)
       val time4 = Instant.ofEpochSecond(4)
 
-      val projectId = insertProject(cohortId = inserted.cohortId)
+      val projectId = insertProject(phase = CohortPhase.Phase0DueDiligence)
 
       insertProjectScore(
           phase = CohortPhase.Phase0DueDiligence,
@@ -144,7 +143,7 @@ class ProjectScoreStoreTest : DatabaseTest(), RunsAsUser {
 
     @Test
     fun `throws exception if no permission to read scores`() {
-      val projectId = insertProject(cohortId = inserted.cohortId)
+      val projectId = insertProject(phase = CohortPhase.Phase0DueDiligence)
 
       every { user.canReadProjectScores(projectId) } returns false
 
@@ -156,8 +155,7 @@ class ProjectScoreStoreTest : DatabaseTest(), RunsAsUser {
   inner class UpdateScores {
     @Test
     fun `creates scores that do not exist`() {
-      val projectId =
-          insertProject(cohortId = inserted.cohortId, phase = CohortPhase.Phase0DueDiligence)
+      val projectId = insertProject(phase = CohortPhase.Phase0DueDiligence)
 
       clock.instant = Instant.ofEpochSecond(123)
 
@@ -199,8 +197,7 @@ class ProjectScoreStoreTest : DatabaseTest(), RunsAsUser {
 
     @Test
     fun `updates scores that already exist`() {
-      val projectId =
-          insertProject(cohortId = inserted.cohortId, phase = CohortPhase.Phase0DueDiligence)
+      val projectId = insertProject(phase = CohortPhase.Phase0DueDiligence)
 
       insertProjectScore(phase = CohortPhase.Phase0DueDiligence, category = ScoreCategory.Legal)
       insertProjectScore(
@@ -250,7 +247,7 @@ class ProjectScoreStoreTest : DatabaseTest(), RunsAsUser {
 
     @Test
     fun `throws exception if no permission to update scores`() {
-      val projectId = insertProject(cohortId = inserted.cohortId)
+      val projectId = insertProject(phase = CohortPhase.Phase0DueDiligence)
 
       every { user.canUpdateProjectScores(projectId) } returns false
 
@@ -278,8 +275,7 @@ class ProjectScoreStoreTest : DatabaseTest(), RunsAsUser {
 
     @Test
     fun `throws exception if updating scores for a different phase than the current one`() {
-      val projectId =
-          insertProject(cohortId = inserted.cohortId, phase = CohortPhase.Phase0DueDiligence)
+      val projectId = insertProject(phase = CohortPhase.Phase0DueDiligence)
 
       assertThrows<ProjectNotInCohortPhaseException> {
         store.updateScores(

--- a/src/test/kotlin/com/terraformation/backend/accelerator/db/VoteStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/db/VoteStoreTest.kt
@@ -35,7 +35,6 @@ class VoteStoreTest : DatabaseTest(), RunsAsUser {
   @BeforeEach
   fun setUp() {
     insertOrganization()
-    insertCohort(phase = CohortPhase.Phase1FeasibilityStudy)
 
     every { user.canReadProject(any()) } returns true
     every { user.canReadProjectVotes(any()) } returns true
@@ -46,7 +45,7 @@ class VoteStoreTest : DatabaseTest(), RunsAsUser {
   inner class FetchAllVotes {
     @Test
     fun `fetches with no vote`() {
-      val projectId = insertProject(cohortId = inserted.cohortId)
+      val projectId = insertProject(phase = CohortPhase.Phase0DueDiligence)
       clock.instant = Instant.EPOCH.plusSeconds(500)
 
       assertEquals(emptyList<VoteModel>(), store.fetchAllVotes(projectId))
@@ -54,7 +53,7 @@ class VoteStoreTest : DatabaseTest(), RunsAsUser {
 
     @Test
     fun `fetches all votes`() {
-      val projectId = insertProject(cohortId = inserted.cohortId)
+      val projectId = insertProject(phase = CohortPhase.Phase0DueDiligence)
       val phase: CohortPhase = CohortPhase.Phase1FeasibilityStudy
       clock.instant = Instant.EPOCH.plusSeconds(500)
 
@@ -118,7 +117,7 @@ class VoteStoreTest : DatabaseTest(), RunsAsUser {
 
     @Test
     fun `fetches votes by phase`() {
-      val projectId = insertProject(cohortId = inserted.cohortId)
+      val projectId = insertProject(phase = CohortPhase.Phase0DueDiligence)
       val phase0: CohortPhase = CohortPhase.Phase0DueDiligence
       val phase1: CohortPhase = CohortPhase.Phase1FeasibilityStudy
       clock.instant = Instant.EPOCH.plusSeconds(500)
@@ -175,7 +174,7 @@ class VoteStoreTest : DatabaseTest(), RunsAsUser {
 
     @Test
     fun `throws exception on fetch if no permission to read votes `() {
-      val projectId = insertProject(cohortId = inserted.cohortId)
+      val projectId = insertProject(phase = CohortPhase.Phase0DueDiligence)
 
       every { user.canReadProjectVotes(projectId) } returns false
 
@@ -187,7 +186,7 @@ class VoteStoreTest : DatabaseTest(), RunsAsUser {
   inner class FetchAllVoteDecisions {
     @Test
     fun `fetches with no vote`() {
-      val projectId = insertProject(cohortId = inserted.cohortId)
+      val projectId = insertProject(phase = CohortPhase.Phase0DueDiligence)
       clock.instant = Instant.EPOCH.plusSeconds(500)
 
       assertEquals(emptyList<VoteDecisionModel>(), store.fetchAllVoteDecisions(projectId))
@@ -195,7 +194,7 @@ class VoteStoreTest : DatabaseTest(), RunsAsUser {
 
     @Test
     fun `fetches all vote decisions`() {
-      val projectId = insertProject(cohortId = inserted.cohortId)
+      val projectId = insertProject(phase = CohortPhase.Phase0DueDiligence)
       val phase: CohortPhase = CohortPhase.Phase1FeasibilityStudy
 
       insertVoteDecision(projectId, phase, VoteOption.Yes, clock.instant)
@@ -212,7 +211,7 @@ class VoteStoreTest : DatabaseTest(), RunsAsUser {
     fun `fetches vote decisions by phase`() {
       val phase0: CohortPhase = CohortPhase.Phase0DueDiligence
       val phase1: CohortPhase = CohortPhase.Phase1FeasibilityStudy
-      val projectId = insertProject(cohortId = inserted.cohortId, phase = phase1)
+      val projectId = insertProject(phase = phase1)
 
       insertVoteDecision(projectId, phase0, VoteOption.Yes, clock.instant)
       insertVoteDecision(projectId, phase1, VoteOption.No, clock.instant)
@@ -231,7 +230,7 @@ class VoteStoreTest : DatabaseTest(), RunsAsUser {
     @Test
     fun `delete only vote`() {
       val phase: CohortPhase = CohortPhase.Phase1FeasibilityStudy
-      val projectId = insertProject(cohortId = inserted.cohortId, phase = phase)
+      val projectId = insertProject(phase = phase)
 
       val newUser = insertUser()
       val vote = VoteOption.No
@@ -246,7 +245,7 @@ class VoteStoreTest : DatabaseTest(), RunsAsUser {
     @Test
     fun `delete one vote from multiple voters`() {
       val phase: CohortPhase = CohortPhase.Phase1FeasibilityStudy
-      val projectId = insertProject(cohortId = inserted.cohortId, phase = phase)
+      val projectId = insertProject(phase = phase)
       clock.instant = Instant.EPOCH.plusSeconds(500)
 
       val user1 = insertUser()
@@ -295,7 +294,7 @@ class VoteStoreTest : DatabaseTest(), RunsAsUser {
     fun `delete one phase of votes from multiple phases`() {
       val phase0: CohortPhase = CohortPhase.Phase0DueDiligence
       val phase1: CohortPhase = CohortPhase.Phase1FeasibilityStudy
-      val projectId = insertProject(cohortId = inserted.cohortId, phase = phase1)
+      val projectId = insertProject(phase = phase1)
       clock.instant = Instant.EPOCH.plusSeconds(500)
 
       val user1 = insertUser()
@@ -371,7 +370,7 @@ class VoteStoreTest : DatabaseTest(), RunsAsUser {
     @Test
     fun `throws exception on delete if no permission to update votes`() {
       val phase: CohortPhase = CohortPhase.Phase1FeasibilityStudy
-      val projectId = insertProject(cohortId = inserted.cohortId, phase = phase)
+      val projectId = insertProject(phase = phase)
       val newUser = insertUser()
       val vote = VoteOption.No
       insertVote(projectId, phase, newUser, vote)
@@ -395,8 +394,7 @@ class VoteStoreTest : DatabaseTest(), RunsAsUser {
     @Test
     fun `throws exception on delete for wrong phase`() {
       val phase: CohortPhase = CohortPhase.Phase0DueDiligence
-      val projectId =
-          insertProject(cohortId = inserted.cohortId, phase = CohortPhase.Phase1FeasibilityStudy)
+      val projectId = insertProject(phase = CohortPhase.Phase1FeasibilityStudy)
       val newUser = insertUser()
       val vote = VoteOption.No
       insertVote(projectId, phase, newUser, vote)
@@ -407,7 +405,7 @@ class VoteStoreTest : DatabaseTest(), RunsAsUser {
     @Test
     fun `computes vote decision on deleting one vote from many`() {
       val phase: CohortPhase = CohortPhase.Phase1FeasibilityStudy
-      val projectId = insertProject(cohortId = inserted.cohortId, phase = phase)
+      val projectId = insertProject(phase = phase)
 
       val user1 = insertUser()
       val user2 = insertUser()
@@ -428,7 +426,7 @@ class VoteStoreTest : DatabaseTest(), RunsAsUser {
     @Test
     fun `computes vote decision on deleting only vote`() {
       val phase: CohortPhase = CohortPhase.Phase1FeasibilityStudy
-      val projectId = insertProject(cohortId = inserted.cohortId, phase = phase)
+      val projectId = insertProject(phase = phase)
 
       val newUser = insertUser()
       val vote = VoteOption.No
@@ -449,7 +447,7 @@ class VoteStoreTest : DatabaseTest(), RunsAsUser {
     @Test
     fun `creates blank vote for self`() {
       val phase: CohortPhase = CohortPhase.Phase1FeasibilityStudy
-      val projectId = insertProject(cohortId = inserted.cohortId, phase = phase)
+      val projectId = insertProject(phase = phase)
 
       clock.instant = Instant.EPOCH.plusSeconds(500)
       store.upsert(projectId, phase, user.userId, null, null)
@@ -472,7 +470,7 @@ class VoteStoreTest : DatabaseTest(), RunsAsUser {
     @Test
     fun `creates blank vote for other user`() {
       val phase: CohortPhase = CohortPhase.Phase1FeasibilityStudy
-      val projectId = insertProject(cohortId = inserted.cohortId, phase = phase)
+      val projectId = insertProject(phase = phase)
       val otherUser = insertUser()
 
       clock.instant = Instant.EPOCH.plusSeconds(500)
@@ -496,7 +494,7 @@ class VoteStoreTest : DatabaseTest(), RunsAsUser {
     @Test
     fun `creates conditional vote for other user`() {
       val phase: CohortPhase = CohortPhase.Phase1FeasibilityStudy
-      val projectId = insertProject(cohortId = inserted.cohortId, phase = phase)
+      val projectId = insertProject(phase = phase)
       val otherUser = insertUser()
 
       clock.instant = Instant.EPOCH.plusSeconds(500)
@@ -522,7 +520,7 @@ class VoteStoreTest : DatabaseTest(), RunsAsUser {
     @Test
     fun `update only voter selection`() {
       val phase: CohortPhase = CohortPhase.Phase1FeasibilityStudy
-      val projectId = insertProject(cohortId = inserted.cohortId, phase = phase)
+      val projectId = insertProject(phase = phase)
 
       val newUser = insertUser()
       val vote = VoteOption.No
@@ -554,7 +552,7 @@ class VoteStoreTest : DatabaseTest(), RunsAsUser {
     @Test
     fun `update voter selection with multiple voters`() {
       val phase: CohortPhase = CohortPhase.Phase1FeasibilityStudy
-      val projectId = insertProject(cohortId = inserted.cohortId, phase = phase)
+      val projectId = insertProject(phase = phase)
 
       val createdTime = Instant.EPOCH.plusSeconds(500)
 
@@ -620,7 +618,7 @@ class VoteStoreTest : DatabaseTest(), RunsAsUser {
     fun `update voter selection for multiple phases`() {
       val phase0: CohortPhase = CohortPhase.Phase0DueDiligence
       val phase1: CohortPhase = CohortPhase.Phase1FeasibilityStudy
-      val projectId = insertProject(cohortId = inserted.cohortId, phase = phase1)
+      val projectId = insertProject(phase = phase1)
 
       val createdTime = Instant.EPOCH.plusSeconds(500)
 
@@ -668,8 +666,8 @@ class VoteStoreTest : DatabaseTest(), RunsAsUser {
     @Test
     fun `update voter selection for multiple projects`() {
       val phase: CohortPhase = CohortPhase.Phase1FeasibilityStudy
-      val project1 = insertProject(cohortId = inserted.cohortId, phase = phase)
-      val project2 = insertProject(cohortId = inserted.cohortId, phase = phase)
+      val project1 = insertProject(phase = phase)
+      val project2 = insertProject(phase = phase)
 
       val createdTime = Instant.EPOCH.plusSeconds(500)
 
@@ -717,7 +715,7 @@ class VoteStoreTest : DatabaseTest(), RunsAsUser {
     @Test
     fun `throws exception on upsert if no permission to update votes`() {
       val phase: CohortPhase = CohortPhase.Phase1FeasibilityStudy
-      val projectId = insertProject(cohortId = inserted.cohortId, phase = phase)
+      val projectId = insertProject(phase = phase)
       val newUser = insertUser()
       val vote = VoteOption.No
       insertVote(projectId, phase, newUser, vote)
@@ -742,8 +740,7 @@ class VoteStoreTest : DatabaseTest(), RunsAsUser {
 
     @Test
     fun `throws exception on upsert if project in wrong phase`() {
-      val projectId =
-          insertProject(cohortId = inserted.cohortId, phase = CohortPhase.Phase1FeasibilityStudy)
+      val projectId = insertProject(phase = CohortPhase.Phase1FeasibilityStudy)
       val phase: CohortPhase = CohortPhase.Phase0DueDiligence
       val newUser = insertUser()
       val vote = VoteOption.No
@@ -757,7 +754,7 @@ class VoteStoreTest : DatabaseTest(), RunsAsUser {
     @Test
     fun `computes vote decision on creating one vote`() {
       val phase: CohortPhase = CohortPhase.Phase1FeasibilityStudy
-      val projectId = insertProject(cohortId = inserted.cohortId, phase = phase)
+      val projectId = insertProject(phase = phase)
       clock.instant = Instant.EPOCH.plusSeconds(500)
 
       val newUser = insertUser()
@@ -771,7 +768,7 @@ class VoteStoreTest : DatabaseTest(), RunsAsUser {
     @Test
     fun `computes vote decision on creating one null vote`() {
       val phase: CohortPhase = CohortPhase.Phase1FeasibilityStudy
-      val projectId = insertProject(cohortId = inserted.cohortId, phase = phase)
+      val projectId = insertProject(phase = phase)
       clock.instant = Instant.EPOCH.plusSeconds(500)
 
       val newUser = insertUser()
@@ -784,7 +781,7 @@ class VoteStoreTest : DatabaseTest(), RunsAsUser {
     @Test
     fun `computes vote decision on updating one vote`() {
       val phase: CohortPhase = CohortPhase.Phase1FeasibilityStudy
-      val projectId = insertProject(cohortId = inserted.cohortId, phase = phase)
+      val projectId = insertProject(phase = phase)
       clock.instant = Instant.EPOCH.plusSeconds(500)
 
       val newUser = insertUser()
@@ -802,7 +799,7 @@ class VoteStoreTest : DatabaseTest(), RunsAsUser {
     @Test
     fun `computes vote decision on upserting to a tie`() {
       val phase: CohortPhase = CohortPhase.Phase1FeasibilityStudy
-      val projectId = insertProject(cohortId = inserted.cohortId, phase = phase)
+      val projectId = insertProject(phase = phase)
       clock.instant = Instant.EPOCH.plusSeconds(500)
 
       val user1 = insertUser()
@@ -822,7 +819,7 @@ class VoteStoreTest : DatabaseTest(), RunsAsUser {
     @Test
     fun `computes vote decision on updating to no vote`() {
       val phase: CohortPhase = CohortPhase.Phase1FeasibilityStudy
-      val projectId = insertProject(cohortId = inserted.cohortId, phase = phase)
+      val projectId = insertProject(phase = phase)
       clock.instant = Instant.EPOCH.plusSeconds(500)
 
       val user1 = insertUser()

--- a/src/test/kotlin/com/terraformation/backend/db/DatabaseBackedTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/db/DatabaseBackedTest.kt
@@ -20,7 +20,6 @@ import com.terraformation.backend.db.accelerator.ApplicationHistoryId
 import com.terraformation.backend.db.accelerator.ApplicationId
 import com.terraformation.backend.db.accelerator.ApplicationModuleStatus
 import com.terraformation.backend.db.accelerator.ApplicationStatus
-import com.terraformation.backend.db.accelerator.CohortId
 import com.terraformation.backend.db.accelerator.CohortPhase
 import com.terraformation.backend.db.accelerator.DealStage
 import com.terraformation.backend.db.accelerator.DeliverableCategory
@@ -51,13 +50,11 @@ import com.terraformation.backend.db.accelerator.SubmissionSnapshotId
 import com.terraformation.backend.db.accelerator.SubmissionStatus
 import com.terraformation.backend.db.accelerator.SystemMetric
 import com.terraformation.backend.db.accelerator.VoteOption
-import com.terraformation.backend.db.accelerator.keys.COHORTS_PKEY
 import com.terraformation.backend.db.accelerator.tables.daos.ActivitiesDao
 import com.terraformation.backend.db.accelerator.tables.daos.ActivityMediaFilesDao
 import com.terraformation.backend.db.accelerator.tables.daos.ApplicationHistoriesDao
 import com.terraformation.backend.db.accelerator.tables.daos.ApplicationModulesDao
 import com.terraformation.backend.db.accelerator.tables.daos.ApplicationsDao
-import com.terraformation.backend.db.accelerator.tables.daos.CohortsDao
 import com.terraformation.backend.db.accelerator.tables.daos.DefaultVotersDao
 import com.terraformation.backend.db.accelerator.tables.daos.DeliverableDocumentsDao
 import com.terraformation.backend.db.accelerator.tables.daos.DeliverableProjectDueDatesDao
@@ -95,7 +92,6 @@ import com.terraformation.backend.db.accelerator.tables.pojos.ActivityMediaFiles
 import com.terraformation.backend.db.accelerator.tables.pojos.ApplicationHistoriesRow
 import com.terraformation.backend.db.accelerator.tables.pojos.ApplicationModulesRow
 import com.terraformation.backend.db.accelerator.tables.pojos.ApplicationsRow
-import com.terraformation.backend.db.accelerator.tables.pojos.CohortsRow
 import com.terraformation.backend.db.accelerator.tables.pojos.DefaultVotersRow
 import com.terraformation.backend.db.accelerator.tables.pojos.DeliverableDocumentsRow
 import com.terraformation.backend.db.accelerator.tables.pojos.DeliverableProjectDueDatesRow
@@ -629,7 +625,6 @@ abstract class DatabaseBackedTest {
   protected val batchSubLocationsDao: BatchSubLocationsDao by lazyDao()
   protected val batchWithdrawalsDao: BatchWithdrawalsDao by lazyDao()
   protected val birdnetResultsDao: BirdnetResultsDao by lazyDao()
-  protected val cohortsDao: CohortsDao by lazyDao()
   protected val countriesDao: CountriesDao by lazyDao()
   protected val countrySubdivisionsDao: CountrySubdivisionsDao by lazyDao()
   protected val defaultVotersDao: DefaultVotersDao by lazyDao()
@@ -869,7 +864,6 @@ abstract class DatabaseBackedTest {
   protected fun insertProject(
       organizationId: OrganizationId = inserted.organizationId,
       name: String = "Project ${nextProjectNumber++}",
-      cohortId: CohortId? = null,
       createdBy: UserId = currentUser().userId,
       createdTime: Instant = Instant.EPOCH,
       description: String? = null,
@@ -878,7 +872,6 @@ abstract class DatabaseBackedTest {
   ): ProjectId {
     val row =
         ProjectsRow(
-            cohortId = cohortId,
             countryCode = countryCode,
             createdBy = createdBy,
             createdTime = createdTime,
@@ -4231,29 +4224,6 @@ abstract class DatabaseBackedTest {
     return row.id!!.also { inserted.participantProjectSpeciesIds.add(it) }
   }
 
-  fun insertCohort(
-      name: String = "Cohort ${UUID.randomUUID()}",
-      phase: CohortPhase = CohortPhase.Phase0DueDiligence,
-      createdBy: UserId = currentUser().userId,
-      createdTime: Instant = Instant.EPOCH,
-      modifiedBy: UserId = createdBy,
-      modifiedTime: Instant = createdTime,
-  ): CohortId {
-    val row =
-        CohortsRow(
-            createdBy = createdBy,
-            createdTime = createdTime,
-            modifiedBy = modifiedBy,
-            modifiedTime = modifiedTime,
-            name = name,
-            phaseId = phase,
-        )
-
-    cohortsDao.insert(row)
-
-    return row.id!!.also { inserted.cohortIds.add(it) }
-  }
-
   private val nextProjectModuleStartDates = mutableMapOf<ProjectId, LocalDate>()
 
   fun insertProjectModule(
@@ -5234,7 +5204,6 @@ abstract class DatabaseBackedTest {
     val bagsIds = mutableListOf<BagId>()
     val batchIds = mutableListOf<BatchId>()
     val biomassSpeciesIds = mutableListOf<BiomassSpeciesId>()
-    val cohortIds = mutableListOf<CohortId>()
     val deliverableIds = mutableListOf<DeliverableId>()
     val deliveryIds = mutableListOf<DeliveryId>()
     val deviceIds = mutableListOf<DeviceId>()
@@ -5311,9 +5280,6 @@ abstract class DatabaseBackedTest {
 
     val biomassSpeciesId
       get() = biomassSpeciesIds.last()
-
-    val cohortId
-      get() = cohortIds.last()
 
     val deliverableId
       get() = deliverableIds.last()
@@ -5491,7 +5457,6 @@ abstract class DatabaseBackedTest {
       // from the generated Keys.kt file for each schema.
       ACCESSION_PKEY
       BATCHES_PKEY
-      COHORTS_PKEY
       PLANTING_SITES_PKEY
       USERS_PKEY
       VARIABLES_PKEY


### PR DESCRIPTION
The application code no longer looks at projects' cohorts, so there's no need to
insert cohorts in tests any more.