### PR TITLE
SW-8059 Rename CohortPhase to AcceleratorPhase

### DIFF
--- a/jooq/src/main/kotlin/com/terraformation/backend/jooq/Config.kt
+++ b/jooq/src/main/kotlin/com/terraformation/backend/jooq/Config.kt
@@ -20,12 +20,12 @@ val ENUM_TABLES =
     mapOf(
         "accelerator" to
             listOf(
+                EnumTable("accelerator_phases", listOf(".*\\.phase_id")),
                 EnumTable("activity_statuses"),
                 EnumTable("activity_types"),
                 EnumTable("activity_media_types", isLocalizable = false),
                 EnumTable("application_module_statuses"),
                 EnumTable("application_statuses"),
-                EnumTable("cohort_phases", listOf(".*\\.phase_id")),
                 EnumTable("deal_stages", isLocalizable = false),
                 EnumTable(
                     "deliverable_categories",

--- a/src/main/kotlin/com/terraformation/backend/accelerator/DeliverableCompleter.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/DeliverableCompleter.kt
@@ -7,8 +7,8 @@ import com.terraformation.backend.accelerator.db.SubmissionStore
 import com.terraformation.backend.accelerator.event.DeliverableDocumentUploadedEvent
 import com.terraformation.backend.accelerator.event.ParticipantProjectSpeciesAddedEvent
 import com.terraformation.backend.customer.model.SystemUser
+import com.terraformation.backend.db.accelerator.AcceleratorPhase
 import com.terraformation.backend.db.accelerator.ApplicationModuleStatus
-import com.terraformation.backend.db.accelerator.CohortPhase
 import com.terraformation.backend.db.accelerator.DeliverableId
 import com.terraformation.backend.db.accelerator.SubmissionStatus
 import com.terraformation.backend.db.default_schema.ProjectId
@@ -50,7 +50,7 @@ class DeliverableCompleter(
       val moduleId = deliverableStore.fetchDeliverableModuleId(deliverableId)
       val phase = moduleStore.fetchCohortPhase(moduleId)
 
-      if (phase == CohortPhase.PreScreen || phase == CohortPhase.Application) {
+      if (phase == AcceleratorPhase.PreScreen || phase == AcceleratorPhase.Application) {
         if (predicate == null || predicate()) {
           submissionStore.createSubmission(deliverableId, projectId, SubmissionStatus.Completed)
 

--- a/src/main/kotlin/com/terraformation/backend/accelerator/DeliverableCompleter.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/DeliverableCompleter.kt
@@ -48,7 +48,7 @@ class DeliverableCompleter(
   ) {
     systemUser.run {
       val moduleId = deliverableStore.fetchDeliverableModuleId(deliverableId)
-      val phase = moduleStore.fetchCohortPhase(moduleId)
+      val phase = moduleStore.fetchAcceleratorPhase(moduleId)
 
       if (phase == AcceleratorPhase.PreScreen || phase == AcceleratorPhase.Application) {
         if (predicate == null || predicate()) {

--- a/src/main/kotlin/com/terraformation/backend/accelerator/DeliverableService.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/DeliverableService.kt
@@ -6,8 +6,8 @@ import com.terraformation.backend.accelerator.db.DeliverableStore
 import com.terraformation.backend.accelerator.db.ModuleStore
 import com.terraformation.backend.accelerator.db.SubmissionStore
 import com.terraformation.backend.customer.model.SystemUser
+import com.terraformation.backend.db.accelerator.AcceleratorPhase
 import com.terraformation.backend.db.accelerator.ApplicationModuleStatus
-import com.terraformation.backend.db.accelerator.CohortPhase
 import com.terraformation.backend.db.accelerator.DeliverableId
 import com.terraformation.backend.db.accelerator.DeliverableType
 import com.terraformation.backend.db.accelerator.SubmissionId
@@ -55,8 +55,8 @@ class DeliverableService(
         moduleStore.fetchOneById(deliverableStore.fetchDeliverableModuleId(deliverableId))
 
     val isApplicationModule =
-        deliverableModule.phase == CohortPhase.PreScreen ||
-            deliverableModule.phase == CohortPhase.Application
+        deliverableModule.phase == AcceleratorPhase.PreScreen ||
+            deliverableModule.phase == AcceleratorPhase.Application
 
     val status =
         if (isComplete) {

--- a/src/main/kotlin/com/terraformation/backend/accelerator/api/ApplicationsController.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/api/ApplicationsController.kt
@@ -16,10 +16,10 @@ import com.terraformation.backend.api.SuccessResponsePayload
 import com.terraformation.backend.api.toInputStream
 import com.terraformation.backend.api.toResponseEntity
 import com.terraformation.backend.auth.currentUser
+import com.terraformation.backend.db.accelerator.AcceleratorPhase
 import com.terraformation.backend.db.accelerator.ApplicationId
 import com.terraformation.backend.db.accelerator.ApplicationModuleStatus
 import com.terraformation.backend.db.accelerator.ApplicationStatus
-import com.terraformation.backend.db.accelerator.CohortPhase
 import com.terraformation.backend.db.accelerator.DeliverableCategory
 import com.terraformation.backend.db.accelerator.DeliverableId
 import com.terraformation.backend.db.accelerator.DeliverableType
@@ -384,7 +384,7 @@ data class ApplicationModulePayload(
     val applicationId: ApplicationId?,
     val moduleId: ModuleId,
     val name: String,
-    val phase: CohortPhase,
+    val phase: AcceleratorPhase,
     val overview: String? = null,
     val status: ApplicationModuleStatus?,
 ) {

--- a/src/main/kotlin/com/terraformation/backend/accelerator/api/ProjectAcceleratorDetailsController.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/api/ProjectAcceleratorDetailsController.kt
@@ -12,7 +12,7 @@ import com.terraformation.backend.api.ApiResponse404
 import com.terraformation.backend.api.ApiResponseSimpleSuccess
 import com.terraformation.backend.api.SimpleSuccessResponsePayload
 import com.terraformation.backend.api.SuccessResponsePayload
-import com.terraformation.backend.db.accelerator.CohortPhase
+import com.terraformation.backend.db.accelerator.AcceleratorPhase
 import com.terraformation.backend.db.accelerator.DealStage
 import com.terraformation.backend.db.accelerator.Pipeline
 import com.terraformation.backend.db.accelerator.SystemMetric
@@ -108,7 +108,7 @@ data class ProjectAcceleratorDetailsPayload(
     val numCommunities: Int?,
     val numNativeSpecies: Int?,
     val perHectareBudget: BigDecimal?,
-    val phase: CohortPhase?,
+    val phase: AcceleratorPhase?,
     val pipeline: Pipeline?,
     val plantingSitesCql: String?,
     val projectArea: BigDecimal?,
@@ -238,7 +238,7 @@ data class UpdateProjectAcceleratorDetailsRequestPayload(
     val numCommunities: Int?,
     val numNativeSpecies: Int?,
     val perHectareBudget: BigDecimal?,
-    val phase: CohortPhase?,
+    val phase: AcceleratorPhase?,
     val pipeline: Pipeline?,
     val projectArea: BigDecimal? = null,
     val riskTrackerLink: URI? = null,

--- a/src/main/kotlin/com/terraformation/backend/accelerator/api/ProjectScoresController.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/api/ProjectScoresController.kt
@@ -8,7 +8,7 @@ import com.terraformation.backend.api.ApiResponse200
 import com.terraformation.backend.api.ApiResponse404
 import com.terraformation.backend.api.SimpleSuccessResponsePayload
 import com.terraformation.backend.api.SuccessResponsePayload
-import com.terraformation.backend.db.accelerator.CohortPhase
+import com.terraformation.backend.db.accelerator.AcceleratorPhase
 import com.terraformation.backend.db.accelerator.ScoreCategory
 import com.terraformation.backend.db.default_schema.ProjectId
 import io.swagger.v3.oas.annotations.Operation
@@ -99,13 +99,13 @@ data class UpsertScore(
 }
 
 data class PhaseScores(
-    val phase: CohortPhase,
+    val phase: AcceleratorPhase,
     val scores: List<Score>,
     val totalScore: BigDecimal? = null,
 )
 
 data class UpsertProjectScoresRequestPayload(
-    val phase: CohortPhase,
+    val phase: AcceleratorPhase,
     @field:Valid val scores: List<UpsertScore>,
 )
 

--- a/src/main/kotlin/com/terraformation/backend/accelerator/api/ProjectVotesController.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/api/ProjectVotesController.kt
@@ -11,7 +11,7 @@ import com.terraformation.backend.api.ApiResponse404
 import com.terraformation.backend.api.ApiResponse409
 import com.terraformation.backend.api.SimpleSuccessResponsePayload
 import com.terraformation.backend.api.SuccessResponsePayload
-import com.terraformation.backend.db.accelerator.CohortPhase
+import com.terraformation.backend.db.accelerator.AcceleratorPhase
 import com.terraformation.backend.db.accelerator.VoteOption
 import com.terraformation.backend.db.default_schema.ProjectId
 import com.terraformation.backend.db.default_schema.UserId
@@ -126,7 +126,7 @@ data class VoteSelection(
 
 data class PhaseVotes(
     val decision: VoteOption? = null,
-    val phase: CohortPhase,
+    val phase: AcceleratorPhase,
     val votes: List<VoteSelection> = emptyList(),
 )
 
@@ -138,12 +138,12 @@ data class UpsertVoteSelection(
 )
 
 data class UpsertProjectVotesRequestPayload(
-    val phase: CohortPhase,
+    val phase: AcceleratorPhase,
     val votes: List<UpsertVoteSelection>,
 )
 
 data class DeleteProjectVotesRequestPayload(
-    val phase: CohortPhase,
+    val phase: AcceleratorPhase,
     @Schema(
         description =
             "A safeguard flag that must be set to `true` for deleting all voters in " +

--- a/src/main/kotlin/com/terraformation/backend/accelerator/db/ActivityStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/db/ActivityStore.kt
@@ -34,7 +34,7 @@ class ActivityStore(
     requirePermissions { createActivity(model.projectId) }
 
     if (!parentStore.isProjectInPhase(model.projectId)) {
-      throw ProjectNotInCohortPhaseException(model.projectId)
+      throw ProjectNotInAcceleratorPhaseException(model.projectId)
     }
 
     val now = clock.instant()

--- a/src/main/kotlin/com/terraformation/backend/accelerator/db/ApplicationStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/db/ApplicationStore.kt
@@ -11,10 +11,10 @@ import com.terraformation.backend.accelerator.model.PreScreenProjectType
 import com.terraformation.backend.accelerator.model.SubmissionDocumentModel
 import com.terraformation.backend.auth.currentUser
 import com.terraformation.backend.customer.model.requirePermissions
+import com.terraformation.backend.db.accelerator.AcceleratorPhase
 import com.terraformation.backend.db.accelerator.ApplicationId
 import com.terraformation.backend.db.accelerator.ApplicationModuleStatus
 import com.terraformation.backend.db.accelerator.ApplicationStatus
-import com.terraformation.backend.db.accelerator.CohortPhase
 import com.terraformation.backend.db.accelerator.DeliverableId
 import com.terraformation.backend.db.accelerator.ModuleId
 import com.terraformation.backend.db.accelerator.SubmissionStatus
@@ -147,18 +147,18 @@ class ApplicationStore(
 
   fun fetchModulesByApplicationId(
       applicationId: ApplicationId,
-      phase: CohortPhase? = null,
+      phase: AcceleratorPhase? = null,
   ): List<ApplicationModuleModel> {
     requirePermissions { readApplication(applicationId) }
 
     val phaseCondition =
         when (phase) {
-          CohortPhase.PreScreen -> MODULES.PHASE_ID.eq(CohortPhase.PreScreen)
-          CohortPhase.Application -> MODULES.PHASE_ID.eq(CohortPhase.Application)
+          AcceleratorPhase.PreScreen -> MODULES.PHASE_ID.eq(AcceleratorPhase.PreScreen)
+          AcceleratorPhase.Application -> MODULES.PHASE_ID.eq(AcceleratorPhase.Application)
           else ->
               DSL.or(
-                  MODULES.PHASE_ID.eq(CohortPhase.PreScreen),
-                  MODULES.PHASE_ID.eq(CohortPhase.Application),
+                  MODULES.PHASE_ID.eq(AcceleratorPhase.PreScreen),
+                  MODULES.PHASE_ID.eq(AcceleratorPhase.Application),
               )
         }
 
@@ -207,8 +207,8 @@ class ApplicationStore(
             deliverableId?.let { DELIVERABLES.ID.eq(it) },
             moduleId?.let { DELIVERABLES.MODULE_ID.eq(it) },
             DSL.or(
-                MODULES.PHASE_ID.eq(CohortPhase.PreScreen),
-                MODULES.PHASE_ID.eq(CohortPhase.Application),
+                MODULES.PHASE_ID.eq(AcceleratorPhase.PreScreen),
+                MODULES.PHASE_ID.eq(AcceleratorPhase.Application),
             ),
         )
 
@@ -320,8 +320,8 @@ class ApplicationStore(
 
       insertHistory(applicationId)
 
-      assignModules(applicationId, CohortPhase.PreScreen)
-      assignModules(applicationId, CohortPhase.Application)
+      assignModules(applicationId, AcceleratorPhase.PreScreen)
+      assignModules(applicationId, AcceleratorPhase.Application)
 
       updateInternalName(applicationId)
 
@@ -392,14 +392,14 @@ class ApplicationStore(
         updateStatus(applicationId, ApplicationStatus.FailedPreScreen)
       } else {
         updateStatus(applicationId, ApplicationStatus.PassedPreScreen)
-        assignModules(applicationId, CohortPhase.Application)
+        assignModules(applicationId, AcceleratorPhase.Application)
 
         applicationVariableValues.countryCode?.let { updateCountryCode(applicationId, it) }
       }
 
       ApplicationSubmissionResult(fetchOneById(applicationId), problems)
     } else if (existing.status == ApplicationStatus.PassedPreScreen) {
-      val modules = fetchModulesByApplicationId(existing.id, CohortPhase.Application)
+      val modules = fetchModulesByApplicationId(existing.id, AcceleratorPhase.Application)
       if (modules.all { it.applicationModuleStatus == ApplicationModuleStatus.Complete }) {
         updateStatus(applicationId, ApplicationStatus.Submitted)
         eventPublisher.publishEvent(ApplicationSubmittedEvent(applicationId))
@@ -610,8 +610,8 @@ class ApplicationStore(
         .execute()
   }
 
-  private fun assignModules(applicationId: ApplicationId, phase: CohortPhase) {
-    if (phase == CohortPhase.PreScreen || phase == CohortPhase.Application) {
+  private fun assignModules(applicationId: ApplicationId, phase: AcceleratorPhase) {
+    if (phase == AcceleratorPhase.PreScreen || phase == AcceleratorPhase.Application) {
       with(APPLICATION_MODULES) {
         dslContext
             .insertInto(

--- a/src/main/kotlin/com/terraformation/backend/accelerator/db/DeliverableStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/db/DeliverableStore.kt
@@ -4,7 +4,7 @@ import com.terraformation.backend.accelerator.model.DeliverableSubmissionModel
 import com.terraformation.backend.accelerator.model.ModuleDeliverableModel
 import com.terraformation.backend.accelerator.model.SubmissionDocumentModel
 import com.terraformation.backend.customer.model.requirePermissions
-import com.terraformation.backend.db.accelerator.CohortPhase
+import com.terraformation.backend.db.accelerator.AcceleratorPhase
 import com.terraformation.backend.db.accelerator.DeliverableCategory
 import com.terraformation.backend.db.accelerator.DeliverableId
 import com.terraformation.backend.db.accelerator.ModuleId
@@ -122,7 +122,7 @@ class DeliverableStore(
                 // Exclude pre-screen and application deliverables unless the caller is asking for
                 // specific deliverables.
                 if (deliverableId == null) {
-                  MODULES.PHASE_ID.notIn(CohortPhase.PreScreen, CohortPhase.Application)
+                  MODULES.PHASE_ID.notIn(AcceleratorPhase.PreScreen, AcceleratorPhase.Application)
                 } else {
                   null
                 },

--- a/src/main/kotlin/com/terraformation/backend/accelerator/db/Exceptions.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/db/Exceptions.kt
@@ -2,9 +2,9 @@ package com.terraformation.backend.accelerator.db
 
 import com.terraformation.backend.db.EntityNotFoundException
 import com.terraformation.backend.db.MismatchedStateException
+import com.terraformation.backend.db.accelerator.AcceleratorPhase
 import com.terraformation.backend.db.accelerator.ActivityId
 import com.terraformation.backend.db.accelerator.ApplicationId
-import com.terraformation.backend.db.accelerator.CohortPhase
 import com.terraformation.backend.db.accelerator.DeliverableId
 import com.terraformation.backend.db.accelerator.ModuleId
 import com.terraformation.backend.db.accelerator.ParticipantProjectSpeciesId
@@ -60,12 +60,12 @@ class ProjectDocumentSettingsNotConfiguredException(id: ProjectId) :
 class ProjectModuleNotFoundException(projectId: ProjectId, moduleId: ModuleId) :
     MismatchedStateException("Project $projectId is not associated with module $moduleId")
 
-class ProjectNotInCohortPhaseException(id: ProjectId, phase: CohortPhase? = null) :
+class ProjectNotInCohortPhaseException(id: ProjectId, phase: AcceleratorPhase? = null) :
     MismatchedStateException("Project $id is not currently in ${phase ?: "an accelerator phase"}")
 
 class ProjectVoteNotFoundException(
     projectId: ProjectId,
-    phase: CohortPhase? = null,
+    phase: AcceleratorPhase? = null,
     userId: UserId? = null,
 ) :
     EntityNotFoundException(

--- a/src/main/kotlin/com/terraformation/backend/accelerator/db/Exceptions.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/db/Exceptions.kt
@@ -60,8 +60,13 @@ class ProjectDocumentSettingsNotConfiguredException(id: ProjectId) :
 class ProjectModuleNotFoundException(projectId: ProjectId, moduleId: ModuleId) :
     MismatchedStateException("Project $projectId is not associated with module $moduleId")
 
-class ProjectNotInCohortPhaseException(id: ProjectId, phase: AcceleratorPhase? = null) :
-    MismatchedStateException("Project $id is not currently in ${phase ?: "an accelerator phase"}")
+class ProjectNotInAcceleratorPhaseException(
+    id: ProjectId,
+    expectedPhase: AcceleratorPhase? = null,
+) :
+    MismatchedStateException(
+        "Project $id is not currently in ${expectedPhase ?: "an accelerator phase"}"
+    )
 
 class ProjectVoteNotFoundException(
     projectId: ProjectId,

--- a/src/main/kotlin/com/terraformation/backend/accelerator/db/ModuleStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/db/ModuleStore.kt
@@ -3,7 +3,7 @@ package com.terraformation.backend.accelerator.db
 import com.terraformation.backend.accelerator.model.ModuleModel
 import com.terraformation.backend.auth.currentUser
 import com.terraformation.backend.customer.model.requirePermissions
-import com.terraformation.backend.db.accelerator.CohortPhase
+import com.terraformation.backend.db.accelerator.AcceleratorPhase
 import com.terraformation.backend.db.accelerator.ModuleId
 import com.terraformation.backend.db.accelerator.tables.references.MODULES
 import jakarta.inject.Named
@@ -22,7 +22,7 @@ class ModuleStore(
     return fetch()
   }
 
-  fun fetchCohortPhase(moduleId: ModuleId): CohortPhase {
+  fun fetchCohortPhase(moduleId: ModuleId): AcceleratorPhase {
     requirePermissions { readModule(moduleId) }
 
     return dslContext

--- a/src/main/kotlin/com/terraformation/backend/accelerator/db/ModuleStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/db/ModuleStore.kt
@@ -22,7 +22,7 @@ class ModuleStore(
     return fetch()
   }
 
-  fun fetchCohortPhase(moduleId: ModuleId): AcceleratorPhase {
+  fun fetchAcceleratorPhase(moduleId: ModuleId): AcceleratorPhase {
     requirePermissions { readModule(moduleId) }
 
     return dslContext

--- a/src/main/kotlin/com/terraformation/backend/accelerator/db/ModulesImporter.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/db/ModulesImporter.kt
@@ -3,7 +3,7 @@ package com.terraformation.backend.accelerator.db
 import com.terraformation.backend.accelerator.event.ModulesUploadedEvent
 import com.terraformation.backend.auth.currentUser
 import com.terraformation.backend.customer.model.requirePermissions
-import com.terraformation.backend.db.accelerator.CohortPhase
+import com.terraformation.backend.db.accelerator.AcceleratorPhase
 import com.terraformation.backend.db.accelerator.ModuleId
 import com.terraformation.backend.db.accelerator.tables.references.MODULES
 import com.terraformation.backend.importer.processCsvFile
@@ -34,9 +34,9 @@ class ModulesImporter(
     private const val NUM_COLUMNS = COLUMN_RECORDED_SESSION_INFO + 1
 
     /** Lookup table for phases with both lower-case names and numeric IDs. */
-    private val phases: Map<String, CohortPhase> =
-        CohortPhase.entries.associateBy { it.jsonValue.lowercase() } +
-            CohortPhase.entries.associateBy { "${it.id}" }
+    private val phases: Map<String, AcceleratorPhase> =
+        AcceleratorPhase.entries.associateBy { it.jsonValue.lowercase() } +
+            AcceleratorPhase.entries.associateBy { "${it.id}" }
   }
 
   fun importModules(inputStream: InputStream) {

--- a/src/main/kotlin/com/terraformation/backend/accelerator/db/ParticipantProjectSpeciesStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/db/ParticipantProjectSpeciesStore.kt
@@ -49,7 +49,7 @@ class ParticipantProjectSpeciesStore(
     // Participant project species can only be associated with projects that are in a phase
     val project = projectsDao.fetchOneById(model.projectId)
     if (project?.phaseId == null) {
-      throw ProjectNotInCohortPhaseException(model.projectId)
+      throw ProjectNotInAcceleratorPhaseException(model.projectId)
     }
 
     val userId = currentUser().userId
@@ -84,7 +84,7 @@ class ParticipantProjectSpeciesStore(
       requirePermissions { createParticipantProjectSpecies(it.id!!) }
 
       if (it.phaseId == null) {
-        throw ProjectNotInCohortPhaseException(it.id!!)
+        throw ProjectNotInAcceleratorPhaseException(it.id!!)
       }
     }
 

--- a/src/main/kotlin/com/terraformation/backend/accelerator/db/ProjectModuleStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/db/ProjectModuleStore.kt
@@ -117,7 +117,7 @@ class ProjectModuleStore(
       throw ProjectNotFoundException(projectId)
     }
     if (projectPhases.first() == null) {
-      throw ProjectNotInCohortPhaseException(projectId)
+      throw ProjectNotInAcceleratorPhaseException(projectId)
     }
   }
 }

--- a/src/main/kotlin/com/terraformation/backend/accelerator/db/ProjectPhaseFetcher.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/db/ProjectPhaseFetcher.kt
@@ -1,8 +1,8 @@
 package com.terraformation.backend.accelerator.db
 
 import com.terraformation.backend.customer.model.requirePermissions
+import com.terraformation.backend.db.accelerator.AcceleratorPhase
 import com.terraformation.backend.db.accelerator.ApplicationStatus
-import com.terraformation.backend.db.accelerator.CohortPhase
 import com.terraformation.backend.db.accelerator.tables.references.APPLICATIONS
 import com.terraformation.backend.db.default_schema.ProjectId
 import com.terraformation.backend.db.default_schema.tables.references.PROJECTS
@@ -12,7 +12,7 @@ import org.jooq.DSLContext
 @Named
 class ProjectPhaseFetcher(private val dslContext: DSLContext) {
   /** Returns the current phase of a project, or null if the project has no phase or application. */
-  fun getProjectPhase(projectId: ProjectId): CohortPhase? {
+  fun getProjectPhase(projectId: ProjectId): AcceleratorPhase? {
     requirePermissions { readProject(projectId) }
 
     return dslContext
@@ -26,10 +26,10 @@ class ProjectPhaseFetcher(private val dslContext: DSLContext) {
               ?: when (applicationStatus) {
                 ApplicationStatus.NotSubmitted,
                 ApplicationStatus.FailedPreScreen,
-                ApplicationStatus.PassedPreScreen -> CohortPhase.PreScreen
+                ApplicationStatus.PassedPreScreen -> AcceleratorPhase.PreScreen
 
                 null -> null
-                else -> CohortPhase.Application
+                else -> AcceleratorPhase.Application
               }
         }
   }
@@ -40,15 +40,15 @@ class ProjectPhaseFetcher(private val dslContext: DSLContext) {
    *
    * @throws ProjectNotInCohortPhaseException The project is not in the requested phase.
    */
-  fun ensureProjectPhase(projectId: ProjectId, phase: CohortPhase) {
+  fun ensureProjectPhase(projectId: ProjectId, phase: AcceleratorPhase) {
     val currentPhase = getProjectPhase(projectId)
 
     val samePhase =
         when (phase) {
-          CohortPhase.Phase0DueDiligence ->
+          AcceleratorPhase.Phase0DueDiligence ->
               // Application phases are considered to be part of phase 0.
-              currentPhase == CohortPhase.PreScreen ||
-                  currentPhase == CohortPhase.Application ||
+              currentPhase == AcceleratorPhase.PreScreen ||
+                  currentPhase == AcceleratorPhase.Application ||
                   currentPhase == phase
           else -> currentPhase == phase
         }

--- a/src/main/kotlin/com/terraformation/backend/accelerator/db/ProjectPhaseFetcher.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/db/ProjectPhaseFetcher.kt
@@ -38,7 +38,7 @@ class ProjectPhaseFetcher(private val dslContext: DSLContext) {
    * Ensures the project is in the specified phase, or that the project has an application and is in
    * phase 0.
    *
-   * @throws ProjectNotInCohortPhaseException The project is not in the requested phase.
+   * @throws ProjectNotInAcceleratorPhaseException The project is not in the requested phase.
    */
   fun ensureProjectPhase(projectId: ProjectId, phase: AcceleratorPhase) {
     val currentPhase = getProjectPhase(projectId)
@@ -54,7 +54,7 @@ class ProjectPhaseFetcher(private val dslContext: DSLContext) {
         }
 
     if (!samePhase) {
-      throw ProjectNotInCohortPhaseException(projectId, phase)
+      throw ProjectNotInAcceleratorPhaseException(projectId, phase)
     }
   }
 }

--- a/src/main/kotlin/com/terraformation/backend/accelerator/db/ProjectScoreStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/db/ProjectScoreStore.kt
@@ -5,7 +5,7 @@ import com.terraformation.backend.accelerator.model.NewProjectScoreModel
 import com.terraformation.backend.accelerator.model.ProjectScoreModel
 import com.terraformation.backend.auth.currentUser
 import com.terraformation.backend.customer.model.requirePermissions
-import com.terraformation.backend.db.accelerator.CohortPhase
+import com.terraformation.backend.db.accelerator.AcceleratorPhase
 import com.terraformation.backend.db.accelerator.tables.references.PROJECT_SCORES
 import com.terraformation.backend.db.asNonNullable
 import com.terraformation.backend.db.default_schema.ProjectId
@@ -26,8 +26,8 @@ class ProjectScoreStore(
    */
   fun fetchScores(
       projectId: ProjectId,
-      phases: Collection<CohortPhase>? = null,
-  ): Map<CohortPhase, List<ExistingProjectScoreModel>> {
+      phases: Collection<AcceleratorPhase>? = null,
+  ): Map<AcceleratorPhase, List<ExistingProjectScoreModel>> {
     requirePermissions { readProjectScores(projectId) }
 
     return with(PROJECT_SCORES) {
@@ -48,7 +48,7 @@ class ProjectScoreStore(
 
   fun updateScores(
       projectId: ProjectId,
-      phase: CohortPhase,
+      phase: AcceleratorPhase,
       scores: Collection<NewProjectScoreModel>,
   ) {
     requirePermissions { updateProjectScores(projectId) }

--- a/src/main/kotlin/com/terraformation/backend/accelerator/db/VoteStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/db/VoteStore.kt
@@ -4,7 +4,7 @@ import com.terraformation.backend.accelerator.model.VoteDecisionModel
 import com.terraformation.backend.accelerator.model.VoteModel
 import com.terraformation.backend.auth.currentUser
 import com.terraformation.backend.customer.model.requirePermissions
-import com.terraformation.backend.db.accelerator.CohortPhase
+import com.terraformation.backend.db.accelerator.AcceleratorPhase
 import com.terraformation.backend.db.accelerator.VoteOption
 import com.terraformation.backend.db.accelerator.tables.references.DEFAULT_VOTERS
 import com.terraformation.backend.db.accelerator.tables.references.PROJECT_VOTES
@@ -24,7 +24,7 @@ class VoteStore(
     private val dslContext: DSLContext,
     private val projectPhaseFetcher: ProjectPhaseFetcher,
 ) {
-  fun fetchAllVotes(projectId: ProjectId, phase: CohortPhase? = null): List<VoteModel> {
+  fun fetchAllVotes(projectId: ProjectId, phase: AcceleratorPhase? = null): List<VoteModel> {
     requirePermissions { readProjectVotes(projectId) }
     return with(PROJECT_VOTES) {
       dslContext
@@ -41,7 +41,7 @@ class VoteStore(
 
   fun fetchAllVoteDecisions(
       projectId: ProjectId,
-      phase: CohortPhase? = null,
+      phase: AcceleratorPhase? = null,
   ): List<VoteDecisionModel> {
     requirePermissions { readProjectVotes(projectId) }
     return with(PROJECT_VOTE_DECISIONS) {
@@ -60,7 +60,7 @@ class VoteStore(
    *
    * Returns the vote decision after the removal of voter.
    */
-  fun delete(projectId: ProjectId, phase: CohortPhase, userId: UserId? = null) {
+  fun delete(projectId: ProjectId, phase: AcceleratorPhase, userId: UserId? = null) {
     requirePermissions { updateProjectVotes(projectId) }
 
     projectPhaseFetcher.ensureProjectPhase(projectId, phase)
@@ -85,7 +85,7 @@ class VoteStore(
   /** Returns the vote decision after the upsert. */
   fun upsert(
       projectId: ProjectId,
-      phase: CohortPhase,
+      phase: AcceleratorPhase,
       userId: UserId,
       voteOption: VoteOption? = null,
       conditionalInfo: String? = null,
@@ -168,7 +168,7 @@ class VoteStore(
 
   private fun updateProjectVoteDecisions(
       projectId: ProjectId,
-      phase: CohortPhase,
+      phase: AcceleratorPhase,
       now: Instant = clock.instant(),
   ) {
     val votes =

--- a/src/main/kotlin/com/terraformation/backend/accelerator/event/ProjectPhaseUpdatedEvent.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/event/ProjectPhaseUpdatedEvent.kt
@@ -1,9 +1,9 @@
 package com.terraformation.backend.accelerator.event
 
-import com.terraformation.backend.db.accelerator.CohortPhase
+import com.terraformation.backend.db.accelerator.AcceleratorPhase
 import com.terraformation.backend.db.default_schema.ProjectId
 
 data class ProjectPhaseUpdatedEvent(
     val projectId: ProjectId,
-    val newPhase: CohortPhase?,
+    val newPhase: AcceleratorPhase?,
 )

--- a/src/main/kotlin/com/terraformation/backend/accelerator/migration/ProjectSetUpImporter.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/migration/ProjectSetUpImporter.kt
@@ -10,8 +10,8 @@ import com.terraformation.backend.customer.model.ExistingProjectModel
 import com.terraformation.backend.customer.model.NewProjectModel
 import com.terraformation.backend.customer.model.SystemUser
 import com.terraformation.backend.customer.model.requirePermissions
+import com.terraformation.backend.db.accelerator.AcceleratorPhase
 import com.terraformation.backend.db.accelerator.ApplicationStatus
-import com.terraformation.backend.db.accelerator.CohortPhase
 import com.terraformation.backend.db.accelerator.ScoreCategory
 import com.terraformation.backend.db.accelerator.tables.references.APPLICATIONS
 import com.terraformation.backend.db.accelerator.tables.references.APPLICATION_HISTORIES
@@ -146,8 +146,8 @@ class ProjectSetUpImporter(
   private fun updateScores(valuesByName: Map<String, String>, project: ExistingProjectModel) {
     val columnNamePrefixes =
         listOf(
-            "Phase 0: " to CohortPhase.Phase0DueDiligence,
-            "Phase 1: " to CohortPhase.Phase1FeasibilityStudy,
+            "Phase 0: " to AcceleratorPhase.Phase0DueDiligence,
+            "Phase 1: " to AcceleratorPhase.Phase1FeasibilityStudy,
         )
 
     val userId = currentUser().userId

--- a/src/main/kotlin/com/terraformation/backend/accelerator/model/AcceleratorProjectModel.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/model/AcceleratorProjectModel.kt
@@ -1,6 +1,6 @@
 package com.terraformation.backend.accelerator.model
 
-import com.terraformation.backend.db.accelerator.CohortPhase
+import com.terraformation.backend.db.accelerator.AcceleratorPhase
 import com.terraformation.backend.db.accelerator.VoteOption
 import com.terraformation.backend.db.default_schema.ProjectId
 import com.terraformation.backend.db.default_schema.tables.references.PROJECTS
@@ -8,16 +8,16 @@ import org.jooq.Field
 import org.jooq.Record
 
 data class AcceleratorProjectModel(
-    val phase: CohortPhase,
+    val phase: AcceleratorPhase,
     val phaseName: String = phase.getDisplayName(null),
     val projectId: ProjectId,
     val projectName: String,
-    val voteDecisions: Map<CohortPhase, VoteOption> = emptyMap(),
+    val voteDecisions: Map<AcceleratorPhase, VoteOption> = emptyMap(),
 ) {
   companion object {
     fun of(
         record: Record,
-        decisionsField: Field<Map<CohortPhase, VoteOption>>,
+        decisionsField: Field<Map<AcceleratorPhase, VoteOption>>,
     ): AcceleratorProjectModel {
       return AcceleratorProjectModel(
           phase = record[PROJECTS.PHASE_ID]!!,

--- a/src/main/kotlin/com/terraformation/backend/accelerator/model/ApplicationModuleModel.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/model/ApplicationModuleModel.kt
@@ -1,8 +1,8 @@
 package com.terraformation.backend.accelerator.model
 
+import com.terraformation.backend.db.accelerator.AcceleratorPhase
 import com.terraformation.backend.db.accelerator.ApplicationId
 import com.terraformation.backend.db.accelerator.ApplicationModuleStatus
-import com.terraformation.backend.db.accelerator.CohortPhase
 import com.terraformation.backend.db.accelerator.ModuleId
 import com.terraformation.backend.db.accelerator.tables.references.APPLICATION_MODULES
 import com.terraformation.backend.db.accelerator.tables.references.MODULES
@@ -11,7 +11,7 @@ import org.jooq.Record
 data class ApplicationModuleModel(
     val id: ModuleId,
     val name: String,
-    val phase: CohortPhase,
+    val phase: AcceleratorPhase,
     val overview: String? = null,
     val applicationId: ApplicationId?,
     val applicationModuleStatus: ApplicationModuleStatus?,

--- a/src/main/kotlin/com/terraformation/backend/accelerator/model/ModuleModel.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/model/ModuleModel.kt
@@ -1,6 +1,6 @@
 package com.terraformation.backend.accelerator.model
 
-import com.terraformation.backend.db.accelerator.CohortPhase
+import com.terraformation.backend.db.accelerator.AcceleratorPhase
 import com.terraformation.backend.db.accelerator.EventType
 import com.terraformation.backend.db.accelerator.ModuleId
 import com.terraformation.backend.db.accelerator.tables.references.MODULES
@@ -11,7 +11,7 @@ import org.jooq.Record
 data class ModuleModel(
     val id: ModuleId,
     val name: String,
-    val phase: CohortPhase,
+    val phase: AcceleratorPhase,
     val position: Int,
     val additionalResources: String? = null,
     val eventDescriptions: Map<EventType, String> = emptyMap(),

--- a/src/main/kotlin/com/terraformation/backend/accelerator/model/ProjectAcceleratorDetailsModel.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/model/ProjectAcceleratorDetailsModel.kt
@@ -1,8 +1,8 @@
 package com.terraformation.backend.accelerator.model
 
+import com.terraformation.backend.db.accelerator.AcceleratorPhase
 import com.terraformation.backend.db.accelerator.ApplicationId
 import com.terraformation.backend.db.accelerator.ApplicationStatus
-import com.terraformation.backend.db.accelerator.CohortPhase
 import com.terraformation.backend.db.accelerator.DealStage
 import com.terraformation.backend.db.accelerator.Pipeline
 import com.terraformation.backend.db.accelerator.tables.references.PROJECT_ACCELERATOR_DETAILS
@@ -48,7 +48,7 @@ data class ProjectAcceleratorDetailsModel(
     val numCommunities: Int? = null,
     val numNativeSpecies: Int? = null,
     val perHectareBudget: BigDecimal? = null,
-    val phase: CohortPhase? = null,
+    val phase: AcceleratorPhase? = null,
     val pipeline: Pipeline? = null,
     val plantingSitesCql: String? = null,
     val projectArea: BigDecimal? = null,

--- a/src/main/kotlin/com/terraformation/backend/accelerator/model/ProjectScoreModel.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/model/ProjectScoreModel.kt
@@ -1,6 +1,6 @@
 package com.terraformation.backend.accelerator.model
 
-import com.terraformation.backend.db.accelerator.CohortPhase
+import com.terraformation.backend.db.accelerator.AcceleratorPhase
 import com.terraformation.backend.db.accelerator.ScoreCategory
 import com.terraformation.backend.db.accelerator.tables.references.PROJECT_SCORES
 import com.terraformation.backend.log.perClassLogger
@@ -30,10 +30,10 @@ data class ProjectScoreModel<INSTANT : Instant?>(
      * Returns the total (average) score for a set of per-category scores, rounded to 2 decimal
      * places.
      */
-    fun totalScore(phase: CohortPhase, scores: Collection<ProjectScoreModel<*>>): BigDecimal? {
+    fun totalScore(phase: AcceleratorPhase, scores: Collection<ProjectScoreModel<*>>): BigDecimal? {
       return when (phase) {
-        CohortPhase.Phase0DueDiligence -> phase0Total(scores)
-        CohortPhase.Phase1FeasibilityStudy -> phase1Total(scores)
+        AcceleratorPhase.Phase0DueDiligence -> phase0Total(scores)
+        AcceleratorPhase.Phase1FeasibilityStudy -> phase1Total(scores)
         else -> {
           log.error("BUG! Should not be trying to calculate score for phase $phase")
           null

--- a/src/main/kotlin/com/terraformation/backend/accelerator/model/VoteDecisionModel.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/model/VoteDecisionModel.kt
@@ -1,13 +1,13 @@
 package com.terraformation.backend.accelerator.model
 
-import com.terraformation.backend.db.accelerator.CohortPhase
+import com.terraformation.backend.db.accelerator.AcceleratorPhase
 import com.terraformation.backend.db.accelerator.VoteOption
 import com.terraformation.backend.db.accelerator.tables.references.PROJECT_VOTE_DECISIONS
 import java.time.Instant
 import org.jooq.Record
 
 data class VoteDecisionModel(
-    val phase: CohortPhase,
+    val phase: AcceleratorPhase,
     val modifiedTime: Instant,
     val decision: VoteOption? = null,
 ) {

--- a/src/main/kotlin/com/terraformation/backend/accelerator/model/VoteModel.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/model/VoteModel.kt
@@ -1,6 +1,6 @@
 package com.terraformation.backend.accelerator.model
 
-import com.terraformation.backend.db.accelerator.CohortPhase
+import com.terraformation.backend.db.accelerator.AcceleratorPhase
 import com.terraformation.backend.db.accelerator.VoteOption
 import com.terraformation.backend.db.accelerator.tables.references.PROJECT_VOTES
 import com.terraformation.backend.db.default_schema.UserId
@@ -12,7 +12,7 @@ data class VoteModel(
     val email: String,
     val firstName: String? = null,
     val lastName: String? = null,
-    val phase: CohortPhase,
+    val phase: AcceleratorPhase,
     val userId: UserId,
     val voteOption: VoteOption? = null,
 ) {

--- a/src/main/kotlin/com/terraformation/backend/customer/api/ProjectsController.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/api/ProjectsController.kt
@@ -11,7 +11,7 @@ import com.terraformation.backend.customer.model.ExistingProjectModel
 import com.terraformation.backend.customer.model.NewProjectModel
 import com.terraformation.backend.customer.model.ProjectInternalUserModel
 import com.terraformation.backend.customer.model.TerrawareUser
-import com.terraformation.backend.db.accelerator.CohortPhase
+import com.terraformation.backend.db.accelerator.AcceleratorPhase
 import com.terraformation.backend.db.default_schema.OrganizationId
 import com.terraformation.backend.db.default_schema.ProjectId
 import com.terraformation.backend.db.default_schema.ProjectInternalRole
@@ -162,7 +162,7 @@ data class ProjectPayload(
     val modifiedTime: Instant?,
     val name: String,
     val organizationId: OrganizationId,
-    val phase: CohortPhase?,
+    val phase: AcceleratorPhase?,
 ) {
   constructor(
       model: ExistingProjectModel

--- a/src/main/kotlin/com/terraformation/backend/customer/db/OrganizationFeatureStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/db/OrganizationFeatureStore.kt
@@ -2,7 +2,7 @@ package com.terraformation.backend.customer.db
 
 import com.terraformation.backend.customer.model.OrganizationFeature
 import com.terraformation.backend.customer.model.requirePermissions
-import com.terraformation.backend.db.accelerator.CohortPhase
+import com.terraformation.backend.db.accelerator.AcceleratorPhase
 import com.terraformation.backend.db.accelerator.ReportStatus
 import com.terraformation.backend.db.accelerator.tables.references.APPLICATIONS
 import com.terraformation.backend.db.accelerator.tables.references.DELIVERABLES
@@ -72,7 +72,12 @@ class OrganizationFeatureStore(private val dslContext: DSLContext) {
                   .on(PROJECT_MODULES.PROJECT_ID.eq(PROJECTS.ID))
                   .or(PROJECTS.ID.eq(SUBMISSIONS.PROJECT_ID))
                   .where(PROJECTS.ORGANIZATION_ID.eq(ORGANIZATIONS.ID))
-                  .and(MODULES.PHASE_ID.notIn(CohortPhase.PreScreen, CohortPhase.Application))
+                  .and(
+                      MODULES.PHASE_ID.notIn(
+                          AcceleratorPhase.PreScreen,
+                          AcceleratorPhase.Application,
+                      )
+                  )
           )
           .convertFrom { result -> result.map { record -> record[PROJECTS.ID] }.toSet() }
 

--- a/src/main/kotlin/com/terraformation/backend/customer/model/ProjectModel.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/ProjectModel.kt
@@ -1,6 +1,6 @@
 package com.terraformation.backend.customer.model
 
-import com.terraformation.backend.db.accelerator.CohortPhase
+import com.terraformation.backend.db.accelerator.AcceleratorPhase
 import com.terraformation.backend.db.default_schema.OrganizationId
 import com.terraformation.backend.db.default_schema.ProjectId
 import com.terraformation.backend.db.default_schema.UserId
@@ -19,7 +19,7 @@ data class ProjectModel<ID : ProjectId?>(
     val modifiedTime: Instant? = null,
     val name: String,
     val organizationId: OrganizationId,
-    val phase: CohortPhase? = null,
+    val phase: AcceleratorPhase? = null,
 ) {
   companion object {
     fun of(row: ProjectsRow): ExistingProjectModel {

--- a/src/main/resources/db/migration/0450/V455__AcceleratorPhases.sql
+++ b/src/main/resources/db/migration/0450/V455__AcceleratorPhases.sql
@@ -1,0 +1,3 @@
+ALTER TABLE accelerator.cohort_phases RENAME TO accelerator_phases;
+ALTER TABLE accelerator.accelerator_phases RENAME CONSTRAINT cohort_phases_pkey TO accelerator_phases_pkey;
+ALTER TABLE accelerator.accelerator_phases RENAME CONSTRAINT cohort_phases_name_key TO accelerator_phases_name_key;

--- a/src/main/resources/db/migration/R__Comments.sql
+++ b/src/main/resources/db/migration/R__Comments.sql
@@ -648,7 +648,7 @@ COMMENT ON TABLE accelerator.metric_components IS '(Enum) Components of metrics 
 
 COMMENT ON TABLE accelerator.metric_types IS '(Enum) Types of metrics for reports.';
 
-COMMENT ON TABLE accelerator.modules IS 'Possible steps in the workflow of a cohort phase.';
+COMMENT ON TABLE accelerator.modules IS 'Possible steps in the workflow of an accelerator phase.';
 COMMENT ON COLUMN accelerator.modules.position IS 'This model''s ordinal position in the modules spreadsheet. This can be used to present modules in the same order they appear in the spreadsheet.';
 
 COMMENT ON TABLE accelerator.participant_project_species IS 'Species that are associated to a participant project';

--- a/src/main/resources/db/migration/R__Comments.sql
+++ b/src/main/resources/db/migration/R__Comments.sql
@@ -587,6 +587,8 @@ COMMENT ON TABLE tracking.tree_growth_forms IS '(Enum) Growth form of each speci
 
 COMMENT ON CONSTRAINT num_plants_sign_consistent_with_type ON tracking.plantings IS 'If the planting represents the "from" side of a reassignment or an undo of a withdrawal, the number of plants must be negative. Otherwise it must be positive.';
 
+COMMENT ON TABLE accelerator.accelerator_phases IS '(Enum) Phases that accelerator projects go through.';
+
 COMMENT ON VIEW accelerator.accelerator_projects IS 'All projects that are in the accelerator, by any of the definitions. The 3 definitions at the time of creation were: having an application, having a cohort, or the project''s org having an internal tag of "Accelerator".';
 
 COMMENT ON TABLE accelerator.activities IS 'User-supplied descriptions of project activities.';
@@ -608,8 +610,6 @@ COMMENT ON TABLE accelerator.application_modules IS 'Current states of the modul
 COMMENT ON TABLE accelerator.application_statuses IS '(Enum) Possible statuses for an application to the accelerator program.';
 
 COMMENT ON TABLE accelerator.applications IS 'Information about projects that are applying for the accelerator program.';
-
-COMMENT ON TABLE accelerator.cohort_phases IS '(Enum) Available cohort phases';
 
 COMMENT ON TABLE accelerator.deal_stages IS '(Enum) Stages in the deal workflow that a project progresses through.';
 

--- a/src/main/resources/db/migration/R__TypeCodes.sql
+++ b/src/main/resources/db/migration/R__TypeCodes.sql
@@ -1,3 +1,12 @@
+INSERT INTO accelerator.accelerator_phases (id, name)
+VALUES (0, 'Phase 0 - Due Diligence'),
+       (1, 'Phase 1 - Feasibility Study'),
+       (2, 'Phase 2 - Plan and Scale'),
+       (3, 'Phase 3 - Implement and Monitor'),
+       (100, 'Pre-Screen'),
+       (101, 'Application')
+ON CONFLICT (id) DO UPDATE SET name = excluded.name;
+
 INSERT INTO seedbank.accession_quantity_history_types (id, name)
 VALUES (1, 'Observed'),
        (2, 'Computed')
@@ -92,15 +101,6 @@ VALUES (1, 'Assistant'),
        (2, 'System'),
        (3, 'ToolResponse'),
        (4, 'User')
-ON CONFLICT (id) DO UPDATE SET name = excluded.name;
-
-INSERT INTO accelerator.cohort_phases (id, name)
-VALUES (0, 'Phase 0 - Due Diligence'),
-       (1, 'Phase 1 - Feasibility Study'),
-       (2, 'Phase 2 - Plan and Scale'),
-       (3, 'Phase 3 - Implement and Monitor'),
-       (100, 'Pre-Screen'),
-       (101, 'Application')
 ON CONFLICT (id) DO UPDATE SET name = excluded.name;
 
 INSERT INTO seedbank.collection_sources (id, name)

--- a/src/main/resources/i18n/Enums_en.properties
+++ b/src/main/resources/i18n/Enums_en.properties
@@ -1,3 +1,9 @@
+accelerator.AcceleratorPhase.Application=Application
+accelerator.AcceleratorPhase.Phase0DueDiligence=Phase 0 - Due Diligence
+accelerator.AcceleratorPhase.Phase1FeasibilityStudy=Phase 1 - Feasibility Study
+accelerator.AcceleratorPhase.Phase2PlanAndScale=Phase 2 - Plan and Scale
+accelerator.AcceleratorPhase.Phase3ImplementAndMonitor=Phase 3 - Implement and Monitor
+accelerator.AcceleratorPhase.PreScreen=Pre-Screen
 accelerator.ActivityStatus.DoNotUse=Do Not Use
 accelerator.ActivityStatus.NotVerified=Not Verified
 accelerator.ActivityStatus.Verified=Verified
@@ -33,12 +39,6 @@ accelerator.ApplicationStatus.ReadyForReview=Ready for Review
 accelerator.ApplicationStatus.SourcingTeamReview=Sourcing Team Review
 accelerator.ApplicationStatus.Submitted=Submitted
 accelerator.ApplicationStatus.Waitlist=Waitlist
-accelerator.CohortPhase.Application=Application
-accelerator.CohortPhase.Phase0DueDiligence=Phase 0 - Due Diligence
-accelerator.CohortPhase.Phase1FeasibilityStudy=Phase 1 - Feasibility Study
-accelerator.CohortPhase.Phase2PlanAndScale=Phase 2 - Plan and Scale
-accelerator.CohortPhase.Phase3ImplementAndMonitor=Phase 3 - Implement and Monitor
-accelerator.CohortPhase.PreScreen=Pre-Screen
 accelerator.DeliverableCategory.CarbonEligibility=Carbon Eligibility
 # As in compliance with legal requirements
 accelerator.DeliverableCategory.Compliance=Compliance
@@ -158,10 +158,6 @@ nursery.WithdrawalPurpose.NurseryTransfer=Nursery Transfer
 nursery.WithdrawalPurpose.Other=Other
 nursery.WithdrawalPurpose.OutPlant=Out Plant
 nursery.WithdrawalPurpose.Undo=Undo
-public.CohortPhase.Phase0DueDiligence=Phase 0 - Due Diligence
-public.CohortPhase.Phase1FeasibilityStudy=Phase 1 - Feasibility Study
-public.CohortPhase.Phase2PlanAndScale=Phase 2 - Plan and Scale
-public.CohortPhase.Phase3ImplementAndMonitor=Phase 3 - Implement and Monitor
 # IUCN conservation category. Only the description should be translated; keep the two-letter code as is.
 public.ConservationCategory.CriticallyEndangered=Critically Endangered (CR)
 # IUCN conservation category. Only the description should be translated; keep the two-letter code as is.

--- a/src/main/resources/i18n/Enums_es.properties
+++ b/src/main/resources/i18n/Enums_es.properties
@@ -1,4 +1,16 @@
 # encoding: UTF-8
+# 83d372a5
+accelerator.AcceleratorPhase.Application=Aplicación
+# 6c20cb46
+accelerator.AcceleratorPhase.Phase0DueDiligence=Fase 0 - Diligencia debida
+# 94889837
+accelerator.AcceleratorPhase.Phase1FeasibilityStudy=Fase 1 - Estudio de viabilidad
+# a51c9fc2
+accelerator.AcceleratorPhase.Phase2PlanAndScale=Fase 2 - Planificar y escalar
+# d8def4af
+accelerator.AcceleratorPhase.Phase3ImplementAndMonitor=Fase 3 - Implementar y supervisar
+# 28db3746
+accelerator.AcceleratorPhase.PreScreen=Preselección
 # 6950f9e5
 accelerator.ActivityStatus.DoNotUse=No usar
 # fbd9066a
@@ -69,18 +81,6 @@ accelerator.ApplicationStatus.SourcingTeamReview=Revisión por el equipo de comp
 accelerator.ApplicationStatus.Submitted=Presentado
 # 9373381f
 accelerator.ApplicationStatus.Waitlist=Lista de espera
-# 83d372a5
-accelerator.CohortPhase.Application=Aplicación
-# 6c20cb46
-accelerator.CohortPhase.Phase0DueDiligence=Fase 0 - Diligencia debida
-# 94889837
-accelerator.CohortPhase.Phase1FeasibilityStudy=Fase 1 - Estudio de viabilidad
-# a51c9fc2
-accelerator.CohortPhase.Phase2PlanAndScale=Fase 2 - Planificar y escalar
-# d8def4af
-accelerator.CohortPhase.Phase3ImplementAndMonitor=Fase 3 - Implementar y supervisar
-# 28db3746
-accelerator.CohortPhase.PreScreen=Preselección
 # 90b7ac55
 accelerator.DeliverableCategory.CarbonEligibility=Elegibilidad de carbono
 # 55baeedc
@@ -309,14 +309,6 @@ nursery.WithdrawalPurpose.Other=Otros
 nursery.WithdrawalPurpose.OutPlant=Planta exterior
 # 5f150050
 nursery.WithdrawalPurpose.Undo=Deshacer
-# 6c20cb46
-public.CohortPhase.Phase0DueDiligence=Fase 0: Debida diligencia
-# 94889837
-public.CohortPhase.Phase1FeasibilityStudy=Fase 1: Estudio de viabilidad
-# a51c9fc2
-public.CohortPhase.Phase2PlanAndScale=Fase 2: Planificar y escalar
-# d8def4af
-public.CohortPhase.Phase3ImplementAndMonitor=Fase 3: Implementar y monitorear
 # 8a4a60a3
 public.ConservationCategory.CriticallyEndangered=En peligro crítico de extinción (CR)
 # 31ac4b22

--- a/src/main/resources/i18n/Enums_fr.properties
+++ b/src/main/resources/i18n/Enums_fr.properties
@@ -1,4 +1,16 @@
 # encoding: UTF-8
+# 83d372a5
+accelerator.AcceleratorPhase.Application=Demande
+# 6c20cb46
+accelerator.AcceleratorPhase.Phase0DueDiligence=Phase 0 - Diligence raisonnable
+# 94889837
+accelerator.AcceleratorPhase.Phase1FeasibilityStudy=Phase 1 - Étude de faisabilité
+# a51c9fc2
+accelerator.AcceleratorPhase.Phase2PlanAndScale=Phase 2 - Plan et échelle
+# d8def4af
+accelerator.AcceleratorPhase.Phase3ImplementAndMonitor=Phase 3 - Mise en œuvre et suivi
+# 28db3746
+accelerator.AcceleratorPhase.PreScreen=Présélection
 # 6950f9e5
 accelerator.ActivityStatus.DoNotUse=Ne pas utiliser
 # fbd9066a
@@ -69,18 +81,6 @@ accelerator.ApplicationStatus.SourcingTeamReview=Examen par l''équipe d''approv
 accelerator.ApplicationStatus.Submitted=Soumis
 # 9373381f
 accelerator.ApplicationStatus.Waitlist=Liste d''attente
-# 83d372a5
-accelerator.CohortPhase.Application=Demande
-# 6c20cb46
-accelerator.CohortPhase.Phase0DueDiligence=Phase 0 - Diligence raisonnable
-# 94889837
-accelerator.CohortPhase.Phase1FeasibilityStudy=Phase 1 - Étude de faisabilité
-# a51c9fc2
-accelerator.CohortPhase.Phase2PlanAndScale=Phase 2 - Plan et échelle
-# d8def4af
-accelerator.CohortPhase.Phase3ImplementAndMonitor=Phase 3 - Mise en œuvre et suivi
-# 28db3746
-accelerator.CohortPhase.PreScreen=Présélection
 # 90b7ac55
 accelerator.DeliverableCategory.CarbonEligibility=Admissibilité au carbone
 # 55baeedc
@@ -309,14 +309,6 @@ nursery.WithdrawalPurpose.Other=Autre
 nursery.WithdrawalPurpose.OutPlant=Sortie de l''usine
 # 5f150050
 nursery.WithdrawalPurpose.Undo=Annuler
-# 6c20cb46
-public.CohortPhase.Phase0DueDiligence=Phase 0 - Diligence raisonnable
-# 94889837
-public.CohortPhase.Phase1FeasibilityStudy=Phase 1 - Étude de faisabilité
-# a51c9fc2
-public.CohortPhase.Phase2PlanAndScale=Phase 2 - Plan et échelle
-# d8def4af
-public.CohortPhase.Phase3ImplementAndMonitor=Phase 3 - Mise en œuvre et suivi
 # 8a4a60a3
 public.ConservationCategory.CriticallyEndangered=En danger critique (CR)
 # 31ac4b22

--- a/src/test/kotlin/com/terraformation/backend/accelerator/AcceleratorProjectServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/AcceleratorProjectServiceTest.kt
@@ -6,7 +6,7 @@ import com.terraformation.backend.customer.model.TerrawareUser
 import com.terraformation.backend.db.AcceleratorProjectNotFoundException
 import com.terraformation.backend.db.DatabaseTest
 import com.terraformation.backend.db.ProjectNotFoundException
-import com.terraformation.backend.db.accelerator.CohortPhase
+import com.terraformation.backend.db.accelerator.AcceleratorPhase
 import com.terraformation.backend.db.accelerator.VoteOption
 import com.terraformation.backend.db.default_schema.GlobalRole
 import com.terraformation.backend.db.default_schema.Role
@@ -26,21 +26,21 @@ class AcceleratorProjectServiceTest : DatabaseTest(), RunsAsDatabaseUser {
     insertOrganization()
     insertProject(
         countryCode = "KE",
-        phase = CohortPhase.Phase1FeasibilityStudy,
+        phase = AcceleratorPhase.Phase1FeasibilityStudy,
     )
     insertVoteDecision(
         projectId = inserted.projectId,
-        phase = CohortPhase.Phase0DueDiligence,
+        phase = AcceleratorPhase.Phase0DueDiligence,
         voteOption = VoteOption.Yes,
     )
     insertVoteDecision(
         projectId = inserted.projectId,
-        phase = CohortPhase.Phase1FeasibilityStudy,
+        phase = AcceleratorPhase.Phase1FeasibilityStudy,
         voteOption = VoteOption.No,
     )
     insertVoteDecision(
         projectId = inserted.projectId,
-        phase = CohortPhase.Phase2PlanAndScale,
+        phase = AcceleratorPhase.Phase2PlanAndScale,
         voteOption = null,
     )
 
@@ -51,13 +51,13 @@ class AcceleratorProjectServiceTest : DatabaseTest(), RunsAsDatabaseUser {
   fun `fetches one by Id, or throws not found exception`() {
     assertEquals(
         AcceleratorProjectModel(
-            phase = CohortPhase.Phase1FeasibilityStudy,
+            phase = AcceleratorPhase.Phase1FeasibilityStudy,
             projectId = inserted.projectId,
             projectName = projectsDao.fetchOneById(inserted.projectId)!!.name!!,
             voteDecisions =
                 mapOf(
-                    CohortPhase.Phase0DueDiligence to VoteOption.Yes,
-                    CohortPhase.Phase1FeasibilityStudy to VoteOption.No,
+                    AcceleratorPhase.Phase0DueDiligence to VoteOption.Yes,
+                    AcceleratorPhase.Phase1FeasibilityStudy to VoteOption.No,
                 ),
         ),
         service.fetchOneById(inserted.projectId),
@@ -72,13 +72,13 @@ class AcceleratorProjectServiceTest : DatabaseTest(), RunsAsDatabaseUser {
     assertEquals(
         listOf(
             AcceleratorProjectModel(
-                phase = CohortPhase.Phase1FeasibilityStudy,
+                phase = AcceleratorPhase.Phase1FeasibilityStudy,
                 projectId = inserted.projectId,
                 projectName = projectsDao.fetchOneById(inserted.projectId)!!.name!!,
                 voteDecisions =
                     mapOf(
-                        CohortPhase.Phase0DueDiligence to VoteOption.Yes,
-                        CohortPhase.Phase1FeasibilityStudy to VoteOption.No,
+                        AcceleratorPhase.Phase0DueDiligence to VoteOption.Yes,
+                        AcceleratorPhase.Phase1FeasibilityStudy to VoteOption.No,
                     ),
             )
         ),

--- a/src/test/kotlin/com/terraformation/backend/accelerator/AcceleratorSearchTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/AcceleratorSearchTest.kt
@@ -4,7 +4,7 @@ import com.terraformation.backend.RunsAsUser
 import com.terraformation.backend.TestClock
 import com.terraformation.backend.assertJsonEquals
 import com.terraformation.backend.db.DatabaseTest
-import com.terraformation.backend.db.accelerator.CohortPhase
+import com.terraformation.backend.db.accelerator.AcceleratorPhase
 import com.terraformation.backend.db.accelerator.DealStage
 import com.terraformation.backend.db.accelerator.Pipeline
 import com.terraformation.backend.db.default_schema.LandUseModelType
@@ -38,7 +38,7 @@ class AcceleratorSearchTest : DatabaseTest(), RunsAsUser {
   @BeforeEach
   fun setUp() {
     organizationId = insertOrganization()
-    insertProject(countryCode = "KE", phase = CohortPhase.Phase0DueDiligence)
+    insertProject(countryCode = "KE", phase = AcceleratorPhase.Phase0DueDiligence)
 
     every { user.canReadAllAcceleratorDetails() } returns true
     every { user.canReadInternalTags() } returns true
@@ -149,7 +149,7 @@ class AcceleratorSearchTest : DatabaseTest(), RunsAsUser {
     insertOrganizationUser()
 
     insertOrganization()
-    insertProject(phase = CohortPhase.Phase0DueDiligence)
+    insertProject(phase = AcceleratorPhase.Phase0DueDiligence)
 
     insertOrganization()
 
@@ -178,7 +178,7 @@ class AcceleratorSearchTest : DatabaseTest(), RunsAsUser {
     insertOrganizationUser()
 
     insertOrganization()
-    insertProject(phase = CohortPhase.Phase0DueDiligence)
+    insertProject(phase = AcceleratorPhase.Phase0DueDiligence)
 
     val prefix = SearchFieldPrefix(searchTables.organizations)
     val fields = listOf(prefix.resolve("name"))
@@ -219,7 +219,10 @@ class AcceleratorSearchTest : DatabaseTest(), RunsAsUser {
     insertOrganizationUser()
 
     val otherAcceleratorOrgId = insertOrganization()
-    insertProject(organizationId = otherAcceleratorOrgId, phase = CohortPhase.Phase0DueDiligence)
+    insertProject(
+        organizationId = otherAcceleratorOrgId,
+        phase = AcceleratorPhase.Phase0DueDiligence,
+    )
 
     val prefix = SearchFieldPrefix(searchTables.projects)
     val fields = listOf(prefix.resolve("name"))
@@ -323,14 +326,14 @@ class AcceleratorSearchTest : DatabaseTest(), RunsAsUser {
     val deliverableId2 = insertDeliverable(name = "Deliverable 2 $suffix")
     val moduleId2 = insertModule(name = "Module 2 $suffix")
     insertDeliverable(name = "Deliverable 3 $suffix")
-    val projectId1 = insertProject(phase = CohortPhase.Phase0DueDiligence)
+    val projectId1 = insertProject(phase = AcceleratorPhase.Phase0DueDiligence)
     insertProjectModule(moduleId = moduleId1)
-    val projectId2 = insertProject(phase = CohortPhase.Phase0DueDiligence)
+    val projectId2 = insertProject(phase = AcceleratorPhase.Phase0DueDiligence)
     insertProjectModule(moduleId = moduleId1)
-    val projectId3 = insertProject(phase = CohortPhase.Phase0DueDiligence)
+    val projectId3 = insertProject(phase = AcceleratorPhase.Phase0DueDiligence)
     insertProjectModule(moduleId = moduleId1)
     insertProjectModule(moduleId = moduleId2)
-    insertProject(phase = CohortPhase.Phase1FeasibilityStudy)
+    insertProject(phase = AcceleratorPhase.Phase1FeasibilityStudy)
     insertProjectModule(moduleId = moduleId2)
 
     val prefix = SearchFieldPrefix(searchTables.modules)

--- a/src/test/kotlin/com/terraformation/backend/accelerator/DeliverableCompleterTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/DeliverableCompleterTest.kt
@@ -14,9 +14,9 @@ import com.terraformation.backend.accelerator.model.ExistingParticipantProjectSp
 import com.terraformation.backend.customer.model.SystemUser
 import com.terraformation.backend.customer.model.TerrawareUser
 import com.terraformation.backend.db.DatabaseTest
+import com.terraformation.backend.db.accelerator.AcceleratorPhase
 import com.terraformation.backend.db.accelerator.ApplicationId
 import com.terraformation.backend.db.accelerator.ApplicationModuleStatus
-import com.terraformation.backend.db.accelerator.CohortPhase
 import com.terraformation.backend.db.accelerator.DeliverableId
 import com.terraformation.backend.db.accelerator.DeliverableType
 import com.terraformation.backend.db.accelerator.ModuleId
@@ -73,8 +73,8 @@ class DeliverableCompleterTest : DatabaseTest(), RunsAsUser {
     projectId = insertProject()
     applicationId = insertApplication()
 
-    applicationModuleId = insertModule(phase = CohortPhase.Application)
-    preScreenModuleId = insertModule(phase = CohortPhase.PreScreen)
+    applicationModuleId = insertModule(phase = AcceleratorPhase.Application)
+    preScreenModuleId = insertModule(phase = AcceleratorPhase.PreScreen)
 
     every { user.adminOrganizations() } returns setOf(organizationId)
     every { user.canCreateSubmission(projectId) } returns true
@@ -169,7 +169,7 @@ class DeliverableCompleterTest : DatabaseTest(), RunsAsUser {
 
     @Test
     fun `does not update deliverable status for non-application phase`() {
-      insertModule(phase = CohortPhase.Phase0DueDiligence)
+      insertModule(phase = AcceleratorPhase.Phase0DueDiligence)
       val otherModuleDeliverableId = insertDeliverable()
 
       completer.on(

--- a/src/test/kotlin/com/terraformation/backend/accelerator/DeliverableFilesRenamerTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/DeliverableFilesRenamerTest.kt
@@ -12,9 +12,9 @@ import com.terraformation.backend.config.TerrawareServerConfig
 import com.terraformation.backend.customer.model.SystemUser
 import com.terraformation.backend.customer.model.TerrawareUser
 import com.terraformation.backend.db.DatabaseTest
+import com.terraformation.backend.db.accelerator.AcceleratorPhase
 import com.terraformation.backend.db.accelerator.ApplicationId
 import com.terraformation.backend.db.accelerator.ApplicationStatus
-import com.terraformation.backend.db.accelerator.CohortPhase
 import com.terraformation.backend.db.accelerator.DeliverableType
 import com.terraformation.backend.db.accelerator.DocumentStore
 import com.terraformation.backend.db.default_schema.ProjectId
@@ -79,7 +79,7 @@ class DeliverableFilesRenamerTest : DatabaseTest(), RunsAsUser {
   @BeforeEach
   fun setUp() {
     insertOrganization()
-    projectId = insertProject(phase = CohortPhase.Phase0DueDiligence)
+    projectId = insertProject(phase = AcceleratorPhase.Phase0DueDiligence)
     applicationId = insertApplication(internalName = "XXX_Organization")
 
     every { config.accelerator } returns
@@ -135,7 +135,7 @@ class DeliverableFilesRenamerTest : DatabaseTest(), RunsAsUser {
     @Test
     fun `renames project document submissions and moves them to the folder`() {
       // Application Modules
-      insertModule(phase = CohortPhase.Application)
+      insertModule(phase = AcceleratorPhase.Application)
       insertApplicationModule()
       insertDeliverable(
           name = "Application Documents",

--- a/src/test/kotlin/com/terraformation/backend/accelerator/DeliverableServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/DeliverableServiceTest.kt
@@ -9,8 +9,8 @@ import com.terraformation.backend.accelerator.db.ModuleStore
 import com.terraformation.backend.accelerator.db.SubmissionStore
 import com.terraformation.backend.customer.model.SystemUser
 import com.terraformation.backend.db.DatabaseTest
+import com.terraformation.backend.db.accelerator.AcceleratorPhase
 import com.terraformation.backend.db.accelerator.ApplicationModuleStatus
-import com.terraformation.backend.db.accelerator.CohortPhase
 import com.terraformation.backend.db.accelerator.DeliverableId
 import com.terraformation.backend.db.accelerator.DeliverableType
 import com.terraformation.backend.db.accelerator.SubmissionStatus
@@ -58,7 +58,7 @@ class DeliverableServiceTest : DatabaseTest(), RunsAsUser {
     insertOrganization()
     insertProject()
     insertApplication()
-    insertModule(phase = CohortPhase.PreScreen)
+    insertModule(phase = AcceleratorPhase.PreScreen)
     insertApplicationModule(
         inserted.applicationId,
         inserted.moduleId,

--- a/src/test/kotlin/com/terraformation/backend/accelerator/ModuleEventSearchTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/ModuleEventSearchTest.kt
@@ -4,7 +4,7 @@ import com.terraformation.backend.RunsAsUser
 import com.terraformation.backend.TestClock
 import com.terraformation.backend.assertJsonEquals
 import com.terraformation.backend.db.DatabaseTest
-import com.terraformation.backend.db.accelerator.CohortPhase
+import com.terraformation.backend.db.accelerator.AcceleratorPhase
 import com.terraformation.backend.db.accelerator.EventStatus
 import com.terraformation.backend.db.accelerator.EventType
 import com.terraformation.backend.db.default_schema.Role
@@ -148,17 +148,17 @@ class ModuleEventSearchTest : DatabaseTest(), RunsAsUser {
 
   @Test
   fun `can search for associated projects`() {
-    val project1 = insertProject(phase = CohortPhase.Phase0DueDiligence)
-    val project2 = insertProject(phase = CohortPhase.Phase0DueDiligence)
-    val project3 = insertProject(phase = CohortPhase.Phase0DueDiligence)
+    val project1 = insertProject(phase = AcceleratorPhase.Phase0DueDiligence)
+    val project2 = insertProject(phase = AcceleratorPhase.Phase0DueDiligence)
+    val project3 = insertProject(phase = AcceleratorPhase.Phase0DueDiligence)
     val event1 = insertEvent()
     insertEventProject(event1, project1)
     insertEventProject(event1, project2)
     insertEventProject(event1, project3)
 
-    val project4 = insertProject(phase = CohortPhase.Phase0DueDiligence)
-    val project5 = insertProject(phase = CohortPhase.Phase0DueDiligence)
-    val project6 = insertProject(phase = CohortPhase.Phase0DueDiligence)
+    val project4 = insertProject(phase = AcceleratorPhase.Phase0DueDiligence)
+    val project5 = insertProject(phase = AcceleratorPhase.Phase0DueDiligence)
+    val project6 = insertProject(phase = AcceleratorPhase.Phase0DueDiligence)
     val event2 = insertEvent()
     insertEventProject(event2, project4)
     insertEventProject(event2, project5)
@@ -204,8 +204,8 @@ class ModuleEventSearchTest : DatabaseTest(), RunsAsUser {
     val event3 = insertEvent()
     val hiddenEvent = insertEvent()
 
-    val project1 = insertProject(phase = CohortPhase.Phase0DueDiligence)
-    val project2 = insertProject(phase = CohortPhase.Phase0DueDiligence)
+    val project1 = insertProject(phase = AcceleratorPhase.Phase0DueDiligence)
+    val project2 = insertProject(phase = AcceleratorPhase.Phase0DueDiligence)
 
     insertEventProject(event1, project1)
     insertEventProject(event2, project1)
@@ -247,8 +247,8 @@ class ModuleEventSearchTest : DatabaseTest(), RunsAsUser {
 
   @Test
   fun `can search for events sublists using projects as prefix`() {
-    val project1 = insertProject(phase = CohortPhase.Phase0DueDiligence)
-    val project2 = insertProject(phase = CohortPhase.Phase0DueDiligence)
+    val project1 = insertProject(phase = AcceleratorPhase.Phase0DueDiligence)
+    val project2 = insertProject(phase = AcceleratorPhase.Phase0DueDiligence)
     val event1 = insertEvent()
     val event2 = insertEvent()
     val event3 = insertEvent()
@@ -292,7 +292,7 @@ class ModuleEventSearchTest : DatabaseTest(), RunsAsUser {
     val userProject =
         insertProject(
             organizationId = inserted.organizationId,
-            phase = CohortPhase.Phase0DueDiligence,
+            phase = AcceleratorPhase.Phase0DueDiligence,
         )
 
     val otherUser = insertUser()
@@ -305,7 +305,7 @@ class ModuleEventSearchTest : DatabaseTest(), RunsAsUser {
     val otherProject =
         insertProject(
             organizationId = otherOrganization,
-            phase = CohortPhase.Phase0DueDiligence,
+            phase = AcceleratorPhase.Phase0DueDiligence,
             createdBy = otherUser,
         )
 

--- a/src/test/kotlin/com/terraformation/backend/accelerator/ModuleEventServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/ModuleEventServiceTest.kt
@@ -10,7 +10,7 @@ import com.terraformation.backend.assertIsEventListener
 import com.terraformation.backend.customer.model.SystemUser
 import com.terraformation.backend.customer.model.TerrawareUser
 import com.terraformation.backend.db.DatabaseTest
-import com.terraformation.backend.db.accelerator.CohortPhase
+import com.terraformation.backend.db.accelerator.AcceleratorPhase
 import com.terraformation.backend.db.accelerator.EventId
 import com.terraformation.backend.db.accelerator.EventStatus
 import com.terraformation.backend.db.default_schema.ProjectId
@@ -57,7 +57,7 @@ class ModuleEventServiceTest : DatabaseTest(), RunsAsUser {
     insertOrganization()
     insertModule()
 
-    projectId = insertProject(phase = CohortPhase.Phase0DueDiligence)
+    projectId = insertProject(phase = AcceleratorPhase.Phase0DueDiligence)
 
     every { scheduler.schedule<ModuleEventService>(any<Instant>(), any()) } returns
         JobId(UUID.randomUUID())

--- a/src/test/kotlin/com/terraformation/backend/accelerator/ModuleSearchTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/ModuleSearchTest.kt
@@ -4,7 +4,7 @@ import com.terraformation.backend.RunsAsUser
 import com.terraformation.backend.TestClock
 import com.terraformation.backend.assertJsonEquals
 import com.terraformation.backend.db.DatabaseTest
-import com.terraformation.backend.db.accelerator.CohortPhase
+import com.terraformation.backend.db.accelerator.AcceleratorPhase
 import com.terraformation.backend.db.default_schema.Role
 import com.terraformation.backend.i18n.Locales
 import com.terraformation.backend.i18n.use
@@ -64,7 +64,7 @@ class ModuleSearchTest : DatabaseTest(), RunsAsUser {
             oneOnOneSessionDescription = "1:1 meetings",
             overview = "<h> Overview </h>",
             preparationMaterials = "<i> Preps </i>",
-            phase = CohortPhase.Phase1FeasibilityStudy,
+            phase = AcceleratorPhase.Phase1FeasibilityStudy,
             workshopDescription = "Workshop ideas",
         )
 
@@ -79,7 +79,8 @@ class ModuleSearchTest : DatabaseTest(), RunsAsUser {
                     "oneOnOneSessionDescription" to "1:1 meetings",
                     "overview" to "<h> Overview </h>",
                     "preparationMaterials" to "<i> Preps </i>",
-                    "phase" to CohortPhase.Phase1FeasibilityStudy.getDisplayName(Locales.GIBBERISH),
+                    "phase" to
+                        AcceleratorPhase.Phase1FeasibilityStudy.getDisplayName(Locales.GIBBERISH),
                     "workshopDescription" to "Workshop ideas",
                 )
             )
@@ -110,8 +111,8 @@ class ModuleSearchTest : DatabaseTest(), RunsAsUser {
     val module2 = insertModule()
     val module3 = insertModule()
 
-    val project1 = insertProject(phase = CohortPhase.Phase0DueDiligence)
-    val project2 = insertProject(phase = CohortPhase.Phase0DueDiligence)
+    val project1 = insertProject(phase = AcceleratorPhase.Phase0DueDiligence)
+    val project2 = insertProject(phase = AcceleratorPhase.Phase0DueDiligence)
 
     insertProjectModule(
         project1,
@@ -223,12 +224,12 @@ class ModuleSearchTest : DatabaseTest(), RunsAsUser {
     val module2 = insertModule()
     val invisibleModule = insertModule()
 
-    val userProject = insertProject(phase = CohortPhase.Phase0DueDiligence)
+    val userProject = insertProject(phase = AcceleratorPhase.Phase0DueDiligence)
 
     val otherUser = insertUser()
     val otherOrganization = insertOrganization()
     insertOrganizationUser(otherUser, otherOrganization)
-    val otherProject = insertProject(phase = CohortPhase.Phase0DueDiligence)
+    val otherProject = insertProject(phase = AcceleratorPhase.Phase0DueDiligence)
 
     insertProjectModule(userProject, module1)
     insertProjectModule(userProject, module2)

--- a/src/test/kotlin/com/terraformation/backend/accelerator/ParticipantProjectSpeciesServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/ParticipantProjectSpeciesServiceTest.kt
@@ -10,7 +10,7 @@ import com.terraformation.backend.accelerator.event.ParticipantProjectSpeciesAdd
 import com.terraformation.backend.accelerator.model.NewParticipantProjectSpeciesModel
 import com.terraformation.backend.auth.currentUser
 import com.terraformation.backend.db.DatabaseTest
-import com.terraformation.backend.db.accelerator.CohortPhase
+import com.terraformation.backend.db.accelerator.AcceleratorPhase
 import com.terraformation.backend.db.accelerator.DeliverableType
 import com.terraformation.backend.db.accelerator.SubmissionStatus
 import com.terraformation.backend.db.accelerator.tables.pojos.SubmissionSnapshotsRow
@@ -93,7 +93,7 @@ class ParticipantProjectSpeciesServiceTest : DatabaseTest(), RunsAsUser {
   inner class Create {
     @Test
     fun `creates a submission for the project and deliverable if one does not exist for the active module when a species is added to a project`() {
-      val projectId = insertProject(phase = CohortPhase.Phase0DueDiligence)
+      val projectId = insertProject(phase = AcceleratorPhase.Phase0DueDiligence)
       val speciesId = insertSpecies()
       val moduleId = insertModule()
       val deliverableId =
@@ -151,7 +151,7 @@ class ParticipantProjectSpeciesServiceTest : DatabaseTest(), RunsAsUser {
 
     @Test
     fun `does not create another submission for a project if a deliverable submission for the active module already exists`() {
-      val projectId = insertProject(phase = CohortPhase.Phase0DueDiligence)
+      val projectId = insertProject(phase = AcceleratorPhase.Phase0DueDiligence)
       val speciesId = insertSpecies()
       val moduleId = insertModule()
       val deliverableId =
@@ -199,9 +199,9 @@ class ParticipantProjectSpeciesServiceTest : DatabaseTest(), RunsAsUser {
       val deliverableId =
           insertDeliverable(moduleId = moduleId, deliverableTypeId = DeliverableType.Species)
 
-      val projectId1 = insertProject(phase = CohortPhase.Phase0DueDiligence)
+      val projectId1 = insertProject(phase = AcceleratorPhase.Phase0DueDiligence)
       insertProjectModule()
-      val projectId2 = insertProject(phase = CohortPhase.Phase0DueDiligence)
+      val projectId2 = insertProject(phase = AcceleratorPhase.Phase0DueDiligence)
       insertProjectModule()
       val speciesId1 = insertSpecies()
       val speciesId2 = insertSpecies()
@@ -276,7 +276,7 @@ class ParticipantProjectSpeciesServiceTest : DatabaseTest(), RunsAsUser {
       // Between the most recent and future module
       clock.instant = Instant.EPOCH.plus(20, ChronoUnit.DAYS)
 
-      val projectId1 = insertProject(phase = CohortPhase.Phase0DueDiligence)
+      val projectId1 = insertProject(phase = AcceleratorPhase.Phase0DueDiligence)
       insertProjectModule(moduleId = moduleIdOld)
       insertProjectModule(moduleId = moduleIdMostRecent)
       insertProjectModule(
@@ -284,7 +284,7 @@ class ParticipantProjectSpeciesServiceTest : DatabaseTest(), RunsAsUser {
           startDate = LocalDate.EPOCH.plusDays(21),
           moduleId = moduleIdFuture,
       )
-      val projectId2 = insertProject(phase = CohortPhase.Phase0DueDiligence)
+      val projectId2 = insertProject(phase = AcceleratorPhase.Phase0DueDiligence)
       insertProjectModule(moduleId = moduleIdOld)
       insertProjectModule(moduleId = moduleIdMostRecent)
       insertProjectModule(
@@ -344,8 +344,8 @@ class ParticipantProjectSpeciesServiceTest : DatabaseTest(), RunsAsUser {
 
     @Test
     fun `creates an entity for each project ID and species ID pairing even if there isn't any associated deliverable`() {
-      val projectId1 = insertProject(phase = CohortPhase.Phase0DueDiligence)
-      val projectId2 = insertProject(phase = CohortPhase.Phase0DueDiligence)
+      val projectId1 = insertProject(phase = AcceleratorPhase.Phase0DueDiligence)
+      val projectId2 = insertProject(phase = AcceleratorPhase.Phase0DueDiligence)
       val speciesId1 = insertSpecies()
       val speciesId2 = insertSpecies()
 
@@ -371,9 +371,9 @@ class ParticipantProjectSpeciesServiceTest : DatabaseTest(), RunsAsUser {
   inner class UpdateStatusEvent {
     @Test
     fun `updates the status for the participant project species if species fields are edited by non-accelerator-users`() {
-      val projectId1 = insertProject(phase = CohortPhase.Phase0DueDiligence)
-      val projectId2 = insertProject(phase = CohortPhase.Phase0DueDiligence)
-      val projectId3 = insertProject(phase = CohortPhase.Phase0DueDiligence)
+      val projectId1 = insertProject(phase = AcceleratorPhase.Phase0DueDiligence)
+      val projectId2 = insertProject(phase = AcceleratorPhase.Phase0DueDiligence)
+      val projectId3 = insertProject(phase = AcceleratorPhase.Phase0DueDiligence)
       val speciesId = insertSpecies()
 
       val participantProjectSpeciesId1 =
@@ -418,7 +418,7 @@ class ParticipantProjectSpeciesServiceTest : DatabaseTest(), RunsAsUser {
 
     @Test
     fun `does not update the status of the participant project species if the species fields are edited by accelerator-users`() {
-      val projectId = insertProject(phase = CohortPhase.Phase0DueDiligence)
+      val projectId = insertProject(phase = AcceleratorPhase.Phase0DueDiligence)
       val speciesId = insertSpecies()
 
       insertParticipantProjectSpecies(
@@ -454,7 +454,7 @@ class ParticipantProjectSpeciesServiceTest : DatabaseTest(), RunsAsUser {
       val deliverableId =
           insertDeliverable(moduleId = moduleId, deliverableTypeId = DeliverableType.Species)
 
-      val projectId = insertProject(phase = CohortPhase.Phase0DueDiligence)
+      val projectId = insertProject(phase = AcceleratorPhase.Phase0DueDiligence)
       insertProjectModule()
       val submissionId = insertSubmission(deliverableId = deliverableId, projectId = projectId)
 
@@ -524,7 +524,7 @@ class ParticipantProjectSpeciesServiceTest : DatabaseTest(), RunsAsUser {
       val deliverableId =
           insertDeliverable(moduleId = moduleId, deliverableTypeId = DeliverableType.Species)
 
-      val projectId = insertProject(phase = CohortPhase.Phase0DueDiligence)
+      val projectId = insertProject(phase = AcceleratorPhase.Phase0DueDiligence)
       insertProjectModule()
       val submissionId = insertSubmission(deliverableId = deliverableId, projectId = projectId)
 
@@ -560,7 +560,7 @@ class ParticipantProjectSpeciesServiceTest : DatabaseTest(), RunsAsUser {
       val deliverableId =
           insertDeliverable(moduleId = moduleId, deliverableTypeId = DeliverableType.Document)
 
-      val projectId = insertProject(phase = CohortPhase.Phase0DueDiligence)
+      val projectId = insertProject(phase = AcceleratorPhase.Phase0DueDiligence)
       insertProjectModule()
       val submissionId = insertSubmission(deliverableId = deliverableId, projectId = projectId)
 

--- a/src/test/kotlin/com/terraformation/backend/accelerator/PreScreenBoundarySubmissionFetcherTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/PreScreenBoundarySubmissionFetcherTest.kt
@@ -7,7 +7,7 @@ import com.terraformation.backend.accelerator.model.DeliverableSubmissionModel
 import com.terraformation.backend.accelerator.model.SubmissionDocumentModel
 import com.terraformation.backend.customer.model.TerrawareUser
 import com.terraformation.backend.db.DatabaseTest
-import com.terraformation.backend.db.accelerator.CohortPhase
+import com.terraformation.backend.db.accelerator.AcceleratorPhase
 import com.terraformation.backend.db.accelerator.DeliverableCategory
 import com.terraformation.backend.db.accelerator.DeliverableId
 import com.terraformation.backend.db.accelerator.DeliverableType
@@ -42,7 +42,7 @@ class PreScreenBoundarySubmissionFetcherTest : DatabaseTest(), RunsAsUser {
     insertOrganization(name = "Org name")
     insertProject(name = "Project name")
     insertApplication(internalName = "XXX_internalName")
-    insertModule(name = "Pre-screen module", phase = CohortPhase.PreScreen)
+    insertModule(name = "Pre-screen module", phase = AcceleratorPhase.PreScreen)
     insertApplicationModule()
 
     deliverableId =

--- a/src/test/kotlin/com/terraformation/backend/accelerator/ProjectDeliverableSearchTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/ProjectDeliverableSearchTest.kt
@@ -4,7 +4,7 @@ import com.terraformation.backend.RunsAsUser
 import com.terraformation.backend.TestClock
 import com.terraformation.backend.assertJsonEquals
 import com.terraformation.backend.db.DatabaseTest
-import com.terraformation.backend.db.accelerator.CohortPhase
+import com.terraformation.backend.db.accelerator.AcceleratorPhase
 import com.terraformation.backend.db.accelerator.DeliverableCategory
 import com.terraformation.backend.db.accelerator.DeliverableType
 import com.terraformation.backend.db.accelerator.SubmissionStatus
@@ -45,7 +45,7 @@ class ProjectDeliverableSearchTest : DatabaseTest(), RunsAsUser {
         role = Role.Admin,
     )
     insertModule()
-    projectId = insertProject(phase = CohortPhase.Phase0DueDiligence)
+    projectId = insertProject(phase = AcceleratorPhase.Phase0DueDiligence)
     insertProjectModule(
         projectId,
         inserted.moduleId,
@@ -186,7 +186,7 @@ class ProjectDeliverableSearchTest : DatabaseTest(), RunsAsUser {
             submissionStatus = SubmissionStatus.Approved,
         )
 
-    val hiddenProject = insertProject(phase = CohortPhase.Phase0DueDiligence)
+    val hiddenProject = insertProject(phase = AcceleratorPhase.Phase0DueDiligence)
     insertSubmission(
         deliverableId = deliverableWithSubmission,
         projectId = hiddenProject,
@@ -300,7 +300,7 @@ class ProjectDeliverableSearchTest : DatabaseTest(), RunsAsUser {
     val deliverableWithoutSubmissions = insertDeliverable(moduleId = moduleId)
 
     insertOrganization()
-    val otherProject = insertProject(phase = CohortPhase.Phase0DueDiligence)
+    val otherProject = insertProject(phase = AcceleratorPhase.Phase0DueDiligence)
     insertProjectModule()
     insertSubmission(
         deliverableId = deliverableWithSubmission,

--- a/src/test/kotlin/com/terraformation/backend/accelerator/ProjectVariableSearchTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/ProjectVariableSearchTest.kt
@@ -4,7 +4,7 @@ import com.terraformation.backend.RunsAsUser
 import com.terraformation.backend.TestClock
 import com.terraformation.backend.assertJsonEquals
 import com.terraformation.backend.db.DatabaseTest
-import com.terraformation.backend.db.accelerator.CohortPhase
+import com.terraformation.backend.db.accelerator.AcceleratorPhase
 import com.terraformation.backend.db.default_schema.Role
 import com.terraformation.backend.db.docprod.VariableType
 import com.terraformation.backend.i18n.Locales
@@ -41,7 +41,7 @@ class ProjectVariableSearchTest : DatabaseTest(), RunsAsUser {
 
   @Test
   fun `returns variables for project, ignoring old variables`() {
-    val projectId = insertProject(phase = CohortPhase.Phase0DueDiligence)
+    val projectId = insertProject(phase = AcceleratorPhase.Phase0DueDiligence)
 
     val textStableId = "123"
     val numberStableId = "456"
@@ -116,7 +116,7 @@ class ProjectVariableSearchTest : DatabaseTest(), RunsAsUser {
 
   @Test
   fun `can retrieve nested variables from projects`() {
-    val projectId = insertProject(phase = CohortPhase.Phase0DueDiligence)
+    val projectId = insertProject(phase = AcceleratorPhase.Phase0DueDiligence)
     val variableId1 = insertVariable()
     val variableId2 = insertVariable()
     insertValue(variableId = variableId1)
@@ -155,7 +155,7 @@ class ProjectVariableSearchTest : DatabaseTest(), RunsAsUser {
   fun `returns only variables of projects visible to non-accelerator admin users`() {
     every { user.canReadAllAcceleratorDetails() } returns false
 
-    val projectId1 = insertProject(phase = CohortPhase.Phase0DueDiligence)
+    val projectId1 = insertProject(phase = AcceleratorPhase.Phase0DueDiligence)
     val variableId1 = insertVariable()
     insertValue(variableId = variableId1, textValue = "Visible")
 
@@ -192,8 +192,8 @@ class ProjectVariableSearchTest : DatabaseTest(), RunsAsUser {
 
   @Test
   fun `filters by stable id when prefix starts at project`() {
-    val projectId1 = insertProject(name = "Project 1", phase = CohortPhase.Phase0DueDiligence)
-    val projectId2 = insertProject(name = "Project 2", phase = CohortPhase.Phase0DueDiligence)
+    val projectId1 = insertProject(name = "Project 1", phase = AcceleratorPhase.Phase0DueDiligence)
+    val projectId2 = insertProject(name = "Project 2", phase = AcceleratorPhase.Phase0DueDiligence)
 
     val stableId1 = "123"
     val stableId2 = "456"

--- a/src/test/kotlin/com/terraformation/backend/accelerator/ProjectVariableValueSearchTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/ProjectVariableValueSearchTest.kt
@@ -4,7 +4,7 @@ import com.terraformation.backend.RunsAsUser
 import com.terraformation.backend.TestClock
 import com.terraformation.backend.assertJsonEquals
 import com.terraformation.backend.db.DatabaseTest
-import com.terraformation.backend.db.accelerator.CohortPhase
+import com.terraformation.backend.db.accelerator.AcceleratorPhase
 import com.terraformation.backend.db.default_schema.Role
 import com.terraformation.backend.db.docprod.VariableType
 import com.terraformation.backend.i18n.Locales
@@ -43,7 +43,7 @@ class ProjectVariableValueSearchTest : DatabaseTest(), RunsAsUser {
 
   @Test
   fun `returns variable values for project, ignoring old values`() {
-    val projectId = insertProject(phase = CohortPhase.Phase0DueDiligence)
+    val projectId = insertProject(phase = AcceleratorPhase.Phase0DueDiligence)
 
     val textStableId = "123"
     val numberStableId = "456"
@@ -201,7 +201,7 @@ class ProjectVariableValueSearchTest : DatabaseTest(), RunsAsUser {
 
   @Test
   fun `can retrieve nested variableValues from projects`() {
-    val projectId = insertProject(phase = CohortPhase.Phase0DueDiligence)
+    val projectId = insertProject(phase = AcceleratorPhase.Phase0DueDiligence)
     val variableId1 = insertVariable()
     val variableId2 = insertVariable()
     val valueId1 = insertValue(variableId = variableId1)
@@ -243,7 +243,7 @@ class ProjectVariableValueSearchTest : DatabaseTest(), RunsAsUser {
 
   @Test
   fun `old variable with value doesn't show up when new version does not have value`() {
-    val projectId = insertProject(phase = CohortPhase.Phase0DueDiligence)
+    val projectId = insertProject(phase = AcceleratorPhase.Phase0DueDiligence)
     val stableId = "123"
     val oldVariableId = insertVariable(stableId = stableId)
     insertVariable(stableId = stableId, replacesVariableId = oldVariableId)
@@ -273,7 +273,7 @@ class ProjectVariableValueSearchTest : DatabaseTest(), RunsAsUser {
 
   @Test
   fun `deleted values exclude the variables fully`() {
-    insertProject(phase = CohortPhase.Phase0DueDiligence)
+    insertProject(phase = AcceleratorPhase.Phase0DueDiligence)
     val variableId1 = insertVariable()
     val variableId2 = insertVariable()
     insertValue(variableId = variableId1, textValue = "Value1")
@@ -301,7 +301,7 @@ class ProjectVariableValueSearchTest : DatabaseTest(), RunsAsUser {
   fun `returns only variables of projects visible to non-accelerator admin users`() {
     every { user.canReadAllAcceleratorDetails() } returns false
 
-    val projectId1 = insertProject(phase = CohortPhase.Phase0DueDiligence)
+    val projectId1 = insertProject(phase = AcceleratorPhase.Phase0DueDiligence)
     val variableId1 = insertVariable()
     val valueId1 = insertValue(variableId = variableId1, textValue = "Visible")
 

--- a/src/test/kotlin/com/terraformation/backend/accelerator/SpeciesNotifierTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/SpeciesNotifierTest.kt
@@ -12,7 +12,7 @@ import com.terraformation.backend.accelerator.model.ExistingParticipantProjectSp
 import com.terraformation.backend.assertIsEventListener
 import com.terraformation.backend.customer.model.TerrawareUser
 import com.terraformation.backend.db.DatabaseTest
-import com.terraformation.backend.db.accelerator.CohortPhase
+import com.terraformation.backend.db.accelerator.AcceleratorPhase
 import com.terraformation.backend.db.accelerator.DeliverableId
 import com.terraformation.backend.db.accelerator.DeliverableType
 import com.terraformation.backend.db.accelerator.ParticipantProjectSpeciesId
@@ -44,7 +44,7 @@ class SpeciesNotifierTest : DatabaseTest(), RunsAsUser {
     insertOrganization()
     insertModule()
 
-    projectId = insertProject(phase = CohortPhase.Phase0DueDiligence)
+    projectId = insertProject(phase = AcceleratorPhase.Phase0DueDiligence)
     insertProjectModule()
     deliverableId = insertDeliverable(deliverableTypeId = DeliverableType.Species)
 

--- a/src/test/kotlin/com/terraformation/backend/accelerator/SpeciesSubmissionUpdaterTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/SpeciesSubmissionUpdaterTest.kt
@@ -9,7 +9,7 @@ import com.terraformation.backend.accelerator.model.ExistingParticipantProjectSp
 import com.terraformation.backend.auth.currentUser
 import com.terraformation.backend.customer.model.TerrawareUser
 import com.terraformation.backend.db.DatabaseTest
-import com.terraformation.backend.db.accelerator.CohortPhase
+import com.terraformation.backend.db.accelerator.AcceleratorPhase
 import com.terraformation.backend.db.accelerator.DeliverableType
 import com.terraformation.backend.db.accelerator.SubmissionStatus
 import com.terraformation.backend.db.accelerator.tables.pojos.SubmissionsRow
@@ -47,7 +47,7 @@ class SpeciesSubmissionUpdaterTest : DatabaseTest(), RunsAsUser {
   inner class ResetSubmission {
     @Test
     fun `resets the submission status if it exists and is currently 'Approved'`() {
-      val projectId = insertProject(phase = CohortPhase.Phase0DueDiligence)
+      val projectId = insertProject(phase = AcceleratorPhase.Phase0DueDiligence)
       val speciesId = insertSpecies()
       val moduleId = insertModule()
       val deliverableId =
@@ -100,7 +100,7 @@ class SpeciesSubmissionUpdaterTest : DatabaseTest(), RunsAsUser {
 
     @Test
     fun `does nothing if the submission status is not 'Approved'`() {
-      val projectId = insertProject(phase = CohortPhase.Phase0DueDiligence)
+      val projectId = insertProject(phase = AcceleratorPhase.Phase0DueDiligence)
       val speciesId = insertSpecies()
       val moduleId = insertModule()
       val deliverableId =

--- a/src/test/kotlin/com/terraformation/backend/accelerator/VoteServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/VoteServiceTest.kt
@@ -9,7 +9,7 @@ import com.terraformation.backend.assertIsEventListener
 import com.terraformation.backend.customer.model.SystemUser
 import com.terraformation.backend.customer.model.TerrawareUser
 import com.terraformation.backend.db.DatabaseTest
-import com.terraformation.backend.db.accelerator.CohortPhase
+import com.terraformation.backend.db.accelerator.AcceleratorPhase
 import com.terraformation.backend.db.accelerator.VoteOption
 import com.terraformation.backend.db.accelerator.tables.records.ProjectVotesRecord
 import com.terraformation.backend.db.default_schema.ProjectId
@@ -49,12 +49,12 @@ class VoteServiceTest : DatabaseTest(), RunsAsDatabaseUser {
   inner class ProjectPhaseUpdated {
     @Test
     fun `inserts voters`() {
-      val projectId1 = insertProject(phase = CohortPhase.Phase0DueDiligence)
+      val projectId1 = insertProject(phase = AcceleratorPhase.Phase0DueDiligence)
 
       // Should leave this one alone
-      insertProject(phase = CohortPhase.Phase0DueDiligence)
+      insertProject(phase = AcceleratorPhase.Phase0DueDiligence)
 
-      service.on(ProjectPhaseUpdatedEvent(projectId1, CohortPhase.Phase0DueDiligence))
+      service.on(ProjectPhaseUpdatedEvent(projectId1, AcceleratorPhase.Phase0DueDiligence))
 
       assertTableEquals(
           setOf(
@@ -73,7 +73,7 @@ class VoteServiceTest : DatabaseTest(), RunsAsDatabaseUser {
   private fun votesRecord(
       userId: UserId,
       projectId: ProjectId = inserted.projectId,
-      phase: CohortPhase = CohortPhase.Phase0DueDiligence,
+      phase: AcceleratorPhase = AcceleratorPhase.Phase0DueDiligence,
       createdTime: Instant = clock.instant,
       voteOption: VoteOption? = null,
       conditionalInfo: String? = null,

--- a/src/test/kotlin/com/terraformation/backend/accelerator/api/ParticipantProjectSpeciesControllerTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/api/ParticipantProjectSpeciesControllerTest.kt
@@ -1,7 +1,7 @@
 package com.terraformation.backend.accelerator.api
 
 import com.terraformation.backend.api.ControllerIntegrationTest
-import com.terraformation.backend.db.accelerator.CohortPhase
+import com.terraformation.backend.db.accelerator.AcceleratorPhase
 import com.terraformation.backend.db.accelerator.DeliverableCategory
 import com.terraformation.backend.db.accelerator.DeliverableType
 import com.terraformation.backend.db.accelerator.SubmissionStatus
@@ -17,10 +17,10 @@ class ParticipantProjectSpeciesControllerTest : ControllerIntegrationTest() {
   inner class CreateParticipantProjectSpecies {
     @Test
     fun `can add species to approved species list`() {
-      insertModule(phase = CohortPhase.Phase1FeasibilityStudy)
+      insertModule(phase = AcceleratorPhase.Phase1FeasibilityStudy)
       insertOrganization()
       insertOrganizationUser(role = Role.Owner)
-      val projectId = insertProject(phase = CohortPhase.Phase0DueDiligence)
+      val projectId = insertProject(phase = AcceleratorPhase.Phase0DueDiligence)
       val speciesId = insertSpecies()
       insertProjectModule()
       insertDeliverable(

--- a/src/test/kotlin/com/terraformation/backend/accelerator/db/AcceleratorOrganizationStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/db/AcceleratorOrganizationStoreTest.kt
@@ -6,7 +6,7 @@ import com.terraformation.backend.customer.model.InternalTagIds
 import com.terraformation.backend.customer.model.OrganizationModel
 import com.terraformation.backend.customer.model.TerrawareUser
 import com.terraformation.backend.db.DatabaseTest
-import com.terraformation.backend.db.accelerator.CohortPhase
+import com.terraformation.backend.db.accelerator.AcceleratorPhase
 import com.terraformation.backend.db.default_schema.GlobalRole
 import java.time.Instant
 import org.junit.jupiter.api.Assertions.*
@@ -43,7 +43,7 @@ class AcceleratorOrganizationStoreTest : DatabaseTest(), RunsAsDatabaseUser {
           insertProject(
               organizationId = acceleratorOrgId1,
               name = "D",
-              phase = CohortPhase.Phase0DueDiligence,
+              phase = AcceleratorPhase.Phase0DueDiligence,
           )
       val unassignedProjectId1 = insertProject(organizationId = acceleratorOrgId1, name = "A")
 
@@ -93,7 +93,7 @@ class AcceleratorOrganizationStoreTest : DatabaseTest(), RunsAsDatabaseUser {
                           modifiedTime = Instant.EPOCH,
                           name = "D",
                           organizationId = acceleratorOrgId1,
-                          phase = CohortPhase.Phase0DueDiligence,
+                          phase = AcceleratorPhase.Phase0DueDiligence,
                       ),
                   ),
               OrganizationModel(

--- a/src/test/kotlin/com/terraformation/backend/accelerator/db/ActivityStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/db/ActivityStoreTest.kt
@@ -13,11 +13,11 @@ import com.terraformation.backend.customer.db.ParentStore
 import com.terraformation.backend.customer.model.TerrawareUser
 import com.terraformation.backend.db.DatabaseTest
 import com.terraformation.backend.db.ProjectNotFoundException
+import com.terraformation.backend.db.accelerator.AcceleratorPhase
 import com.terraformation.backend.db.accelerator.ActivityId
 import com.terraformation.backend.db.accelerator.ActivityMediaType
 import com.terraformation.backend.db.accelerator.ActivityStatus
 import com.terraformation.backend.db.accelerator.ActivityType
-import com.terraformation.backend.db.accelerator.CohortPhase
 import com.terraformation.backend.db.accelerator.tables.records.ActivitiesRecord
 import com.terraformation.backend.db.accelerator.tables.references.ACTIVITIES
 import com.terraformation.backend.db.default_schema.GlobalRole
@@ -49,7 +49,7 @@ class ActivityStoreTest : DatabaseTest(), RunsAsDatabaseUser {
   @BeforeEach
   fun setUp() {
     insertOrganization()
-    projectId = insertProject(phase = CohortPhase.Phase0DueDiligence)
+    projectId = insertProject(phase = AcceleratorPhase.Phase0DueDiligence)
   }
 
   @Nested

--- a/src/test/kotlin/com/terraformation/backend/accelerator/db/ActivityStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/db/ActivityStoreTest.kt
@@ -152,7 +152,7 @@ class ActivityStoreTest : DatabaseTest(), RunsAsDatabaseUser {
               projectId = projectId,
           )
 
-      assertThrows<ProjectNotInCohortPhaseException> { store.create(model) }
+      assertThrows<ProjectNotInAcceleratorPhaseException> { store.create(model) }
     }
   }
 

--- a/src/test/kotlin/com/terraformation/backend/accelerator/db/ApplicationStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/db/ApplicationStoreTest.kt
@@ -17,10 +17,10 @@ import com.terraformation.backend.customer.model.TerrawareUser
 import com.terraformation.backend.db.DatabaseTest
 import com.terraformation.backend.db.OrganizationNotFoundException
 import com.terraformation.backend.db.ProjectNotFoundException
+import com.terraformation.backend.db.accelerator.AcceleratorPhase
 import com.terraformation.backend.db.accelerator.ApplicationId
 import com.terraformation.backend.db.accelerator.ApplicationModuleStatus
 import com.terraformation.backend.db.accelerator.ApplicationStatus
-import com.terraformation.backend.db.accelerator.CohortPhase
 import com.terraformation.backend.db.accelerator.DeliverableCategory
 import com.terraformation.backend.db.accelerator.DeliverableId
 import com.terraformation.backend.db.accelerator.DeliverableType
@@ -101,9 +101,9 @@ class ApplicationStoreTest : DatabaseTest(), RunsAsUser {
   inner class Create {
     @Test
     fun `populates initial values and creates history entry`() {
-      val prescreenModuleId = insertModule(phase = CohortPhase.PreScreen)
-      val applicationModuleId = insertModule(phase = CohortPhase.Application)
-      insertModule(name = "Not assigned", phase = CohortPhase.Phase1FeasibilityStudy)
+      val prescreenModuleId = insertModule(phase = AcceleratorPhase.PreScreen)
+      val applicationModuleId = insertModule(phase = AcceleratorPhase.Application)
+      insertModule(name = "Not assigned", phase = AcceleratorPhase.Phase1FeasibilityStudy)
       val now = Instant.ofEpochSecond(30)
       clock.instant = now
 
@@ -539,13 +539,13 @@ class ApplicationStoreTest : DatabaseTest(), RunsAsUser {
             insertModule(
                 name = "Pre-screen",
                 overview = "Pre-screen Overview",
-                phase = CohortPhase.PreScreen,
+                phase = AcceleratorPhase.PreScreen,
             )
         val applicationModule2 =
             insertModule(
                 name = "Application 2",
                 overview = "Application 2 Overview",
-                phase = CohortPhase.Application,
+                phase = AcceleratorPhase.Application,
                 position = 2,
             )
 
@@ -553,10 +553,10 @@ class ApplicationStoreTest : DatabaseTest(), RunsAsUser {
             insertModule(
                 name = "Application 1",
                 overview = "Application 1 Overview",
-                phase = CohortPhase.Application,
+                phase = AcceleratorPhase.Application,
                 position = 1,
             )
-        insertModule(name = "Hidden module", phase = CohortPhase.Phase1FeasibilityStudy)
+        insertModule(name = "Hidden module", phase = AcceleratorPhase.Phase1FeasibilityStudy)
 
         insertApplicationModule(
             inserted.applicationId,
@@ -579,7 +579,7 @@ class ApplicationStoreTest : DatabaseTest(), RunsAsUser {
                 ApplicationModuleModel(
                     id = prescreenModule,
                     name = "Pre-screen",
-                    phase = CohortPhase.PreScreen,
+                    phase = AcceleratorPhase.PreScreen,
                     overview = "Pre-screen Overview",
                     applicationId = inserted.applicationId,
                     applicationModuleStatus = ApplicationModuleStatus.Complete,
@@ -587,7 +587,7 @@ class ApplicationStoreTest : DatabaseTest(), RunsAsUser {
                 ApplicationModuleModel(
                     id = applicationModule1,
                     name = "Application 1",
-                    phase = CohortPhase.Application,
+                    phase = AcceleratorPhase.Application,
                     overview = "Application 1 Overview",
                     applicationId = inserted.applicationId,
                     applicationModuleStatus = ApplicationModuleStatus.Incomplete,
@@ -595,7 +595,7 @@ class ApplicationStoreTest : DatabaseTest(), RunsAsUser {
                 ApplicationModuleModel(
                     id = applicationModule2,
                     name = "Application 2",
-                    phase = CohortPhase.Application,
+                    phase = AcceleratorPhase.Application,
                     overview = "Application 2 Overview",
                     applicationId = inserted.applicationId,
                     applicationModuleStatus = ApplicationModuleStatus.Incomplete,
@@ -648,13 +648,13 @@ class ApplicationStoreTest : DatabaseTest(), RunsAsUser {
             insertModule(
                 name = "Pre-screen",
                 overview = "Pre-screen Overview",
-                phase = CohortPhase.PreScreen,
+                phase = AcceleratorPhase.PreScreen,
             )
         applicationModuleId =
             insertModule(
                 name = "Application",
                 overview = "Application Overview",
-                phase = CohortPhase.Application,
+                phase = AcceleratorPhase.Application,
             )
 
         // Extra module only for org 2 project 1, not visible to Org 1.
@@ -662,7 +662,7 @@ class ApplicationStoreTest : DatabaseTest(), RunsAsUser {
             insertModule(
                 name = "Extra Application",
                 overview = "Extra Application Overview",
-                phase = CohortPhase.Application,
+                phase = AcceleratorPhase.Application,
             )
 
         insertApplicationModule(org1Project1ApplicationId, prescreenModuleId)
@@ -1585,9 +1585,9 @@ class ApplicationStoreTest : DatabaseTest(), RunsAsUser {
       val boundary = Turtle(point(-100, 41)).makePolygon { rectangle(10000, 20000) }
       val applicationId = insertApplication(boundary = boundary, createdBy = otherUserId)
       val initial = applicationsDao.findAll().single()
-      val moduleId1 = insertModule(phase = CohortPhase.Application)
-      val moduleId2 = insertModule(phase = CohortPhase.Application)
-      insertModule(phase = CohortPhase.PreScreen)
+      val moduleId1 = insertModule(phase = AcceleratorPhase.Application)
+      val moduleId2 = insertModule(phase = AcceleratorPhase.Application)
+      insertModule(phase = AcceleratorPhase.PreScreen)
 
       clock.instant = Instant.ofEpochSecond(30)
 
@@ -1642,8 +1642,8 @@ class ApplicationStoreTest : DatabaseTest(), RunsAsUser {
           insertApplication(createdBy = otherUserId, status = ApplicationStatus.PassedPreScreen)
       val initial = applicationsDao.findAll().single()
 
-      val moduleId1 = insertModule(phase = CohortPhase.Application)
-      val moduleId2 = insertModule(phase = CohortPhase.Application)
+      val moduleId1 = insertModule(phase = AcceleratorPhase.Application)
+      val moduleId2 = insertModule(phase = AcceleratorPhase.Application)
 
       insertApplicationModule(applicationId, moduleId1, ApplicationModuleStatus.Complete)
       insertApplicationModule(applicationId, moduleId2, ApplicationModuleStatus.Complete)
@@ -1685,8 +1685,8 @@ class ApplicationStoreTest : DatabaseTest(), RunsAsUser {
           insertApplication(createdBy = otherUserId, status = ApplicationStatus.PassedPreScreen)
       val initial = applicationsDao.findAll()
 
-      val moduleId1 = insertModule(phase = CohortPhase.Application)
-      val moduleId2 = insertModule(phase = CohortPhase.Application)
+      val moduleId1 = insertModule(phase = AcceleratorPhase.Application)
+      val moduleId2 = insertModule(phase = AcceleratorPhase.Application)
 
       insertApplicationModule(applicationId, moduleId1, ApplicationModuleStatus.Complete)
       insertApplicationModule(applicationId, moduleId2, ApplicationModuleStatus.Incomplete)
@@ -1701,8 +1701,8 @@ class ApplicationStoreTest : DatabaseTest(), RunsAsUser {
     fun `does not update existing module status on resubmit`() {
       val boundary = Turtle(point(-100, 41)).makePolygon { rectangle(10000, 20000) }
       val applicationId = insertApplication(boundary = boundary)
-      val moduleId1 = insertModule(phase = CohortPhase.Application)
-      val moduleId2 = insertModule(phase = CohortPhase.Application)
+      val moduleId1 = insertModule(phase = AcceleratorPhase.Application)
+      val moduleId2 = insertModule(phase = AcceleratorPhase.Application)
 
       insertApplicationModule(applicationId, moduleId1, ApplicationModuleStatus.Complete)
 

--- a/src/test/kotlin/com/terraformation/backend/accelerator/db/DeliverableDueDateStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/db/DeliverableDueDateStoreTest.kt
@@ -4,7 +4,7 @@ import com.terraformation.backend.RunsAsUser
 import com.terraformation.backend.accelerator.model.DeliverableDueDateModel
 import com.terraformation.backend.assertSetEquals
 import com.terraformation.backend.db.DatabaseTest
-import com.terraformation.backend.db.accelerator.CohortPhase
+import com.terraformation.backend.db.accelerator.AcceleratorPhase
 import com.terraformation.backend.db.accelerator.tables.pojos.DeliverableProjectDueDatesRow
 import com.terraformation.backend.db.accelerator.tables.references.DELIVERABLE_PROJECT_DUE_DATES
 import com.terraformation.backend.mockUser
@@ -34,8 +34,8 @@ class DeliverableDueDateStoreTest : DatabaseTest(), RunsAsUser {
   inner class FetchDeliverableDueDates {
     @Test
     fun `can filter by IDs`() {
-      val projectId1 = insertProject(phase = CohortPhase.Phase0DueDiligence)
-      val projectId2 = insertProject(phase = CohortPhase.Phase1FeasibilityStudy)
+      val projectId1 = insertProject(phase = AcceleratorPhase.Phase0DueDiligence)
+      val projectId2 = insertProject(phase = AcceleratorPhase.Phase1FeasibilityStudy)
 
       val moduleId1 = insertModule()
       val moduleId2 = insertModule()
@@ -190,7 +190,7 @@ class DeliverableDueDateStoreTest : DatabaseTest(), RunsAsUser {
       every { user.canReadAllDeliverables() } returns false
 
       insertModule()
-      insertProject(phase = CohortPhase.Phase0DueDiligence)
+      insertProject(phase = AcceleratorPhase.Phase0DueDiligence)
       insertProjectModule()
       insertDeliverable()
 
@@ -205,9 +205,9 @@ class DeliverableDueDateStoreTest : DatabaseTest(), RunsAsUser {
       insertModule()
       insertDeliverable()
 
-      val projectToUpdate = insertProject(phase = CohortPhase.Phase0DueDiligence)
+      val projectToUpdate = insertProject(phase = AcceleratorPhase.Phase0DueDiligence)
       insertProjectModule()
-      val projectToInsert = insertProject(phase = CohortPhase.Phase0DueDiligence)
+      val projectToInsert = insertProject(phase = AcceleratorPhase.Phase0DueDiligence)
       insertProjectModule()
 
       insertDeliverableProjectDueDate(
@@ -250,7 +250,7 @@ class DeliverableDueDateStoreTest : DatabaseTest(), RunsAsUser {
       insertModule()
       insertDeliverable()
 
-      val projectId = insertProject(phase = CohortPhase.Phase0DueDiligence)
+      val projectId = insertProject(phase = AcceleratorPhase.Phase0DueDiligence)
       insertProjectModule()
 
       assertThrows<AccessDeniedException> {
@@ -270,7 +270,7 @@ class DeliverableDueDateStoreTest : DatabaseTest(), RunsAsUser {
       insertModule()
       insertDeliverable()
 
-      val projectId = insertProject(phase = CohortPhase.Phase0DueDiligence)
+      val projectId = insertProject(phase = AcceleratorPhase.Phase0DueDiligence)
       insertProjectModule()
 
       insertDeliverableProjectDueDate(
@@ -303,7 +303,7 @@ class DeliverableDueDateStoreTest : DatabaseTest(), RunsAsUser {
       insertModule()
       insertDeliverable()
 
-      val projectId = insertProject(phase = CohortPhase.Phase0DueDiligence)
+      val projectId = insertProject(phase = AcceleratorPhase.Phase0DueDiligence)
       insertProjectModule()
 
       insertDeliverableProjectDueDate(

--- a/src/test/kotlin/com/terraformation/backend/accelerator/db/DeliverableStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/db/DeliverableStoreTest.kt
@@ -7,7 +7,7 @@ import com.terraformation.backend.accelerator.model.SubmissionDocumentModel
 import com.terraformation.backend.db.DatabaseTest
 import com.terraformation.backend.db.OrganizationNotFoundException
 import com.terraformation.backend.db.ProjectNotFoundException
-import com.terraformation.backend.db.accelerator.CohortPhase
+import com.terraformation.backend.db.accelerator.AcceleratorPhase
 import com.terraformation.backend.db.accelerator.DeliverableCategory
 import com.terraformation.backend.db.accelerator.DeliverableType
 import com.terraformation.backend.db.accelerator.DocumentStore
@@ -67,10 +67,10 @@ class DeliverableStoreTest : DatabaseTest(), RunsAsUser {
       clock.instant = now
 
       val organizationId1 = insertOrganization()
-      val projectId1 = insertProject(phase = CohortPhase.Phase0DueDiligence)
-      val projectId2 = insertProject(phase = CohortPhase.Phase1FeasibilityStudy)
+      val projectId1 = insertProject(phase = AcceleratorPhase.Phase0DueDiligence)
+      val projectId2 = insertProject(phase = AcceleratorPhase.Phase1FeasibilityStudy)
       val organizationId2 = insertOrganization()
-      val projectId3 = insertProject(phase = CohortPhase.Phase0DueDiligence)
+      val projectId3 = insertProject(phase = AcceleratorPhase.Phase0DueDiligence)
       val projectId4 = insertProject()
 
       val moduleId1 = insertModule(name = "Name 1")
@@ -365,10 +365,10 @@ class DeliverableStoreTest : DatabaseTest(), RunsAsUser {
       val documentId = insertSubmissionDocument()
 
       // Pre-screen and application submissions should not be included
-      insertModule(phase = CohortPhase.PreScreen)
+      insertModule(phase = AcceleratorPhase.PreScreen)
       insertDeliverable()
       insertSubmission()
-      insertModule(phase = CohortPhase.Application)
+      insertModule(phase = AcceleratorPhase.Application)
       insertDeliverable()
       insertSubmission()
 
@@ -420,7 +420,7 @@ class DeliverableStoreTest : DatabaseTest(), RunsAsUser {
     fun `returns application submissions for non-participant projects if deliverable ID is specified`() {
       val organizationId = insertOrganization()
       val projectId = insertProject()
-      val moduleId = insertModule(phase = CohortPhase.PreScreen)
+      val moduleId = insertModule(phase = AcceleratorPhase.PreScreen)
       val deliverableId = insertDeliverable()
       val submissionId = insertSubmission(submissionStatus = SubmissionStatus.Approved)
       val documentId = insertSubmissionDocument()
@@ -472,11 +472,11 @@ class DeliverableStoreTest : DatabaseTest(), RunsAsUser {
     @Test
     fun `returns application submissions for participant projects if deliverable ID is specified`() {
       val organizationId = insertOrganization()
-      val projectId = insertProject(phase = CohortPhase.Phase0DueDiligence)
-      val moduleId = insertModule(phase = CohortPhase.PreScreen)
+      val projectId = insertProject(phase = AcceleratorPhase.Phase0DueDiligence)
+      val moduleId = insertModule(phase = AcceleratorPhase.PreScreen)
       val deliverableId = insertDeliverable()
       val submissionId = insertSubmission(submissionStatus = SubmissionStatus.Approved)
-      insertModule(phase = CohortPhase.Phase0DueDiligence)
+      insertModule(phase = AcceleratorPhase.Phase0DueDiligence)
       insertProjectModule()
 
       assertEquals(
@@ -516,7 +516,7 @@ class DeliverableStoreTest : DatabaseTest(), RunsAsUser {
     fun `returns default submission for non-participant project if deliverable and project IDs are specified`() {
       val organizationId = insertOrganization()
       val projectId = insertProject()
-      val moduleId = insertModule(phase = CohortPhase.PreScreen)
+      val moduleId = insertModule(phase = AcceleratorPhase.PreScreen)
       val deliverableId = insertDeliverable()
 
       assertEquals(
@@ -559,8 +559,8 @@ class DeliverableStoreTest : DatabaseTest(), RunsAsUser {
 
       insertOrganization()
 
-      val projectWithProjectDueDate = insertProject(phase = CohortPhase.Phase0DueDiligence)
-      val projectWithDefaultDueDate = insertProject(phase = CohortPhase.Phase0DueDiligence)
+      val projectWithProjectDueDate = insertProject(phase = AcceleratorPhase.Phase0DueDiligence)
+      val projectWithDefaultDueDate = insertProject(phase = AcceleratorPhase.Phase0DueDiligence)
 
       val projectModuleEndDate = LocalDate.of(2024, 1, 2)
 

--- a/src/test/kotlin/com/terraformation/backend/accelerator/db/ModuleEventStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/db/ModuleEventStoreTest.kt
@@ -9,7 +9,7 @@ import com.terraformation.backend.accelerator.model.EventModel
 import com.terraformation.backend.assertSetEquals
 import com.terraformation.backend.db.DatabaseTest
 import com.terraformation.backend.db.EventNotFoundException
-import com.terraformation.backend.db.accelerator.CohortPhase
+import com.terraformation.backend.db.accelerator.AcceleratorPhase
 import com.terraformation.backend.db.accelerator.EventId
 import com.terraformation.backend.db.accelerator.EventStatus
 import com.terraformation.backend.db.accelerator.EventType
@@ -47,7 +47,7 @@ class ModuleEventStoreTest : DatabaseTest(), RunsAsUser {
   @BeforeEach
   fun setUp() {
     insertOrganization()
-    projectId = insertProject(phase = CohortPhase.Phase0DueDiligence)
+    projectId = insertProject(phase = AcceleratorPhase.Phase0DueDiligence)
     moduleId =
         insertModule(
             liveSessionDescription = "Live session description",
@@ -83,8 +83,8 @@ class ModuleEventStoreTest : DatabaseTest(), RunsAsUser {
       val startTime = clock.instant.plusSeconds(3600)
       val endTime = startTime.plusSeconds(3600)
       val project1 = projectId
-      val project2 = insertProject(phase = CohortPhase.Phase0DueDiligence)
-      val invisibleProject = insertProject(phase = CohortPhase.Phase0DueDiligence)
+      val project2 = insertProject(phase = AcceleratorPhase.Phase0DueDiligence)
+      val invisibleProject = insertProject(phase = AcceleratorPhase.Phase0DueDiligence)
 
       val workshop =
           insertEvent(
@@ -134,8 +134,8 @@ class ModuleEventStoreTest : DatabaseTest(), RunsAsUser {
       val time4 = time3.plusSeconds(3600)
 
       val project1 = projectId
-      val project2 = insertProject(phase = CohortPhase.Phase0DueDiligence)
-      val invisibleProject = insertProject(phase = CohortPhase.Phase0DueDiligence)
+      val project2 = insertProject(phase = AcceleratorPhase.Phase0DueDiligence)
+      val invisibleProject = insertProject(phase = AcceleratorPhase.Phase0DueDiligence)
 
       val otherModule = insertModule(oneOnOneSessionDescription = "1:1 description")
       insertProjectModule(projectId = project1)
@@ -364,7 +364,7 @@ class ModuleEventStoreTest : DatabaseTest(), RunsAsUser {
       clock.instant = Instant.EPOCH.plusSeconds(500)
       val startTime = clock.instant.plusSeconds(3600)
       val project1 = projectId
-      val project2 = insertProject(phase = CohortPhase.Phase0DueDiligence)
+      val project2 = insertProject(phase = AcceleratorPhase.Phase0DueDiligence)
       val model =
           store.create(
               moduleId,

--- a/src/test/kotlin/com/terraformation/backend/accelerator/db/ModuleStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/db/ModuleStoreTest.kt
@@ -175,23 +175,23 @@ class ModuleStoreTest : DatabaseTest(), RunsAsUser {
   }
 
   @Nested
-  inner class FetchCohortPhase {
+  inner class FetchAcceleratorPhase {
     @Test
-    fun `returns module cohort phase`() {
+    fun `returns module accelerator phase`() {
       val moduleId = insertModule(phase = AcceleratorPhase.Phase1FeasibilityStudy)
-      assertEquals(AcceleratorPhase.Phase1FeasibilityStudy, store.fetchCohortPhase(moduleId))
+      assertEquals(AcceleratorPhase.Phase1FeasibilityStudy, store.fetchAcceleratorPhase(moduleId))
     }
 
     @Test
     fun `throws exception if no permission to read module`() {
       val moduleId = insertModule()
       every { user.canReadModule(any()) } returns false
-      assertThrows<ModuleNotFoundException> { store.fetchCohortPhase(moduleId) }
+      assertThrows<ModuleNotFoundException> { store.fetchAcceleratorPhase(moduleId) }
     }
 
     @Test
     fun `throws exception if no module found`() {
-      assertThrows<ModuleNotFoundException> { store.fetchCohortPhase(ModuleId(-1)) }
+      assertThrows<ModuleNotFoundException> { store.fetchAcceleratorPhase(ModuleId(-1)) }
     }
   }
 }

--- a/src/test/kotlin/com/terraformation/backend/accelerator/db/ModuleStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/db/ModuleStoreTest.kt
@@ -3,7 +3,7 @@ package com.terraformation.backend.accelerator.db
 import com.terraformation.backend.RunsAsUser
 import com.terraformation.backend.accelerator.model.ModuleModel
 import com.terraformation.backend.db.DatabaseTest
-import com.terraformation.backend.db.accelerator.CohortPhase
+import com.terraformation.backend.db.accelerator.AcceleratorPhase
 import com.terraformation.backend.db.accelerator.EventType
 import com.terraformation.backend.db.accelerator.ModuleId
 import com.terraformation.backend.db.default_schema.ProjectId
@@ -27,7 +27,7 @@ class ModuleStoreTest : DatabaseTest(), RunsAsUser {
   @BeforeEach
   fun setUp() {
     insertOrganization()
-    projectId = insertProject(phase = CohortPhase.Phase0DueDiligence)
+    projectId = insertProject(phase = AcceleratorPhase.Phase0DueDiligence)
 
     every { user.canManageModules() } returns true
     every { user.canReadModule(any()) } returns true
@@ -70,7 +70,7 @@ class ModuleStoreTest : DatabaseTest(), RunsAsUser {
               oneOnOneSessionDescription = "1:1 meetings",
               overview = "<h> Overview </h>",
               preparationMaterials = "<i> Preps </i>",
-              phase = CohortPhase.Phase1FeasibilityStudy,
+              phase = AcceleratorPhase.Phase1FeasibilityStudy,
               workshopDescription = "Workshop ideas",
           )
 
@@ -78,7 +78,7 @@ class ModuleStoreTest : DatabaseTest(), RunsAsUser {
           ModuleModel(
               id = moduleId,
               name = "TestModule",
-              phase = CohortPhase.Phase1FeasibilityStudy,
+              phase = AcceleratorPhase.Phase1FeasibilityStudy,
               position = 1,
               additionalResources = "<b> Additional Resources </b>",
               eventDescriptions =
@@ -130,7 +130,7 @@ class ModuleStoreTest : DatabaseTest(), RunsAsUser {
               oneOnOneSessionDescription = "1:1 meetings",
               overview = "<h> Overview </h>",
               preparationMaterials = "<i> Preps </i>",
-              phase = CohortPhase.Phase1FeasibilityStudy,
+              phase = AcceleratorPhase.Phase1FeasibilityStudy,
               workshopDescription = "Workshop ideas",
           )
 
@@ -148,7 +148,7 @@ class ModuleStoreTest : DatabaseTest(), RunsAsUser {
               ModuleModel(
                   id = moduleId,
                   name = "TestModule",
-                  phase = CohortPhase.Phase1FeasibilityStudy,
+                  phase = AcceleratorPhase.Phase1FeasibilityStudy,
                   position = 1,
                   additionalResources = "<b> Additional Resources </b>",
                   eventDescriptions =
@@ -178,8 +178,8 @@ class ModuleStoreTest : DatabaseTest(), RunsAsUser {
   inner class FetchCohortPhase {
     @Test
     fun `returns module cohort phase`() {
-      val moduleId = insertModule(phase = CohortPhase.Phase1FeasibilityStudy)
-      assertEquals(CohortPhase.Phase1FeasibilityStudy, store.fetchCohortPhase(moduleId))
+      val moduleId = insertModule(phase = AcceleratorPhase.Phase1FeasibilityStudy)
+      assertEquals(AcceleratorPhase.Phase1FeasibilityStudy, store.fetchCohortPhase(moduleId))
     }
 
     @Test

--- a/src/test/kotlin/com/terraformation/backend/accelerator/db/ModulesImporterTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/db/ModulesImporterTest.kt
@@ -5,7 +5,7 @@ import com.terraformation.backend.TestClock
 import com.terraformation.backend.TestEventPublisher
 import com.terraformation.backend.accelerator.event.ModulesUploadedEvent
 import com.terraformation.backend.db.DatabaseTest
-import com.terraformation.backend.db.accelerator.CohortPhase
+import com.terraformation.backend.db.accelerator.AcceleratorPhase
 import com.terraformation.backend.db.accelerator.ModuleId
 import com.terraformation.backend.db.accelerator.tables.records.ModulesRecord
 import com.terraformation.backend.db.accelerator.tables.references.MODULES
@@ -52,13 +52,13 @@ class ModulesImporterTest : DatabaseTest(), RunsAsUser {
       val newModuleId2 = getUnusedModuleId()
 
       val existingModuleCsv =
-          "Existing Module,$existingModuleId,${CohortPhase.Application.jsonValue},New Overview,,,,,New Workshop,"
+          "Existing Module,$existingModuleId,${AcceleratorPhase.Application.jsonValue},New Overview,,,,,New Workshop,"
 
       val module1Csv =
-          "Module 1,$newModuleId1,${CohortPhase.Phase1FeasibilityStudy.jsonValue},Phase 1 Overview,Phase 1 Prep,Phase 1 Add,Phase 1 Live,Phase 1 1:1,Phase 1 Workshop,"
+          "Module 1,$newModuleId1,${AcceleratorPhase.Phase1FeasibilityStudy.jsonValue},Phase 1 Overview,Phase 1 Prep,Phase 1 Add,Phase 1 Live,Phase 1 1:1,Phase 1 Workshop,"
 
       val module2Csv =
-          "Module 2,$newModuleId2,${CohortPhase.Phase2PlanAndScale.id},Phase 2 Overview,Phase 2 Prep,Phase 2 Add,Phase 2 Live,Phase 2 1:1,Phase 2 Workshop,Phase 2 Recorded"
+          "Module 2,$newModuleId2,${AcceleratorPhase.Phase2PlanAndScale.id},Phase 2 Overview,Phase 2 Prep,Phase 2 Add,Phase 2 Live,Phase 2 1:1,Phase 2 Workshop,Phase 2 Recorded"
 
       clock.instant = Instant.ofEpochSecond(3000)
 
@@ -70,7 +70,7 @@ class ModulesImporterTest : DatabaseTest(), RunsAsUser {
               ModulesRecord(
                   id = existingModuleId,
                   name = "Existing Module",
-                  phaseId = CohortPhase.Application,
+                  phaseId = AcceleratorPhase.Application,
                   overview = "New Overview",
                   preparationMaterials = null,
                   additionalResources = null,
@@ -86,7 +86,7 @@ class ModulesImporterTest : DatabaseTest(), RunsAsUser {
               ModulesRecord(
                   id = newModuleId1,
                   name = "Module 1",
-                  phaseId = CohortPhase.Phase1FeasibilityStudy,
+                  phaseId = AcceleratorPhase.Phase1FeasibilityStudy,
                   overview = "Phase 1 Overview",
                   preparationMaterials = "Phase 1 Prep",
                   additionalResources = "Phase 1 Add",
@@ -102,7 +102,7 @@ class ModulesImporterTest : DatabaseTest(), RunsAsUser {
               ModulesRecord(
                   id = newModuleId2,
                   name = "Module 2",
-                  phaseId = CohortPhase.Phase2PlanAndScale,
+                  phaseId = AcceleratorPhase.Phase2PlanAndScale,
                   overview = "Phase 2 Overview",
                   preparationMaterials = "Phase 2 Prep",
                   additionalResources = "Phase 2 Add",

--- a/src/test/kotlin/com/terraformation/backend/accelerator/db/ParticipantProjectSpeciesStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/db/ParticipantProjectSpeciesStoreTest.kt
@@ -589,7 +589,7 @@ class ParticipantProjectSpeciesStoreTest : DatabaseTest(), RunsAsUser {
       val projectId = insertProject()
       val speciesId = insertSpecies()
 
-      assertThrows<ProjectNotInCohortPhaseException> {
+      assertThrows<ProjectNotInAcceleratorPhaseException> {
         store.create(
             NewParticipantProjectSpeciesModel(
                 feedback = "feedback",

--- a/src/test/kotlin/com/terraformation/backend/accelerator/db/ParticipantProjectSpeciesStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/db/ParticipantProjectSpeciesStoreTest.kt
@@ -12,7 +12,7 @@ import com.terraformation.backend.auth.currentUser
 import com.terraformation.backend.customer.model.ExistingProjectModel
 import com.terraformation.backend.db.DatabaseTest
 import com.terraformation.backend.db.ProjectNotFoundException
-import com.terraformation.backend.db.accelerator.CohortPhase
+import com.terraformation.backend.db.accelerator.AcceleratorPhase
 import com.terraformation.backend.db.accelerator.DeliverableType
 import com.terraformation.backend.db.accelerator.ParticipantProjectSpeciesId
 import com.terraformation.backend.db.accelerator.SubmissionStatus
@@ -64,7 +64,7 @@ class ParticipantProjectSpeciesStoreTest : DatabaseTest(), RunsAsUser {
   inner class FetchLastCreatedSpeciesTime {
     @Test
     fun `fetches the last created species time for a given project`() {
-      val projectId = insertProject(phase = CohortPhase.Phase0DueDiligence)
+      val projectId = insertProject(phase = AcceleratorPhase.Phase0DueDiligence)
       val speciesId1 = insertSpecies()
       val speciesId2 = insertSpecies()
       val speciesId3 = insertSpecies()
@@ -105,7 +105,7 @@ class ParticipantProjectSpeciesStoreTest : DatabaseTest(), RunsAsUser {
   inner class FetchLastModifiedSpeciesTime {
     @Test
     fun `fetches the last updated species time for a given project`() {
-      val projectId = insertProject(phase = CohortPhase.Phase0DueDiligence)
+      val projectId = insertProject(phase = AcceleratorPhase.Phase0DueDiligence)
       val speciesId1 = insertSpecies()
       val speciesId2 = insertSpecies()
       val speciesId3 = insertSpecies()
@@ -146,7 +146,7 @@ class ParticipantProjectSpeciesStoreTest : DatabaseTest(), RunsAsUser {
   inner class FetchOneById {
     @Test
     fun `populates all fields and includes associated entities where applicable`() {
-      val projectId = insertProject(phase = CohortPhase.Phase0DueDiligence)
+      val projectId = insertProject(phase = AcceleratorPhase.Phase0DueDiligence)
       val speciesId = insertSpecies()
       val participantProjectSpeciesId =
           insertParticipantProjectSpecies(
@@ -178,7 +178,7 @@ class ParticipantProjectSpeciesStoreTest : DatabaseTest(), RunsAsUser {
 
     @Test
     fun `throws exception if no permission to read participant project species`() {
-      val projectId = insertProject(phase = CohortPhase.Phase0DueDiligence)
+      val projectId = insertProject(phase = AcceleratorPhase.Phase0DueDiligence)
       val speciesId = insertSpecies()
       val participantProjectSpeciesId =
           insertParticipantProjectSpecies(
@@ -206,9 +206,9 @@ class ParticipantProjectSpeciesStoreTest : DatabaseTest(), RunsAsUser {
       // This one should not be returned because it is not a species type deliverable
       insertDeliverable(moduleId = moduleId, deliverableTypeId = DeliverableType.Document)
 
-      val projectId1 = insertProject(phase = CohortPhase.Phase0DueDiligence)
+      val projectId1 = insertProject(phase = AcceleratorPhase.Phase0DueDiligence)
       insertProjectModule()
-      val projectId2 = insertProject(phase = CohortPhase.Phase0DueDiligence)
+      val projectId2 = insertProject(phase = AcceleratorPhase.Phase0DueDiligence)
       insertProjectModule()
 
       val speciesId = insertSpecies()
@@ -265,7 +265,7 @@ class ParticipantProjectSpeciesStoreTest : DatabaseTest(), RunsAsUser {
       // Between the most recent and future module
       clock.instant = Instant.EPOCH.plus(20, ChronoUnit.DAYS)
 
-      val projectId1 = insertProject(phase = CohortPhase.Phase0DueDiligence)
+      val projectId1 = insertProject(phase = AcceleratorPhase.Phase0DueDiligence)
       insertProjectModule(moduleId = moduleIdOld)
       insertProjectModule(moduleId = moduleIdMostRecent)
       insertProjectModule(
@@ -273,7 +273,7 @@ class ParticipantProjectSpeciesStoreTest : DatabaseTest(), RunsAsUser {
           startDate = LocalDate.EPOCH.plusDays(21),
           endDate = LocalDate.EPOCH.plusDays(27),
       )
-      val projectId2 = insertProject(phase = CohortPhase.Phase0DueDiligence)
+      val projectId2 = insertProject(phase = AcceleratorPhase.Phase0DueDiligence)
       insertProjectModule(moduleId = moduleIdOld)
       insertProjectModule(moduleId = moduleIdMostRecent)
       insertProjectModule(
@@ -315,8 +315,8 @@ class ParticipantProjectSpeciesStoreTest : DatabaseTest(), RunsAsUser {
 
     @Test
     fun `fetches the projects a species is associated to by species ID without an active or recent deliverable`() {
-      val projectId1 = insertProject(phase = CohortPhase.Phase0DueDiligence)
-      val projectId2 = insertProject(phase = CohortPhase.Phase0DueDiligence)
+      val projectId1 = insertProject(phase = AcceleratorPhase.Phase0DueDiligence)
+      val projectId2 = insertProject(phase = AcceleratorPhase.Phase0DueDiligence)
 
       val speciesId = insertSpecies()
       val participantProjectSpeciesId1 =
@@ -354,9 +354,9 @@ class ParticipantProjectSpeciesStoreTest : DatabaseTest(), RunsAsUser {
       val moduleId = insertModule()
       insertDeliverable(moduleId = moduleId, deliverableTypeId = DeliverableType.Species)
 
-      val projectId1 = insertProject(phase = CohortPhase.Phase0DueDiligence)
+      val projectId1 = insertProject(phase = AcceleratorPhase.Phase0DueDiligence)
       insertProjectModule()
-      val projectId2 = insertProject(phase = CohortPhase.Phase0DueDiligence)
+      val projectId2 = insertProject(phase = AcceleratorPhase.Phase0DueDiligence)
       insertProjectModule()
 
       val speciesId = insertSpecies()
@@ -397,7 +397,7 @@ class ParticipantProjectSpeciesStoreTest : DatabaseTest(), RunsAsUser {
       val moduleId = insertModule()
       insertDeliverable(moduleId = moduleId, deliverableTypeId = DeliverableType.Species)
 
-      val projectId = insertProject(phase = CohortPhase.Phase0DueDiligence)
+      val projectId = insertProject(phase = AcceleratorPhase.Phase0DueDiligence)
       insertProjectModule()
 
       val speciesId = insertSpecies()
@@ -416,7 +416,7 @@ class ParticipantProjectSpeciesStoreTest : DatabaseTest(), RunsAsUser {
   inner class FetchSpeciesForParticipantProject {
     @Test
     fun `fetches the species and participant project species data associated to a participant project`() {
-      val projectId = insertProject(phase = CohortPhase.Phase0DueDiligence)
+      val projectId = insertProject(phase = AcceleratorPhase.Phase0DueDiligence)
 
       val speciesId1 = insertSpecies(scientificName = "Acacia Kochi")
       val speciesId2 = insertSpecies(scientificName = "Juniperus scopulorum")
@@ -451,7 +451,7 @@ class ParticipantProjectSpeciesStoreTest : DatabaseTest(), RunsAsUser {
                           modifiedTime = now,
                           name = "Project 1",
                           organizationId = inserted.organizationId,
-                          phase = CohortPhase.Phase0DueDiligence,
+                          phase = AcceleratorPhase.Phase0DueDiligence,
                       ),
                   species =
                       ExistingSpeciesModel(
@@ -484,7 +484,7 @@ class ParticipantProjectSpeciesStoreTest : DatabaseTest(), RunsAsUser {
                           modifiedTime = now,
                           name = "Project 1",
                           organizationId = inserted.organizationId,
-                          phase = CohortPhase.Phase0DueDiligence,
+                          phase = AcceleratorPhase.Phase0DueDiligence,
                       ),
                   species =
                       ExistingSpeciesModel(
@@ -503,7 +503,7 @@ class ParticipantProjectSpeciesStoreTest : DatabaseTest(), RunsAsUser {
 
     @Test
     fun `returns an empty list of the user does not have permission to read the project`() {
-      val projectId = insertProject(phase = CohortPhase.Phase0DueDiligence)
+      val projectId = insertProject(phase = AcceleratorPhase.Phase0DueDiligence)
 
       val speciesId = insertSpecies()
       insertParticipantProjectSpecies(projectId = projectId, speciesId = speciesId)
@@ -521,12 +521,12 @@ class ParticipantProjectSpeciesStoreTest : DatabaseTest(), RunsAsUser {
   inner class FindAll {
     @Test
     fun `only includes participant project species the user has permission to read`() {
-      val projectId1 = insertProject(phase = CohortPhase.Phase0DueDiligence)
+      val projectId1 = insertProject(phase = AcceleratorPhase.Phase0DueDiligence)
       val speciesId1 = insertSpecies()
       val participantProjectSpeciesId1 =
           insertParticipantProjectSpecies(projectId = projectId1, speciesId = speciesId1)
 
-      val projectId2 = insertProject(phase = CohortPhase.Phase0DueDiligence)
+      val projectId2 = insertProject(phase = AcceleratorPhase.Phase0DueDiligence)
       val speciesId2 = insertSpecies()
       val participantProjectSpeciesId2 =
           insertParticipantProjectSpecies(projectId = projectId2, speciesId = speciesId2)
@@ -550,7 +550,7 @@ class ParticipantProjectSpeciesStoreTest : DatabaseTest(), RunsAsUser {
   inner class Create {
     @Test
     fun `creates the entity with the supplied fields`() {
-      val projectId = insertProject(phase = CohortPhase.Phase0DueDiligence)
+      val projectId = insertProject(phase = AcceleratorPhase.Phase0DueDiligence)
       val speciesId = insertSpecies()
 
       val participantProjectSpecies =
@@ -604,7 +604,7 @@ class ParticipantProjectSpeciesStoreTest : DatabaseTest(), RunsAsUser {
 
     @Test
     fun `throws an exception if no permission to create a participant project species`() {
-      val projectId = insertProject(phase = CohortPhase.Phase0DueDiligence)
+      val projectId = insertProject(phase = AcceleratorPhase.Phase0DueDiligence)
       val speciesId = insertSpecies()
 
       every { user.canCreateParticipantProjectSpecies(projectId) } returns false
@@ -624,8 +624,8 @@ class ParticipantProjectSpeciesStoreTest : DatabaseTest(), RunsAsUser {
 
     @Test
     fun `creates an entity for each project ID and species ID pairing`() {
-      val projectId1 = insertProject(phase = CohortPhase.Phase1FeasibilityStudy)
-      val projectId2 = insertProject(phase = CohortPhase.Phase2PlanAndScale)
+      val projectId1 = insertProject(phase = AcceleratorPhase.Phase1FeasibilityStudy)
+      val projectId2 = insertProject(phase = AcceleratorPhase.Phase2PlanAndScale)
       val speciesId1 = insertSpecies()
       val speciesId2 = insertSpecies()
 
@@ -692,7 +692,7 @@ class ParticipantProjectSpeciesStoreTest : DatabaseTest(), RunsAsUser {
   inner class Update {
     @Test
     fun `updates the entity with the supplied fields`() {
-      val projectId = insertProject(phase = CohortPhase.Phase0DueDiligence)
+      val projectId = insertProject(phase = AcceleratorPhase.Phase0DueDiligence)
       val speciesId = insertSpecies()
       val participantProjectSpeciesId =
           insertParticipantProjectSpecies(projectId = projectId, speciesId = speciesId)
@@ -769,7 +769,7 @@ class ParticipantProjectSpeciesStoreTest : DatabaseTest(), RunsAsUser {
 
     @Test
     fun `throws exception if no permission to update the entry`() {
-      val projectId = insertProject(phase = CohortPhase.Phase0DueDiligence)
+      val projectId = insertProject(phase = AcceleratorPhase.Phase0DueDiligence)
       val speciesId = insertSpecies()
       val participantProjectSpeciesId =
           insertParticipantProjectSpecies(projectId = projectId, speciesId = speciesId)
@@ -786,7 +786,7 @@ class ParticipantProjectSpeciesStoreTest : DatabaseTest(), RunsAsUser {
   inner class Delete {
     @Test
     fun `deletes the supplied list of entities by ID`() {
-      val projectId = insertProject(phase = CohortPhase.Phase0DueDiligence)
+      val projectId = insertProject(phase = AcceleratorPhase.Phase0DueDiligence)
       val speciesId1 = insertSpecies()
       val speciesId2 = insertSpecies()
       val speciesId3 = insertSpecies()
@@ -827,7 +827,7 @@ class ParticipantProjectSpeciesStoreTest : DatabaseTest(), RunsAsUser {
 
     @Test
     fun `throws exception if no permission to delete an entry`() {
-      val projectId = insertProject(phase = CohortPhase.Phase0DueDiligence)
+      val projectId = insertProject(phase = AcceleratorPhase.Phase0DueDiligence)
       val speciesId1 = insertSpecies()
       val speciesId2 = insertSpecies()
       val participantProjectSpeciesId1 =

--- a/src/test/kotlin/com/terraformation/backend/accelerator/db/ProjectAcceleratorDetailsStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/db/ProjectAcceleratorDetailsStoreTest.kt
@@ -10,7 +10,7 @@ import com.terraformation.backend.accelerator.model.ProjectAcceleratorDetailsMod
 import com.terraformation.backend.accelerator.model.ProjectAcceleratorVariableValuesModel
 import com.terraformation.backend.assertSetEquals
 import com.terraformation.backend.db.DatabaseTest
-import com.terraformation.backend.db.accelerator.CohortPhase
+import com.terraformation.backend.db.accelerator.AcceleratorPhase
 import com.terraformation.backend.db.accelerator.DealStage
 import com.terraformation.backend.db.accelerator.Pipeline
 import com.terraformation.backend.db.accelerator.SystemMetric
@@ -52,7 +52,7 @@ class ProjectAcceleratorDetailsStoreTest : DatabaseTest(), RunsAsUser {
   inner class FetchOneById {
     @Test
     fun `returns all details fields`() {
-      val projectId = insertProject(phase = CohortPhase.Phase0DueDiligence)
+      val projectId = insertProject(phase = AcceleratorPhase.Phase0DueDiligence)
       insertProjectLandUseModelType(landUseModelType = LandUseModelType.Agroforestry)
       insertProjectLandUseModelType(landUseModelType = LandUseModelType.Mangroves)
 
@@ -155,7 +155,7 @@ class ProjectAcceleratorDetailsStoreTest : DatabaseTest(), RunsAsUser {
               numCommunities = detailsRow.numCommunities,
               numNativeSpecies = detailsRow.numNativeSpecies,
               perHectareBudget = detailsRow.perHectareBudget,
-              phase = CohortPhase.Phase0DueDiligence,
+              phase = AcceleratorPhase.Phase0DueDiligence,
               pipeline = detailsRow.pipelineId,
               plantingSitesCql = "tf_accelerator:fid=123",
               projectBoundariesCql = "project_no=5",
@@ -524,8 +524,8 @@ class ProjectAcceleratorDetailsStoreTest : DatabaseTest(), RunsAsUser {
 
     @Test
     fun `updates phase and publishes event when project phase changes`() {
-      val projectId = insertProject(phase = CohortPhase.Phase0DueDiligence)
-      insertProject(phase = CohortPhase.Phase0DueDiligence)
+      val projectId = insertProject(phase = AcceleratorPhase.Phase0DueDiligence)
+      insertProject(phase = AcceleratorPhase.Phase0DueDiligence)
 
       val existingValues =
           ProjectAcceleratorVariableValuesModel(
@@ -536,7 +536,7 @@ class ProjectAcceleratorDetailsStoreTest : DatabaseTest(), RunsAsUser {
 
       store.update(projectId, existingValues) {
         it.copy(
-            phase = CohortPhase.Phase1FeasibilityStudy,
+            phase = AcceleratorPhase.Phase1FeasibilityStudy,
             fileNaming = "test-naming",
             dropboxFolderPath = "/dropbox/test",
             googleFolderUrl = URI("https://drive.google.com/test"),
@@ -544,19 +544,19 @@ class ProjectAcceleratorDetailsStoreTest : DatabaseTest(), RunsAsUser {
       }
 
       assertEquals(
-          setOf(CohortPhase.Phase0DueDiligence, CohortPhase.Phase1FeasibilityStudy),
+          setOf(AcceleratorPhase.Phase0DueDiligence, AcceleratorPhase.Phase1FeasibilityStudy),
           projectsDao.findAll().map { it.phaseId }.toSet(),
           "Project phases",
       )
 
       eventPublisher.assertEventPublished(
-          ProjectPhaseUpdatedEvent(projectId, CohortPhase.Phase1FeasibilityStudy)
+          ProjectPhaseUpdatedEvent(projectId, AcceleratorPhase.Phase1FeasibilityStudy)
       )
     }
 
     @Test
     fun `does not publish event when project phase is unchanged`() {
-      val projectId = insertProject(phase = CohortPhase.Phase0DueDiligence)
+      val projectId = insertProject(phase = AcceleratorPhase.Phase0DueDiligence)
 
       val existingValues =
           ProjectAcceleratorVariableValuesModel(
@@ -566,7 +566,7 @@ class ProjectAcceleratorDetailsStoreTest : DatabaseTest(), RunsAsUser {
       store.update(projectId, existingValues) {
         it.copy(
             numCommunities = 5,
-            phase = CohortPhase.Phase0DueDiligence,
+            phase = AcceleratorPhase.Phase0DueDiligence,
             fileNaming = "test-naming",
             dropboxFolderPath = "/dropbox/test",
             googleFolderUrl = URI("https://drive.google.com/test"),
@@ -586,7 +586,7 @@ class ProjectAcceleratorDetailsStoreTest : DatabaseTest(), RunsAsUser {
           assertThrows<IllegalArgumentException> {
             store.update(projectId, existingValues) {
               it.copy(
-                  phase = CohortPhase.Phase1FeasibilityStudy,
+                  phase = AcceleratorPhase.Phase1FeasibilityStudy,
                   fileNaming = null,
                   dropboxFolderPath = "/dropbox/test",
                   googleFolderUrl = URI("https://drive.google.com/test"),
@@ -610,7 +610,7 @@ class ProjectAcceleratorDetailsStoreTest : DatabaseTest(), RunsAsUser {
           assertThrows<IllegalArgumentException> {
             store.update(projectId, existingValues) {
               it.copy(
-                  phase = CohortPhase.Phase1FeasibilityStudy,
+                  phase = AcceleratorPhase.Phase1FeasibilityStudy,
                   fileNaming = "test-naming",
                   dropboxFolderPath = null,
                   googleFolderUrl = URI("https://drive.google.com/test"),
@@ -634,7 +634,7 @@ class ProjectAcceleratorDetailsStoreTest : DatabaseTest(), RunsAsUser {
           assertThrows<IllegalArgumentException> {
             store.update(projectId, existingValues) {
               it.copy(
-                  phase = CohortPhase.Phase1FeasibilityStudy,
+                  phase = AcceleratorPhase.Phase1FeasibilityStudy,
                   fileNaming = "test-naming",
                   dropboxFolderPath = "/dropbox/test",
                   googleFolderUrl = null,
@@ -683,7 +683,7 @@ class ProjectAcceleratorDetailsStoreTest : DatabaseTest(), RunsAsUser {
 
       store.update(projectId, existingValues) {
         it.copy(
-            phase = CohortPhase.Phase1FeasibilityStudy,
+            phase = AcceleratorPhase.Phase1FeasibilityStudy,
             fileNaming = "test-naming",
             dropboxFolderPath = "/dropbox/test",
             googleFolderUrl = URI("https://drive.google.com/test"),

--- a/src/test/kotlin/com/terraformation/backend/accelerator/db/ProjectModuleStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/db/ProjectModuleStoreTest.kt
@@ -5,7 +5,7 @@ import com.terraformation.backend.accelerator.model.ModuleModel
 import com.terraformation.backend.customer.model.TerrawareUser
 import com.terraformation.backend.db.DatabaseTest
 import com.terraformation.backend.db.ProjectNotFoundException
-import com.terraformation.backend.db.accelerator.CohortPhase
+import com.terraformation.backend.db.accelerator.AcceleratorPhase
 import com.terraformation.backend.db.accelerator.tables.records.ProjectModulesRecord
 import com.terraformation.backend.db.accelerator.tables.references.PROJECT_MODULES
 import com.terraformation.backend.db.default_schema.GlobalRole
@@ -38,7 +38,7 @@ class ProjectModuleStoreTest : DatabaseTest(), RunsAsDatabaseUser {
     @Test
     fun `throws exceptions if no associated permissions`() {
       insertOrganization()
-      insertProject(phase = CohortPhase.Phase1FeasibilityStudy)
+      insertProject(phase = AcceleratorPhase.Phase1FeasibilityStudy)
 
       deleteUserGlobalRole(role = GlobalRole.ReadOnly)
 
@@ -50,17 +50,33 @@ class ProjectModuleStoreTest : DatabaseTest(), RunsAsDatabaseUser {
     fun `filters by IDs, ordered by project ID, start date, end date, position`() {
       insertOrganization()
 
-      val projectA = insertProject(phase = CohortPhase.Phase0DueDiligence)
-      val projectB = insertProject(phase = CohortPhase.Phase0DueDiligence)
+      val projectA = insertProject(phase = AcceleratorPhase.Phase0DueDiligence)
+      val projectB = insertProject(phase = AcceleratorPhase.Phase0DueDiligence)
 
       val module1 =
-          insertModule(name = "Module 1", position = 3, phase = CohortPhase.Phase1FeasibilityStudy)
+          insertModule(
+              name = "Module 1",
+              position = 3,
+              phase = AcceleratorPhase.Phase1FeasibilityStudy,
+          )
       val module2 =
-          insertModule(name = "Module 2", position = 1, phase = CohortPhase.Phase1FeasibilityStudy)
+          insertModule(
+              name = "Module 2",
+              position = 1,
+              phase = AcceleratorPhase.Phase1FeasibilityStudy,
+          )
       val module3 =
-          insertModule(name = "Module 3", position = 2, phase = CohortPhase.Phase1FeasibilityStudy)
+          insertModule(
+              name = "Module 3",
+              position = 2,
+              phase = AcceleratorPhase.Phase1FeasibilityStudy,
+          )
       val module4 =
-          insertModule(name = "Module 4", position = 10, phase = CohortPhase.Phase1FeasibilityStudy)
+          insertModule(
+              name = "Module 4",
+              position = 10,
+              phase = AcceleratorPhase.Phase1FeasibilityStudy,
+          )
       insertModule(name = "Hidden Module")
 
       val date1 = LocalDate.of(2024, 1, 5)
@@ -79,7 +95,7 @@ class ProjectModuleStoreTest : DatabaseTest(), RunsAsDatabaseUser {
           ModuleModel(
               id = module1,
               name = "Module 1",
-              phase = CohortPhase.Phase1FeasibilityStudy,
+              phase = AcceleratorPhase.Phase1FeasibilityStudy,
               position = 3,
               projectId = projectA,
               title = "Equal dates, later position",
@@ -91,7 +107,7 @@ class ProjectModuleStoreTest : DatabaseTest(), RunsAsDatabaseUser {
           ModuleModel(
               id = module2,
               name = "Module 2",
-              phase = CohortPhase.Phase1FeasibilityStudy,
+              phase = AcceleratorPhase.Phase1FeasibilityStudy,
               position = 1,
               projectId = projectA,
               title = "Equal dates, earlier position",
@@ -103,7 +119,7 @@ class ProjectModuleStoreTest : DatabaseTest(), RunsAsDatabaseUser {
           ModuleModel(
               id = module3,
               name = "Module 3",
-              phase = CohortPhase.Phase1FeasibilityStudy,
+              phase = AcceleratorPhase.Phase1FeasibilityStudy,
               position = 2,
               projectId = projectA,
               title = "Equal start date, later end date",
@@ -115,7 +131,7 @@ class ProjectModuleStoreTest : DatabaseTest(), RunsAsDatabaseUser {
           ModuleModel(
               id = module4,
               name = "Module 4",
-              phase = CohortPhase.Phase1FeasibilityStudy,
+              phase = AcceleratorPhase.Phase1FeasibilityStudy,
               position = 10,
               projectId = projectA,
               title = "Earliest Start Date",
@@ -187,7 +203,7 @@ class ProjectModuleStoreTest : DatabaseTest(), RunsAsDatabaseUser {
     fun `throws exception if no associated permissions`() {
       insertUserGlobalRole(role = GlobalRole.TFExpert)
 
-      insertProject(phase = CohortPhase.Phase0DueDiligence)
+      insertProject(phase = AcceleratorPhase.Phase0DueDiligence)
       insertModule()
 
       assertThrows<AccessDeniedException> {
@@ -223,7 +239,7 @@ class ProjectModuleStoreTest : DatabaseTest(), RunsAsDatabaseUser {
     fun `assigns new module to project`() {
       insertUserGlobalRole(role = GlobalRole.AcceleratorAdmin)
 
-      insertProject(phase = CohortPhase.Phase0DueDiligence)
+      insertProject(phase = AcceleratorPhase.Phase0DueDiligence)
       insertModule()
 
       store.assign(
@@ -249,7 +265,7 @@ class ProjectModuleStoreTest : DatabaseTest(), RunsAsDatabaseUser {
     fun `updates existing project module`() {
       insertUserGlobalRole(role = GlobalRole.AcceleratorAdmin)
 
-      insertProject(phase = CohortPhase.Phase0DueDiligence)
+      insertProject(phase = AcceleratorPhase.Phase0DueDiligence)
       insertModule()
 
       insertProjectModule(
@@ -284,7 +300,7 @@ class ProjectModuleStoreTest : DatabaseTest(), RunsAsDatabaseUser {
     fun `throws exception if no associated permissions`() {
       insertUserGlobalRole(role = GlobalRole.TFExpert)
 
-      insertProject(phase = CohortPhase.Phase0DueDiligence)
+      insertProject(phase = AcceleratorPhase.Phase0DueDiligence)
       insertModule()
       insertProjectModule()
 
@@ -309,7 +325,7 @@ class ProjectModuleStoreTest : DatabaseTest(), RunsAsDatabaseUser {
     fun `removes existing project module`() {
       insertUserGlobalRole(role = GlobalRole.AcceleratorAdmin)
 
-      insertProject(phase = CohortPhase.Phase0DueDiligence)
+      insertProject(phase = AcceleratorPhase.Phase0DueDiligence)
       insertModule()
 
       insertProjectModule(

--- a/src/test/kotlin/com/terraformation/backend/accelerator/db/ProjectModuleStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/db/ProjectModuleStoreTest.kt
@@ -224,7 +224,7 @@ class ProjectModuleStoreTest : DatabaseTest(), RunsAsDatabaseUser {
       insertProject()
       insertModule()
 
-      assertThrows<ProjectNotInCohortPhaseException> {
+      assertThrows<ProjectNotInAcceleratorPhaseException> {
         store.assign(
             inserted.projectId,
             inserted.moduleId,
@@ -316,7 +316,7 @@ class ProjectModuleStoreTest : DatabaseTest(), RunsAsDatabaseUser {
       insertProject()
       insertModule()
 
-      assertThrows<ProjectNotInCohortPhaseException> {
+      assertThrows<ProjectNotInAcceleratorPhaseException> {
         store.remove(inserted.projectId, inserted.moduleId)
       }
     }

--- a/src/test/kotlin/com/terraformation/backend/accelerator/db/ProjectPhaseFetcherTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/db/ProjectPhaseFetcherTest.kt
@@ -49,7 +49,7 @@ class ProjectPhaseFetcherTest : DatabaseTest(), RunsAsUser {
     }
 
     @Test
-    fun `returns correct cohort phase for each application state`() {
+    fun `returns correct phase for each application state`() {
       val projectId = insertProject()
       insertApplication()
 

--- a/src/test/kotlin/com/terraformation/backend/accelerator/db/ProjectPhaseFetcherTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/db/ProjectPhaseFetcherTest.kt
@@ -4,8 +4,8 @@ import com.terraformation.backend.RunsAsUser
 import com.terraformation.backend.customer.model.TerrawareUser
 import com.terraformation.backend.db.DatabaseTest
 import com.terraformation.backend.db.ProjectNotFoundException
+import com.terraformation.backend.db.accelerator.AcceleratorPhase
 import com.terraformation.backend.db.accelerator.ApplicationStatus
-import com.terraformation.backend.db.accelerator.CohortPhase
 import com.terraformation.backend.db.accelerator.tables.references.APPLICATIONS
 import com.terraformation.backend.db.default_schema.OrganizationId
 import com.terraformation.backend.mockUser
@@ -35,17 +35,17 @@ class ProjectPhaseFetcherTest : DatabaseTest(), RunsAsUser {
   inner class GetProjectPhase {
     @Test
     fun `fetches project's phase`() {
-      val projectId = insertProject(phase = CohortPhase.Phase0DueDiligence)
+      val projectId = insertProject(phase = AcceleratorPhase.Phase0DueDiligence)
 
-      assertEquals(CohortPhase.Phase0DueDiligence, fetcher.getProjectPhase(projectId))
+      assertEquals(AcceleratorPhase.Phase0DueDiligence, fetcher.getProjectPhase(projectId))
     }
 
     @Test
     fun `uses project phase even if project has an application`() {
-      val projectId = insertProject(phase = CohortPhase.Phase0DueDiligence)
+      val projectId = insertProject(phase = AcceleratorPhase.Phase0DueDiligence)
       insertApplication()
 
-      assertEquals(CohortPhase.Phase0DueDiligence, fetcher.getProjectPhase(projectId))
+      assertEquals(AcceleratorPhase.Phase0DueDiligence, fetcher.getProjectPhase(projectId))
     }
 
     @Test
@@ -61,19 +61,19 @@ class ProjectPhaseFetcherTest : DatabaseTest(), RunsAsUser {
 
       assertEquals(
           mapOf(
-              ApplicationStatus.Accepted to CohortPhase.Application,
-              ApplicationStatus.CarbonAssessment to CohortPhase.Application,
-              ApplicationStatus.ExpertReview to CohortPhase.Application,
-              ApplicationStatus.FailedPreScreen to CohortPhase.PreScreen,
-              ApplicationStatus.GISAssessment to CohortPhase.Application,
-              ApplicationStatus.IssueActive to CohortPhase.Application,
-              ApplicationStatus.IssueReassessment to CohortPhase.Application,
-              ApplicationStatus.NotEligible to CohortPhase.Application,
-              ApplicationStatus.NotSubmitted to CohortPhase.PreScreen,
-              ApplicationStatus.P0Eligible to CohortPhase.Application,
-              ApplicationStatus.PassedPreScreen to CohortPhase.PreScreen,
-              ApplicationStatus.SourcingTeamReview to CohortPhase.Application,
-              ApplicationStatus.Submitted to CohortPhase.Application,
+              ApplicationStatus.Accepted to AcceleratorPhase.Application,
+              ApplicationStatus.CarbonAssessment to AcceleratorPhase.Application,
+              ApplicationStatus.ExpertReview to AcceleratorPhase.Application,
+              ApplicationStatus.FailedPreScreen to AcceleratorPhase.PreScreen,
+              ApplicationStatus.GISAssessment to AcceleratorPhase.Application,
+              ApplicationStatus.IssueActive to AcceleratorPhase.Application,
+              ApplicationStatus.IssueReassessment to AcceleratorPhase.Application,
+              ApplicationStatus.NotEligible to AcceleratorPhase.Application,
+              ApplicationStatus.NotSubmitted to AcceleratorPhase.PreScreen,
+              ApplicationStatus.P0Eligible to AcceleratorPhase.Application,
+              ApplicationStatus.PassedPreScreen to AcceleratorPhase.PreScreen,
+              ApplicationStatus.SourcingTeamReview to AcceleratorPhase.Application,
+              ApplicationStatus.Submitted to AcceleratorPhase.Application,
           ),
           phasesByState,
       )
@@ -81,7 +81,7 @@ class ProjectPhaseFetcherTest : DatabaseTest(), RunsAsUser {
 
     @Test
     fun `throws exception if no permission to read project`() {
-      val projectId = insertProject(phase = CohortPhase.Phase0DueDiligence)
+      val projectId = insertProject(phase = AcceleratorPhase.Phase0DueDiligence)
 
       every { user.canReadProject(projectId) } returns false
 

--- a/src/test/kotlin/com/terraformation/backend/accelerator/db/ProjectScoreStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/db/ProjectScoreStoreTest.kt
@@ -267,7 +267,7 @@ class ProjectScoreStoreTest : DatabaseTest(), RunsAsUser {
     fun `throws exception if updating scores for a non-phase project`() {
       val projectId = insertProject()
 
-      assertThrows<ProjectNotInCohortPhaseException> {
+      assertThrows<ProjectNotInAcceleratorPhaseException> {
         store.updateScores(
             projectId,
             AcceleratorPhase.Phase0DueDiligence,
@@ -280,7 +280,7 @@ class ProjectScoreStoreTest : DatabaseTest(), RunsAsUser {
     fun `throws exception if updating scores for a different phase than the current one`() {
       val projectId = insertProject(phase = AcceleratorPhase.Phase0DueDiligence)
 
-      assertThrows<ProjectNotInCohortPhaseException> {
+      assertThrows<ProjectNotInAcceleratorPhaseException> {
         store.updateScores(
             projectId,
             AcceleratorPhase.Phase1FeasibilityStudy,

--- a/src/test/kotlin/com/terraformation/backend/accelerator/db/ProjectScoreStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/db/ProjectScoreStoreTest.kt
@@ -6,7 +6,7 @@ import com.terraformation.backend.accelerator.model.ExistingProjectScoreModel
 import com.terraformation.backend.accelerator.model.NewProjectScoreModel
 import com.terraformation.backend.assertSetEquals
 import com.terraformation.backend.db.DatabaseTest
-import com.terraformation.backend.db.accelerator.CohortPhase
+import com.terraformation.backend.db.accelerator.AcceleratorPhase
 import com.terraformation.backend.db.accelerator.ScoreCategory
 import com.terraformation.backend.db.accelerator.tables.pojos.ProjectScoresRow
 import com.terraformation.backend.mockUser
@@ -44,17 +44,17 @@ class ProjectScoreStoreTest : DatabaseTest(), RunsAsUser {
       val time2 = Instant.ofEpochSecond(2)
       val time3 = Instant.ofEpochSecond(3)
 
-      val projectId = insertProject(phase = CohortPhase.Phase0DueDiligence)
+      val projectId = insertProject(phase = AcceleratorPhase.Phase0DueDiligence)
 
       insertProjectScore(
-          phase = CohortPhase.Phase0DueDiligence,
+          phase = AcceleratorPhase.Phase0DueDiligence,
           category = ScoreCategory.Legal,
           qualitative = "q1",
           score = 1,
           createdTime = time1,
       )
       insertProjectScore(
-          phase = CohortPhase.Phase1FeasibilityStudy,
+          phase = AcceleratorPhase.Phase1FeasibilityStudy,
           category = ScoreCategory.Carbon,
           createdTime = time2,
       )
@@ -62,7 +62,7 @@ class ProjectScoreStoreTest : DatabaseTest(), RunsAsUser {
       insertProject()
 
       insertProjectScore(
-          phase = CohortPhase.Phase0DueDiligence,
+          phase = AcceleratorPhase.Phase0DueDiligence,
           category = ScoreCategory.SocialImpact,
           score = -1,
           createdTime = time3,
@@ -70,9 +70,9 @@ class ProjectScoreStoreTest : DatabaseTest(), RunsAsUser {
 
       val expected =
           mapOf(
-              CohortPhase.Phase0DueDiligence to
+              AcceleratorPhase.Phase0DueDiligence to
                   listOf(ExistingProjectScoreModel(ScoreCategory.Legal, time1, "q1", 1)),
-              CohortPhase.Phase1FeasibilityStudy to
+              AcceleratorPhase.Phase1FeasibilityStudy to
                   listOf(ExistingProjectScoreModel(ScoreCategory.Carbon, time2, null, null)),
           )
 
@@ -88,28 +88,28 @@ class ProjectScoreStoreTest : DatabaseTest(), RunsAsUser {
       val time3 = Instant.ofEpochSecond(3)
       val time4 = Instant.ofEpochSecond(4)
 
-      val projectId = insertProject(phase = CohortPhase.Phase0DueDiligence)
+      val projectId = insertProject(phase = AcceleratorPhase.Phase0DueDiligence)
 
       insertProjectScore(
-          phase = CohortPhase.Phase0DueDiligence,
+          phase = AcceleratorPhase.Phase0DueDiligence,
           category = ScoreCategory.Legal,
           qualitative = "q1",
           score = 1,
           createdTime = time1,
       )
       insertProjectScore(
-          phase = CohortPhase.Phase0DueDiligence,
+          phase = AcceleratorPhase.Phase0DueDiligence,
           category = ScoreCategory.Carbon,
           score = 2,
           createdTime = time2,
       )
       insertProjectScore(
-          phase = CohortPhase.Phase1FeasibilityStudy,
+          phase = AcceleratorPhase.Phase1FeasibilityStudy,
           category = ScoreCategory.Carbon,
           createdTime = time3,
       )
       insertProjectScore(
-          phase = CohortPhase.Phase2PlanAndScale,
+          phase = AcceleratorPhase.Phase2PlanAndScale,
           category = ScoreCategory.Carbon,
           score = -1,
           createdTime = time4,
@@ -117,12 +117,12 @@ class ProjectScoreStoreTest : DatabaseTest(), RunsAsUser {
 
       val expected =
           mapOf(
-              CohortPhase.Phase0DueDiligence to
+              AcceleratorPhase.Phase0DueDiligence to
                   listOf(
                       ExistingProjectScoreModel(ScoreCategory.Carbon, time2, null, 2),
                       ExistingProjectScoreModel(ScoreCategory.Legal, time1, "q1", 1),
                   ),
-              CohortPhase.Phase1FeasibilityStudy to
+              AcceleratorPhase.Phase1FeasibilityStudy to
                   listOf(
                       ExistingProjectScoreModel(ScoreCategory.Carbon, time3, null, null),
                   ),
@@ -132,9 +132,9 @@ class ProjectScoreStoreTest : DatabaseTest(), RunsAsUser {
           store.fetchScores(
               projectId,
               setOf(
-                  CohortPhase.Phase0DueDiligence,
-                  CohortPhase.Phase1FeasibilityStudy,
-                  CohortPhase.Phase3ImplementAndMonitor,
+                  AcceleratorPhase.Phase0DueDiligence,
+                  AcceleratorPhase.Phase1FeasibilityStudy,
+                  AcceleratorPhase.Phase3ImplementAndMonitor,
               ),
           )
 
@@ -143,7 +143,7 @@ class ProjectScoreStoreTest : DatabaseTest(), RunsAsUser {
 
     @Test
     fun `throws exception if no permission to read scores`() {
-      val projectId = insertProject(phase = CohortPhase.Phase0DueDiligence)
+      val projectId = insertProject(phase = AcceleratorPhase.Phase0DueDiligence)
 
       every { user.canReadProjectScores(projectId) } returns false
 
@@ -155,13 +155,13 @@ class ProjectScoreStoreTest : DatabaseTest(), RunsAsUser {
   inner class UpdateScores {
     @Test
     fun `creates scores that do not exist`() {
-      val projectId = insertProject(phase = CohortPhase.Phase0DueDiligence)
+      val projectId = insertProject(phase = AcceleratorPhase.Phase0DueDiligence)
 
       clock.instant = Instant.ofEpochSecond(123)
 
       store.updateScores(
           projectId,
-          CohortPhase.Phase0DueDiligence,
+          AcceleratorPhase.Phase0DueDiligence,
           listOf(
               NewProjectScoreModel(ScoreCategory.Carbon, null, "q1", 1),
               NewProjectScoreModel(ScoreCategory.Legal, null, null, null),
@@ -171,7 +171,7 @@ class ProjectScoreStoreTest : DatabaseTest(), RunsAsUser {
       val commonRow =
           ProjectScoresRow(
               projectId = projectId,
-              phaseId = CohortPhase.Phase0DueDiligence,
+              phaseId = AcceleratorPhase.Phase0DueDiligence,
               createdBy = user.userId,
               createdTime = clock.instant,
               modifiedBy = user.userId,
@@ -197,11 +197,14 @@ class ProjectScoreStoreTest : DatabaseTest(), RunsAsUser {
 
     @Test
     fun `updates scores that already exist`() {
-      val projectId = insertProject(phase = CohortPhase.Phase0DueDiligence)
+      val projectId = insertProject(phase = AcceleratorPhase.Phase0DueDiligence)
 
-      insertProjectScore(phase = CohortPhase.Phase0DueDiligence, category = ScoreCategory.Legal)
       insertProjectScore(
-          phase = CohortPhase.Phase0DueDiligence,
+          phase = AcceleratorPhase.Phase0DueDiligence,
+          category = ScoreCategory.Legal,
+      )
+      insertProjectScore(
+          phase = AcceleratorPhase.Phase0DueDiligence,
           category = ScoreCategory.Forestry,
           qualitative = "q",
           score = 1,
@@ -211,7 +214,7 @@ class ProjectScoreStoreTest : DatabaseTest(), RunsAsUser {
 
       store.updateScores(
           projectId,
-          CohortPhase.Phase0DueDiligence,
+          AcceleratorPhase.Phase0DueDiligence,
           listOf(
               NewProjectScoreModel(ScoreCategory.Legal, null, "q1", 1),
               NewProjectScoreModel(ScoreCategory.Forestry, null, null, null),
@@ -221,7 +224,7 @@ class ProjectScoreStoreTest : DatabaseTest(), RunsAsUser {
       val commonRow =
           ProjectScoresRow(
               projectId = projectId,
-              phaseId = CohortPhase.Phase0DueDiligence,
+              phaseId = AcceleratorPhase.Phase0DueDiligence,
               createdBy = user.userId,
               createdTime = Instant.EPOCH,
               modifiedBy = user.userId,
@@ -247,14 +250,14 @@ class ProjectScoreStoreTest : DatabaseTest(), RunsAsUser {
 
     @Test
     fun `throws exception if no permission to update scores`() {
-      val projectId = insertProject(phase = CohortPhase.Phase0DueDiligence)
+      val projectId = insertProject(phase = AcceleratorPhase.Phase0DueDiligence)
 
       every { user.canUpdateProjectScores(projectId) } returns false
 
       assertThrows<AccessDeniedException> {
         store.updateScores(
             projectId,
-            CohortPhase.Phase0DueDiligence,
+            AcceleratorPhase.Phase0DueDiligence,
             listOf(NewProjectScoreModel(ScoreCategory.Legal, null, null, 1)),
         )
       }
@@ -267,7 +270,7 @@ class ProjectScoreStoreTest : DatabaseTest(), RunsAsUser {
       assertThrows<ProjectNotInCohortPhaseException> {
         store.updateScores(
             projectId,
-            CohortPhase.Phase0DueDiligence,
+            AcceleratorPhase.Phase0DueDiligence,
             listOf(NewProjectScoreModel(ScoreCategory.Legal, null, null, 1)),
         )
       }
@@ -275,12 +278,12 @@ class ProjectScoreStoreTest : DatabaseTest(), RunsAsUser {
 
     @Test
     fun `throws exception if updating scores for a different phase than the current one`() {
-      val projectId = insertProject(phase = CohortPhase.Phase0DueDiligence)
+      val projectId = insertProject(phase = AcceleratorPhase.Phase0DueDiligence)
 
       assertThrows<ProjectNotInCohortPhaseException> {
         store.updateScores(
             projectId,
-            CohortPhase.Phase1FeasibilityStudy,
+            AcceleratorPhase.Phase1FeasibilityStudy,
             listOf(NewProjectScoreModel(ScoreCategory.Legal, null, null, 1)),
         )
       }

--- a/src/test/kotlin/com/terraformation/backend/accelerator/db/SubmissionStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/db/SubmissionStoreTest.kt
@@ -6,7 +6,7 @@ import com.terraformation.backend.TestEventPublisher
 import com.terraformation.backend.accelerator.event.DeliverableStatusUpdatedEvent
 import com.terraformation.backend.accelerator.model.ExistingSpeciesDeliverableSubmissionModel
 import com.terraformation.backend.db.DatabaseTest
-import com.terraformation.backend.db.accelerator.CohortPhase
+import com.terraformation.backend.db.accelerator.AcceleratorPhase
 import com.terraformation.backend.db.accelerator.DeliverableType
 import com.terraformation.backend.db.accelerator.SubmissionStatus
 import com.terraformation.backend.db.accelerator.tables.pojos.SubmissionsRow
@@ -42,7 +42,7 @@ class SubmissionStoreTest : DatabaseTest(), RunsAsUser {
   inner class FetchMostRecentSpeciesDeliverableSubmission {
     @Test
     fun `fetches the deliverable ID if no submission present for an active deliverable`() {
-      val projectId = insertProject(phase = CohortPhase.Phase0DueDiligence)
+      val projectId = insertProject(phase = AcceleratorPhase.Phase0DueDiligence)
 
       // Module goes from epoch -> epoch + 6 days
       val moduleIdOld = insertModule()
@@ -73,7 +73,7 @@ class SubmissionStoreTest : DatabaseTest(), RunsAsUser {
 
     @Test
     fun `fetches the deliverable ID if no submission present for the most recent inactive deliverable if there is no active deliverable`() {
-      val projectId = insertProject(phase = CohortPhase.Phase1FeasibilityStudy)
+      val projectId = insertProject(phase = AcceleratorPhase.Phase1FeasibilityStudy)
 
       // Module goes from epoch -> epoch + 6 days
       val moduleIdOld = insertModule()
@@ -113,7 +113,7 @@ class SubmissionStoreTest : DatabaseTest(), RunsAsUser {
 
     @Test
     fun `fetches both deliverable ID and submission ID if present for active deliverable`() {
-      val projectId = insertProject(phase = CohortPhase.Phase0DueDiligence)
+      val projectId = insertProject(phase = AcceleratorPhase.Phase0DueDiligence)
 
       // Module goes from epoch -> epoch + 6 days
       val moduleIdOld = insertModule()
@@ -150,7 +150,7 @@ class SubmissionStoreTest : DatabaseTest(), RunsAsUser {
 
     @Test
     fun `fetches both deliverable ID and submission ID if present for most recent deliverable if there is no active deliverable`() {
-      val projectId = insertProject(phase = CohortPhase.Phase2PlanAndScale)
+      val projectId = insertProject(phase = AcceleratorPhase.Phase2PlanAndScale)
 
       // Module goes from epoch -> epoch + 6 days
       val moduleIdOld = insertModule()
@@ -196,7 +196,7 @@ class SubmissionStoreTest : DatabaseTest(), RunsAsUser {
 
     @Test
     fun `throws an exception if no permission to read the submission`() {
-      val projectId = insertProject(phase = CohortPhase.Phase0DueDiligence)
+      val projectId = insertProject(phase = AcceleratorPhase.Phase0DueDiligence)
 
       val moduleId = insertModule()
       insertProjectModule()

--- a/src/test/kotlin/com/terraformation/backend/accelerator/db/VoteStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/db/VoteStoreTest.kt
@@ -5,7 +5,7 @@ import com.terraformation.backend.TestClock
 import com.terraformation.backend.accelerator.model.VoteDecisionModel
 import com.terraformation.backend.accelerator.model.VoteModel
 import com.terraformation.backend.db.DatabaseTest
-import com.terraformation.backend.db.accelerator.CohortPhase
+import com.terraformation.backend.db.accelerator.AcceleratorPhase
 import com.terraformation.backend.db.accelerator.VoteOption
 import com.terraformation.backend.db.accelerator.tables.records.ProjectVoteDecisionsRecord
 import com.terraformation.backend.db.accelerator.tables.records.ProjectVotesRecord
@@ -30,7 +30,7 @@ class VoteStoreTest : DatabaseTest(), RunsAsUser {
     VoteStore(clock, dslContext, ProjectPhaseFetcher(dslContext))
   }
 
-  data class VoteKey(val userId: UserId, val projectId: ProjectId, val phase: CohortPhase)
+  data class VoteKey(val userId: UserId, val projectId: ProjectId, val phase: AcceleratorPhase)
 
   @BeforeEach
   fun setUp() {
@@ -45,7 +45,7 @@ class VoteStoreTest : DatabaseTest(), RunsAsUser {
   inner class FetchAllVotes {
     @Test
     fun `fetches with no vote`() {
-      val projectId = insertProject(phase = CohortPhase.Phase0DueDiligence)
+      val projectId = insertProject(phase = AcceleratorPhase.Phase0DueDiligence)
       clock.instant = Instant.EPOCH.plusSeconds(500)
 
       assertEquals(emptyList<VoteModel>(), store.fetchAllVotes(projectId))
@@ -53,8 +53,8 @@ class VoteStoreTest : DatabaseTest(), RunsAsUser {
 
     @Test
     fun `fetches all votes`() {
-      val projectId = insertProject(phase = CohortPhase.Phase0DueDiligence)
-      val phase: CohortPhase = CohortPhase.Phase1FeasibilityStudy
+      val projectId = insertProject(phase = AcceleratorPhase.Phase0DueDiligence)
+      val phase: AcceleratorPhase = AcceleratorPhase.Phase1FeasibilityStudy
       clock.instant = Instant.EPOCH.plusSeconds(500)
 
       val email1 = "batman@terraformation.com"
@@ -117,9 +117,9 @@ class VoteStoreTest : DatabaseTest(), RunsAsUser {
 
     @Test
     fun `fetches votes by phase`() {
-      val projectId = insertProject(phase = CohortPhase.Phase0DueDiligence)
-      val phase0: CohortPhase = CohortPhase.Phase0DueDiligence
-      val phase1: CohortPhase = CohortPhase.Phase1FeasibilityStudy
+      val projectId = insertProject(phase = AcceleratorPhase.Phase0DueDiligence)
+      val phase0: AcceleratorPhase = AcceleratorPhase.Phase0DueDiligence
+      val phase1: AcceleratorPhase = AcceleratorPhase.Phase1FeasibilityStudy
       clock.instant = Instant.EPOCH.plusSeconds(500)
 
       val email1 = "batman@terraformation.com"
@@ -174,7 +174,7 @@ class VoteStoreTest : DatabaseTest(), RunsAsUser {
 
     @Test
     fun `throws exception on fetch if no permission to read votes `() {
-      val projectId = insertProject(phase = CohortPhase.Phase0DueDiligence)
+      val projectId = insertProject(phase = AcceleratorPhase.Phase0DueDiligence)
 
       every { user.canReadProjectVotes(projectId) } returns false
 
@@ -186,7 +186,7 @@ class VoteStoreTest : DatabaseTest(), RunsAsUser {
   inner class FetchAllVoteDecisions {
     @Test
     fun `fetches with no vote`() {
-      val projectId = insertProject(phase = CohortPhase.Phase0DueDiligence)
+      val projectId = insertProject(phase = AcceleratorPhase.Phase0DueDiligence)
       clock.instant = Instant.EPOCH.plusSeconds(500)
 
       assertEquals(emptyList<VoteDecisionModel>(), store.fetchAllVoteDecisions(projectId))
@@ -194,8 +194,8 @@ class VoteStoreTest : DatabaseTest(), RunsAsUser {
 
     @Test
     fun `fetches all vote decisions`() {
-      val projectId = insertProject(phase = CohortPhase.Phase0DueDiligence)
-      val phase: CohortPhase = CohortPhase.Phase1FeasibilityStudy
+      val projectId = insertProject(phase = AcceleratorPhase.Phase0DueDiligence)
+      val phase: AcceleratorPhase = AcceleratorPhase.Phase1FeasibilityStudy
 
       insertVoteDecision(projectId, phase, VoteOption.Yes, clock.instant)
 
@@ -209,8 +209,8 @@ class VoteStoreTest : DatabaseTest(), RunsAsUser {
 
     @Test
     fun `fetches vote decisions by phase`() {
-      val phase0: CohortPhase = CohortPhase.Phase0DueDiligence
-      val phase1: CohortPhase = CohortPhase.Phase1FeasibilityStudy
+      val phase0: AcceleratorPhase = AcceleratorPhase.Phase0DueDiligence
+      val phase1: AcceleratorPhase = AcceleratorPhase.Phase1FeasibilityStudy
       val projectId = insertProject(phase = phase1)
 
       insertVoteDecision(projectId, phase0, VoteOption.Yes, clock.instant)
@@ -229,7 +229,7 @@ class VoteStoreTest : DatabaseTest(), RunsAsUser {
   inner class Delete {
     @Test
     fun `delete only vote`() {
-      val phase: CohortPhase = CohortPhase.Phase1FeasibilityStudy
+      val phase: AcceleratorPhase = AcceleratorPhase.Phase1FeasibilityStudy
       val projectId = insertProject(phase = phase)
 
       val newUser = insertUser()
@@ -244,7 +244,7 @@ class VoteStoreTest : DatabaseTest(), RunsAsUser {
 
     @Test
     fun `delete one vote from multiple voters`() {
-      val phase: CohortPhase = CohortPhase.Phase1FeasibilityStudy
+      val phase: AcceleratorPhase = AcceleratorPhase.Phase1FeasibilityStudy
       val projectId = insertProject(phase = phase)
       clock.instant = Instant.EPOCH.plusSeconds(500)
 
@@ -292,8 +292,8 @@ class VoteStoreTest : DatabaseTest(), RunsAsUser {
 
     @Test
     fun `delete one phase of votes from multiple phases`() {
-      val phase0: CohortPhase = CohortPhase.Phase0DueDiligence
-      val phase1: CohortPhase = CohortPhase.Phase1FeasibilityStudy
+      val phase0: AcceleratorPhase = AcceleratorPhase.Phase0DueDiligence
+      val phase1: AcceleratorPhase = AcceleratorPhase.Phase1FeasibilityStudy
       val projectId = insertProject(phase = phase1)
       clock.instant = Instant.EPOCH.plusSeconds(500)
 
@@ -369,7 +369,7 @@ class VoteStoreTest : DatabaseTest(), RunsAsUser {
 
     @Test
     fun `throws exception on delete if no permission to update votes`() {
-      val phase: CohortPhase = CohortPhase.Phase1FeasibilityStudy
+      val phase: AcceleratorPhase = AcceleratorPhase.Phase1FeasibilityStudy
       val projectId = insertProject(phase = phase)
       val newUser = insertUser()
       val vote = VoteOption.No
@@ -383,7 +383,7 @@ class VoteStoreTest : DatabaseTest(), RunsAsUser {
     @Test
     fun `throws exception on delete if project not in phase`() {
       val projectId = insertProject()
-      val phase: CohortPhase = CohortPhase.Phase1FeasibilityStudy
+      val phase: AcceleratorPhase = AcceleratorPhase.Phase1FeasibilityStudy
       val newUser = insertUser()
       val vote = VoteOption.No
       insertVote(projectId, phase, newUser, vote)
@@ -393,8 +393,8 @@ class VoteStoreTest : DatabaseTest(), RunsAsUser {
 
     @Test
     fun `throws exception on delete for wrong phase`() {
-      val phase: CohortPhase = CohortPhase.Phase0DueDiligence
-      val projectId = insertProject(phase = CohortPhase.Phase1FeasibilityStudy)
+      val phase: AcceleratorPhase = AcceleratorPhase.Phase0DueDiligence
+      val projectId = insertProject(phase = AcceleratorPhase.Phase1FeasibilityStudy)
       val newUser = insertUser()
       val vote = VoteOption.No
       insertVote(projectId, phase, newUser, vote)
@@ -404,7 +404,7 @@ class VoteStoreTest : DatabaseTest(), RunsAsUser {
 
     @Test
     fun `computes vote decision on deleting one vote from many`() {
-      val phase: CohortPhase = CohortPhase.Phase1FeasibilityStudy
+      val phase: AcceleratorPhase = AcceleratorPhase.Phase1FeasibilityStudy
       val projectId = insertProject(phase = phase)
 
       val user1 = insertUser()
@@ -425,7 +425,7 @@ class VoteStoreTest : DatabaseTest(), RunsAsUser {
 
     @Test
     fun `computes vote decision on deleting only vote`() {
-      val phase: CohortPhase = CohortPhase.Phase1FeasibilityStudy
+      val phase: AcceleratorPhase = AcceleratorPhase.Phase1FeasibilityStudy
       val projectId = insertProject(phase = phase)
 
       val newUser = insertUser()
@@ -446,7 +446,7 @@ class VoteStoreTest : DatabaseTest(), RunsAsUser {
   inner class Upsert {
     @Test
     fun `creates blank vote for self`() {
-      val phase: CohortPhase = CohortPhase.Phase1FeasibilityStudy
+      val phase: AcceleratorPhase = AcceleratorPhase.Phase1FeasibilityStudy
       val projectId = insertProject(phase = phase)
 
       clock.instant = Instant.EPOCH.plusSeconds(500)
@@ -469,7 +469,7 @@ class VoteStoreTest : DatabaseTest(), RunsAsUser {
 
     @Test
     fun `creates blank vote for other user`() {
-      val phase: CohortPhase = CohortPhase.Phase1FeasibilityStudy
+      val phase: AcceleratorPhase = AcceleratorPhase.Phase1FeasibilityStudy
       val projectId = insertProject(phase = phase)
       val otherUser = insertUser()
 
@@ -493,7 +493,7 @@ class VoteStoreTest : DatabaseTest(), RunsAsUser {
 
     @Test
     fun `creates conditional vote for other user`() {
-      val phase: CohortPhase = CohortPhase.Phase1FeasibilityStudy
+      val phase: AcceleratorPhase = AcceleratorPhase.Phase1FeasibilityStudy
       val projectId = insertProject(phase = phase)
       val otherUser = insertUser()
 
@@ -519,7 +519,7 @@ class VoteStoreTest : DatabaseTest(), RunsAsUser {
 
     @Test
     fun `update only voter selection`() {
-      val phase: CohortPhase = CohortPhase.Phase1FeasibilityStudy
+      val phase: AcceleratorPhase = AcceleratorPhase.Phase1FeasibilityStudy
       val projectId = insertProject(phase = phase)
 
       val newUser = insertUser()
@@ -551,7 +551,7 @@ class VoteStoreTest : DatabaseTest(), RunsAsUser {
 
     @Test
     fun `update voter selection with multiple voters`() {
-      val phase: CohortPhase = CohortPhase.Phase1FeasibilityStudy
+      val phase: AcceleratorPhase = AcceleratorPhase.Phase1FeasibilityStudy
       val projectId = insertProject(phase = phase)
 
       val createdTime = Instant.EPOCH.plusSeconds(500)
@@ -616,8 +616,8 @@ class VoteStoreTest : DatabaseTest(), RunsAsUser {
 
     @Test
     fun `update voter selection for multiple phases`() {
-      val phase0: CohortPhase = CohortPhase.Phase0DueDiligence
-      val phase1: CohortPhase = CohortPhase.Phase1FeasibilityStudy
+      val phase0: AcceleratorPhase = AcceleratorPhase.Phase0DueDiligence
+      val phase1: AcceleratorPhase = AcceleratorPhase.Phase1FeasibilityStudy
       val projectId = insertProject(phase = phase1)
 
       val createdTime = Instant.EPOCH.plusSeconds(500)
@@ -665,7 +665,7 @@ class VoteStoreTest : DatabaseTest(), RunsAsUser {
 
     @Test
     fun `update voter selection for multiple projects`() {
-      val phase: CohortPhase = CohortPhase.Phase1FeasibilityStudy
+      val phase: AcceleratorPhase = AcceleratorPhase.Phase1FeasibilityStudy
       val project1 = insertProject(phase = phase)
       val project2 = insertProject(phase = phase)
 
@@ -714,7 +714,7 @@ class VoteStoreTest : DatabaseTest(), RunsAsUser {
 
     @Test
     fun `throws exception on upsert if no permission to update votes`() {
-      val phase: CohortPhase = CohortPhase.Phase1FeasibilityStudy
+      val phase: AcceleratorPhase = AcceleratorPhase.Phase1FeasibilityStudy
       val projectId = insertProject(phase = phase)
       val newUser = insertUser()
       val vote = VoteOption.No
@@ -728,7 +728,7 @@ class VoteStoreTest : DatabaseTest(), RunsAsUser {
     @Test
     fun `throws exception on upsert if project not in phase`() {
       val projectId = insertProject()
-      val phase: CohortPhase = CohortPhase.Phase1FeasibilityStudy
+      val phase: AcceleratorPhase = AcceleratorPhase.Phase1FeasibilityStudy
       val newUser = insertUser()
       val vote = VoteOption.No
       insertVote(projectId, phase, newUser, vote)
@@ -740,8 +740,8 @@ class VoteStoreTest : DatabaseTest(), RunsAsUser {
 
     @Test
     fun `throws exception on upsert if project in wrong phase`() {
-      val projectId = insertProject(phase = CohortPhase.Phase1FeasibilityStudy)
-      val phase: CohortPhase = CohortPhase.Phase0DueDiligence
+      val projectId = insertProject(phase = AcceleratorPhase.Phase1FeasibilityStudy)
+      val phase: AcceleratorPhase = AcceleratorPhase.Phase0DueDiligence
       val newUser = insertUser()
       val vote = VoteOption.No
       insertVote(projectId, phase, newUser, vote)
@@ -753,7 +753,7 @@ class VoteStoreTest : DatabaseTest(), RunsAsUser {
 
     @Test
     fun `computes vote decision on creating one vote`() {
-      val phase: CohortPhase = CohortPhase.Phase1FeasibilityStudy
+      val phase: AcceleratorPhase = AcceleratorPhase.Phase1FeasibilityStudy
       val projectId = insertProject(phase = phase)
       clock.instant = Instant.EPOCH.plusSeconds(500)
 
@@ -767,7 +767,7 @@ class VoteStoreTest : DatabaseTest(), RunsAsUser {
 
     @Test
     fun `computes vote decision on creating one null vote`() {
-      val phase: CohortPhase = CohortPhase.Phase1FeasibilityStudy
+      val phase: AcceleratorPhase = AcceleratorPhase.Phase1FeasibilityStudy
       val projectId = insertProject(phase = phase)
       clock.instant = Instant.EPOCH.plusSeconds(500)
 
@@ -780,7 +780,7 @@ class VoteStoreTest : DatabaseTest(), RunsAsUser {
 
     @Test
     fun `computes vote decision on updating one vote`() {
-      val phase: CohortPhase = CohortPhase.Phase1FeasibilityStudy
+      val phase: AcceleratorPhase = AcceleratorPhase.Phase1FeasibilityStudy
       val projectId = insertProject(phase = phase)
       clock.instant = Instant.EPOCH.plusSeconds(500)
 
@@ -798,7 +798,7 @@ class VoteStoreTest : DatabaseTest(), RunsAsUser {
 
     @Test
     fun `computes vote decision on upserting to a tie`() {
-      val phase: CohortPhase = CohortPhase.Phase1FeasibilityStudy
+      val phase: AcceleratorPhase = AcceleratorPhase.Phase1FeasibilityStudy
       val projectId = insertProject(phase = phase)
       clock.instant = Instant.EPOCH.plusSeconds(500)
 
@@ -818,7 +818,7 @@ class VoteStoreTest : DatabaseTest(), RunsAsUser {
 
     @Test
     fun `computes vote decision on updating to no vote`() {
-      val phase: CohortPhase = CohortPhase.Phase1FeasibilityStudy
+      val phase: AcceleratorPhase = AcceleratorPhase.Phase1FeasibilityStudy
       val projectId = insertProject(phase = phase)
       clock.instant = Instant.EPOCH.plusSeconds(500)
 

--- a/src/test/kotlin/com/terraformation/backend/accelerator/db/VoteStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/db/VoteStoreTest.kt
@@ -388,7 +388,9 @@ class VoteStoreTest : DatabaseTest(), RunsAsUser {
       val vote = VoteOption.No
       insertVote(projectId, phase, newUser, vote)
 
-      assertThrows<ProjectNotInCohortPhaseException> { store.delete(projectId, phase, newUser) }
+      assertThrows<ProjectNotInAcceleratorPhaseException> {
+        store.delete(projectId, phase, newUser)
+      }
     }
 
     @Test
@@ -399,7 +401,9 @@ class VoteStoreTest : DatabaseTest(), RunsAsUser {
       val vote = VoteOption.No
       insertVote(projectId, phase, newUser, vote)
 
-      assertThrows<ProjectNotInCohortPhaseException> { store.delete(projectId, phase, newUser) }
+      assertThrows<ProjectNotInAcceleratorPhaseException> {
+        store.delete(projectId, phase, newUser)
+      }
     }
 
     @Test
@@ -733,7 +737,7 @@ class VoteStoreTest : DatabaseTest(), RunsAsUser {
       val vote = VoteOption.No
       insertVote(projectId, phase, newUser, vote)
 
-      assertThrows<ProjectNotInCohortPhaseException> {
+      assertThrows<ProjectNotInAcceleratorPhaseException> {
         store.upsert(projectId, phase, newUser, null, null)
       }
     }
@@ -746,7 +750,7 @@ class VoteStoreTest : DatabaseTest(), RunsAsUser {
       val vote = VoteOption.No
       insertVote(projectId, phase, newUser, vote)
 
-      assertThrows<ProjectNotInCohortPhaseException> {
+      assertThrows<ProjectNotInAcceleratorPhaseException> {
         store.upsert(projectId, phase, newUser, null, null)
       }
     }

--- a/src/test/kotlin/com/terraformation/backend/accelerator/model/ProjectScoreModelTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/model/ProjectScoreModelTest.kt
@@ -1,6 +1,6 @@
 package com.terraformation.backend.accelerator.model
 
-import com.terraformation.backend.db.accelerator.CohortPhase
+import com.terraformation.backend.db.accelerator.AcceleratorPhase
 import com.terraformation.backend.db.accelerator.ScoreCategory
 import java.math.BigDecimal
 import java.math.RoundingMode
@@ -31,7 +31,7 @@ class ProjectScoreModelTest {
       // Average of 7 values of 1.0 (finance counted twice) and 1 value of 2.0
       assertEquals(
           BigDecimal(9.0 / 8.0).setScale(2, RoundingMode.HALF_UP),
-          ProjectScoreModel.totalScore(CohortPhase.Phase0DueDiligence, scores),
+          ProjectScoreModel.totalScore(AcceleratorPhase.Phase0DueDiligence, scores),
       )
     }
 
@@ -55,7 +55,7 @@ class ProjectScoreModelTest {
       // (finance counted twice)
       assertEquals(
           BigDecimal(10.0 / 8.0).setScale(2, RoundingMode.HALF_UP),
-          ProjectScoreModel.totalScore(CohortPhase.Phase0DueDiligence, scores),
+          ProjectScoreModel.totalScore(AcceleratorPhase.Phase0DueDiligence, scores),
       )
     }
 
@@ -75,7 +75,7 @@ class ProjectScoreModelTest {
               // Missing ValuesAlignment
           )
 
-      assertNull(ProjectScoreModel.totalScore(CohortPhase.Phase0DueDiligence, scores))
+      assertNull(ProjectScoreModel.totalScore(AcceleratorPhase.Phase0DueDiligence, scores))
     }
   }
 
@@ -94,7 +94,7 @@ class ProjectScoreModelTest {
       // Average of 1 value of 1.0 and 1 value of 2.5 (average of the two project lead scores)
       assertEquals(
           BigDecimal(3.5 / 2.0).setScale(2, RoundingMode.HALF_UP),
-          ProjectScoreModel.totalScore(CohortPhase.Phase1FeasibilityStudy, scores),
+          ProjectScoreModel.totalScore(AcceleratorPhase.Phase1FeasibilityStudy, scores),
       )
     }
 
@@ -109,7 +109,7 @@ class ProjectScoreModelTest {
 
       assertEquals(
           BigDecimal(3.0 / 2.0).setScale(2, RoundingMode.HALF_UP),
-          ProjectScoreModel.totalScore(CohortPhase.Phase1FeasibilityStudy, scores),
+          ProjectScoreModel.totalScore(AcceleratorPhase.Phase1FeasibilityStudy, scores),
       )
     }
 
@@ -121,7 +121,7 @@ class ProjectScoreModelTest {
               newModel(ScoreCategory.SocialImpact, null),
           )
 
-      assertNull(ProjectScoreModel.totalScore(CohortPhase.Phase1FeasibilityStudy, scores))
+      assertNull(ProjectScoreModel.totalScore(AcceleratorPhase.Phase1FeasibilityStudy, scores))
     }
   }
 
@@ -129,9 +129,9 @@ class ProjectScoreModelTest {
   fun `returns null for non-scored cohort phases`() {
     val scores = listOf(NewProjectScoreModel(ScoreCategory.GIS, null, null, 1))
 
-    assertNull(ProjectScoreModel.totalScore(CohortPhase.Phase2PlanAndScale, scores), "Phase 2")
+    assertNull(ProjectScoreModel.totalScore(AcceleratorPhase.Phase2PlanAndScale, scores), "Phase 2")
     assertNull(
-        ProjectScoreModel.totalScore(CohortPhase.Phase3ImplementAndMonitor, scores),
+        ProjectScoreModel.totalScore(AcceleratorPhase.Phase3ImplementAndMonitor, scores),
         "Phase 3",
     )
   }

--- a/src/test/kotlin/com/terraformation/backend/accelerator/model/ProjectScoreModelTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/model/ProjectScoreModelTest.kt
@@ -126,7 +126,7 @@ class ProjectScoreModelTest {
   }
 
   @Test
-  fun `returns null for non-scored cohort phases`() {
+  fun `returns null for non-scored phases`() {
     val scores = listOf(NewProjectScoreModel(ScoreCategory.GIS, null, null, 1))
 
     assertNull(ProjectScoreModel.totalScore(AcceleratorPhase.Phase2PlanAndScale, scores), "Phase 2")

--- a/src/test/kotlin/com/terraformation/backend/accelerator/variables/ApplicationVariableValuesServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/variables/ApplicationVariableValuesServiceTest.kt
@@ -9,7 +9,7 @@ import com.terraformation.backend.customer.model.SystemUser
 import com.terraformation.backend.customer.model.TerrawareUser
 import com.terraformation.backend.db.DatabaseTest
 import com.terraformation.backend.db.StableId
-import com.terraformation.backend.db.accelerator.CohortPhase
+import com.terraformation.backend.db.accelerator.AcceleratorPhase
 import com.terraformation.backend.db.default_schema.LandUseModelType
 import com.terraformation.backend.db.docprod.VariableId
 import com.terraformation.backend.db.docprod.VariableSelectOptionId
@@ -72,7 +72,7 @@ class ApplicationVariableValuesServiceTest : DatabaseTest(), RunsAsUser {
   fun setUp() {
     insertOrganization()
     insertProject()
-    insertModule(phase = CohortPhase.PreScreen)
+    insertModule(phase = AcceleratorPhase.PreScreen)
 
     variableIdsByStableId = setupStableIdVariables()
 

--- a/src/test/kotlin/com/terraformation/backend/customer/AppNotificationServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/AppNotificationServiceTest.kt
@@ -43,8 +43,8 @@ import com.terraformation.backend.customer.model.SystemUser
 import com.terraformation.backend.customer.model.TerrawareUser
 import com.terraformation.backend.db.DatabaseTest
 import com.terraformation.backend.db.IdentifierGenerator
+import com.terraformation.backend.db.accelerator.AcceleratorPhase
 import com.terraformation.backend.db.accelerator.ActivityType
-import com.terraformation.backend.db.accelerator.CohortPhase
 import com.terraformation.backend.db.accelerator.DeliverableCategory
 import com.terraformation.backend.db.accelerator.DeliverableId
 import com.terraformation.backend.db.accelerator.EventType
@@ -798,7 +798,7 @@ internal class AppNotificationServiceTest : DatabaseTest(), RunsAsUser {
   fun `should store deliverable ready for review notification for admin with correct category`() {
     insertModule()
     insertUserGlobalRole(user.userId, GlobalRole.TFExpert)
-    val projectId = insertProject(phase = CohortPhase.Phase0DueDiligence)
+    val projectId = insertProject(phase = AcceleratorPhase.Phase0DueDiligence)
     insertProjectModule()
 
     insertUserInternalInterest(InternalInterest.GIS, user.userId)
@@ -819,7 +819,7 @@ internal class AppNotificationServiceTest : DatabaseTest(), RunsAsUser {
     insertModule()
     insertUserGlobalRole(user.userId, GlobalRole.TFExpert)
 
-    val projectId = insertProject(phase = CohortPhase.Phase0DueDiligence)
+    val projectId = insertProject(phase = AcceleratorPhase.Phase0DueDiligence)
     insertProjectModule()
 
     insertUserInternalInterest(InternalInterest.Compliance, user.userId)
@@ -838,7 +838,7 @@ internal class AppNotificationServiceTest : DatabaseTest(), RunsAsUser {
     val tfContact = insertUser(email = "tfcontact@terraformation.com")
     insertOrganizationUser(tfContact, role = Role.TerraformationContact)
 
-    val projectId = insertProject(phase = CohortPhase.Phase0DueDiligence)
+    val projectId = insertProject(phase = AcceleratorPhase.Phase0DueDiligence)
     insertProjectModule()
 
     // TF contact has the wrong deliverable category but we should notify them anyway because
@@ -869,7 +869,7 @@ internal class AppNotificationServiceTest : DatabaseTest(), RunsAsUser {
     insertOrganizationUser(tfContact, role = Role.TerraformationContact)
     insertUserGlobalRole(tfContact, role = GlobalRole.TFExpert)
 
-    val projectId = insertProject(phase = CohortPhase.Phase0DueDiligence)
+    val projectId = insertProject(phase = AcceleratorPhase.Phase0DueDiligence)
     insertModule()
     insertProjectModule()
     val deliverableId =
@@ -950,7 +950,7 @@ internal class AppNotificationServiceTest : DatabaseTest(), RunsAsUser {
   @Test
   fun `should store species added to project notification for global users with interest`() {
     insertUserGlobalRole(user.userId, GlobalRole.TFExpert)
-    val projectId = insertProject(phase = CohortPhase.Phase0DueDiligence)
+    val projectId = insertProject(phase = AcceleratorPhase.Phase0DueDiligence)
     val speciesId = insertSpecies()
     insertParticipantProjectSpecies(projectId = projectId, speciesId = speciesId)
     insertModule()
@@ -976,7 +976,7 @@ internal class AppNotificationServiceTest : DatabaseTest(), RunsAsUser {
   @Test
   fun `should store species approved species edited notification`() {
     insertUserGlobalRole(user.userId, GlobalRole.TFExpert)
-    val projectId = insertProject(phase = CohortPhase.Phase0DueDiligence)
+    val projectId = insertProject(phase = AcceleratorPhase.Phase0DueDiligence)
     val speciesId = insertSpecies()
     insertParticipantProjectSpecies(projectId = projectId, speciesId = speciesId)
     insertModule()

--- a/src/test/kotlin/com/terraformation/backend/customer/db/OrganizationFeatureStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/db/OrganizationFeatureStoreTest.kt
@@ -5,7 +5,7 @@ import com.terraformation.backend.customer.model.OrganizationFeature
 import com.terraformation.backend.customer.model.TerrawareUser
 import com.terraformation.backend.db.DatabaseTest
 import com.terraformation.backend.db.OrganizationNotFoundException
-import com.terraformation.backend.db.accelerator.CohortPhase
+import com.terraformation.backend.db.accelerator.AcceleratorPhase
 import com.terraformation.backend.db.default_schema.OrganizationId
 import com.terraformation.backend.db.default_schema.ProjectId
 import com.terraformation.backend.db.default_schema.Role
@@ -87,7 +87,7 @@ class OrganizationFeatureStoreTest : DatabaseTest(), RunsAsDatabaseUser {
         "No modules",
     )
 
-    val projectId = insertProject(phase = CohortPhase.Phase0DueDiligence)
+    val projectId = insertProject(phase = AcceleratorPhase.Phase0DueDiligence)
 
     insertModule()
     insertProjectModule()
@@ -110,7 +110,7 @@ class OrganizationFeatureStoreTest : DatabaseTest(), RunsAsDatabaseUser {
         "No deliverables",
     )
 
-    val projectId = insertProject(phase = CohortPhase.Phase0DueDiligence)
+    val projectId = insertProject(phase = AcceleratorPhase.Phase0DueDiligence)
 
     insertModule()
     insertDeliverable()
@@ -135,7 +135,7 @@ class OrganizationFeatureStoreTest : DatabaseTest(), RunsAsDatabaseUser {
         "No submission",
     )
 
-    insertModule(phase = CohortPhase.Application)
+    insertModule(phase = AcceleratorPhase.Application)
     insertDeliverable()
     insertProject()
     insertSubmission()
@@ -219,7 +219,7 @@ class OrganizationFeatureStoreTest : DatabaseTest(), RunsAsDatabaseUser {
 
     val applicationProjectId = insertProject(name = "Application project")
     insertApplication()
-    insertModule(phase = CohortPhase.Application)
+    insertModule(phase = AcceleratorPhase.Application)
     insertDeliverable()
     insertSubmission()
 
@@ -232,8 +232,8 @@ class OrganizationFeatureStoreTest : DatabaseTest(), RunsAsDatabaseUser {
     )
 
     val moduleProjectId =
-        insertProject(name = "Phase 1 project", phase = CohortPhase.Phase1FeasibilityStudy)
-    insertModule(phase = CohortPhase.Phase1FeasibilityStudy)
+        insertProject(name = "Phase 1 project", phase = AcceleratorPhase.Phase1FeasibilityStudy)
+    insertModule(phase = AcceleratorPhase.Phase1FeasibilityStudy)
     insertDeliverable()
     insertProjectModule()
 

--- a/src/test/kotlin/com/terraformation/backend/customer/db/OrganizationFeatureStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/db/OrganizationFeatureStoreTest.kt
@@ -128,7 +128,7 @@ class OrganizationFeatureStoreTest : DatabaseTest(), RunsAsDatabaseUser {
   }
 
   @Test
-  fun `checks for projects of submissions for projects not in a cohort for the deliverables feature`() {
+  fun `checks for projects of submissions for projects not in a phase for the deliverables feature`() {
     assertEquals(
         emptyOrganizationFeatureProjects,
         store.listOrganizationFeatureProjects(organizationId),
@@ -243,7 +243,7 @@ class OrganizationFeatureStoreTest : DatabaseTest(), RunsAsDatabaseUser {
     assertEquals(
         expectedFeatureProjects.toMap(),
         store.listOrganizationFeatureProjects(organizationId),
-        "One application project and one cohort phase 1 project",
+        "One application project and one phase 1 project",
     )
 
     val reportProjectId = insertProject(name = "Report project")
@@ -255,7 +255,7 @@ class OrganizationFeatureStoreTest : DatabaseTest(), RunsAsDatabaseUser {
     assertEquals(
         expectedFeatureProjects.toMap(),
         store.listOrganizationFeatureProjects(organizationId),
-        "One application project, one cohort phase 1 project, and one report projects",
+        "One application project, one phase 1 project, and one report project",
     )
 
     val seedFundProjectId = insertProject()

--- a/src/test/kotlin/com/terraformation/backend/customer/model/PermissionTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/model/PermissionTest.kt
@@ -6,9 +6,9 @@ import com.terraformation.backend.customer.db.ParentStore
 import com.terraformation.backend.customer.db.PermissionStore
 import com.terraformation.backend.customer.db.UserStore
 import com.terraformation.backend.db.DatabaseTest
+import com.terraformation.backend.db.accelerator.AcceleratorPhase
 import com.terraformation.backend.db.accelerator.ActivityId
 import com.terraformation.backend.db.accelerator.ApplicationId
-import com.terraformation.backend.db.accelerator.CohortPhase
 import com.terraformation.backend.db.accelerator.DeliverableId
 import com.terraformation.backend.db.accelerator.EventId
 import com.terraformation.backend.db.accelerator.ModuleId
@@ -258,7 +258,7 @@ internal class PermissionTest : DatabaseTest() {
           insertProject(
               createdBy = userId,
               organizationId = getDatabaseId(OrganizationId(projectId.value / 1000)),
-              phase = CohortPhase.Phase1FeasibilityStudy,
+              phase = AcceleratorPhase.Phase1FeasibilityStudy,
           ),
       )
     }

--- a/src/test/kotlin/com/terraformation/backend/customer/search/ProjectInternalUsersSearchTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/search/ProjectInternalUsersSearchTest.kt
@@ -4,7 +4,7 @@ import com.terraformation.backend.RunsAsUser
 import com.terraformation.backend.TestClock
 import com.terraformation.backend.assertJsonEquals
 import com.terraformation.backend.db.DatabaseTest
-import com.terraformation.backend.db.accelerator.CohortPhase
+import com.terraformation.backend.db.accelerator.AcceleratorPhase
 import com.terraformation.backend.db.default_schema.OrganizationId
 import com.terraformation.backend.db.default_schema.ProjectInternalRole
 import com.terraformation.backend.db.default_schema.Role
@@ -84,11 +84,11 @@ class ProjectInternalUsersSearchTest : DatabaseTest(), RunsAsUser {
   @Test
   fun `allows accelerator readers to see internal users of other organizations`() {
     every { user.canReadAllAcceleratorDetails() } returns true
-    val projectId = insertProject(phase = CohortPhase.Phase0DueDiligence)
+    val projectId = insertProject(phase = AcceleratorPhase.Phase0DueDiligence)
     val projectLead = insertUser()
     insertProjectInternalUser(role = ProjectInternalRole.ProjectLead)
     val otherOrg = insertOrganization()
-    val otherProject = insertProject(phase = CohortPhase.Phase1FeasibilityStudy)
+    val otherProject = insertProject(phase = AcceleratorPhase.Phase1FeasibilityStudy)
     val otherOrgUser = insertUser()
     insertProjectInternalUser(role = ProjectInternalRole.RestorationLead)
 

--- a/src/test/kotlin/com/terraformation/backend/daily/PlantingSeasonSchedulerTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/daily/PlantingSeasonSchedulerTest.kt
@@ -9,7 +9,7 @@ import com.terraformation.backend.customer.db.ParentStore
 import com.terraformation.backend.customer.model.SystemUser
 import com.terraformation.backend.db.DatabaseTest
 import com.terraformation.backend.db.IdentifierGenerator
-import com.terraformation.backend.db.accelerator.CohortPhase
+import com.terraformation.backend.db.accelerator.AcceleratorPhase
 import com.terraformation.backend.db.default_schema.ProjectId
 import com.terraformation.backend.db.tracking.PlantingSiteId
 import com.terraformation.backend.mockUser
@@ -130,7 +130,7 @@ class PlantingSeasonSchedulerTest : DatabaseTest(), RunsAsUser {
 
     @Test
     fun `sends support notifications for accelerator planting sites`() {
-      insertProject(phase = CohortPhase.Phase2PlanAndScale)
+      insertProject(phase = AcceleratorPhase.Phase2PlanAndScale)
       val plantingSiteId = insertPlantingSiteWithSubzone(inserted.projectId)
 
       assertNoEventsBeforeWeekNumber(
@@ -224,7 +224,7 @@ class PlantingSeasonSchedulerTest : DatabaseTest(), RunsAsUser {
 
     @Test
     fun `sends support notifications for accelerator planting sites`() {
-      insertProject(phase = CohortPhase.Phase2PlanAndScale)
+      insertProject(phase = AcceleratorPhase.Phase2PlanAndScale)
       val plantingSiteId = insertPlantingSiteWithSeason(projectId = inserted.projectId)
 
       assertNoEventsBeforeWeekNumber(

--- a/src/test/kotlin/com/terraformation/backend/db/DatabaseBackedTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/db/DatabaseBackedTest.kt
@@ -12,6 +12,7 @@ import com.terraformation.backend.auth.currentUser
 import com.terraformation.backend.config.TerrawareServerConfig
 import com.terraformation.backend.customer.model.AutomationModel
 import com.terraformation.backend.customer.model.InternalTagIds
+import com.terraformation.backend.db.accelerator.AcceleratorPhase
 import com.terraformation.backend.db.accelerator.ActivityId
 import com.terraformation.backend.db.accelerator.ActivityMediaType
 import com.terraformation.backend.db.accelerator.ActivityStatus
@@ -20,7 +21,6 @@ import com.terraformation.backend.db.accelerator.ApplicationHistoryId
 import com.terraformation.backend.db.accelerator.ApplicationId
 import com.terraformation.backend.db.accelerator.ApplicationModuleStatus
 import com.terraformation.backend.db.accelerator.ApplicationStatus
-import com.terraformation.backend.db.accelerator.CohortPhase
 import com.terraformation.backend.db.accelerator.DealStage
 import com.terraformation.backend.db.accelerator.DeliverableCategory
 import com.terraformation.backend.db.accelerator.DeliverableId
@@ -867,7 +867,7 @@ abstract class DatabaseBackedTest {
       createdBy: UserId = currentUser().userId,
       createdTime: Instant = Instant.EPOCH,
       description: String? = null,
-      phase: CohortPhase? = null,
+      phase: AcceleratorPhase? = null,
       countryCode: String? = null,
   ): ProjectId {
     val row =
@@ -1155,7 +1155,7 @@ abstract class DatabaseBackedTest {
 
   protected fun insertProjectScore(
       projectId: ProjectId = inserted.projectId,
-      phase: CohortPhase = CohortPhase.Phase0DueDiligence,
+      phase: AcceleratorPhase = AcceleratorPhase.Phase0DueDiligence,
       category: ScoreCategory = ScoreCategory.Legal,
       score: Int? = null,
       qualitative: String? = null,
@@ -2490,7 +2490,7 @@ abstract class DatabaseBackedTest {
       workshopDescription: String? = null,
       oneOnOneSessionDescription: String? = null,
       additionalResources: String? = null,
-      phase: CohortPhase = CohortPhase.Phase1FeasibilityStudy,
+      phase: AcceleratorPhase = AcceleratorPhase.Phase1FeasibilityStudy,
   ): ModuleId {
     nextModuleNumber++
 
@@ -4294,7 +4294,7 @@ abstract class DatabaseBackedTest {
 
   fun insertVote(
       projectId: ProjectId = inserted.projectId,
-      phase: CohortPhase = CohortPhase.Phase0DueDiligence,
+      phase: AcceleratorPhase = AcceleratorPhase.Phase0DueDiligence,
       user: UserId = currentUser().userId,
       voteOption: VoteOption? = null,
       conditionalInfo: String? = null,
@@ -4321,7 +4321,7 @@ abstract class DatabaseBackedTest {
 
   fun insertVoteDecision(
       projectId: ProjectId = inserted.projectId,
-      phase: CohortPhase = CohortPhase.Phase0DueDiligence,
+      phase: AcceleratorPhase = AcceleratorPhase.Phase0DueDiligence,
       voteOption: VoteOption? = null,
       modifiedTime: Instant = Instant.EPOCH,
   ): ProjectVoteDecisionsRow {

--- a/src/test/kotlin/com/terraformation/backend/db/SchemaDocsGenerator.kt
+++ b/src/test/kotlin/com/terraformation/backend/db/SchemaDocsGenerator.kt
@@ -132,6 +132,7 @@ class SchemaDocsGenerator : DatabaseTest() {
       mapOf(
           "accelerator" to
               mapOf(
+                  "accelerator_phases" to setOf(ALL, ACCELERATOR),
                   "activities" to setOf(ALL, ACCELERATOR),
                   "activity_media_files" to setOf(ALL, ACCELERATOR),
                   "activity_media_types" to setOf(ALL, ACCELERATOR),
@@ -142,7 +143,6 @@ class SchemaDocsGenerator : DatabaseTest() {
                   "application_modules" to setOf(ALL, ACCELERATOR),
                   "application_statuses" to setOf(ALL, ACCELERATOR),
                   "applications" to setOf(ALL, ACCELERATOR),
-                  "cohort_phases" to setOf(ALL, ACCELERATOR),
                   "deal_stages" to setOf(ALL, ACCELERATOR),
                   "default_voters" to setOf(ALL, ACCELERATOR),
                   "deliverable_categories" to setOf(ALL, ACCELERATOR),

--- a/src/test/kotlin/com/terraformation/backend/documentproducer/api/ValuesControllerTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/documentproducer/api/ValuesControllerTest.kt
@@ -3,7 +3,7 @@ package com.terraformation.backend.documentproducer.api
 import com.terraformation.backend.api.ControllerIntegrationTest
 import com.terraformation.backend.assertSetEquals
 import com.terraformation.backend.auth.currentUser
-import com.terraformation.backend.db.accelerator.CohortPhase
+import com.terraformation.backend.db.accelerator.AcceleratorPhase
 import com.terraformation.backend.db.default_schema.GlobalRole
 import com.terraformation.backend.db.default_schema.ProjectId
 import com.terraformation.backend.db.default_schema.tables.references.USER_GLOBAL_ROLES
@@ -26,7 +26,7 @@ class ValuesControllerTest : ControllerIntegrationTest() {
   fun setUp() {
     insertUserGlobalRole(userId = currentUser().userId, GlobalRole.TFExpert)
     insertOrganization()
-    insertProject(phase = CohortPhase.Phase1FeasibilityStudy)
+    insertProject(phase = AcceleratorPhase.Phase1FeasibilityStudy)
   }
 
   private fun path(projectId: ProjectId = inserted.projectId) =

--- a/src/test/kotlin/com/terraformation/backend/email/EmailNotificationServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/email/EmailNotificationServiceTest.kt
@@ -42,11 +42,11 @@ import com.terraformation.backend.customer.model.SystemUser
 import com.terraformation.backend.daily.NotificationJobFinishedEvent
 import com.terraformation.backend.daily.NotificationJobSucceededEvent
 import com.terraformation.backend.db.StableId
+import com.terraformation.backend.db.accelerator.AcceleratorPhase
 import com.terraformation.backend.db.accelerator.ActivityId
 import com.terraformation.backend.db.accelerator.ActivityStatus
 import com.terraformation.backend.db.accelerator.ActivityType
 import com.terraformation.backend.db.accelerator.ApplicationId
-import com.terraformation.backend.db.accelerator.CohortPhase
 import com.terraformation.backend.db.accelerator.DeliverableCategory
 import com.terraformation.backend.db.accelerator.DeliverableId
 import com.terraformation.backend.db.accelerator.DeliverableType
@@ -352,7 +352,7 @@ internal class EmailNotificationServiceTest {
           id = ProjectId(1),
           name = "My Project",
           organizationId = organization.id,
-          phase = CohortPhase.Phase1FeasibilityStudy,
+          phase = AcceleratorPhase.Phase1FeasibilityStudy,
       )
   private val species =
       ExistingSpeciesModel(

--- a/src/test/kotlin/com/terraformation/backend/search/table/VariableSelectOptionsTableTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/search/table/VariableSelectOptionsTableTest.kt
@@ -4,7 +4,7 @@ import com.terraformation.backend.RunsAsUser
 import com.terraformation.backend.TestClock
 import com.terraformation.backend.assertJsonEquals
 import com.terraformation.backend.db.DatabaseTest
-import com.terraformation.backend.db.accelerator.CohortPhase
+import com.terraformation.backend.db.accelerator.AcceleratorPhase
 import com.terraformation.backend.db.default_schema.Role
 import com.terraformation.backend.db.docprod.VariableType
 import com.terraformation.backend.mockUser
@@ -31,7 +31,7 @@ class VariableSelectOptionsTableTest : DatabaseTest(), RunsAsUser {
         organizationId = inserted.organizationId,
         role = Role.Admin,
     )
-    insertProject(phase = CohortPhase.Phase1FeasibilityStudy)
+    insertProject(phase = AcceleratorPhase.Phase1FeasibilityStudy)
 
     every { user.canReadAllAcceleratorDetails() } returns true
     every { user.organizationRoles } returns mapOf(inserted.organizationId to Role.Admin)

--- a/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceUserSearchTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceUserSearchTest.kt
@@ -1,7 +1,7 @@
 package com.terraformation.backend.seedbank.search
 
 import com.terraformation.backend.assertJsonEquals
-import com.terraformation.backend.db.accelerator.CohortPhase
+import com.terraformation.backend.db.accelerator.AcceleratorPhase
 import com.terraformation.backend.db.default_schema.OrganizationId
 import com.terraformation.backend.db.default_schema.ProjectInternalRole
 import com.terraformation.backend.db.default_schema.Role
@@ -198,7 +198,7 @@ internal class SearchServiceUserSearchTest : SearchServiceTest() {
     every { user.canReadAllAcceleratorDetails() } returns true
 
     val projectId =
-        insertProject(organizationId = organizationId, phase = CohortPhase.Phase0DueDiligence)
+        insertProject(organizationId = organizationId, phase = AcceleratorPhase.Phase0DueDiligence)
     insertProjectInternalUser(userId = bothOrgsUserId, role = ProjectInternalRole.RegionalExpert)
     insertProjectInternalUser(userId = otherOrgUserId, role = ProjectInternalRole.GISLead)
 


### PR DESCRIPTION
Change the enum (and its table) to stop referring to cohorts. It's renamed to
AcceleratorPhase rather than Phase just because Phase is kind of generic and
is already defined as a class by several of our dependencies.
