### PR TITLE
SW-7926 Remove remaining references to cohorts

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/accelerator/DeliverableFilesRenamer.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/DeliverableFilesRenamer.kt
@@ -76,7 +76,7 @@ class DeliverableFilesRenamer(
       fileNaming: String,
       folderUrl: URI,
   ) {
-    val cohortDeliverables =
+    val projectDeliverables =
         deliverableStore.fetchDeliverableSubmissions(projectId = projectId).filter {
           it.documents.isNotEmpty()
         }
@@ -93,7 +93,7 @@ class DeliverableFilesRenamer(
           log.warn("Folder $folderUrl is not a valid Google drive")
           null
         }
-    val allDeliverables = listOf(cohortDeliverables, applicationDeliverables).flatten()
+    val allDeliverables = listOf(projectDeliverables, applicationDeliverables).flatten()
 
     allDeliverables.forEach { deliverable ->
       deliverable.documents

--- a/src/main/kotlin/com/terraformation/backend/accelerator/api/ParticipantProjectSpeciesController.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/api/ParticipantProjectSpeciesController.kt
@@ -223,7 +223,8 @@ data class GetParticipantProjectSpeciesResponsePayload(
 data class ParticipantProjectForSpeciesPayload(
     @Schema(
         description =
-            "This deliverable ID is associated to the active or most recent cohort module, if available."
+            "This deliverable ID is associated with the project's active or most recent module, " +
+                "if any."
     )
     val deliverableId: DeliverableId?,
     val participantProjectSpeciesId: ParticipantProjectSpeciesId,

--- a/src/main/kotlin/com/terraformation/backend/accelerator/db/VoteStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/db/VoteStore.kt
@@ -121,7 +121,7 @@ class VoteStore(
   }
 
   /**
-   * Assigns the correct set of voters to a project for its cohort's current phase, if any.
+   * Assigns the correct set of voters to a project for its current phase, if any.
    *
    * The initial implementation assigns all the default voters.
    */

--- a/src/main/kotlin/com/terraformation/backend/accelerator/model/ParticipantProjectForSpecies.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/model/ParticipantProjectForSpecies.kt
@@ -15,7 +15,7 @@ import org.jooq.impl.DSL
 
 data class ParticipantProjectsForSpecies(
     /**
-     * This deliverable ID is associated to the active or most recent cohort module, if available
+     * This deliverable ID is associated with the project's active or most recent module, if any.
      */
     val deliverableId: DeliverableId? = null,
     val participantProjectSpeciesId: ParticipantProjectSpeciesId,

--- a/src/main/kotlin/com/terraformation/backend/customer/db/ParentStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/db/ParentStore.kt
@@ -356,7 +356,7 @@ class ParentStore(private val dslContext: DSLContext) {
           .isNotEmpty
 
   fun exists(moduleId: ModuleId, userId: UserId): Boolean {
-    val cohortModuleExists =
+    val projectModuleExists =
         dslContext
             .selectOne()
             .from(PROJECT_MODULES)
@@ -383,7 +383,7 @@ class ParentStore(private val dslContext: DSLContext) {
             .fetch()
             .isNotEmpty
 
-    return cohortModuleExists || applicationModuleExists
+    return projectModuleExists || applicationModuleExists
   }
 
   fun exists(fundingEntityId: FundingEntityId, userId: UserId): Boolean =

--- a/src/main/resources/db/migration/R__Comments.sql
+++ b/src/main/resources/db/migration/R__Comments.sql
@@ -589,7 +589,7 @@ COMMENT ON CONSTRAINT num_plants_sign_consistent_with_type ON tracking.plantings
 
 COMMENT ON TABLE accelerator.accelerator_phases IS '(Enum) Phases that accelerator projects go through.';
 
-COMMENT ON VIEW accelerator.accelerator_projects IS 'All projects that are in the accelerator, by any of the definitions. The 3 definitions at the time of creation were: having an application, having a cohort, or the project''s org having an internal tag of "Accelerator".';
+COMMENT ON VIEW accelerator.accelerator_projects IS 'All projects that are in the accelerator, due to either having an application or being in an accelerator phase.';
 
 COMMENT ON TABLE accelerator.activities IS 'User-supplied descriptions of project activities.';
 

--- a/src/test/kotlin/com/terraformation/backend/accelerator/ParticipantProjectSpeciesServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/ParticipantProjectSpeciesServiceTest.kt
@@ -255,11 +255,11 @@ class ParticipantProjectSpeciesServiceTest : DatabaseTest(), RunsAsUser {
 
     @Test
     fun `creates an entity for each project ID and species ID pairing and ensures there is a submission for each most recent project deliverable, if there is no active one`() {
-      // This cohort module goes from 0 to 6 days
+      // This module goes from 0 to 6 days
       val moduleIdOld = insertModule()
       insertDeliverable(moduleId = moduleIdOld, deliverableTypeId = DeliverableType.Species)
 
-      // This cohort module goes from 7 to 13 days
+      // This module goes from 7 to 13 days
       val moduleIdMostRecent = insertModule()
       val deliverableIdMostRecent =
           insertDeliverable(
@@ -267,9 +267,9 @@ class ParticipantProjectSpeciesServiceTest : DatabaseTest(), RunsAsUser {
               deliverableTypeId = DeliverableType.Species,
           )
 
-      // The clock is between these two cohort modules
+      // The clock is between these two modules
 
-      // This cohort module goes from 21 to 27 days
+      // This module goes from 21 to 27 days
       val moduleIdFuture = insertModule()
       insertDeliverable(moduleId = moduleIdFuture, deliverableTypeId = DeliverableType.Species)
 

--- a/src/test/kotlin/com/terraformation/backend/accelerator/ProjectDeliverableSearchTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/ProjectDeliverableSearchTest.kt
@@ -175,7 +175,7 @@ class ProjectDeliverableSearchTest : DatabaseTest(), RunsAsUser {
   }
 
   @Test
-  fun `can filter by project and only includes deliverables that are part of project cohort`() {
+  fun `can filter by project and only includes deliverables that are part of project modules`() {
     val moduleId = inserted.moduleId
 
     val deliverableWithSubmission = insertDeliverable(moduleId = moduleId)

--- a/src/test/kotlin/com/terraformation/backend/accelerator/db/DeliverableDueDateStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/db/DeliverableDueDateStoreTest.kt
@@ -66,8 +66,7 @@ class DeliverableDueDateStoreTest : DatabaseTest(), RunsAsUser {
       )
 
       val deliverableId1 = insertDeliverable(moduleId = moduleId1)
-      val deliverableId2 =
-          insertDeliverable(moduleId = moduleId1) // Has project and cohort overrides
+      val deliverableId2 = insertDeliverable(moduleId = moduleId1) // Has project override
 
       val deliverableId3 = insertDeliverable(moduleId = moduleId2)
       val deliverableId4 = insertDeliverable(moduleId = moduleId2)
@@ -134,7 +133,7 @@ class DeliverableDueDateStoreTest : DatabaseTest(), RunsAsUser {
               project1Deliverable4,
           ),
           store.fetchDeliverableDueDates(projectId = projectId1).toSet(),
-          "Fetch with cohort filter",
+          "Fetch with project filter",
       )
 
       assertSetEquals(
@@ -154,7 +153,7 @@ class DeliverableDueDateStoreTest : DatabaseTest(), RunsAsUser {
               project1Deliverable4,
           ),
           store.fetchDeliverableDueDates(projectId = projectId1, moduleId = moduleId2).toSet(),
-          "Fetch with cohort and module filter",
+          "Fetch with project and module filter",
       )
 
       assertSetEquals(
@@ -173,7 +172,7 @@ class DeliverableDueDateStoreTest : DatabaseTest(), RunsAsUser {
           store
               .fetchDeliverableDueDates(projectId = projectId1, deliverableId = deliverableId3)
               .toSet(),
-          "Fetch with cohort and deliverable filter",
+          "Fetch with project and deliverable filter",
       )
 
       assertSetEquals(

--- a/src/test/kotlin/com/terraformation/backend/accelerator/db/DeliverableStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/db/DeliverableStoreTest.kt
@@ -603,7 +603,7 @@ class DeliverableStoreTest : DatabaseTest(), RunsAsUser {
               )
               .firstOrNull()
               ?.dueDate,
-          "Deliverable for project with neither project nor cohort due date",
+          "Deliverable for project with no project due date",
       )
     }
 

--- a/src/test/kotlin/com/terraformation/backend/accelerator/db/ModuleStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/db/ModuleStoreTest.kt
@@ -61,7 +61,7 @@ class ModuleStoreTest : DatabaseTest(), RunsAsUser {
   @Nested
   inner class FetchOneById {
     @Test
-    fun `returns one module with all cohorts`() {
+    fun `returns one module`() {
       val moduleId =
           insertModule(
               additionalResources = "<b> Additional Resources </b>",

--- a/src/test/kotlin/com/terraformation/backend/accelerator/db/ParticipantProjectSpeciesStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/db/ParticipantProjectSpeciesStoreTest.kt
@@ -585,7 +585,7 @@ class ParticipantProjectSpeciesStoreTest : DatabaseTest(), RunsAsUser {
     }
 
     @Test
-    fun `does not create the species association if the project is not associated to a cohort`() {
+    fun `does not create the species association if the project is not in an accelerator phase`() {
       val projectId = insertProject()
       val speciesId = insertSpecies()
 


### PR DESCRIPTION
Get rid of all the remaining occurrences of the word "cohort" in the code base,
aside from the ones in already-applied database migrations.