### PR TITLE
SW-8082 Remove report_frequencies table

### DIFF
--- a/jooq/src/main/kotlin/com/terraformation/backend/jooq/Config.kt
+++ b/jooq/src/main/kotlin/com/terraformation/backend/jooq/Config.kt
@@ -52,7 +52,6 @@ val ENUM_TABLES =
                     listOf("[a-z_]+_indicators\\.level_id"),
                 ),
                 EnumTable("pipelines", isLocalizable = false),
-                EnumTable("report_frequencies"),
                 EnumTable(
                     "report_indicator_statuses",
                     listOf(

--- a/src/main/kotlin/com/terraformation/backend/accelerator/api/ProjectReportsController.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/api/ProjectReportsController.kt
@@ -35,7 +35,6 @@ import com.terraformation.backend.db.accelerator.IndicatorCategory
 import com.terraformation.backend.db.accelerator.IndicatorLevel
 import com.terraformation.backend.db.accelerator.ProjectIndicatorId
 import com.terraformation.backend.db.accelerator.ProjectReportConfigId
-import com.terraformation.backend.db.accelerator.ReportFrequency
 import com.terraformation.backend.db.accelerator.ReportId
 import com.terraformation.backend.db.accelerator.ReportIndicatorStatus
 import com.terraformation.backend.db.accelerator.ReportQuarter
@@ -347,9 +346,7 @@ class ProjectReportsController(
       @PathVariable projectId: ProjectId,
       @RequestBody payload: CreateAcceleratorReportConfigRequestPayload,
   ): SimpleSuccessResponsePayload {
-    reportStore.insertProjectReportConfig(
-        payload.config.toModel(projectId, ReportFrequency.Quarterly)
-    )
+    reportStore.insertProjectReportConfig(payload.config.toModel(projectId))
 
     return SimpleSuccessResponsePayload()
   }
@@ -528,7 +525,6 @@ class ProjectReportsController(
 data class ExistingAcceleratorReportConfigPayload(
     val configId: ProjectReportConfigId,
     val projectId: ProjectId,
-    val frequency: ReportFrequency,
     val reportingStartDate: LocalDate,
     val reportingEndDate: LocalDate,
     val logframeUrl: URI?,
@@ -538,7 +534,6 @@ data class ExistingAcceleratorReportConfigPayload(
   ) : this(
       configId = model.id,
       projectId = model.projectId,
-      frequency = model.frequency,
       reportingStartDate = model.reportingStartDate,
       reportingEndDate = model.reportingEndDate,
       logframeUrl = model.logframeUrl,
@@ -556,9 +551,8 @@ data class NewAcceleratorReportConfigPayload(
     val reportingEndDate: LocalDate,
     val reportingStartDate: LocalDate,
 ) {
-  fun toModel(projectId: ProjectId, frequency: ReportFrequency): NewProjectReportConfigModel =
+  fun toModel(projectId: ProjectId): NewProjectReportConfigModel =
       NewProjectReportConfigModel(
-          frequency = frequency,
           id = null,
           logframeUrl = logframeUrl,
           projectId = projectId,
@@ -581,7 +575,6 @@ data class AcceleratorReportPayload(
     val endDate: LocalDate,
     val feedback: String?,
     val financialSummaries: String?,
-    val frequency: ReportFrequency,
     val highlights: String?,
     val id: ReportId,
     val internalComment: String?,
@@ -609,7 +602,6 @@ data class AcceleratorReportPayload(
       endDate = model.endDate,
       feedback = model.feedback,
       financialSummaries = model.financialSummaries,
-      frequency = model.frequency,
       highlights = model.highlights,
       id = model.id,
       internalComment = model.internalComment,

--- a/src/main/kotlin/com/terraformation/backend/accelerator/db/ReportStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/db/ReportStore.kt
@@ -25,7 +25,6 @@ import com.terraformation.backend.db.ReportNotFoundException
 import com.terraformation.backend.db.accelerator.AutoCalculatedIndicator
 import com.terraformation.backend.db.accelerator.ProjectIndicatorId
 import com.terraformation.backend.db.accelerator.ProjectReportConfigId
-import com.terraformation.backend.db.accelerator.ReportFrequency
 import com.terraformation.backend.db.accelerator.ReportId
 import com.terraformation.backend.db.accelerator.ReportIdConverter
 import com.terraformation.backend.db.accelerator.ReportIndicatorStatusConverter
@@ -241,7 +240,6 @@ class ReportStore(
             dslContext
                 .insertInto(this)
                 .set(PROJECT_ID, newModel.projectId)
-                .set(REPORT_FREQUENCY_ID, newModel.frequency)
                 .set(REPORTING_START_DATE, newModel.reportingStartDate)
                 .set(REPORTING_END_DATE, newModel.reportingEndDate)
                 .returning(ID.asNonNullable())
@@ -504,7 +502,6 @@ class ReportStore(
             .set(PROJECT_ID, report.projectId)
             .set(PUBLISHED_BY, userId)
             .set(PUBLISHED_TIME, now)
-            .set(REPORT_FREQUENCY_ID, report.frequency)
             .set(REPORT_ID, report.id)
             .set(REPORT_QUARTER_ID, report.quarter)
             .set(START_DATE, report.startDate)
@@ -517,7 +514,6 @@ class ReportStore(
             .set(PROJECT_ID, report.projectId)
             .set(PUBLISHED_BY, userId)
             .set(PUBLISHED_TIME, now)
-            .set(REPORT_FREQUENCY_ID, report.frequency)
             .set(REPORT_ID, report.id)
             .set(REPORT_QUARTER_ID, report.quarter)
             .set(START_DATE, report.startDate)
@@ -622,7 +618,6 @@ class ReportStore(
                 .from(this)
                 .where(STATUS_ID.eq(ReportStatus.NotSubmitted))
                 .and(UPCOMING_NOTIFICATION_SENT_TIME.isNull)
-                .and(REPORT_FREQUENCY_ID.eq(ReportFrequency.Quarterly))
                 .and(END_DATE.between(today).and(today.plusDays(15)))
                 .forUpdate()
                 .skipLocked()
@@ -705,12 +700,9 @@ class ReportStore(
     }
   }
 
-  private fun getStartOfReportingPeriod(date: LocalDate, frequency: ReportFrequency): LocalDate {
+  private fun getStartOfReportingPeriod(date: LocalDate): LocalDate {
     val startYear = date.year
-    val startMonth =
-        when (frequency) {
-          ReportFrequency.Quarterly -> date.month.firstMonthOfQuarter()
-        }
+    val startMonth = date.month.firstMonthOfQuarter()
 
     return LocalDate.of(startYear, startMonth, 1)
   }
@@ -720,12 +712,9 @@ class ReportStore(
       throw IllegalArgumentException("Reporting end date must be after reporting start date.")
     }
 
-    val durationMonths =
-        when (config.frequency) {
-          ReportFrequency.Quarterly -> 3L
-        }
+    val durationMonths = 3L
 
-    var startDate = getStartOfReportingPeriod(config.reportingStartDate, config.frequency)
+    var startDate = getStartOfReportingPeriod(config.reportingStartDate)
 
     val now = clock.instant()
 
@@ -736,31 +725,25 @@ class ReportStore(
       val reportEndDate = startDate.minusDays(1)
 
       val quarter =
-          if (config.frequency == ReportFrequency.Quarterly) {
-            when (reportStartDate.month) {
-              Month.JANUARY,
-              Month.FEBRUARY,
-              Month.MARCH -> ReportQuarter.Q1
-              Month.APRIL,
-              Month.MAY,
-              Month.JUNE -> ReportQuarter.Q2
-              Month.JULY,
-              Month.AUGUST,
-              Month.SEPTEMBER -> ReportQuarter.Q3
-              Month.OCTOBER,
-              Month.NOVEMBER,
-              Month.DECEMBER -> ReportQuarter.Q4
-              else -> null
-            }
-          } else {
-            null
+          when (reportStartDate.month) {
+            Month.JANUARY,
+            Month.FEBRUARY,
+            Month.MARCH -> ReportQuarter.Q1
+            Month.APRIL,
+            Month.MAY,
+            Month.JUNE -> ReportQuarter.Q2
+            Month.JULY,
+            Month.AUGUST,
+            Month.SEPTEMBER -> ReportQuarter.Q3
+            Month.OCTOBER,
+            Month.NOVEMBER,
+            Month.DECEMBER -> ReportQuarter.Q4
           }
 
       rows.add(
           ReportsRow(
               configId = config.id,
               projectId = config.projectId,
-              reportFrequencyId = config.frequency,
               reportQuarterId = quarter,
               statusId = ReportStatus.NotSubmitted,
               startDate = reportStartDate,

--- a/src/main/kotlin/com/terraformation/backend/accelerator/model/ProjectReportConfigModel.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/model/ProjectReportConfigModel.kt
@@ -1,7 +1,6 @@
 package com.terraformation.backend.accelerator.model
 
 import com.terraformation.backend.db.accelerator.ProjectReportConfigId
-import com.terraformation.backend.db.accelerator.ReportFrequency
 import com.terraformation.backend.db.accelerator.tables.references.PROJECT_ACCELERATOR_DETAILS
 import com.terraformation.backend.db.accelerator.tables.references.PROJECT_REPORT_CONFIGS
 import com.terraformation.backend.db.default_schema.ProjectId
@@ -12,7 +11,6 @@ import org.jooq.Record
 data class ProjectReportConfigModel<ConfigId : ProjectReportConfigId?>(
     val id: ConfigId,
     val projectId: ProjectId,
-    val frequency: ReportFrequency,
     val reportingStartDate: LocalDate,
     val reportingEndDate: LocalDate,
     val logframeUrl: URI?,
@@ -22,7 +20,6 @@ data class ProjectReportConfigModel<ConfigId : ProjectReportConfigId?>(
         ExistingProjectReportConfigModel(
             id = id,
             projectId = model.projectId,
-            frequency = model.frequency,
             reportingStartDate = model.reportingStartDate,
             reportingEndDate = model.reportingEndDate,
             logframeUrl = model.logframeUrl,
@@ -33,7 +30,6 @@ data class ProjectReportConfigModel<ConfigId : ProjectReportConfigId?>(
           ExistingProjectReportConfigModel(
               id = record[ID]!!,
               projectId = record[PROJECT_ID]!!,
-              frequency = record[REPORT_FREQUENCY_ID]!!,
               reportingStartDate = record[REPORTING_START_DATE]!!,
               reportingEndDate = record[REPORTING_END_DATE]!!,
               logframeUrl = record[PROJECT_ACCELERATOR_DETAILS.LOGFRAME_URL],

--- a/src/main/kotlin/com/terraformation/backend/accelerator/model/ReportModel.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/model/ReportModel.kt
@@ -4,7 +4,6 @@ import com.terraformation.backend.auth.currentUser
 import com.terraformation.backend.customer.model.SimpleUserModel
 import com.terraformation.backend.db.accelerator.ProjectIndicatorId
 import com.terraformation.backend.db.accelerator.ProjectReportConfigId
-import com.terraformation.backend.db.accelerator.ReportFrequency
 import com.terraformation.backend.db.accelerator.ReportId
 import com.terraformation.backend.db.accelerator.ReportQuarter
 import com.terraformation.backend.db.accelerator.ReportStatus
@@ -68,7 +67,6 @@ data class ReportModel(
     val endDate: LocalDate,
     val feedback: String? = null,
     val financialSummaries: String? = null,
-    val frequency: ReportFrequency,
     val highlights: String? = null,
     val id: ReportId,
     val internalComment: String? = null,
@@ -92,12 +90,9 @@ data class ReportModel(
   /** Describes the reporting period of this report. For example "2025 Q1" or "2025 Annual" */
   val prefix: String
     get() {
-      val reportYear = endDate.year
       val reportQuarter = quarter?.name ?: "Quarterly"
 
-      return when (frequency) {
-        ReportFrequency.Quarterly -> "$reportYear $reportQuarter"
-      }
+      return "${endDate.year} $reportQuarter"
     }
 
   fun isEditable(): Boolean {
@@ -171,7 +166,6 @@ data class ReportModel(
             projectId = record[PROJECT_ID]!!,
             projectDealName = record[PROJECT_ACCELERATOR_DETAILS.DEAL_NAME],
             quarter = record[REPORT_QUARTER_ID],
-            frequency = record[REPORT_FREQUENCY_ID]!!,
             status = record[STATUS_ID]!!,
             startDate = record[START_DATE]!!,
             endDate = record[END_DATE]!!,

--- a/src/main/kotlin/com/terraformation/backend/funder/api/FunderReportsController.kt
+++ b/src/main/kotlin/com/terraformation/backend/funder/api/FunderReportsController.kt
@@ -12,7 +12,6 @@ import com.terraformation.backend.api.SuccessResponsePayload
 import com.terraformation.backend.api.toResponseEntity
 import com.terraformation.backend.db.accelerator.IndicatorCategory
 import com.terraformation.backend.db.accelerator.IndicatorLevel
-import com.terraformation.backend.db.accelerator.ReportFrequency
 import com.terraformation.backend.db.accelerator.ReportId
 import com.terraformation.backend.db.accelerator.ReportIndicatorStatus
 import com.terraformation.backend.db.accelerator.ReportQuarter
@@ -119,7 +118,6 @@ data class PublishedReportPayload(
     val challenges: List<ReportChallengePayload>,
     val endDate: LocalDate,
     val financialSummaries: String?,
-    val frequency: ReportFrequency,
     val highlights: String?,
     val photos: List<ReportPhotoPayload>,
     val projectId: ProjectId,
@@ -141,7 +139,6 @@ data class PublishedReportPayload(
       challenges = model.challenges.map { ReportChallengePayload(it.challenge, it.mitigationPlan) },
       endDate = model.endDate,
       financialSummaries = model.financialSummaries,
-      frequency = model.frequency,
       highlights = model.highlights,
       photos = model.photos.map { ReportPhotoPayload(it) },
       projectId = model.projectId,

--- a/src/main/kotlin/com/terraformation/backend/funder/db/PublishedReportStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/funder/db/PublishedReportStore.kt
@@ -67,7 +67,6 @@ class PublishedReportStore(
               challenges = record[challengesMultiset],
               endDate = record[PUBLISHED_REPORTS.END_DATE]!!,
               financialSummaries = record[PUBLISHED_REPORTS.FINANCIAL_SUMMARIES],
-              frequency = record[PUBLISHED_REPORTS.REPORT_FREQUENCY_ID]!!,
               highlights = record[PUBLISHED_REPORTS.HIGHLIGHTS],
               photos = record[photosMultiset],
               projectId = record[PUBLISHED_REPORTS.PROJECT_ID]!!,

--- a/src/main/kotlin/com/terraformation/backend/funder/model/PublishedReportModel.kt
+++ b/src/main/kotlin/com/terraformation/backend/funder/model/PublishedReportModel.kt
@@ -4,7 +4,6 @@ import com.terraformation.backend.accelerator.model.ReportChallengeModel
 import com.terraformation.backend.accelerator.model.ReportPhotoModel
 import com.terraformation.backend.db.accelerator.AutoCalculatedIndicator
 import com.terraformation.backend.db.accelerator.ProjectIndicatorId
-import com.terraformation.backend.db.accelerator.ReportFrequency
 import com.terraformation.backend.db.accelerator.ReportId
 import com.terraformation.backend.db.accelerator.ReportQuarter
 import com.terraformation.backend.db.accelerator.StandardIndicatorId
@@ -20,7 +19,6 @@ data class PublishedReportModel(
     val challenges: List<ReportChallengeModel>,
     val endDate: LocalDate,
     val financialSummaries: String?,
-    val frequency: ReportFrequency,
     val highlights: String?,
     val photos: List<ReportPhotoModel>,
     val projectId: ProjectId,

--- a/src/main/resources/db/migration/0450/V460__DropReportFrequencies.sql
+++ b/src/main/resources/db/migration/0450/V460__DropReportFrequencies.sql
@@ -1,0 +1,10 @@
+ALTER TABLE accelerator.reports
+    DROP COLUMN report_frequency_id;
+
+ALTER TABLE funder.published_reports
+    DROP COLUMN report_frequency_id;
+
+ALTER TABLE accelerator.project_report_configs
+    DROP COLUMN report_frequency_id;
+
+DROP TABLE accelerator.report_frequencies;

--- a/src/main/resources/db/migration/R__Comments.sql
+++ b/src/main/resources/db/migration/R__Comments.sql
@@ -695,8 +695,6 @@ COMMENT ON COLUMN accelerator.report_auto_calculated_indicators.system_value IS 
 
 COMMENT ON TABLE accelerator.report_challenges IS 'List of challenges and mitigation plans for accelerator project reports.';
 
-COMMENT ON TABLE accelerator.report_frequencies IS '(Enum) Frequencies of accelerator project reports. Acts as the report type as well.';
-
 COMMENT ON TABLE accelerator.report_indicator_statuses IS '(Enum) Statuses of accelerator project report indicators.';
 
 COMMENT ON TABLE accelerator.report_photos IS 'Photos for the accelerator project report.';
@@ -715,7 +713,6 @@ COMMENT ON TABLE accelerator.report_standard_indicators IS 'Report entries of ta
 COMMENT ON TABLE accelerator.report_statuses IS '(Enum) Statuses of accelerator project reports.';
 
 COMMENT ON TABLE accelerator.reports IS 'Accelerator project reports.';
-COMMENT ON COLUMN accelerator.reports.report_frequency_id IS 'Frequency of the report, that can determine report data. Must match with frequency of the configuration.';
 COMMENT ON COLUMN accelerator.reports.report_quarter_id IS 'Quarter of the report. Must be non-null for quarterly reports and null otherwise.';
 
 COMMENT ON TABLE accelerator.score_categories IS '(Enum) Project score categories.';

--- a/src/main/resources/db/migration/R__TypeCodes.sql
+++ b/src/main/resources/db/migration/R__TypeCodes.sql
@@ -486,10 +486,6 @@ VALUES (1, 'Antarctica'),
        (9, 'Sub-Saharan Africa')
 ON CONFLICT (id) DO UPDATE SET name = excluded.name;
 
-INSERT INTO accelerator.report_frequencies (id, name)
-VALUES (1, 'Quarterly')
-ON CONFLICT (id) DO UPDATE SET name = excluded.name;
-
 INSERT INTO accelerator.report_indicator_statuses (id, name)
 VALUES (1, 'Achieved'),
        (2, 'On-Track'),

--- a/src/main/resources/i18n/Enums_en.properties
+++ b/src/main/resources/i18n/Enums_en.properties
@@ -86,7 +86,6 @@ accelerator.InternalInterest.StakeholdersAndCoBenefits=Stakeholders and Co-Benef
 accelerator.InternalInterest.StakeholdersAndCommunityImpact=Stakeholders and Community Impact
 accelerator.InternalInterest.SupplementalFiles=Supplemental Files
 accelerator.InternalInterest.VerraNonPermanenceRiskToolNPRT=Verra Non-Permanence Risk Tool (NPRT)
-accelerator.ReportFrequency.Quarterly=Quarterly
 accelerator.ReportIndicatorStatus.Achieved=Achieved
 accelerator.ReportIndicatorStatus.OnTrack=On-Track
 accelerator.ReportIndicatorStatus.Unlikely=Unlikely

--- a/src/main/resources/i18n/Enums_es.properties
+++ b/src/main/resources/i18n/Enums_es.properties
@@ -165,8 +165,6 @@ accelerator.InternalInterest.StakeholdersAndCommunityImpact=Impacto sobre las pa
 accelerator.InternalInterest.SupplementalFiles=Archivos complementarios
 # 8df572d7
 accelerator.InternalInterest.VerraNonPermanenceRiskToolNPRT=Herramienta de riesgo de no permanencia (HRNP) de Verra
-# f69e32e0
-accelerator.ReportFrequency.Quarterly=Trimestral
 # 845a66be
 accelerator.ReportIndicatorStatus.Achieved=Logrado
 # e2f4a4aa

--- a/src/main/resources/i18n/Enums_fr.properties
+++ b/src/main/resources/i18n/Enums_fr.properties
@@ -165,8 +165,6 @@ accelerator.InternalInterest.StakeholdersAndCommunityImpact=Parties prenantes et
 accelerator.InternalInterest.SupplementalFiles=Fichiers supplémentaires
 # 8df572d7
 accelerator.InternalInterest.VerraNonPermanenceRiskToolNPRT=Outil de gestion des risques non permanents de Verra (NPRT)
-# f69e32e0
-accelerator.ReportFrequency.Quarterly=Trimestriel
 # 845a66be
 accelerator.ReportIndicatorStatus.Achieved=Atteint
 # e2f4a4aa

--- a/src/test/kotlin/com/terraformation/backend/accelerator/db/ReportStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/db/ReportStoreTest.kt
@@ -31,7 +31,6 @@ import com.terraformation.backend.db.ReportNotFoundException
 import com.terraformation.backend.db.accelerator.AutoCalculatedIndicator
 import com.terraformation.backend.db.accelerator.IndicatorCategory
 import com.terraformation.backend.db.accelerator.IndicatorLevel
-import com.terraformation.backend.db.accelerator.ReportFrequency
 import com.terraformation.backend.db.accelerator.ReportId
 import com.terraformation.backend.db.accelerator.ReportIndicatorStatus
 import com.terraformation.backend.db.accelerator.ReportQuarter
@@ -188,7 +187,6 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
               configId = configId,
               projectId = projectId,
               projectDealName = "DEAL_Report Project",
-              frequency = ReportFrequency.Quarterly,
               quarter = ReportQuarter.Q1,
               status = ReportStatus.NeedsUpdate,
               startDate = LocalDate.of(2030, Month.JANUARY, 1),
@@ -532,7 +530,6 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
               configId = configId,
               projectId = projectId,
               projectDealName = "DEAL_Report Project",
-              frequency = ReportFrequency.Quarterly,
               quarter = ReportQuarter.Q1,
               status = ReportStatus.NotSubmitted,
               startDate = LocalDate.EPOCH,
@@ -556,7 +553,6 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
       insertProjectReportConfig()
       insertReport(
           status = ReportStatus.NotSubmitted,
-          frequency = ReportFrequency.Quarterly,
           quarter = ReportQuarter.Q1,
           startDate = LocalDate.of(2025, Month.JANUARY, 1),
           endDate = LocalDate.of(2025, Month.MARCH, 31),
@@ -648,7 +644,6 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
       insertProjectReportConfig()
       insertReport(
           status = ReportStatus.NotSubmitted,
-          frequency = ReportFrequency.Quarterly,
           quarter = ReportQuarter.Q2,
           startDate = startDate,
           endDate = endDate,
@@ -704,7 +699,6 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
               configId = configId,
               projectId = projectId,
               projectDealName = "DEAL_Report Project",
-              frequency = ReportFrequency.Quarterly,
               quarter = ReportQuarter.Q1,
               status = ReportStatus.NotNeeded,
               startDate = LocalDate.EPOCH,
@@ -736,7 +730,6 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
               configId = configId,
               projectId = projectId,
               projectDealName = "DEAL_Report Project",
-              frequency = ReportFrequency.Quarterly,
               quarter = ReportQuarter.Q1,
               status = ReportStatus.NotSubmitted,
               startDate = today,
@@ -767,7 +760,6 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
               configId = configId,
               projectId = projectId,
               projectDealName = "DEAL_Report Project",
-              frequency = ReportFrequency.Quarterly,
               quarter = ReportQuarter.Q1,
               status = ReportStatus.NotSubmitted,
               startDate = LocalDate.EPOCH,
@@ -833,7 +825,6 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
               configId = configId,
               projectId = projectId,
               projectDealName = "DEAL_Report Project",
-              frequency = ReportFrequency.Quarterly,
               quarter = ReportQuarter.Q4,
               status = ReportStatus.NotSubmitted,
               startDate = LocalDate.of(2030, Month.OCTOBER, 1),
@@ -919,7 +910,6 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
               projectId = projectId,
               projectDealName = "DEAL_Report Project",
               quarter = ReportQuarter.Q1,
-              frequency = ReportFrequency.Quarterly,
               status = ReportStatus.NotSubmitted,
               startDate = LocalDate.EPOCH,
               endDate = LocalDate.EPOCH.plusDays(1),
@@ -1279,7 +1269,6 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
               configId = configId,
               projectId = projectId,
               projectDealName = "DEAL_Report Project",
-              frequency = ReportFrequency.Quarterly,
               quarter = ReportQuarter.Q1,
               status = ReportStatus.NotSubmitted,
               startDate = LocalDate.EPOCH,
@@ -1323,7 +1312,6 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
     @Test
     fun `returns earliest and latest report config years`() {
       insertProjectReportConfig(
-          frequency = ReportFrequency.Quarterly,
           reportingStartDate = LocalDate.of(2024, 1, 1),
           reportingEndDate = LocalDate.of(2028, 12, 1),
       )
@@ -1838,7 +1826,6 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
               id = reportId,
               configId = configId,
               projectId = projectId,
-              reportFrequencyId = ReportFrequency.Quarterly,
               reportQuarterId = ReportQuarter.Q1,
               statusId = ReportStatus.Submitted,
               startDate = LocalDate.EPOCH,
@@ -2318,7 +2305,6 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
               id = reportId,
               configId = configId,
               projectId = projectId,
-              reportFrequencyId = ReportFrequency.Quarterly,
               reportQuarterId = ReportQuarter.Q1,
               statusId = ReportStatus.NotSubmitted,
               startDate = LocalDate.EPOCH,
@@ -2597,7 +2583,6 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
               id = reportId,
               configId = configId,
               projectId = projectId,
-              reportFrequencyId = ReportFrequency.Quarterly,
               reportQuarterId = ReportQuarter.Q1,
               statusId = ReportStatus.Submitted,
               startDate = LocalDate.of(2025, Month.JANUARY, 1),
@@ -2695,7 +2680,6 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
       val projectConfigId =
           insertProjectReportConfig(
               projectId = projectId,
-              frequency = ReportFrequency.Quarterly,
               reportingStartDate = LocalDate.of(2025, Month.JANUARY, 7),
               reportingEndDate = LocalDate.of(2031, Month.MAY, 9),
           )
@@ -2703,7 +2687,6 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
       val otherProjectConfigId =
           insertProjectReportConfig(
               projectId = otherProjectId,
-              frequency = ReportFrequency.Quarterly,
               reportingStartDate = LocalDate.of(2031, Month.JANUARY, 18),
               reportingEndDate = LocalDate.of(2039, Month.MAY, 31),
           )
@@ -2712,7 +2695,6 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
           ExistingProjectReportConfigModel(
               id = projectConfigId,
               projectId = projectId,
-              frequency = ReportFrequency.Quarterly,
               reportingStartDate = LocalDate.of(2025, Month.JANUARY, 7),
               reportingEndDate = LocalDate.of(2031, Month.MAY, 9),
               logframeUrl = null,
@@ -2722,7 +2704,6 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
           ExistingProjectReportConfigModel(
               id = otherProjectConfigId,
               projectId = otherProjectId,
-              frequency = ReportFrequency.Quarterly,
               reportingStartDate = LocalDate.of(2031, Month.JANUARY, 18),
               reportingEndDate = LocalDate.of(2039, Month.MAY, 31),
               logframeUrl = URI("https://terraware.io/logframe"),
@@ -2755,7 +2736,6 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
           NewProjectReportConfigModel(
               id = null,
               projectId = projectId,
-              frequency = ReportFrequency.Quarterly,
               reportingStartDate = LocalDate.of(2025, Month.MAY, 5),
               reportingEndDate = LocalDate.of(2028, Month.MARCH, 2),
               logframeUrl = null,
@@ -2765,7 +2745,7 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
     }
 
     @Test
-    fun `inserts config record and creates reports for quarterly frequency`() {
+    fun `inserts config record and creates reports`() {
       clock.instant = Instant.ofEpochSecond(9000)
 
       deleteProjectAcceleratorDetails(projectId)
@@ -2773,7 +2753,6 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
           NewProjectReportConfigModel(
               id = null,
               projectId = projectId,
-              frequency = ReportFrequency.Quarterly,
               reportingStartDate = LocalDate.of(2025, Month.MAY, 5),
               reportingEndDate = LocalDate.of(2026, Month.MARCH, 29),
               logframeUrl = URI("https://example.com"),
@@ -2787,7 +2766,6 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
           ProjectReportConfigsRecord(
               id = configId,
               projectId = projectId,
-              reportFrequencyId = ReportFrequency.Quarterly,
               reportingStartDate = LocalDate.of(2025, Month.MAY, 5),
               reportingEndDate = LocalDate.of(2026, Month.MARCH, 29),
           ),
@@ -2799,7 +2777,6 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
               ReportsRecord(
                   configId = configId,
                   projectId = projectId,
-                  reportFrequencyId = ReportFrequency.Quarterly,
                   reportQuarterId = ReportQuarter.Q2,
                   statusId = ReportStatus.NotSubmitted,
                   startDate = LocalDate.of(2025, Month.MAY, 5),
@@ -2812,7 +2789,6 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
               ReportsRecord(
                   configId = configId,
                   projectId = projectId,
-                  reportFrequencyId = ReportFrequency.Quarterly,
                   reportQuarterId = ReportQuarter.Q3,
                   statusId = ReportStatus.NotSubmitted,
                   startDate = LocalDate.of(2025, Month.JULY, 1),
@@ -2825,7 +2801,6 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
               ReportsRecord(
                   configId = configId,
                   projectId = projectId,
-                  reportFrequencyId = ReportFrequency.Quarterly,
                   reportQuarterId = ReportQuarter.Q4,
                   statusId = ReportStatus.NotSubmitted,
                   startDate = LocalDate.of(2025, Month.OCTOBER, 1),
@@ -2838,7 +2813,6 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
               ReportsRecord(
                   configId = configId,
                   projectId = projectId,
-                  reportFrequencyId = ReportFrequency.Quarterly,
                   reportQuarterId = ReportQuarter.Q1,
                   statusId = ReportStatus.NotSubmitted,
                   startDate = LocalDate.of(2026, Month.JANUARY, 1),
@@ -2897,7 +2871,6 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
           NewProjectReportConfigModel(
               id = null,
               projectId = projectId,
-              frequency = ReportFrequency.Quarterly,
               reportingStartDate = LocalDate.of(2025, Month.MAY, 5),
               reportingEndDate = LocalDate.of(2026, Month.MARCH, 29),
               logframeUrl = null,
@@ -2918,7 +2891,6 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
               ProjectReportConfigsRecord(
                   id = configId,
                   projectId = projectId,
-                  reportFrequencyId = ReportFrequency.Quarterly,
                   reportingStartDate = LocalDate.of(2025, Month.APRIL, 4),
                   reportingEndDate = LocalDate.of(2026, Month.FEBRUARY, 28),
               ),
@@ -2931,7 +2903,6 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
               ReportsRecord(
                   configId = configId,
                   projectId = projectId,
-                  reportFrequencyId = ReportFrequency.Quarterly,
                   reportQuarterId = ReportQuarter.Q2,
                   statusId = ReportStatus.NotSubmitted,
                   startDate = LocalDate.of(2025, Month.APRIL, 4),
@@ -2944,7 +2915,6 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
               ReportsRecord(
                   configId = configId,
                   projectId = projectId,
-                  reportFrequencyId = ReportFrequency.Quarterly,
                   reportQuarterId = ReportQuarter.Q3,
                   statusId = ReportStatus.NotSubmitted,
                   startDate = LocalDate.of(2025, Month.JULY, 1),
@@ -2957,7 +2927,6 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
               ReportsRecord(
                   configId = configId,
                   projectId = projectId,
-                  reportFrequencyId = ReportFrequency.Quarterly,
                   reportQuarterId = ReportQuarter.Q4,
                   statusId = ReportStatus.NotSubmitted,
                   startDate = LocalDate.of(2025, Month.OCTOBER, 1),
@@ -2970,7 +2939,6 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
               ReportsRecord(
                   configId = configId,
                   projectId = projectId,
-                  reportFrequencyId = ReportFrequency.Quarterly,
                   reportQuarterId = ReportQuarter.Q1,
                   statusId = ReportStatus.NotSubmitted,
                   startDate = LocalDate.of(2026, Month.JANUARY, 1),
@@ -2990,7 +2958,6 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
       val configId =
           insertProjectReportConfig(
               projectId = projectId,
-              frequency = ReportFrequency.Quarterly,
               reportingStartDate = LocalDate.of(2021, Month.MARCH, 13),
               reportingEndDate = LocalDate.of(2021, Month.SEPTEMBER, 9),
           )
@@ -3002,7 +2969,6 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
               configId = configId,
               projectId = projectId,
               quarter = ReportQuarter.Q2,
-              frequency = ReportFrequency.Quarterly,
               status = ReportStatus.Submitted,
               startDate = LocalDate.of(2021, Month.APRIL, 1),
               endDate = LocalDate.of(2021, Month.APRIL, 30),
@@ -3015,7 +2981,6 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
               configId = configId,
               projectId = projectId,
               quarter = ReportQuarter.Q1,
-              frequency = ReportFrequency.Quarterly,
               status = ReportStatus.NotNeeded,
               startDate = LocalDate.of(2020, Month.MARCH, 13),
               endDate = LocalDate.of(2020, Month.MARCH, 31),
@@ -3026,7 +2991,6 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
               configId = configId,
               projectId = projectId,
               quarter = ReportQuarter.Q4,
-              frequency = ReportFrequency.Quarterly,
               status = ReportStatus.NotNeeded,
               startDate = LocalDate.of(2021, Month.OCTOBER, 1),
               endDate = LocalDate.of(2021, Month.OCTOBER, 9),
@@ -3038,7 +3002,6 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
               configId = configId,
               projectId = projectId,
               quarter = ReportQuarter.Q1,
-              frequency = ReportFrequency.Quarterly,
               status = ReportStatus.Approved,
               startDate = LocalDate.of(2021, Month.JANUARY, 1),
               endDate = LocalDate.of(2021, Month.MARCH, 31),
@@ -3063,7 +3026,6 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
           ProjectReportConfigsRecord(
               id = configId,
               projectId = projectId,
-              reportFrequencyId = ReportFrequency.Quarterly,
               reportingStartDate = LocalDate.of(2021, Month.FEBRUARY, 14),
               reportingEndDate = LocalDate.of(2021, Month.DECEMBER, 27),
           ),
@@ -3076,7 +3038,6 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
                   id = unchangedReportId,
                   configId = configId,
                   projectId = projectId,
-                  reportFrequencyId = ReportFrequency.Quarterly,
                   reportQuarterId = ReportQuarter.Q1,
                   statusId = ReportStatus.NotNeeded,
                   startDate = LocalDate.of(2020, Month.MARCH, 13),
@@ -3090,7 +3051,6 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
                   id = q1ReportId,
                   configId = configId,
                   projectId = projectId,
-                  reportFrequencyId = ReportFrequency.Quarterly,
                   reportQuarterId = ReportQuarter.Q1,
                   statusId = ReportStatus.NotSubmitted,
                   startDate = LocalDate.of(2021, Month.FEBRUARY, 14),
@@ -3104,7 +3064,6 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
                   id = q2ReportId,
                   configId = configId,
                   projectId = projectId,
-                  reportFrequencyId = ReportFrequency.Quarterly,
                   reportQuarterId = ReportQuarter.Q2,
                   statusId = ReportStatus.NotSubmitted,
                   startDate = LocalDate.of(2021, Month.APRIL, 1),
@@ -3118,7 +3077,6 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
                   id = reportIdsByQuarter[ReportQuarter.Q3],
                   configId = configId,
                   projectId = projectId,
-                  reportFrequencyId = ReportFrequency.Quarterly,
                   reportQuarterId = ReportQuarter.Q3,
                   statusId = ReportStatus.NotSubmitted,
                   startDate = LocalDate.of(2021, Month.JULY, 1),
@@ -3132,7 +3090,6 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
                   id = q4ReportId,
                   configId = configId,
                   projectId = projectId,
-                  reportFrequencyId = ReportFrequency.Quarterly,
                   reportQuarterId = ReportQuarter.Q4,
                   statusId = ReportStatus.NotSubmitted,
                   startDate = LocalDate.of(2021, Month.OCTOBER, 1),
@@ -3154,7 +3111,6 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
           NewProjectReportConfigModel(
               id = null,
               projectId = projectId,
-              frequency = ReportFrequency.Quarterly,
               reportingStartDate = LocalDate.of(2021, Month.MARCH, 13),
               reportingEndDate = LocalDate.of(2021, Month.APRIL, 9),
               logframeUrl = null,
@@ -3179,7 +3135,6 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
               ReportsRecord(
                   configId = configId,
                   projectId = projectId,
-                  reportFrequencyId = ReportFrequency.Quarterly,
                   reportQuarterId = ReportQuarter.Q1,
                   statusId = ReportStatus.NotNeeded,
                   startDate = LocalDate.of(2021, Month.MARCH, 13),
@@ -3192,7 +3147,6 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
               ReportsRecord(
                   configId = configId,
                   projectId = projectId,
-                  reportFrequencyId = ReportFrequency.Quarterly,
                   reportQuarterId = ReportQuarter.Q2,
                   statusId = ReportStatus.NotNeeded,
                   startDate = LocalDate.of(2021, Month.APRIL, 1),
@@ -3205,7 +3159,6 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
               ReportsRecord(
                   configId = configId,
                   projectId = projectId,
-                  reportFrequencyId = ReportFrequency.Quarterly,
                   reportQuarterId = ReportQuarter.Q1,
                   statusId = ReportStatus.NotSubmitted,
                   startDate = LocalDate.of(2023, Month.MARCH, 13),
@@ -3218,7 +3171,6 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
               ReportsRecord(
                   configId = configId,
                   projectId = projectId,
-                  reportFrequencyId = ReportFrequency.Quarterly,
                   reportQuarterId = ReportQuarter.Q2,
                   statusId = ReportStatus.NotSubmitted,
                   startDate = LocalDate.of(2023, Month.APRIL, 1),
@@ -3231,7 +3183,6 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
               ReportsRecord(
                   configId = configId,
                   projectId = projectId,
-                  reportFrequencyId = ReportFrequency.Quarterly,
                   reportQuarterId = ReportQuarter.Q3,
                   statusId = ReportStatus.NotSubmitted,
                   startDate = LocalDate.of(2023, Month.JULY, 1),
@@ -3265,7 +3216,6 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
       val configId =
           insertProjectReportConfig(
               projectId = projectId,
-              frequency = ReportFrequency.Quarterly,
               reportingStartDate = LocalDate.of(2025, Month.MAY, 5),
               reportingEndDate = LocalDate.of(2026, Month.MARCH, 29),
           )
@@ -3281,7 +3231,6 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
           ProjectReportConfigsRecord(
               id = configId,
               projectId = projectId,
-              reportFrequencyId = ReportFrequency.Quarterly,
               reportingStartDate = LocalDate.of(2044, Month.MARCH, 13),
               reportingEndDate = LocalDate.of(2048, Month.JULY, 9),
           ),
@@ -3382,7 +3331,6 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
                   projectId = projectId,
                   configId = configId,
                   statusId = ReportStatus.NotSubmitted,
-                  reportFrequencyId = ReportFrequency.Quarterly,
                   reportQuarterId = ReportQuarter.Q1,
                   startDate = LocalDate.of(2025, Month.JANUARY, 1),
                   endDate = LocalDate.of(2025, Month.MARCH, 31),
@@ -3397,7 +3345,6 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
                   projectId = projectId,
                   configId = configId,
                   statusId = ReportStatus.NotSubmitted,
-                  reportFrequencyId = ReportFrequency.Quarterly,
                   reportQuarterId = ReportQuarter.Q4,
                   startDate = LocalDate.of(2024, Month.OCTOBER, 1),
                   endDate = LocalDate.of(2024, Month.DECEMBER, 31),
@@ -3411,7 +3358,6 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
                   projectId = projectId,
                   configId = configId,
                   statusId = ReportStatus.NotSubmitted,
-                  reportFrequencyId = ReportFrequency.Quarterly,
                   reportQuarterId = ReportQuarter.Q1,
                   startDate = LocalDate.of(2025, Month.JANUARY, 1),
                   endDate = LocalDate.of(2025, Month.MARCH, 31),
@@ -3426,7 +3372,6 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
                   projectId = projectId,
                   configId = configId,
                   statusId = ReportStatus.Submitted,
-                  reportFrequencyId = ReportFrequency.Quarterly,
                   reportQuarterId = ReportQuarter.Q1,
                   startDate = LocalDate.of(2025, Month.JANUARY, 1),
                   endDate = LocalDate.of(2025, Month.MARCH, 31),
@@ -3442,7 +3387,6 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
                   projectId = projectId,
                   configId = configId,
                   statusId = ReportStatus.NotNeeded,
-                  reportFrequencyId = ReportFrequency.Quarterly,
                   reportQuarterId = ReportQuarter.Q1,
                   startDate = LocalDate.of(2025, Month.JANUARY, 1),
                   endDate = LocalDate.of(2025, Month.MARCH, 31),
@@ -3456,7 +3400,6 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
                   projectId = projectId,
                   configId = configId,
                   statusId = ReportStatus.NotSubmitted,
-                  reportFrequencyId = ReportFrequency.Quarterly,
                   reportQuarterId = ReportQuarter.Q2,
                   startDate = LocalDate.of(2025, Month.APRIL, 1),
                   endDate = LocalDate.of(2025, Month.JUNE, 30),
@@ -3826,7 +3769,6 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
           PublishedReportsRecord(
               reportId = reportId,
               projectId = projectId,
-              reportFrequencyId = ReportFrequency.Quarterly,
               reportQuarterId = ReportQuarter.Q1,
               startDate = LocalDate.of(2030, Month.JANUARY, 1),
               endDate = LocalDate.of(2030, Month.MARCH, 31),

--- a/src/test/kotlin/com/terraformation/backend/db/DatabaseBackedTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/db/DatabaseBackedTest.kt
@@ -38,7 +38,6 @@ import com.terraformation.backend.db.accelerator.ParticipantProjectSpeciesId
 import com.terraformation.backend.db.accelerator.Pipeline
 import com.terraformation.backend.db.accelerator.ProjectIndicatorId
 import com.terraformation.backend.db.accelerator.ProjectReportConfigId
-import com.terraformation.backend.db.accelerator.ReportFrequency
 import com.terraformation.backend.db.accelerator.ReportId
 import com.terraformation.backend.db.accelerator.ReportIndicatorStatus
 import com.terraformation.backend.db.accelerator.ReportQuarter
@@ -2862,14 +2861,12 @@ abstract class DatabaseBackedTest {
   fun insertProjectReportConfig(
       row: ProjectReportConfigsRow = ProjectReportConfigsRow(),
       projectId: ProjectId = row.projectId ?: inserted.projectId,
-      frequency: ReportFrequency = row.reportFrequencyId ?: ReportFrequency.Quarterly,
       reportingStartDate: LocalDate = row.reportingStartDate ?: LocalDate.EPOCH,
       reportingEndDate: LocalDate = row.reportingEndDate ?: reportingStartDate.plusDays(1),
   ): ProjectReportConfigId {
     val rowWithDefaults =
         row.copy(
             projectId = projectId,
-            reportFrequencyId = frequency,
             reportingStartDate = reportingStartDate,
             reportingEndDate = reportingEndDate,
         )
@@ -3514,7 +3511,6 @@ abstract class DatabaseBackedTest {
       row: ReportsRow = ReportsRow(),
       configId: ProjectReportConfigId = row.configId ?: inserted.projectReportConfigId,
       projectId: ProjectId = row.projectId ?: inserted.projectId,
-      frequency: ReportFrequency = row.reportFrequencyId ?: ReportFrequency.Quarterly,
       quarter: ReportQuarter? = row.reportQuarterId ?: ReportQuarter.Q1,
       status: ReportStatus = row.statusId ?: ReportStatus.NotSubmitted,
       startDate: LocalDate = row.startDate ?: LocalDate.EPOCH,
@@ -3542,7 +3538,6 @@ abstract class DatabaseBackedTest {
         row.copy(
             configId = configId,
             projectId = projectId,
-            reportFrequencyId = frequency,
             reportQuarterId = quarter,
             statusId = status,
             startDate = startDate,
@@ -3826,7 +3821,6 @@ abstract class DatabaseBackedTest {
       projectId: ProjectId = inserted.projectId,
       startDate: LocalDate = LocalDate.of(2025, 1, 1),
       endDate: LocalDate = LocalDate.of(2025, 3, 31),
-      frequency: ReportFrequency = ReportFrequency.Quarterly,
       quarter: ReportQuarter? = ReportQuarter.Q1,
       publishedBy: UserId = currentUser().userId,
       publishedTime: Instant = Instant.EPOCH,
@@ -3839,7 +3833,6 @@ abstract class DatabaseBackedTest {
           .insertInto(PUBLISHED_REPORTS)
           .set(REPORT_ID, reportId)
           .set(PROJECT_ID, projectId)
-          .set(REPORT_FREQUENCY_ID, frequency)
           .set(REPORT_QUARTER_ID, quarter)
           .set(START_DATE, startDate)
           .set(END_DATE, endDate)

--- a/src/test/kotlin/com/terraformation/backend/db/SchemaDocsGenerator.kt
+++ b/src/test/kotlin/com/terraformation/backend/db/SchemaDocsGenerator.kt
@@ -176,7 +176,6 @@ class SchemaDocsGenerator : DatabaseTest() {
                   "report_auto_calculated_indicator_targets" to setOf(ALL, ACCELERATOR),
                   "report_auto_calculated_indicators" to setOf(ALL, ACCELERATOR),
                   "report_challenges" to setOf(ALL, ACCELERATOR),
-                  "report_frequencies" to setOf(ALL, ACCELERATOR),
                   "report_indicator_statuses" to setOf(ALL, ACCELERATOR),
                   "report_photos" to setOf(ALL, ACCELERATOR),
                   "report_project_indicator_targets" to setOf(ALL, ACCELERATOR),

--- a/src/test/kotlin/com/terraformation/backend/email/EmailNotificationServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/email/EmailNotificationServiceTest.kt
@@ -52,7 +52,6 @@ import com.terraformation.backend.db.accelerator.DeliverableId
 import com.terraformation.backend.db.accelerator.DeliverableType
 import com.terraformation.backend.db.accelerator.ModuleId
 import com.terraformation.backend.db.accelerator.ProjectReportConfigId
-import com.terraformation.backend.db.accelerator.ReportFrequency
 import com.terraformation.backend.db.accelerator.ReportId
 import com.terraformation.backend.db.accelerator.ReportQuarter
 import com.terraformation.backend.db.accelerator.ReportStatus
@@ -484,7 +483,6 @@ internal class EmailNotificationServiceTest {
           configId = ProjectReportConfigId(1),
           projectId = project.id,
           projectDealName = "Deal name",
-          frequency = ReportFrequency.Quarterly,
           quarter = ReportQuarter.Q1,
           status = ReportStatus.Submitted,
           startDate = LocalDate.of(2025, Month.JANUARY, 1),

--- a/src/test/kotlin/com/terraformation/backend/funder/db/PublishedReportStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/funder/db/PublishedReportStoreTest.kt
@@ -9,7 +9,6 @@ import com.terraformation.backend.db.ProjectNotFoundException
 import com.terraformation.backend.db.accelerator.AutoCalculatedIndicator
 import com.terraformation.backend.db.accelerator.IndicatorCategory
 import com.terraformation.backend.db.accelerator.IndicatorLevel
-import com.terraformation.backend.db.accelerator.ReportFrequency
 import com.terraformation.backend.db.accelerator.ReportIndicatorStatus
 import com.terraformation.backend.db.accelerator.ReportQuarter
 import com.terraformation.backend.db.default_schema.ProjectId
@@ -213,7 +212,6 @@ class PublishedReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
                   challenges = emptyList(),
                   endDate = LocalDate.of(2025, 6, 30),
                   financialSummaries = null,
-                  frequency = ReportFrequency.Quarterly,
                   highlights = null,
                   photos = emptyList(),
                   projectId = projectId,
@@ -237,7 +235,6 @@ class PublishedReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
                       ),
                   endDate = LocalDate.of(2025, 3, 31),
                   financialSummaries = "financial summaries",
-                  frequency = ReportFrequency.Quarterly,
                   highlights = "highlights",
                   photos =
                       listOf(


### PR DESCRIPTION
We will no longer be using multiple frequencies for reports and were already using only `Quarterly`. Remove this enum table and references to it.