### PR TITLE
SW-8082 Add remaining tf_owner column to indicator tables

### DIFF
--- a/src/main/resources/db/migration/0450/V463__IndicatorTfOwner.sql
+++ b/src/main/resources/db/migration/0450/V463__IndicatorTfOwner.sql
@@ -1,0 +1,8 @@
+ALTER TABLE accelerator.project_indicators
+    ADD COLUMN tf_owner TEXT;
+
+ALTER TABLE accelerator.common_indicators
+    ADD COLUMN tf_owner TEXT;
+
+ALTER TABLE accelerator.auto_calculated_indicators
+    ADD COLUMN tf_owner TEXT;


### PR DESCRIPTION
Product had not yet decided if the new `tf_owner` text column should be required or optional initially, so I held off on adding it in V461. 

Add this column as optional. Once we get all the data into staging and production, then  it will be required. 
