### PR TITLE
SW-8084 Add indicatorProgress to project-details payloads

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/accelerator/api/ProjectAcceleratorDetailsController.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/api/ProjectAcceleratorDetailsController.kt
@@ -98,10 +98,12 @@ data class ProjectAcceleratorDetailsPayload(
     val googleFolderUrl: URI?,
     val hubSpotUrl: URI?,
     val investmentThesis: String?,
+    val indicatorProgress: List<IndicatorProgressPayload>,
     val landUseModelTypes: Set<LandUseModelType>,
     val landUseModelHectares: Map<LandUseModelType, BigDecimal>?,
     val maxCarbonAccumulation: BigDecimal?,
     val methodologyNumber: String?,
+    @Schema(description = "Use indicatorProgress instead", deprecated = true)
     val metricProgress: List<MetricProgressPayload>,
     val minCarbonAccumulation: BigDecimal?,
     val minProjectArea: BigDecimal?,
@@ -149,6 +151,7 @@ data class ProjectAcceleratorDetailsPayload(
       googleFolderUrl = model.googleFolderUrl,
       hubSpotUrl = model.hubSpotUrl,
       investmentThesis = model.investmentThesis,
+      indicatorProgress = model.indicatorProgress.map { IndicatorProgressPayload(it) },
       landUseModelTypes = model.landUseModelTypes,
       landUseModelHectares = model.landUseModelHectares,
       maxCarbonAccumulation = model.maxCarbonAccumulation,
@@ -180,6 +183,7 @@ data class ProjectAcceleratorDetailsPayload(
   )
 }
 
+@Schema(description = "Use IndicatorProgressPayload instead", deprecated = true)
 data class MetricProgressPayload(
     val metric: AutoCalculatedIndicator,
     val progress: Int,
@@ -188,6 +192,18 @@ data class MetricProgressPayload(
       model: IndicatorProgressModel
   ) : this(
       metric = model.indicator,
+      progress = model.progress,
+  )
+}
+
+data class IndicatorProgressPayload(
+    val indicator: AutoCalculatedIndicator,
+    val progress: Int,
+) {
+  constructor(
+      model: IndicatorProgressModel
+  ) : this(
+      indicator = model.indicator,
       progress = model.progress,
   )
 }

--- a/src/main/kotlin/com/terraformation/backend/funder/api/FundingProjectsController.kt
+++ b/src/main/kotlin/com/terraformation/backend/funder/api/FundingProjectsController.kt
@@ -98,6 +98,8 @@ data class PublishedProjectPayload(
   )
 }
 
+// This should be split into 2 payloads - one for request and one for response, because some of the
+// properties on it are not used in the request (e.g. indicatorProgress)
 data class FunderProjectDetailsPayload(
     val accumulationRate: BigDecimal?,
     val annualCarbon: BigDecimal?,
@@ -107,12 +109,12 @@ data class FunderProjectDetailsPayload(
     val countryCode: String?,
     val dealDescription: String?,
     val dealName: String?,
-    val indicatorProgress: List<IndicatorProgressPayload>,
+    val indicatorProgress: List<IndicatorProgressPayload>?,
     val landUseModelTypes: Set<LandUseModelType>,
     val landUseModelHectares: Map<LandUseModelType, BigDecimal>,
     val methodologyNumber: String?,
     @Schema(description = "Use indicatorProgress instead", deprecated = true)
-    val metricProgress: List<MetricProgressPayload>,
+    val metricProgress: List<MetricProgressPayload>?,
     val minProjectArea: BigDecimal?,
     val numNativeSpecies: Int?,
     val perHectareBudget: BigDecimal?,

--- a/src/main/kotlin/com/terraformation/backend/funder/api/FundingProjectsController.kt
+++ b/src/main/kotlin/com/terraformation/backend/funder/api/FundingProjectsController.kt
@@ -1,5 +1,6 @@
 package com.terraformation.backend.funder.api
 
+import com.terraformation.backend.accelerator.api.IndicatorProgressPayload
 import com.terraformation.backend.accelerator.api.MetricProgressPayload
 import com.terraformation.backend.accelerator.model.CarbonCertification
 import com.terraformation.backend.accelerator.model.SustainableDevelopmentGoal
@@ -16,6 +17,7 @@ import com.terraformation.backend.funder.FunderProjectService
 import com.terraformation.backend.funder.model.FunderProjectDetailsModel
 import com.terraformation.backend.funder.model.PublishedProjectNameModel
 import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.media.Schema
 import java.math.BigDecimal
 import java.net.URI
 import org.springframework.web.bind.annotation.GetMapping
@@ -105,9 +107,11 @@ data class FunderProjectDetailsPayload(
     val countryCode: String?,
     val dealDescription: String?,
     val dealName: String?,
+    val indicatorProgress: List<IndicatorProgressPayload>,
     val landUseModelTypes: Set<LandUseModelType>,
     val landUseModelHectares: Map<LandUseModelType, BigDecimal>,
     val methodologyNumber: String?,
+    @Schema(description = "Use indicatorProgress instead", deprecated = true)
     val metricProgress: List<MetricProgressPayload>,
     val minProjectArea: BigDecimal?,
     val numNativeSpecies: Int?,
@@ -133,6 +137,7 @@ data class FunderProjectDetailsPayload(
       countryCode = model.countryCode,
       dealDescription = model.dealDescription,
       dealName = model.dealName,
+      indicatorProgress = model.indicatorProgress.map { IndicatorProgressPayload(it) },
       landUseModelTypes = model.landUseModelTypes,
       landUseModelHectares = model.landUseModelHectares,
       methodologyNumber = model.methodologyNumber,


### PR DESCRIPTION
Update `ProjectAcceleratorDetailsController` and `FundingProjectsController` to change `metricProgress` to `indicatorProgress` (requiring a new payload class), to ensure backwards compatibility until the FE can update to `indicatorProgress`.