### PR TITLE
SW-8085 Add new indicator fields to response payloads

### DIFF
--- a/jooq/src/main/kotlin/com/terraformation/backend/jooq/Config.kt
+++ b/jooq/src/main/kotlin/com/terraformation/backend/jooq/Config.kt
@@ -81,9 +81,8 @@ val ENUM_TABLES =
                     additionalColumns =
                         listOf(
                             EnumTableColumnInfo(
-                                "level_id",
-                                "IndicatorLevel",
-                                true,
+                                "active",
+                                "Boolean",
                             ),
                             EnumTableColumnInfo(
                                 "category_id",
@@ -91,16 +90,43 @@ val ENUM_TABLES =
                                 true,
                             ),
                             EnumTableColumnInfo(
+                                "class_id",
+                                "IndicatorClass?",
+                                true,
+                            ),
+                            EnumTableColumnInfo(
                                 "description",
                                 "String",
+                            ),
+                            EnumTableColumnInfo(
+                                "frequency_id",
+                                "IndicatorFrequency?",
+                                true,
+                            ),
+                            EnumTableColumnInfo(
+                                "is_publishable",
+                                "Boolean",
+                            ),
+                            EnumTableColumnInfo(
+                                "level_id",
+                                "IndicatorLevel",
+                                true,
+                            ),
+                            EnumTableColumnInfo(
+                                "notes",
+                                "String?",
+                            ),
+                            EnumTableColumnInfo(
+                                "primary_data_source",
+                                "String?",
                             ),
                             EnumTableColumnInfo(
                                 "ref_id",
                                 "String",
                             ),
                             EnumTableColumnInfo(
-                                "is_publishable",
-                                "Boolean",
+                                "tf_owner",
+                                "String?",
                             ),
                             EnumTableColumnInfo(
                                 "unit",

--- a/jooq/src/main/kotlin/com/terraformation/backend/jooq/TerrawareGenerator.kt
+++ b/jooq/src/main/kotlin/com/terraformation/backend/jooq/TerrawareGenerator.kt
@@ -85,7 +85,10 @@ class TerrawareGenerator : KotlinGenerator() {
                           val obj = rs.getObject(2 + i + 1)
                           when {
                             obj is String -> "\"$obj\""
-                            columnInfo.isTableEnum -> "${columnInfo.columnDataType}.forId($obj)!!"
+                            columnInfo.isTableEnum ->
+                                if (columnInfo.columnDataType.endsWith("?") && "$obj" == "null")
+                                    "null"
+                                else "${columnInfo.columnDataType}.forId($obj)!!"
                             else -> "$obj"
                           }
                         })

--- a/src/main/kotlin/com/terraformation/backend/accelerator/api/IndicatorPayloads.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/api/IndicatorPayloads.kt
@@ -6,6 +6,8 @@ import com.terraformation.backend.accelerator.model.NewCommonIndicatorModel
 import com.terraformation.backend.accelerator.model.NewProjectIndicatorModel
 import com.terraformation.backend.db.accelerator.CommonIndicatorId
 import com.terraformation.backend.db.accelerator.IndicatorCategory
+import com.terraformation.backend.db.accelerator.IndicatorClass
+import com.terraformation.backend.db.accelerator.IndicatorFrequency
 import com.terraformation.backend.db.accelerator.IndicatorLevel
 import com.terraformation.backend.db.accelerator.ProjectIndicatorId
 import com.terraformation.backend.db.default_schema.ProjectId
@@ -53,40 +55,58 @@ data class ExistingProjectMetricPayload(
 }
 
 data class ExistingProjectIndicatorPayload(
+    val active: Boolean,
     val category: IndicatorCategory,
+    val classId: IndicatorClass?,
     val description: String?,
+    val frequency: IndicatorFrequency?,
     val id: ProjectIndicatorId,
     val isPublishable: Boolean,
     val level: IndicatorLevel,
     val name: String,
+    val notes: String?,
+    val primaryDataSource: String?,
     val projectId: ProjectId,
     val refId: String,
-    @field:Size(max = 25) val unit: String?,
+    val tfOwner: String?,
+    @field:Size(max = 25) val unit: String? = null,
 ) {
   constructor(
       model: ExistingProjectIndicatorModel
   ) : this(
+      active = model.active,
       category = model.category,
+      classId = model.classId,
       description = model.description,
+      frequency = model.frequency,
       id = model.id,
       isPublishable = model.isPublishable,
       level = model.level,
       name = model.name,
+      notes = model.notes,
+      primaryDataSource = model.primaryDataSource,
       projectId = model.projectId,
       refId = model.refId,
+      tfOwner = model.tfOwner,
       unit = model.unit,
   )
 
   fun toModel(): ExistingProjectIndicatorModel {
     return ExistingProjectIndicatorModel(
+        active = active,
         category = category,
+        classId = classId,
         description = description,
+        frequency = frequency,
         id = id,
         isPublishable = isPublishable,
         level = level,
         name = name,
+        notes = notes,
+        primaryDataSource = primaryDataSource,
         projectId = projectId,
         refId = refId,
+        tfOwner = tfOwner,
         unit = unit,
     )
   }
@@ -131,37 +151,55 @@ data class ExistingStandardMetricPayload(
 }
 
 data class ExistingCommonIndicatorPayload(
+    val active: Boolean,
     val category: IndicatorCategory,
+    val classId: IndicatorClass?,
     val description: String?,
+    val frequency: IndicatorFrequency?,
     val id: CommonIndicatorId,
     val isPublishable: Boolean,
     val level: IndicatorLevel,
     val name: String,
+    val notes: String?,
+    val primaryDataSource: String?,
     val refId: String,
+    val tfOwner: String?,
     @field:Size(max = 25) val unit: String? = null,
 ) {
   constructor(
       model: ExistingCommonIndicatorModel
   ) : this(
+      active = model.active,
       category = model.category,
+      classId = model.classId,
       description = model.description,
+      frequency = model.frequency,
       id = model.id,
       isPublishable = model.isPublishable,
       level = model.level,
       name = model.name,
+      notes = model.notes,
+      primaryDataSource = model.primaryDataSource,
       refId = model.refId,
+      tfOwner = model.tfOwner,
       unit = model.unit,
   )
 
   fun toModel(): ExistingCommonIndicatorModel {
     return ExistingCommonIndicatorModel(
+        active = active,
         category = category,
+        classId = classId,
         description = description,
-        isPublishable = isPublishable,
+        frequency = frequency,
         id = id,
+        isPublishable = isPublishable,
         level = level,
         name = name,
+        notes = notes,
+        primaryDataSource = primaryDataSource,
         refId = refId,
+        tfOwner = tfOwner,
         unit = unit,
     )
   }

--- a/src/main/kotlin/com/terraformation/backend/accelerator/api/ReportIndicatorsController.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/api/ReportIndicatorsController.kt
@@ -8,6 +8,8 @@ import com.terraformation.backend.api.SuccessResponsePayload
 import com.terraformation.backend.db.accelerator.AutoCalculatedIndicator
 import com.terraformation.backend.db.accelerator.CommonIndicatorId
 import com.terraformation.backend.db.accelerator.IndicatorCategory
+import com.terraformation.backend.db.accelerator.IndicatorClass
+import com.terraformation.backend.db.accelerator.IndicatorFrequency
 import com.terraformation.backend.db.accelerator.IndicatorLevel
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.media.Schema
@@ -129,11 +131,18 @@ data class UpdateStandardMetricRequestPayload(
 
 data class AutoCalculatedIndicatorPayload(
     val indicator: AutoCalculatedIndicator,
+    val active: Boolean = indicator.active,
     val category: IndicatorCategory = indicator.categoryId,
+    val classId: IndicatorClass? = indicator.classId,
     val description: String = indicator.description,
+    val frequency: IndicatorFrequency? = indicator.frequencyId,
     val level: IndicatorLevel = indicator.levelId,
     val name: String = indicator.jsonValue,
+    val notes: String? = indicator.notes,
+    val primaryDataSource: String? = indicator.primaryDataSource,
     val refId: String = indicator.refId,
+    val tfOwner: String? = indicator.tfOwner,
+    val unit: String? = indicator.unit,
 )
 
 data class CreateCommonIndicatorRequestPayload(@field:Valid val indicator: NewIndicatorPayload)

--- a/src/main/kotlin/com/terraformation/backend/accelerator/model/CommonIndicatorModel.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/model/CommonIndicatorModel.kt
@@ -2,18 +2,26 @@ package com.terraformation.backend.accelerator.model
 
 import com.terraformation.backend.db.accelerator.CommonIndicatorId
 import com.terraformation.backend.db.accelerator.IndicatorCategory
+import com.terraformation.backend.db.accelerator.IndicatorClass
+import com.terraformation.backend.db.accelerator.IndicatorFrequency
 import com.terraformation.backend.db.accelerator.IndicatorLevel
 import com.terraformation.backend.db.accelerator.tables.references.COMMON_INDICATORS
 import org.jooq.Record
 
 data class CommonIndicatorModel<ID : CommonIndicatorId?>(
     val id: ID,
+    val active: Boolean = true,
     val category: IndicatorCategory,
+    val classId: IndicatorClass? = null,
     val description: String?,
+    val frequency: IndicatorFrequency? = null,
     val isPublishable: Boolean,
     val level: IndicatorLevel,
     val name: String,
+    val notes: String? = null,
+    val primaryDataSource: String? = null,
     val refId: String,
+    val tfOwner: String? = null,
     val unit: String? = null,
 ) {
   companion object {
@@ -21,12 +29,18 @@ data class CommonIndicatorModel<ID : CommonIndicatorId?>(
       return with(COMMON_INDICATORS) {
         ExistingCommonIndicatorModel(
             id = record[ID]!!,
+            active = record[ACTIVE]!!,
             category = record[CATEGORY_ID]!!,
+            classId = record[CLASS_ID],
             description = record[DESCRIPTION],
+            frequency = record[FREQUENCY_ID],
             isPublishable = record[IS_PUBLISHABLE]!!,
             level = record[LEVEL_ID]!!,
             name = record[NAME]!!,
+            notes = record[NOTES],
+            primaryDataSource = record[PRIMARY_DATA_SOURCE],
             refId = record[REF_ID]!!,
+            tfOwner = record[TF_OWNER],
             unit = record[UNIT],
         )
       }

--- a/src/main/kotlin/com/terraformation/backend/accelerator/model/ProjectIndicatorModel.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/model/ProjectIndicatorModel.kt
@@ -1,6 +1,8 @@
 package com.terraformation.backend.accelerator.model
 
 import com.terraformation.backend.db.accelerator.IndicatorCategory
+import com.terraformation.backend.db.accelerator.IndicatorClass
+import com.terraformation.backend.db.accelerator.IndicatorFrequency
 import com.terraformation.backend.db.accelerator.IndicatorLevel
 import com.terraformation.backend.db.accelerator.ProjectIndicatorId
 import com.terraformation.backend.db.accelerator.tables.references.PROJECT_INDICATORS
@@ -9,13 +11,19 @@ import org.jooq.Record
 
 data class ProjectIndicatorModel<ID : ProjectIndicatorId?>(
     val id: ID,
+    val active: Boolean = true,
     val category: IndicatorCategory,
+    val classId: IndicatorClass? = null,
     val description: String?,
+    val frequency: IndicatorFrequency? = null,
     val isPublishable: Boolean,
     val level: IndicatorLevel,
     val name: String,
+    val notes: String? = null,
+    val primaryDataSource: String? = null,
     val projectId: ProjectId,
     val refId: String,
+    val tfOwner: String? = null,
     val unit: String? = null,
 ) {
   companion object {
@@ -23,13 +31,19 @@ data class ProjectIndicatorModel<ID : ProjectIndicatorId?>(
       return with(PROJECT_INDICATORS) {
         ExistingProjectIndicatorModel(
             id = record[ID]!!,
+            active = record[ACTIVE]!!,
             category = record[CATEGORY_ID]!!,
+            classId = record[CLASS_ID],
             description = record[DESCRIPTION],
+            frequency = record[FREQUENCY_ID],
             isPublishable = record[IS_PUBLISHABLE]!!,
             level = record[LEVEL_ID]!!,
             name = record[NAME]!!,
-            refId = record[REF_ID]!!,
+            notes = record[NOTES],
+            primaryDataSource = record[PRIMARY_DATA_SOURCE],
             projectId = record[PROJECT_ID]!!,
+            refId = record[REF_ID]!!,
+            tfOwner = record[TF_OWNER],
             unit = record[UNIT],
         )
       }

--- a/src/test/kotlin/com/terraformation/backend/accelerator/db/ReportIndicatorStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/db/ReportIndicatorStoreTest.kt
@@ -12,6 +12,8 @@ import com.terraformation.backend.db.ProjectIndicatorNotFoundException
 import com.terraformation.backend.db.accelerator.AutoCalculatedIndicator
 import com.terraformation.backend.db.accelerator.CommonIndicatorId
 import com.terraformation.backend.db.accelerator.IndicatorCategory
+import com.terraformation.backend.db.accelerator.IndicatorClass
+import com.terraformation.backend.db.accelerator.IndicatorFrequency
 import com.terraformation.backend.db.accelerator.IndicatorLevel
 import com.terraformation.backend.db.accelerator.ProjectIndicatorId
 import com.terraformation.backend.db.accelerator.tables.records.CommonIndicatorsRecord
@@ -46,10 +48,14 @@ class ReportIndicatorStoreTest : DatabaseTest(), RunsAsDatabaseUser {
         val indicatorId =
             insertCommonIndicator(
                 category = IndicatorCategory.Climate,
+                classId = IndicatorClass.Cumulative,
                 description = "Climate common indicator description",
+                frequency = IndicatorFrequency.Annual,
                 isPublishable = true,
                 level = IndicatorLevel.Activity,
                 name = "Climate Common Indicator",
+                notes = "Some notes",
+                primaryDataSource = "Primary source",
                 refId = "3.0",
                 unit = "degrees",
             )
@@ -58,10 +64,14 @@ class ReportIndicatorStoreTest : DatabaseTest(), RunsAsDatabaseUser {
             ExistingCommonIndicatorModel(
                 id = indicatorId,
                 category = IndicatorCategory.Climate,
+                classId = IndicatorClass.Cumulative,
                 description = "Climate common indicator description",
+                frequency = IndicatorFrequency.Annual,
                 isPublishable = true,
                 level = IndicatorLevel.Activity,
                 name = "Climate Common Indicator",
+                notes = "Some notes",
+                primaryDataSource = "Primary source",
                 refId = "3.0",
                 tfOwner = "Carbon",
                 unit = "degrees",
@@ -216,10 +226,14 @@ class ReportIndicatorStoreTest : DatabaseTest(), RunsAsDatabaseUser {
         val indicatorId =
             insertProjectIndicator(
                 category = IndicatorCategory.Climate,
+                classId = IndicatorClass.Level,
                 description = "Climate project indicator description",
+                frequency = IndicatorFrequency.BiAnnual,
                 isPublishable = false,
                 level = IndicatorLevel.Activity,
                 name = "Climate Project Indicator",
+                notes = "Project notes",
+                primaryDataSource = "Project source",
                 projectId = projectId,
                 refId = "3.0",
                 unit = "degrees",
@@ -230,10 +244,14 @@ class ReportIndicatorStoreTest : DatabaseTest(), RunsAsDatabaseUser {
                 id = indicatorId,
                 projectId = projectId,
                 category = IndicatorCategory.Climate,
+                classId = IndicatorClass.Level,
                 description = "Climate project indicator description",
+                frequency = IndicatorFrequency.BiAnnual,
                 isPublishable = false,
                 level = IndicatorLevel.Activity,
                 name = "Climate Project Indicator",
+                notes = "Project notes",
+                primaryDataSource = "Project source",
                 refId = "3.0",
                 tfOwner = "Carbon",
                 unit = "degrees",
@@ -560,6 +578,7 @@ class ReportIndicatorStoreTest : DatabaseTest(), RunsAsDatabaseUser {
                 ),
                 ProjectIndicatorsRecord(
                     id = newIndicatorId,
+                    active = true,
                     categoryId = IndicatorCategory.ProjectObjectives,
                     description = "Project objectives indicator description",
                     isPublishable = false,
@@ -568,7 +587,6 @@ class ReportIndicatorStoreTest : DatabaseTest(), RunsAsDatabaseUser {
                     projectId = projectId,
                     refId = "1.0",
                     unit = "%",
-                    active = true,
                 ),
             )
         )

--- a/src/test/kotlin/com/terraformation/backend/accelerator/db/ReportIndicatorStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/db/ReportIndicatorStoreTest.kt
@@ -48,9 +48,9 @@ class ReportIndicatorStoreTest : DatabaseTest(), RunsAsDatabaseUser {
                 category = IndicatorCategory.Climate,
                 description = "Climate common indicator description",
                 isPublishable = true,
+                level = IndicatorLevel.Activity,
                 name = "Climate Common Indicator",
                 refId = "3.0",
-                level = IndicatorLevel.Activity,
                 unit = "degrees",
             )
 
@@ -60,9 +60,10 @@ class ReportIndicatorStoreTest : DatabaseTest(), RunsAsDatabaseUser {
                 category = IndicatorCategory.Climate,
                 description = "Climate common indicator description",
                 isPublishable = true,
+                level = IndicatorLevel.Activity,
                 name = "Climate Common Indicator",
                 refId = "3.0",
-                level = IndicatorLevel.Activity,
+                tfOwner = "Carbon",
                 unit = "degrees",
             ),
             store.fetchOneCommonIndicator(indicatorId),
@@ -104,9 +105,9 @@ class ReportIndicatorStoreTest : DatabaseTest(), RunsAsDatabaseUser {
             insertCommonIndicator(
                 category = IndicatorCategory.Climate,
                 description = "Climate common indicator description",
+                level = IndicatorLevel.Activity,
                 name = "Climate Common Indicator",
                 refId = "3.0",
-                level = IndicatorLevel.Activity,
                 unit = "%",
             )
 
@@ -114,9 +115,9 @@ class ReportIndicatorStoreTest : DatabaseTest(), RunsAsDatabaseUser {
             insertCommonIndicator(
                 category = IndicatorCategory.Community,
                 description = "Community indicator description",
+                level = IndicatorLevel.Outcome,
                 name = "Community Indicator",
                 refId = "5.0",
-                level = IndicatorLevel.Outcome,
                 unit = "meters",
             )
 
@@ -125,9 +126,9 @@ class ReportIndicatorStoreTest : DatabaseTest(), RunsAsDatabaseUser {
                 category = IndicatorCategory.ProjectObjectives,
                 description = "Project objectives indicator description",
                 isPublishable = false,
+                level = IndicatorLevel.Impact,
                 name = "Project Objectives Indicator",
                 refId = "3.0",
-                level = IndicatorLevel.Impact,
                 unit = "cm",
             )
 
@@ -139,9 +140,10 @@ class ReportIndicatorStoreTest : DatabaseTest(), RunsAsDatabaseUser {
                     category = IndicatorCategory.Climate,
                     description = "Climate common indicator description",
                     isPublishable = true,
+                    level = IndicatorLevel.Activity,
                     name = "Climate Common Indicator",
                     refId = "3.0",
-                    level = IndicatorLevel.Activity,
+                    tfOwner = "Carbon",
                     unit = "%",
                 ),
                 ExistingCommonIndicatorModel(
@@ -149,9 +151,10 @@ class ReportIndicatorStoreTest : DatabaseTest(), RunsAsDatabaseUser {
                     category = IndicatorCategory.ProjectObjectives,
                     description = "Project objectives indicator description",
                     isPublishable = false,
+                    level = IndicatorLevel.Impact,
                     name = "Project Objectives Indicator",
                     refId = "3.0",
-                    level = IndicatorLevel.Impact,
+                    tfOwner = "Carbon",
                     unit = "cm",
                 ),
                 ExistingCommonIndicatorModel(
@@ -159,9 +162,10 @@ class ReportIndicatorStoreTest : DatabaseTest(), RunsAsDatabaseUser {
                     category = IndicatorCategory.Community,
                     description = "Community indicator description",
                     isPublishable = true,
+                    level = IndicatorLevel.Outcome,
                     name = "Community Indicator",
                     refId = "5.0",
-                    level = IndicatorLevel.Outcome,
+                    tfOwner = "Carbon",
                     unit = "meters",
                 ),
             ),
@@ -213,11 +217,11 @@ class ReportIndicatorStoreTest : DatabaseTest(), RunsAsDatabaseUser {
             insertProjectIndicator(
                 category = IndicatorCategory.Climate,
                 description = "Climate project indicator description",
-                name = "Climate Project Indicator",
                 isPublishable = false,
+                level = IndicatorLevel.Activity,
+                name = "Climate Project Indicator",
                 projectId = projectId,
                 refId = "3.0",
-                level = IndicatorLevel.Activity,
                 unit = "degrees",
             )
 
@@ -228,9 +232,10 @@ class ReportIndicatorStoreTest : DatabaseTest(), RunsAsDatabaseUser {
                 category = IndicatorCategory.Climate,
                 description = "Climate project indicator description",
                 isPublishable = false,
+                level = IndicatorLevel.Activity,
                 name = "Climate Project Indicator",
                 refId = "3.0",
-                level = IndicatorLevel.Activity,
+                tfOwner = "Carbon",
                 unit = "degrees",
             ),
             store.fetchOneProjectIndicator(indicatorId),
@@ -303,10 +308,10 @@ class ReportIndicatorStoreTest : DatabaseTest(), RunsAsDatabaseUser {
             insertProjectIndicator(
                 category = IndicatorCategory.Climate,
                 description = "Climate common indicator description",
+                level = IndicatorLevel.Activity,
                 name = "Climate Common Indicator",
                 projectId = projectId,
                 refId = "3.0",
-                level = IndicatorLevel.Activity,
                 unit = "%",
             )
 
@@ -315,10 +320,10 @@ class ReportIndicatorStoreTest : DatabaseTest(), RunsAsDatabaseUser {
                 category = IndicatorCategory.Community,
                 description = "Community indicator description",
                 isPublishable = false,
+                level = IndicatorLevel.Outcome,
                 name = "Community Indicator",
                 projectId = projectId,
                 refId = "5.0",
-                level = IndicatorLevel.Outcome,
                 unit = "meters",
             )
 
@@ -326,10 +331,10 @@ class ReportIndicatorStoreTest : DatabaseTest(), RunsAsDatabaseUser {
             insertProjectIndicator(
                 category = IndicatorCategory.ProjectObjectives,
                 description = "Project objectives indicator description",
+                level = IndicatorLevel.Impact,
                 name = "Project Objectives Indicator",
                 projectId = projectId,
                 refId = "3.0",
-                level = IndicatorLevel.Impact,
                 unit = "cm",
             )
 
@@ -346,9 +351,10 @@ class ReportIndicatorStoreTest : DatabaseTest(), RunsAsDatabaseUser {
                     category = IndicatorCategory.Climate,
                     description = "Climate common indicator description",
                     isPublishable = true,
+                    level = IndicatorLevel.Activity,
                     name = "Climate Common Indicator",
                     refId = "3.0",
-                    level = IndicatorLevel.Activity,
+                    tfOwner = "Carbon",
                     unit = "%",
                 ),
                 ExistingProjectIndicatorModel(
@@ -357,9 +363,10 @@ class ReportIndicatorStoreTest : DatabaseTest(), RunsAsDatabaseUser {
                     category = IndicatorCategory.ProjectObjectives,
                     description = "Project objectives indicator description",
                     isPublishable = true,
+                    level = IndicatorLevel.Impact,
                     name = "Project Objectives Indicator",
                     refId = "3.0",
-                    level = IndicatorLevel.Impact,
+                    tfOwner = "Carbon",
                     unit = "cm",
                 ),
                 ExistingProjectIndicatorModel(
@@ -368,9 +375,10 @@ class ReportIndicatorStoreTest : DatabaseTest(), RunsAsDatabaseUser {
                     category = IndicatorCategory.Community,
                     description = "Community indicator description",
                     isPublishable = false,
+                    level = IndicatorLevel.Outcome,
                     name = "Community Indicator",
                     refId = "5.0",
-                    level = IndicatorLevel.Outcome,
+                    tfOwner = "Carbon",
                     unit = "meters",
                 ),
             ),
@@ -434,9 +442,9 @@ class ReportIndicatorStoreTest : DatabaseTest(), RunsAsDatabaseUser {
             insertCommonIndicator(
                 category = IndicatorCategory.Climate,
                 description = "Climate common indicator description",
+                level = IndicatorLevel.Activity,
                 name = "Climate Common Indicator",
                 refId = "3.0",
-                level = IndicatorLevel.Activity,
                 unit = "%",
             )
 
@@ -446,9 +454,9 @@ class ReportIndicatorStoreTest : DatabaseTest(), RunsAsDatabaseUser {
                 category = IndicatorCategory.ProjectObjectives,
                 description = "Project objectives indicator description",
                 isPublishable = false,
+                level = IndicatorLevel.Impact,
                 name = "Project Objectives Indicator",
                 refId = "1.0",
-                level = IndicatorLevel.Impact,
                 unit = "meters",
             )
 
@@ -458,25 +466,26 @@ class ReportIndicatorStoreTest : DatabaseTest(), RunsAsDatabaseUser {
             listOf(
                 CommonIndicatorsRecord(
                     id = existingIndicatorId,
+                    active = true,
                     categoryId = IndicatorCategory.Climate,
                     description = "Climate common indicator description",
                     isPublishable = true,
+                    levelId = IndicatorLevel.Activity,
                     name = "Climate Common Indicator",
                     refId = "3.0",
-                    levelId = IndicatorLevel.Activity,
+                    tfOwner = "Carbon",
                     unit = "%",
-                    active = true,
                 ),
                 CommonIndicatorsRecord(
                     id = newIndicatorId,
+                    active = true,
                     categoryId = IndicatorCategory.ProjectObjectives,
                     description = "Project objectives indicator description",
                     isPublishable = false,
+                    levelId = IndicatorLevel.Impact,
                     name = "Project Objectives Indicator",
                     refId = "1.0",
-                    levelId = IndicatorLevel.Impact,
                     unit = "meters",
-                    active = true,
                 ),
             )
         )
@@ -512,10 +521,10 @@ class ReportIndicatorStoreTest : DatabaseTest(), RunsAsDatabaseUser {
             insertProjectIndicator(
                 category = IndicatorCategory.Climate,
                 description = "Climate common indicator description",
+                level = IndicatorLevel.Activity,
                 name = "Climate Common Indicator",
                 projectId = projectId,
                 refId = "3.0",
-                level = IndicatorLevel.Activity,
                 unit = "meters",
             )
 
@@ -526,9 +535,9 @@ class ReportIndicatorStoreTest : DatabaseTest(), RunsAsDatabaseUser {
                 category = IndicatorCategory.ProjectObjectives,
                 description = "Project objectives indicator description",
                 isPublishable = false,
+                level = IndicatorLevel.Impact,
                 name = "Project Objectives Indicator",
                 refId = "1.0",
-                level = IndicatorLevel.Impact,
                 unit = "%",
             )
 
@@ -538,25 +547,26 @@ class ReportIndicatorStoreTest : DatabaseTest(), RunsAsDatabaseUser {
             listOf(
                 ProjectIndicatorsRecord(
                     id = existingIndicatorId,
+                    active = true,
                     categoryId = IndicatorCategory.Climate,
                     description = "Climate common indicator description",
                     isPublishable = true,
+                    levelId = IndicatorLevel.Activity,
                     name = "Climate Common Indicator",
                     projectId = projectId,
                     refId = "3.0",
-                    levelId = IndicatorLevel.Activity,
+                    tfOwner = "Carbon",
                     unit = "meters",
-                    active = true,
                 ),
                 ProjectIndicatorsRecord(
                     id = newIndicatorId,
                     categoryId = IndicatorCategory.ProjectObjectives,
                     description = "Project objectives indicator description",
                     isPublishable = false,
+                    levelId = IndicatorLevel.Impact,
                     name = "Project Objectives Indicator",
                     projectId = projectId,
                     refId = "1.0",
-                    levelId = IndicatorLevel.Impact,
                     unit = "%",
                     active = true,
                 ),
@@ -597,9 +607,9 @@ class ReportIndicatorStoreTest : DatabaseTest(), RunsAsDatabaseUser {
             insertCommonIndicator(
                 category = IndicatorCategory.Climate,
                 description = "Climate common indicator description",
+                level = IndicatorLevel.Activity,
                 name = "Climate Common Indicator",
                 refId = "3.0",
-                level = IndicatorLevel.Activity,
                 unit = "%",
             )
 
@@ -609,9 +619,9 @@ class ReportIndicatorStoreTest : DatabaseTest(), RunsAsDatabaseUser {
                 category = IndicatorCategory.ProjectObjectives,
                 description = "Project objectives indicator description",
                 isPublishable = false,
+                level = IndicatorLevel.Impact,
                 name = "Project Objectives Indicator",
                 refId = "1.0",
-                level = IndicatorLevel.Impact,
                 unit = "meters",
             )
 
@@ -621,14 +631,15 @@ class ReportIndicatorStoreTest : DatabaseTest(), RunsAsDatabaseUser {
             listOf(
                 CommonIndicatorsRecord(
                     id = existingIndicatorId,
+                    active = true,
                     categoryId = IndicatorCategory.ProjectObjectives,
                     description = "Project objectives indicator description",
                     isPublishable = false,
+                    levelId = IndicatorLevel.Impact,
                     name = "Project Objectives Indicator",
                     refId = "1.0",
-                    levelId = IndicatorLevel.Impact,
+                    tfOwner = "Carbon",
                     unit = "meters",
-                    active = true,
                 )
             )
         )
@@ -666,10 +677,10 @@ class ReportIndicatorStoreTest : DatabaseTest(), RunsAsDatabaseUser {
               category = IndicatorCategory.Climate,
               description = "Climate common indicator description",
               isPublishable = false,
+              level = IndicatorLevel.Activity,
               name = "Climate Common Indicator",
               projectId = projectId,
               refId = "3.0",
-              level = IndicatorLevel.Activity,
               unit = "feet",
           )
 
@@ -679,10 +690,10 @@ class ReportIndicatorStoreTest : DatabaseTest(), RunsAsDatabaseUser {
               category = IndicatorCategory.ProjectObjectives,
               description = "Project objectives indicator description",
               isPublishable = true,
+              level = IndicatorLevel.Impact,
               name = "Project Objectives Indicator",
               projectId = ProjectId(99), // this field is ignored
               refId = "1.0",
-              level = IndicatorLevel.Impact,
               unit = "inches",
           )
 
@@ -691,16 +702,17 @@ class ReportIndicatorStoreTest : DatabaseTest(), RunsAsDatabaseUser {
       assertTableEquals(
           listOf(
               ProjectIndicatorsRecord(
-                  id = existingIndicatorId,
+                  active = true,
                   categoryId = IndicatorCategory.ProjectObjectives,
                   description = "Project objectives indicator description",
+                  id = existingIndicatorId,
                   isPublishable = true,
+                  levelId = IndicatorLevel.Impact,
                   name = "Project Objectives Indicator",
                   projectId = projectId,
                   refId = "1.0",
-                  levelId = IndicatorLevel.Impact,
+                  tfOwner = "Carbon",
                   unit = "inches",
-                  active = true,
               )
           )
       )

--- a/src/test/kotlin/com/terraformation/backend/accelerator/db/ReportStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/db/ReportStoreTest.kt
@@ -30,6 +30,8 @@ import com.terraformation.backend.db.DatabaseTest
 import com.terraformation.backend.db.ReportNotFoundException
 import com.terraformation.backend.db.accelerator.AutoCalculatedIndicator
 import com.terraformation.backend.db.accelerator.IndicatorCategory
+import com.terraformation.backend.db.accelerator.IndicatorClass
+import com.terraformation.backend.db.accelerator.IndicatorFrequency
 import com.terraformation.backend.db.accelerator.IndicatorLevel
 import com.terraformation.backend.db.accelerator.ReportId
 import com.terraformation.backend.db.accelerator.ReportIndicatorStatus
@@ -278,8 +280,12 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
       val projectIndicatorId =
           insertProjectIndicator(
               category = IndicatorCategory.ProjectObjectives,
+              classId = IndicatorClass.Cumulative,
               description = "Project Indicator description",
+              frequency = IndicatorFrequency.Annual,
               name = "Project Indicator Name",
+              notes = "Project indicator notes",
+              primaryDataSource = "Project data source",
               refId = "2.0",
               level = IndicatorLevel.Activity,
           )
@@ -304,10 +310,14 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
                   indicator =
                       ProjectIndicatorModel(
                           category = IndicatorCategory.ProjectObjectives,
+                          classId = IndicatorClass.Cumulative,
                           description = "Project Indicator description",
+                          frequency = IndicatorFrequency.Annual,
                           id = projectIndicatorId,
                           isPublishable = true,
                           name = "Project Indicator Name",
+                          notes = "Project indicator notes",
+                          primaryDataSource = "Project data source",
                           level = IndicatorLevel.Activity,
                           projectId = projectId,
                           refId = "2.0",
@@ -326,9 +336,13 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
       val commonIndicatorId1 =
           insertCommonIndicator(
               category = IndicatorCategory.Climate,
+              classId = IndicatorClass.Level,
               description = "Climate common indicator description",
+              frequency = IndicatorFrequency.BiAnnual,
               level = IndicatorLevel.Activity,
               name = "Climate Common Indicator",
+              notes = "Common indicator notes",
+              primaryDataSource = "Common data source",
               refId = "2.1",
           )
 
@@ -393,11 +407,15 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
                   indicator =
                       CommonIndicatorModel(
                           category = IndicatorCategory.Climate,
+                          classId = IndicatorClass.Level,
                           description = "Climate common indicator description",
+                          frequency = IndicatorFrequency.BiAnnual,
                           id = commonIndicatorId1,
                           isPublishable = true,
                           level = IndicatorLevel.Activity,
                           name = "Climate Common Indicator",
+                          notes = "Common indicator notes",
+                          primaryDataSource = "Common data source",
                           refId = "2.1",
                           tfOwner = "Carbon",
                       ),
@@ -1025,8 +1043,12 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
       val projectIndicatorId =
           insertProjectIndicator(
               category = IndicatorCategory.ProjectObjectives,
+              classId = IndicatorClass.Level,
               description = "Project Indicator description",
+              frequency = IndicatorFrequency.MRVCycle,
               name = "Project Indicator Name",
+              notes = "Project indicator notes",
+              primaryDataSource = "Project data source",
               refId = "2.0",
               level = IndicatorLevel.Activity,
           )
@@ -1050,11 +1072,15 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
                   indicator =
                       ProjectIndicatorModel(
                           category = IndicatorCategory.ProjectObjectives,
+                          classId = IndicatorClass.Level,
                           description = "Project Indicator description",
+                          frequency = IndicatorFrequency.MRVCycle,
                           id = projectIndicatorId,
                           isPublishable = true,
                           level = IndicatorLevel.Activity,
                           name = "Project Indicator Name",
+                          notes = "Project indicator notes",
+                          primaryDataSource = "Project data source",
                           projectId = projectId,
                           refId = "2.0",
                           tfOwner = "Carbon",
@@ -1072,9 +1098,13 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
       val commonIndicatorId1 =
           insertCommonIndicator(
               category = IndicatorCategory.Climate,
+              classId = IndicatorClass.Cumulative,
               description = "Climate common indicator description",
+              frequency = IndicatorFrequency.Annual,
               level = IndicatorLevel.Activity,
               name = "Climate Common Indicator",
+              notes = "Common indicator notes",
+              primaryDataSource = "Common data source",
               refId = "2.1",
           )
 
@@ -1139,11 +1169,15 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
                   indicator =
                       CommonIndicatorModel(
                           category = IndicatorCategory.Climate,
+                          classId = IndicatorClass.Cumulative,
                           description = "Climate common indicator description",
+                          frequency = IndicatorFrequency.Annual,
                           id = commonIndicatorId1,
                           isPublishable = true,
                           level = IndicatorLevel.Activity,
                           name = "Climate Common Indicator",
+                          notes = "Common indicator notes",
+                          primaryDataSource = "Common data source",
                           refId = "2.1",
                           tfOwner = "Carbon",
                       ),

--- a/src/test/kotlin/com/terraformation/backend/accelerator/db/ReportStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/db/ReportStoreTest.kt
@@ -303,14 +303,15 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
               ReportProjectIndicatorModel(
                   indicator =
                       ProjectIndicatorModel(
-                          id = projectIndicatorId,
-                          projectId = projectId,
                           category = IndicatorCategory.ProjectObjectives,
                           description = "Project Indicator description",
+                          id = projectIndicatorId,
                           isPublishable = true,
                           name = "Project Indicator Name",
-                          refId = "2.0",
                           level = IndicatorLevel.Activity,
+                          projectId = projectId,
+                          refId = "2.0",
+                          tfOwner = "Carbon",
                       ),
                   entry =
                       ReportIndicatorEntryModel(
@@ -326,27 +327,27 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
           insertCommonIndicator(
               category = IndicatorCategory.Climate,
               description = "Climate common indicator description",
+              level = IndicatorLevel.Activity,
               name = "Climate Common Indicator",
               refId = "2.1",
-              level = IndicatorLevel.Activity,
           )
 
       val commonIndicatorId2 =
           insertCommonIndicator(
               category = IndicatorCategory.Community,
               description = "Community indicator description",
+              level = IndicatorLevel.Outcome,
               name = "Community Indicator",
               refId = "10.0",
-              level = IndicatorLevel.Outcome,
           )
 
       val commonIndicatorId3 =
           insertCommonIndicator(
               category = IndicatorCategory.ProjectObjectives,
               description = "Project objectives indicator description",
+              level = IndicatorLevel.Impact,
               name = "Project Objectives Indicator",
               refId = "2.0",
-              level = IndicatorLevel.Impact,
           )
 
       // Insert targets into new target tables
@@ -376,13 +377,14 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
               ReportCommonIndicatorModel(
                   indicator =
                       CommonIndicatorModel(
-                          id = commonIndicatorId3,
                           category = IndicatorCategory.ProjectObjectives,
                           description = "Project objectives indicator description",
+                          id = commonIndicatorId3,
                           isPublishable = true,
+                          level = IndicatorLevel.Impact,
                           name = "Project Objectives Indicator",
                           refId = "2.0",
-                          level = IndicatorLevel.Impact,
+                          tfOwner = "Carbon",
                       ),
                   // all fields are null because no target/value have been set yet
                   entry = ReportIndicatorEntryModel(),
@@ -390,13 +392,14 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
               ReportCommonIndicatorModel(
                   indicator =
                       CommonIndicatorModel(
-                          id = commonIndicatorId1,
                           category = IndicatorCategory.Climate,
                           description = "Climate common indicator description",
+                          id = commonIndicatorId1,
                           isPublishable = true,
+                          level = IndicatorLevel.Activity,
                           name = "Climate Common Indicator",
                           refId = "2.1",
-                          level = IndicatorLevel.Activity,
+                          tfOwner = "Carbon",
                       ),
                   entry =
                       ReportIndicatorEntryModel(
@@ -411,13 +414,14 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
               ReportCommonIndicatorModel(
                   indicator =
                       CommonIndicatorModel(
-                          id = commonIndicatorId2,
                           category = IndicatorCategory.Community,
                           description = "Community indicator description",
+                          id = commonIndicatorId2,
                           isPublishable = true,
+                          level = IndicatorLevel.Outcome,
                           name = "Community Indicator",
                           refId = "10.0",
-                          level = IndicatorLevel.Outcome,
+                          tfOwner = "Carbon",
                       ),
                   entry =
                       ReportIndicatorEntryModel(
@@ -1045,14 +1049,15 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
               ReportProjectIndicatorModel(
                   indicator =
                       ProjectIndicatorModel(
-                          id = projectIndicatorId,
-                          projectId = projectId,
                           category = IndicatorCategory.ProjectObjectives,
                           description = "Project Indicator description",
+                          id = projectIndicatorId,
                           isPublishable = true,
-                          name = "Project Indicator Name",
-                          refId = "2.0",
                           level = IndicatorLevel.Activity,
+                          name = "Project Indicator Name",
+                          projectId = projectId,
+                          refId = "2.0",
+                          tfOwner = "Carbon",
                       ),
                   entry =
                       ReportIndicatorEntryModel(
@@ -1068,9 +1073,9 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
           insertCommonIndicator(
               category = IndicatorCategory.Climate,
               description = "Climate common indicator description",
+              level = IndicatorLevel.Activity,
               name = "Climate Common Indicator",
               refId = "2.1",
-              level = IndicatorLevel.Activity,
           )
 
       val commonIndicatorId2 =
@@ -1078,18 +1083,18 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
               category = IndicatorCategory.Community,
               description = "Community indicator description",
               isPublishable = false,
+              level = IndicatorLevel.Outcome,
               name = "Community Indicator",
               refId = "10.0",
-              level = IndicatorLevel.Outcome,
           )
 
       val commonIndicatorId3 =
           insertCommonIndicator(
               category = IndicatorCategory.ProjectObjectives,
               description = "Project objectives indicator description",
+              level = IndicatorLevel.Impact,
               name = "Project Objectives Indicator",
               refId = "2.0",
-              level = IndicatorLevel.Impact,
           )
 
       insertCommonIndicatorTarget(commonIndicatorId = commonIndicatorId1, year = 1970, target = 55)
@@ -1118,13 +1123,14 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
               ReportCommonIndicatorModel(
                   indicator =
                       CommonIndicatorModel(
-                          id = commonIndicatorId3,
                           category = IndicatorCategory.ProjectObjectives,
                           description = "Project objectives indicator description",
+                          id = commonIndicatorId3,
                           isPublishable = true,
+                          level = IndicatorLevel.Impact,
                           name = "Project Objectives Indicator",
                           refId = "2.0",
-                          level = IndicatorLevel.Impact,
+                          tfOwner = "Carbon",
                       ),
                   // all fields are null because no target/value have been set yet
                   entry = ReportIndicatorEntryModel(),
@@ -1132,13 +1138,14 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
               ReportCommonIndicatorModel(
                   indicator =
                       CommonIndicatorModel(
-                          id = commonIndicatorId1,
                           category = IndicatorCategory.Climate,
                           description = "Climate common indicator description",
+                          id = commonIndicatorId1,
                           isPublishable = true,
+                          level = IndicatorLevel.Activity,
                           name = "Climate Common Indicator",
                           refId = "2.1",
-                          level = IndicatorLevel.Activity,
+                          tfOwner = "Carbon",
                       ),
                   entry =
                       ReportIndicatorEntryModel(
@@ -1153,13 +1160,14 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
               ReportCommonIndicatorModel(
                   indicator =
                       CommonIndicatorModel(
-                          id = commonIndicatorId2,
                           category = IndicatorCategory.Community,
                           description = "Community indicator description",
+                          id = commonIndicatorId2,
                           isPublishable = false,
+                          level = IndicatorLevel.Outcome,
                           name = "Community Indicator",
                           refId = "10.0",
-                          level = IndicatorLevel.Outcome,
+                          tfOwner = "Carbon",
                       ),
                   entry =
                       ReportIndicatorEntryModel(

--- a/src/test/kotlin/com/terraformation/backend/db/DatabaseBackedTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/db/DatabaseBackedTest.kt
@@ -32,6 +32,8 @@ import com.terraformation.backend.db.accelerator.EventId
 import com.terraformation.backend.db.accelerator.EventStatus
 import com.terraformation.backend.db.accelerator.EventType
 import com.terraformation.backend.db.accelerator.IndicatorCategory
+import com.terraformation.backend.db.accelerator.IndicatorClass
+import com.terraformation.backend.db.accelerator.IndicatorFrequency
 import com.terraformation.backend.db.accelerator.IndicatorLevel
 import com.terraformation.backend.db.accelerator.InternalInterest
 import com.terraformation.backend.db.accelerator.ModuleId
@@ -1110,24 +1112,36 @@ abstract class DatabaseBackedTest {
 
   protected fun insertProjectIndicator(
       row: ProjectIndicatorsRow = ProjectIndicatorsRow(),
+      active: Boolean = row.active ?: true,
       category: IndicatorCategory = row.categoryId ?: IndicatorCategory.ProjectObjectives,
+      classId: IndicatorClass? = row.classId,
       description: String? = row.description,
+      frequency: IndicatorFrequency? = row.frequencyId,
       isPublishable: Boolean = row.isPublishable ?: true,
       level: IndicatorLevel = row.levelId ?: IndicatorLevel.Impact,
       name: String = row.name ?: "Indicator name",
+      notes: String? = row.notes,
+      primaryDataSource: String? = row.primaryDataSource,
       projectId: ProjectId = row.projectId ?: inserted.projectId,
       refId: String = row.refId ?: "1.1",
+      tfOwner: String? = row.tfOwner ?: "Carbon",
       unit: String? = row.unit,
   ): ProjectIndicatorId {
     val rowWithDefaults =
         row.copy(
+            active = active,
             categoryId = category,
+            classId = classId,
             description = description,
+            frequencyId = frequency,
             isPublishable = isPublishable,
             levelId = level,
             name = name,
+            notes = notes,
+            primaryDataSource = primaryDataSource,
             projectId = projectId,
             refId = refId,
+            tfOwner = tfOwner,
             unit = unit,
         )
 
@@ -2819,22 +2833,34 @@ abstract class DatabaseBackedTest {
 
   fun insertCommonIndicator(
       row: CommonIndicatorsRow = CommonIndicatorsRow(),
+      active: Boolean = row.active ?: true,
       category: IndicatorCategory = row.categoryId ?: IndicatorCategory.ProjectObjectives,
+      classId: IndicatorClass? = row.classId,
       description: String? = row.description,
+      frequency: IndicatorFrequency? = row.frequencyId,
       isPublishable: Boolean = row.isPublishable ?: true,
       level: IndicatorLevel = row.levelId ?: IndicatorLevel.Impact,
       name: String = row.name ?: "Indicator name",
+      notes: String? = row.notes,
+      primaryDataSource: String? = row.primaryDataSource,
       refId: String = row.refId ?: "1.1",
+      tfOwner: String? = row.tfOwner ?: "Carbon",
       unit: String? = row.unit,
   ): CommonIndicatorId {
     val rowWithDefaults =
         row.copy(
+            active = active,
             categoryId = category,
+            classId = classId,
             description = description,
+            frequencyId = frequency,
             isPublishable = isPublishable,
             levelId = level,
             name = name,
+            notes = notes,
+            primaryDataSource = primaryDataSource,
             refId = refId,
+            tfOwner = tfOwner,
             unit = unit,
         )
 


### PR DESCRIPTION
This also required adding fields to the AutoCalculatedIndicator enum, some of which were optional. We hadn't yet done optional fields in enum tables, so `TerrawareGenerator` was also updated to handle this.