### PR TITLE
SW-7948 Use deal name in accelerator notifications

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/customer/AppNotificationService.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/AppNotificationService.kt
@@ -316,73 +316,80 @@ class AppNotificationService(
 
   @EventListener
   fun on(event: ParticipantProjectSpeciesApprovedSpeciesEditedNotificationDueEvent) {
-    log.info(
-        "Creating app notifications for an approved participant project species being edited in deliverable ${event.deliverableId} in " +
-            "project ${event.projectId}"
-    )
-
-    val project = projectStore.fetchOneById(event.projectId)
-    if (project.phase == null) {
-      log.error(
-          "Got approved participant project species edited notification for non-accelerator project ${event.projectId}"
+    systemUser.run {
+      log.info(
+          "Creating app notifications for an approved participant project species being edited " +
+              "in deliverable ${event.deliverableId} in project ${event.projectId}"
       )
-      return
-    }
 
-    val species = speciesStore.fetchSpeciesById(event.speciesId)
+      val project = projectStore.fetchOneById(event.projectId)
+      if (project.phase == null) {
+        log.error(
+            "Got approved participant project species edited notification for non-accelerator " +
+                "project ${event.projectId}"
+        )
+        return@run
+      }
 
-    val deliverableCategory = deliverableStore.fetchDeliverableCategory(event.deliverableId)
-    val deliverableUrl =
-        webAppUrls.acceleratorConsoleDeliverable(event.deliverableId, event.projectId)
-    val renderMessage = {
-      messages.participantProjectSpeciesApprovedSpeciesEdited(
-          projectName = project.name,
-          speciesName = species.scientificName,
+      val acceleratorDetails = projectAcceleratorDetailsService.fetchOneById(event.projectId)
+      val species = speciesStore.fetchSpeciesById(event.speciesId)
+
+      val deliverableCategory = deliverableStore.fetchDeliverableCategory(event.deliverableId)
+      val deliverableUrl =
+          webAppUrls.acceleratorConsoleDeliverable(event.deliverableId, event.projectId)
+      val renderMessage = {
+        messages.participantProjectSpeciesApprovedSpeciesEdited(
+            projectName = acceleratorDetails.dealName ?: project.name,
+            speciesName = species.scientificName,
+        )
+      }
+
+      insertAcceleratorNotification(
+          deliverableUrl,
+          NotificationType.ParticipantProjectSpeciesApprovedSpeciesEdited,
+          project.organizationId,
+          renderMessage,
+          deliverableCategory.internalInterestId,
       )
     }
-
-    insertAcceleratorNotification(
-        deliverableUrl,
-        NotificationType.ParticipantProjectSpeciesApprovedSpeciesEdited,
-        project.organizationId,
-        renderMessage,
-        deliverableCategory.internalInterestId,
-    )
   }
 
   @EventListener
   fun on(event: ParticipantProjectSpeciesAddedToProjectNotificationDueEvent) {
-    log.info(
-        "Creating app notifications for a participant project species being added to project ${event.projectId} "
-    )
-
-    val project = projectStore.fetchOneById(event.projectId)
-    if (project.phase == null) {
-      log.error(
-          "Got participant project species added to project notification for non-accelerator project ${event.projectId}"
+    systemUser.run {
+      log.info(
+          "Creating app notifications for a participant project species being added to project ${event.projectId}"
       )
-      return
-    }
 
-    val species = speciesStore.fetchSpeciesById(event.speciesId)
+      val project = projectStore.fetchOneById(event.projectId)
+      if (project.phase == null) {
+        log.error(
+            "Got participant project species added to project notification for non-accelerator project ${event.projectId}"
+        )
+        return@run
+      }
 
-    val deliverableCategory = deliverableStore.fetchDeliverableCategory(event.deliverableId)
-    val deliverableUrl =
-        webAppUrls.acceleratorConsoleDeliverable(event.deliverableId, event.projectId)
-    val renderMessage = {
-      messages.participantProjectSpeciesAddedToProject(
-          projectName = project.name,
-          speciesName = species.scientificName,
+      val acceleratorDetails = projectAcceleratorDetailsService.fetchOneById(event.projectId)
+      val species = speciesStore.fetchSpeciesById(event.speciesId)
+
+      val deliverableCategory = deliverableStore.fetchDeliverableCategory(event.deliverableId)
+      val deliverableUrl =
+          webAppUrls.acceleratorConsoleDeliverable(event.deliverableId, event.projectId)
+      val renderMessage = {
+        messages.participantProjectSpeciesAddedToProject(
+            projectName = acceleratorDetails.dealName ?: project.name,
+            speciesName = species.scientificName,
+        )
+      }
+
+      insertAcceleratorNotification(
+          deliverableUrl,
+          NotificationType.ParticipantProjectSpeciesAddedToProject,
+          project.organizationId,
+          renderMessage,
+          deliverableCategory.internalInterestId,
       )
     }
-
-    insertAcceleratorNotification(
-        deliverableUrl,
-        NotificationType.ParticipantProjectSpeciesAddedToProject,
-        project.organizationId,
-        renderMessage,
-        deliverableCategory.internalInterestId,
-    )
   }
 
   @EventListener
@@ -457,10 +464,13 @@ class AppNotificationService(
         return@run
       }
 
+      val acceleratorDetails = projectAcceleratorDetailsService.fetchOneById(event.projectId)
       val deliverableCategory = deliverableStore.fetchDeliverableCategory(event.deliverableId)
       val deliverableUrl =
           webAppUrls.acceleratorConsoleDeliverable(event.deliverableId, event.projectId)
-      val renderMessage = { messages.deliverableReadyForReview(project.name) }
+      val renderMessage = {
+        messages.deliverableReadyForReview(acceleratorDetails.dealName ?: project.name)
+      }
 
       log.info(
           "Creating app notifications for project ${event.projectId} " +

--- a/src/main/kotlin/com/terraformation/backend/email/EmailNotificationService.kt
+++ b/src/main/kotlin/com/terraformation/backend/email/EmailNotificationService.kt
@@ -600,44 +600,50 @@ class EmailNotificationService(
 
   @EventListener
   fun on(event: ParticipantProjectSpeciesAddedToProjectNotificationDueEvent) {
-    val project = projectStore.fetchOneById(event.projectId)
-    val species = speciesStore.fetchSpeciesById(event.speciesId)
-    val deliverableCategory = deliverableStore.fetchDeliverableCategory(event.deliverableId)
+    systemUser.run {
+      val project = projectStore.fetchOneById(event.projectId)
+      val acceleratorDetails = projectAcceleratorDetailsService.fetchOneById(event.projectId)
+      val species = speciesStore.fetchSpeciesById(event.speciesId)
+      val deliverableCategory = deliverableStore.fetchDeliverableCategory(event.deliverableId)
 
-    sendToAccelerator(
-        project.organizationId,
-        ParticipantProjectSpeciesAdded(
-            config = config,
-            deliverableUrl =
-                webAppUrls
-                    .fullAcceleratorConsoleDeliverable(event.deliverableId, event.projectId)
-                    .toString(),
-            projectName = project.name,
-            speciesName = species.scientificName,
-        ),
-        deliverableCategory.internalInterestId,
-    )
+      sendToAccelerator(
+          project.organizationId,
+          ParticipantProjectSpeciesAdded(
+              config = config,
+              deliverableUrl =
+                  webAppUrls
+                      .fullAcceleratorConsoleDeliverable(event.deliverableId, event.projectId)
+                      .toString(),
+              projectName = acceleratorDetails.dealName ?: project.name,
+              speciesName = species.scientificName,
+          ),
+          deliverableCategory.internalInterestId,
+      )
+    }
   }
 
   @EventListener
   fun on(event: ParticipantProjectSpeciesApprovedSpeciesEditedNotificationDueEvent) {
-    val project = projectStore.fetchOneById(event.projectId)
-    val species = speciesStore.fetchSpeciesById(event.speciesId)
-    val deliverableCategory = deliverableStore.fetchDeliverableCategory(event.deliverableId)
+    systemUser.run {
+      val project = projectStore.fetchOneById(event.projectId)
+      val acceleratorDetails = projectAcceleratorDetailsService.fetchOneById(event.projectId)
+      val species = speciesStore.fetchSpeciesById(event.speciesId)
+      val deliverableCategory = deliverableStore.fetchDeliverableCategory(event.deliverableId)
 
-    sendToAccelerator(
-        project.organizationId,
-        ParticipantProjectSpeciesEdited(
-            config = config,
-            deliverableUrl =
-                webAppUrls
-                    .fullAcceleratorConsoleDeliverable(event.deliverableId, event.projectId)
-                    .toString(),
-            projectName = project.name,
-            speciesName = species.scientificName,
-        ),
-        deliverableCategory.internalInterestId,
-    )
+      sendToAccelerator(
+          project.organizationId,
+          ParticipantProjectSpeciesEdited(
+              config = config,
+              deliverableUrl =
+                  webAppUrls
+                      .fullAcceleratorConsoleDeliverable(event.deliverableId, event.projectId)
+                      .toString(),
+              projectName = acceleratorDetails.dealName ?: project.name,
+              speciesName = species.scientificName,
+          ),
+          deliverableCategory.internalInterestId,
+      )
+    }
   }
 
   @EventListener
@@ -687,6 +693,8 @@ class EmailNotificationService(
 
       val deliverableCategory = deliverableStore.fetchDeliverableCategory(event.deliverableId)
 
+      val acceleratorDetails = projectAcceleratorDetailsService.fetchOneById(event.projectId)
+
       sendToAccelerator(
           project.organizationId,
           DeliverableReadyForReview(
@@ -696,7 +704,7 @@ class EmailNotificationService(
                       .fullAcceleratorConsoleDeliverable(event.deliverableId, event.projectId)
                       .toString(),
               deliverable = deliverableSubmission,
-              projectName = project.name,
+              projectName = acceleratorDetails.dealName ?: project.name,
           ),
           deliverableCategory.internalInterestId,
       )
@@ -748,6 +756,7 @@ class EmailNotificationService(
       if (sectionOwnerUserId != null) {
         val document = documentStore.fetchOneById(event.documentId)
         val project = projectStore.fetchOneById(event.projectId)
+        val acceleratorDetails = projectAcceleratorDetailsService.fetchOneById(event.projectId)
         val sectionVariable =
             variableStore.fetchOneVariable(event.sectionVariableId, document.variableManifestId)
 
@@ -763,7 +772,7 @@ class EmailNotificationService(
                     webAppUrls
                         .fullDocument(event.documentId, event.referencingSectionVariableId)
                         .toString(),
-                projectName = project.name,
+                projectName = acceleratorDetails.dealName ?: project.name,
                 sectionName = sectionVariable.name,
             ),
             false,

--- a/src/test/kotlin/com/terraformation/backend/customer/AppNotificationServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/AppNotificationServiceTest.kt
@@ -649,7 +649,7 @@ internal class AppNotificationServiceTest : DatabaseTest(), RunsAsUser {
     insertOrganizationUser(owner, role = Role.Owner)
 
     val projectId = insertProject()
-    insertProjectAcceleratorDetails(dealName = "DEAL_name")
+    insertDealNameVariable()
     insertProjectReportConfig()
     val reportId =
         insertReport(
@@ -702,8 +702,7 @@ internal class AppNotificationServiceTest : DatabaseTest(), RunsAsUser {
   @Test
   fun `should store activity created notification`() {
     insertProject()
-    val dealNameVariableId = insertTextVariable(stableId = StableIds.dealName.value)
-    insertValue(dealNameVariableId, textValue = "DEAL_name")
+    insertDealNameVariable()
 
     val projectLead = insertUser()
     insertProjectInternalUser(role = ProjectInternalRole.ProjectLead)
@@ -799,6 +798,7 @@ internal class AppNotificationServiceTest : DatabaseTest(), RunsAsUser {
     insertModule()
     insertUserGlobalRole(user.userId, GlobalRole.TFExpert)
     val projectId = insertProject(phase = AcceleratorPhase.Phase0DueDiligence)
+    insertDealNameVariable()
     insertProjectModule()
 
     insertUserInternalInterest(InternalInterest.GIS, user.userId)
@@ -808,7 +808,7 @@ internal class AppNotificationServiceTest : DatabaseTest(), RunsAsUser {
         DeliverableReadyForReviewEvent(deliverableId, projectId),
         type = NotificationType.DeliverableReadyForReview,
         title = "Review a submitted deliverable",
-        body = "A deliverable from Project 1 is ready for review for approval.",
+        body = "A deliverable from DEAL_name is ready for review for approval.",
         localUrl = webAppUrls.acceleratorConsoleDeliverable(deliverableId, projectId),
         organizationId = null,
     )
@@ -951,6 +951,7 @@ internal class AppNotificationServiceTest : DatabaseTest(), RunsAsUser {
   fun `should store species added to project notification for global users with interest`() {
     insertUserGlobalRole(user.userId, GlobalRole.TFExpert)
     val projectId = insertProject(phase = AcceleratorPhase.Phase0DueDiligence)
+    insertDealNameVariable()
     val speciesId = insertSpecies()
     insertParticipantProjectSpecies(projectId = projectId, speciesId = speciesId)
     insertModule()
@@ -965,8 +966,8 @@ internal class AppNotificationServiceTest : DatabaseTest(), RunsAsUser {
             speciesId,
         ),
         type = NotificationType.ParticipantProjectSpeciesAddedToProject,
-        title = "A species has been added to project Project 1.",
-        body = "Species 1 has been submitted for use for Project 1.",
+        title = "A species has been added to project DEAL_name.",
+        body = "Species 1 has been submitted for use for DEAL_name.",
         localUrl = webAppUrls.acceleratorConsoleDeliverable(deliverableId, projectId),
         userId = user.userId,
         organizationId = null,
@@ -977,6 +978,7 @@ internal class AppNotificationServiceTest : DatabaseTest(), RunsAsUser {
   fun `should store species approved species edited notification`() {
     insertUserGlobalRole(user.userId, GlobalRole.TFExpert)
     val projectId = insertProject(phase = AcceleratorPhase.Phase0DueDiligence)
+    insertDealNameVariable()
     val speciesId = insertSpecies()
     insertParticipantProjectSpecies(projectId = projectId, speciesId = speciesId)
     insertModule()
@@ -991,7 +993,7 @@ internal class AppNotificationServiceTest : DatabaseTest(), RunsAsUser {
             speciesId,
         ),
         type = NotificationType.ParticipantProjectSpeciesApprovedSpeciesEdited,
-        title = "An approved species has been edited for Project 1.",
+        title = "An approved species has been edited for DEAL_name.",
         body = "Species 1 has been edited and is ready for approval.",
         localUrl = webAppUrls.acceleratorConsoleDeliverable(deliverableId, projectId),
         userId = user.userId,
@@ -1106,6 +1108,11 @@ internal class AppNotificationServiceTest : DatabaseTest(), RunsAsUser {
         organizationId = null,
         userId = gibberishUserId,
     )
+  }
+
+  private fun insertDealNameVariable() {
+    val dealNameVariableId = insertTextVariable(stableId = StableIds.dealName.value)
+    insertValue(dealNameVariableId, textValue = "DEAL_name")
   }
 
   /**

--- a/src/test/kotlin/com/terraformation/backend/email/EmailNotificationServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/email/EmailNotificationServiceTest.kt
@@ -1230,9 +1230,10 @@ internal class EmailNotificationServiceTest {
 
     service.on(event)
 
+    val dealName = projectAcceleratorDetails.dealName!!
     val message = sentMessageWithSubject("added to")
-    assertSubjectContains(project.name, message = message)
-    assertBodyContains(project.name, message = message)
+    assertSubjectContains(dealName, message = message)
+    assertBodyContains(dealName, message = message)
     assertBodyContains(species.scientificName, message = message)
     assertBodyContains("submitted for use", message = message)
 
@@ -1253,9 +1254,10 @@ internal class EmailNotificationServiceTest {
 
     service.on(event)
 
+    val dealName = projectAcceleratorDetails.dealName!!
     val message = sentMessageWithSubject("added to")
-    assertSubjectContains(project.name, message = message)
-    assertBodyContains(project.name, message = message)
+    assertSubjectContains(dealName, message = message)
+    assertBodyContains(dealName, message = message)
     assertBodyContains(species.scientificName, message = message)
     assertBodyContains("submitted for use", message = message)
 
@@ -1273,9 +1275,10 @@ internal class EmailNotificationServiceTest {
 
     service.on(event)
 
+    val dealName = projectAcceleratorDetails.dealName!!
     val message = sentMessageWithSubject("has been edited")
-    assertSubjectContains(project.name, message = message)
-    assertBodyContains(project.name, message = message)
+    assertSubjectContains(dealName, message = message)
+    assertBodyContains(dealName, message = message)
     assertBodyContains(species.scientificName, message = message)
     assertBodyContains("has been edited", message = message)
 
@@ -1296,9 +1299,10 @@ internal class EmailNotificationServiceTest {
 
     service.on(event)
 
+    val dealName = projectAcceleratorDetails.dealName!!
     val message = sentMessageWithSubject("has been edited")
-    assertSubjectContains(project.name, message = message)
-    assertBodyContains(project.name, message = message)
+    assertSubjectContains(dealName, message = message)
+    assertBodyContains(dealName, message = message)
     assertBodyContains(species.scientificName, message = message)
     assertBodyContains("has been edited", message = message)
 
@@ -1611,9 +1615,10 @@ internal class EmailNotificationServiceTest {
 
     service.on(event)
 
+    val dealName = projectAcceleratorDetails.dealName!!
     val message = sentMessageWithSubject("is ready for review")
-    assertSubjectContains(project.name, message = message)
-    assertBodyContains(project.name, message = message)
+    assertSubjectContains(dealName, message = message)
+    assertBodyContains(dealName, message = message)
 
     assertRecipientsEqual(setOf(tfContactEmail1, tfContactEmail2, acceleratorUser.email))
   }
@@ -1629,9 +1634,10 @@ internal class EmailNotificationServiceTest {
 
     service.on(event)
 
+    val dealName = projectAcceleratorDetails.dealName!!
     val message = sentMessageWithSubject("is ready for review")
-    assertSubjectContains(project.name, message = message)
-    assertBodyContains(project.name, message = message)
+    assertSubjectContains(dealName, message = message)
+    assertBodyContains(dealName, message = message)
 
     assertRecipientsEqual(setOf(tfContactEmail1, tfContactEmail2, acceleratorUser.email))
 
@@ -1646,9 +1652,10 @@ internal class EmailNotificationServiceTest {
 
     service.on(event)
 
+    val dealName = projectAcceleratorDetails.dealName!!
     val message = sentMessageWithSubject("is ready for review")
-    assertSubjectContains(project.name, message = message)
-    assertBodyContains(project.name, message = message)
+    assertSubjectContains(dealName, message = message)
+    assertBodyContains(dealName, message = message)
 
     assertRecipientsEqual(setOf(acceleratorUser.email))
   }
@@ -1704,6 +1711,7 @@ internal class EmailNotificationServiceTest {
 
     assertSubjectContains("Variable edited")
     assertBodyContains("A variable has been")
+    assertBodyContains(projectAcceleratorDetails.dealName!!)
 
     assertRecipientsEqual(setOf(sectionOwnerEmail))
 


### PR DESCRIPTION
Update the notifications that get sent to the accelerator team so they use the
deal name rather than the project name.