### PR TITLE
SW-8124 Update target perms should require admin instead of manager

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/customer/model/IndividualUser.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/IndividualUser.kt
@@ -692,7 +692,7 @@ data class IndividualUser(
   override fun canUpdateProjectInternalUsers(projectId: ProjectId) = isTFExpertOrHigher()
 
   override fun canUpdateProjectReports(projectId: ProjectId): Boolean =
-      isTFExpertOrHigher() || isManagerOrHigher(parentStore.getOrganizationId(projectId))
+      isTFExpertOrHigher() || isAdminOrHigher(parentStore.getOrganizationId(projectId))
 
   override fun canUpdateProjectScores(projectId: ProjectId): Boolean = isTFExpertOrHigher()
 

--- a/src/test/kotlin/com/terraformation/backend/accelerator/db/ReportStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/db/ReportStoreTest.kt
@@ -5379,7 +5379,7 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
     fun `requires permission to update project reports`() {
       deleteUserGlobalRole(role = GlobalRole.AcceleratorAdmin)
       deleteOrganizationUser()
-      insertOrganizationUser(role = Role.Contributor)
+      insertOrganizationUser(role = Role.Manager)
 
       val projectIndicatorId =
           insertProjectIndicator(
@@ -5486,7 +5486,7 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
     fun `requires permission to update project reports`() {
       deleteUserGlobalRole(role = GlobalRole.AcceleratorAdmin)
       deleteOrganizationUser()
-      insertOrganizationUser(role = Role.Contributor)
+      insertOrganizationUser(role = Role.Manager)
 
       val commonIndicatorId =
           insertCommonIndicator(
@@ -5566,7 +5566,7 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
     fun `requires permission to update project reports`() {
       deleteUserGlobalRole(role = GlobalRole.AcceleratorAdmin)
       deleteOrganizationUser()
-      insertOrganizationUser(role = Role.Contributor)
+      insertOrganizationUser(role = Role.Manager)
 
       assertThrows<AccessDeniedException> {
         store.updateAutoCalculatedIndicatorTarget(

--- a/src/test/kotlin/com/terraformation/backend/customer/model/PermissionTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/model/PermissionTest.kt
@@ -1179,7 +1179,6 @@ internal class PermissionTest : DatabaseTest() {
         readProjectDeliverables = true,
         readProjectModules = true,
         readProjectReports = true,
-        updateProjectReports = true,
     )
 
     permissions.expect(


### PR DESCRIPTION
Update the permission `updateProjectReports` to require TF Expert+ or Admin+ instead of Manager+.