### PR TITLE
SW-7949 Rename quadrat abundance percent to count

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/search/table/ObservationBiomassQuadratSpeciesTable.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/table/ObservationBiomassQuadratSpeciesTable.kt
@@ -52,7 +52,11 @@ class ObservationBiomassQuadratSpeciesTable(private val tables: SearchTables) : 
 
   override val fields: List<SearchField> =
       listOf(
-          integerField("abundancePercent", OBSERVATION_BIOMASS_QUADRAT_SPECIES.ABUNDANCE_PERCENT),
+          integerField("abundanceCount", OBSERVATION_BIOMASS_QUADRAT_SPECIES.ABUNDANCE_COUNT),
+          integerField(
+              "abundancePercent",
+              OBSERVATION_BIOMASS_QUADRAT_SPECIES.ABUNDANCE_COUNT.times(4),
+          ),
           enumField("position", OBSERVATION_BIOMASS_QUADRAT_SPECIES.POSITION_ID),
       )
 

--- a/src/main/kotlin/com/terraformation/backend/tracking/api/BiomassPayloads.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/api/BiomassPayloads.kt
@@ -77,7 +77,7 @@ data class ExistingBiomassQuadratSpeciesPayload(
       model: BiomassQuadratSpeciesModel,
       species: Map<BiomassSpeciesKey, BiomassSpeciesModel>,
   ) : this(
-      abundancePercent = model.abundancePercent,
+      abundancePercent = model.abundanceCount,
       isInvasive = species[BiomassSpeciesKey(model.speciesId, model.speciesName)]!!.isInvasive,
       isThreatened = species[BiomassSpeciesKey(model.speciesId, model.speciesName)]!!.isThreatened,
       speciesId = model.speciesId,
@@ -106,7 +106,7 @@ data class NewBiomassQuadratSpeciesPayload(
 ) {
   fun toModel(): BiomassQuadratSpeciesModel {
     return BiomassQuadratSpeciesModel(
-        abundancePercent = abundancePercent,
+        abundanceCount = abundancePercent,
         speciesId = speciesId,
         speciesName = speciesName,
     )

--- a/src/main/kotlin/com/terraformation/backend/tracking/db/BiomassStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/db/BiomassStore.kt
@@ -252,7 +252,7 @@ class BiomassStore(
                           ?: throw IllegalArgumentException(
                               "Biomass species ${it.speciesName ?: "#${it.speciesId}"} not found."
                           ),
-                  abundancePercent = it.abundancePercent,
+                  abundanceCount = it.abundanceCount,
               )
             }
           }
@@ -384,9 +384,9 @@ class BiomassStore(
           .execute()
     }
 
-    // For quadrat species, we need to add the abundance percentages of the numbered species and the
-    // "Other" one if both exist in the quadrat. If only the "Other" one exists, then we can just
-    // switch its biomass species ID in place.
+    // For quadrat species, we need to add the abundance square counts of the numbered species and
+    // the "Other" one if both exist in the quadrat. If only the "Other" one exists, then we can
+    // just switch its biomass species ID in place. The total is capped at 25.
     with(OBSERVATION_BIOMASS_QUADRAT_SPECIES) {
       val quadratSpeciesTable2 = OBSERVATION_BIOMASS_QUADRAT_SPECIES.`as`("quadrat2")
 
@@ -405,14 +405,19 @@ class BiomassStore(
       dslContext
           .update(OBSERVATION_BIOMASS_QUADRAT_SPECIES)
           .set(
-              ABUNDANCE_PERCENT,
-              ABUNDANCE_PERCENT.plus(
-                  DSL.field(
-                      DSL.select(quadratSpeciesTable2.ABUNDANCE_PERCENT)
-                          .from(quadratSpeciesTable2)
-                          .where(quadratSpeciesTable2.BIOMASS_SPECIES_ID.eq(otherBiomassSpeciesId))
-                          .and(quadratSpeciesTable2.POSITION_ID.eq(POSITION_ID))
-                  )
+              ABUNDANCE_COUNT,
+              DSL.least(
+                  ABUNDANCE_COUNT.plus(
+                      DSL.field(
+                          DSL.select(quadratSpeciesTable2.ABUNDANCE_COUNT)
+                              .from(quadratSpeciesTable2)
+                              .where(
+                                  quadratSpeciesTable2.BIOMASS_SPECIES_ID.eq(otherBiomassSpeciesId)
+                              )
+                              .and(quadratSpeciesTable2.POSITION_ID.eq(POSITION_ID))
+                      )
+                  ),
+                  DSL.value(25),
               ),
           )
           .where(BIOMASS_SPECIES_ID.eq(targetBiomassSpeciesId))
@@ -688,7 +693,7 @@ class BiomassStore(
       val existing =
           with(OBSERVATION_BIOMASS_QUADRAT_SPECIES) {
             dslContext
-                .select(ABUNDANCE_PERCENT)
+                .select(ABUNDANCE_COUNT)
                 .from(OBSERVATION_BIOMASS_QUADRAT_SPECIES)
                 .where(OBSERVATION_ID.eq(observationId))
                 .and(MONITORING_PLOT_ID.eq(monitoringPlotId))
@@ -707,7 +712,7 @@ class BiomassStore(
         with(OBSERVATION_BIOMASS_QUADRAT_SPECIES) {
           dslContext
               .update(OBSERVATION_BIOMASS_QUADRAT_SPECIES)
-              .set(ABUNDANCE_PERCENT, updated.abundance)
+              .set(ABUNDANCE_COUNT, updated.abundance)
               .where(OBSERVATION_ID.eq(observationId))
               .and(MONITORING_PLOT_ID.eq(monitoringPlotId))
               .and(POSITION_ID.eq(position))

--- a/src/main/kotlin/com/terraformation/backend/tracking/db/ObservationResultsStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/db/ObservationResultsStore.kt
@@ -274,7 +274,7 @@ class ObservationResultsStore(private val dslContext: DSLContext) {
         DSL.multiset(
                 DSL.select(
                         POSITION_ID,
-                        ABUNDANCE_PERCENT,
+                        ABUNDANCE_COUNT,
                         OBSERVATION_BIOMASS_SPECIES.SPECIES_ID,
                         OBSERVATION_BIOMASS_SPECIES.SCIENTIFIC_NAME,
                     )
@@ -291,7 +291,7 @@ class ObservationResultsStore(private val dslContext: DSLContext) {
                     records
                         .map {
                           BiomassQuadratSpeciesModel(
-                              abundancePercent = it[ABUNDANCE_PERCENT]!!,
+                              abundanceCount = it[ABUNDANCE_COUNT]!!,
                               speciesId = it[OBSERVATION_BIOMASS_SPECIES.SPECIES_ID],
                               speciesName = it[OBSERVATION_BIOMASS_SPECIES.SCIENTIFIC_NAME],
                           )

--- a/src/main/kotlin/com/terraformation/backend/tracking/model/BiomassDetailsModel.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/model/BiomassDetailsModel.kt
@@ -32,7 +32,7 @@ data class BiomassSpeciesModel(
 )
 
 data class BiomassQuadratSpeciesModel(
-    val abundancePercent: Int,
+    val abundanceCount: Int,
     val speciesId: SpeciesId? = null,
     val speciesName: String? = null,
 )

--- a/src/main/kotlin/com/terraformation/backend/tracking/model/EditableObservationModels.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/model/EditableObservationModels.kt
@@ -114,7 +114,7 @@ data class EditableBiomassQuadratSpeciesModel(
     fun of(record: Record): EditableBiomassQuadratSpeciesModel {
       return with(OBSERVATION_BIOMASS_QUADRAT_SPECIES) {
         EditableBiomassQuadratSpeciesModel(
-            abundance = record[ABUNDANCE_PERCENT]!!,
+            abundance = record[ABUNDANCE_COUNT]!!,
         )
       }
     }

--- a/src/main/resources/db/migration/0450/V465__AbundanceCount.sql
+++ b/src/main/resources/db/migration/0450/V465__AbundanceCount.sql
@@ -1,0 +1,15 @@
+ALTER TABLE tracking.observation_biomass_quadrat_species
+    RENAME COLUMN abundance_percent TO abundance_count;
+ALTER TABLE tracking.observation_biomass_quadrat_species
+    DROP CONSTRAINT observation_biomass_quadrat_species_abundance_percent_check;
+
+-- Count is 1/4 of percentage, so should be capped at 25 because that's 100%.
+-- The UI constrains the value to 25, so data from actual users should be within
+-- the required range, but we have early test data with values higher than 25.
+UPDATE tracking.observation_biomass_quadrat_species
+SET abundance_count = 25
+WHERE abundance_count > 25;
+
+ALTER TABLE tracking.observation_biomass_quadrat_species
+    ADD CONSTRAINT abundance_count_check
+        CHECK (abundance_count BETWEEN 0 AND 25);

--- a/src/main/resources/i18n/Messages_en.properties
+++ b/src/main/resources/i18n/Messages_en.properties
@@ -737,6 +737,7 @@ search.observationBiomassDetails.soilAssessment=Soil assessment
 search.observationBiomassDetails.tide=Tide
 search.observationBiomassDetails.tideTime=Time of tide measurement
 search.observationBiomassDetails.waterDepth=Water depth (cm)
+search.observationBiomassQuadratSpecies.abundanceCount=Herbaceous abundance (square count)
 search.observationBiomassQuadratSpecies.abundancePercent=Herbaceous abundance (%)
 # A "quadrat" is a 1-square-meter area used in ecological surveying
 search.observationBiomassQuadratSpecies.position=Quadrat position

--- a/src/main/resources/i18n/Messages_es.properties
+++ b/src/main/resources/i18n/Messages_es.properties
@@ -1289,6 +1289,8 @@ search.observationBiomassDetails.tide=Marea
 search.observationBiomassDetails.tideTime=Hora de medición de la marea
 # 7743251a
 search.observationBiomassDetails.waterDepth=Profundidad del agua (cm)
+# a21be9d4
+search.observationBiomassQuadratSpecies.abundanceCount=Abundancia de herbáceas (conteo por cuadrícula)
 # 5aaea65f
 search.observationBiomassQuadratSpecies.abundancePercent=Abundancia herbácea (%)
 # eee22d8c

--- a/src/main/resources/i18n/Messages_fr.properties
+++ b/src/main/resources/i18n/Messages_fr.properties
@@ -1289,6 +1289,8 @@ search.observationBiomassDetails.tide=Marée
 search.observationBiomassDetails.tideTime=Heure de mesure de la marée
 # 7743251a
 search.observationBiomassDetails.waterDepth=Profondeur de l’eau (cm)
+# a21be9d4
+search.observationBiomassQuadratSpecies.abundanceCount=Abondance herbacée (nombre de carrés)
 # 5aaea65f
 search.observationBiomassQuadratSpecies.abundancePercent=Abondance herbacée (%)
 # eee22d8c

--- a/src/test/kotlin/com/terraformation/backend/db/DatabaseBackedTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/db/DatabaseBackedTest.kt
@@ -3051,7 +3051,7 @@ abstract class DatabaseBackedTest {
       monitoringPlotId: MonitoringPlotId = row.monitoringPlotId ?: inserted.monitoringPlotId,
       position: ObservationPlotPosition = row.positionId ?: ObservationPlotPosition.SouthwestCorner,
       biomassSpeciesId: BiomassSpeciesId? = row.biomassSpeciesId ?: inserted.biomassSpeciesId,
-      abundancePercent: Int = row.abundancePercent ?: 0,
+      abundanceCount: Int = row.abundanceCount ?: 0,
   ) {
     with(OBSERVATION_BIOMASS_QUADRAT_SPECIES) {
       dslContext
@@ -3060,7 +3060,7 @@ abstract class DatabaseBackedTest {
           .set(MONITORING_PLOT_ID, monitoringPlotId)
           .set(POSITION_ID, position)
           .set(BIOMASS_SPECIES_ID, biomassSpeciesId)
-          .set(ABUNDANCE_PERCENT, abundancePercent)
+          .set(ABUNDANCE_COUNT, abundanceCount)
           .execute()
     }
   }

--- a/src/test/kotlin/com/terraformation/backend/tracking/TrackingSearchTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/TrackingSearchTest.kt
@@ -243,7 +243,7 @@ class TrackingSearchTest : DatabaseTest(), RunsAsUser {
         position = ObservationPlotPosition.NorthwestCorner,
     )
     insertObservationBiomassQuadratSpecies(
-        abundancePercent = 33,
+        abundanceCount = 8,
         biomassSpeciesId = inserted.biomassSpeciesId,
         position = ObservationPlotPosition.NorthwestCorner,
     )
@@ -431,8 +431,9 @@ class TrackingSearchTest : DatabaseTest(), RunsAsUser {
                                                                 "quadratSpecies" to
                                                                     listOf(
                                                                         mapOf(
+                                                                            "abundanceCount" to "8",
                                                                             "abundancePercent" to
-                                                                                "33",
+                                                                                "32",
                                                                             "position" to
                                                                                 "Northwest",
                                                                         ),
@@ -768,6 +769,7 @@ class TrackingSearchTest : DatabaseTest(), RunsAsUser {
                 "observations.observationPlots.biomassDetails.species.isInvasive",
                 "observations.observationPlots.biomassDetails.species.isThreatened",
                 "observations.observationPlots.biomassDetails.species.name",
+                "observations.observationPlots.biomassDetails.species.quadratSpecies.abundanceCount",
                 "observations.observationPlots.biomassDetails.species.quadratSpecies.abundancePercent",
                 "observations.observationPlots.biomassDetails.species.quadratSpecies.position",
                 "observations.observationPlots.biomassDetails.tide",

--- a/src/test/kotlin/com/terraformation/backend/tracking/api/BiomassPayloadsTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/api/BiomassPayloadsTest.kt
@@ -26,7 +26,7 @@ class BiomassPayloadsTest {
     @Test
     fun `converts to NewRecordedTreeModels and assign tree and trunk numbers correctly`() {
       val treeList =
-          listOf<NewTreePayload>(
+          listOf(
               NewShrubPayload(
                   description = "Live shrub description",
                   gpsCoordinates = point(1),
@@ -174,7 +174,7 @@ class BiomassPayloadsTest {
                               species =
                                   setOf(
                                       BiomassQuadratSpeciesModel(
-                                          abundancePercent = 40,
+                                          abundanceCount = 10,
                                           speciesId = SpeciesId(1),
                                       )
                                   ),
@@ -185,11 +185,11 @@ class BiomassPayloadsTest {
                               species =
                                   setOf(
                                       BiomassQuadratSpeciesModel(
-                                          abundancePercent = 60,
+                                          abundanceCount = 15,
                                           speciesId = SpeciesId(2),
                                       ),
                                       BiomassQuadratSpeciesModel(
-                                          abundancePercent = 5,
+                                          abundanceCount = 1,
                                           speciesName = "Herbaceous species",
                                       ),
                                   ),
@@ -200,7 +200,7 @@ class BiomassPayloadsTest {
                               species =
                                   setOf(
                                       BiomassQuadratSpeciesModel(
-                                          abundancePercent = 90,
+                                          abundanceCount = 23,
                                           speciesId = SpeciesId(1),
                                       )
                                   ),
@@ -347,7 +347,7 @@ class BiomassPayloadsTest {
                           species =
                               listOf(
                                   ExistingBiomassQuadratSpeciesPayload(
-                                      abundancePercent = 90,
+                                      abundancePercent = 23,
                                       isInvasive = true,
                                       isThreatened = false,
                                       speciesId = SpeciesId(1),
@@ -361,7 +361,7 @@ class BiomassPayloadsTest {
                           species =
                               listOf(
                                   ExistingBiomassQuadratSpeciesPayload(
-                                      abundancePercent = 40,
+                                      abundancePercent = 10,
                                       isInvasive = true,
                                       isThreatened = false,
                                       speciesId = SpeciesId(1),
@@ -375,14 +375,14 @@ class BiomassPayloadsTest {
                           species =
                               listOf(
                                   ExistingBiomassQuadratSpeciesPayload(
-                                      abundancePercent = 60,
+                                      abundancePercent = 15,
                                       isInvasive = false,
                                       isThreatened = false,
                                       speciesId = SpeciesId(2),
                                       speciesName = null,
                                   ),
                                   ExistingBiomassQuadratSpeciesPayload(
-                                      abundancePercent = 5,
+                                      abundancePercent = 1,
                                       isInvasive = false,
                                       isThreatened = true,
                                       speciesId = null,

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/ObservationResultsStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/ObservationResultsStoreTest.kt
@@ -528,7 +528,7 @@ class ObservationResultsStoreTest : ObservationScenarioTest() {
               observationId = observationId,
               monitoringPlotId = plotId,
               positionId = ObservationPlotPosition.NortheastCorner,
-              abundancePercent = 40,
+              abundanceCount = 10,
               biomassSpeciesId = biomassHerbaceousSpeciesId1,
           )
       )
@@ -538,7 +538,7 @@ class ObservationResultsStoreTest : ObservationScenarioTest() {
               observationId = observationId,
               monitoringPlotId = plotId,
               positionId = ObservationPlotPosition.NorthwestCorner,
-              abundancePercent = 5,
+              abundanceCount = 1,
               biomassSpeciesId = biomassHerbaceousSpeciesId3,
           )
       )
@@ -548,7 +548,7 @@ class ObservationResultsStoreTest : ObservationScenarioTest() {
               observationId = observationId,
               monitoringPlotId = plotId,
               positionId = ObservationPlotPosition.NorthwestCorner,
-              abundancePercent = 60,
+              abundanceCount = 15,
               biomassSpeciesId = biomassHerbaceousSpeciesId2,
           )
       )
@@ -558,7 +558,7 @@ class ObservationResultsStoreTest : ObservationScenarioTest() {
               observationId = observationId,
               monitoringPlotId = plotId,
               positionId = ObservationPlotPosition.SoutheastCorner,
-              abundancePercent = 90,
+              abundanceCount = 23,
               biomassSpeciesId = biomassHerbaceousSpeciesId1,
           )
       )
@@ -642,7 +642,7 @@ class ObservationResultsStoreTest : ObservationScenarioTest() {
                               species =
                                   setOf(
                                       BiomassQuadratSpeciesModel(
-                                          abundancePercent = 40,
+                                          abundanceCount = 10,
                                           speciesId = herbaceousSpeciesId1,
                                       )
                                   ),
@@ -653,11 +653,11 @@ class ObservationResultsStoreTest : ObservationScenarioTest() {
                               species =
                                   setOf(
                                       BiomassQuadratSpeciesModel(
-                                          abundancePercent = 60,
+                                          abundanceCount = 15,
                                           speciesId = herbaceousSpeciesId2,
                                       ),
                                       BiomassQuadratSpeciesModel(
-                                          abundancePercent = 5,
+                                          abundanceCount = 1,
                                           speciesName = "Herbaceous species",
                                       ),
                                   ),
@@ -668,7 +668,7 @@ class ObservationResultsStoreTest : ObservationScenarioTest() {
                               species =
                                   setOf(
                                       BiomassQuadratSpeciesModel(
-                                          abundancePercent = 90,
+                                          abundanceCount = 23,
                                           speciesId = herbaceousSpeciesId1,
                                       )
                                   ),

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/biomassStore/BiomassStoreInsertBiomassDetailsTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/biomassStore/BiomassStoreInsertBiomassDetailsTest.kt
@@ -71,7 +71,7 @@ class BiomassStoreInsertBiomassDetailsTest : BaseBiomassStoreTest() {
                             species =
                                 setOf(
                                     BiomassQuadratSpeciesModel(
-                                        abundancePercent = 40,
+                                        abundanceCount = 10,
                                         speciesId = herbaceousSpeciesId1,
                                     )
                                 ),
@@ -82,11 +82,11 @@ class BiomassStoreInsertBiomassDetailsTest : BaseBiomassStoreTest() {
                             species =
                                 setOf(
                                     BiomassQuadratSpeciesModel(
-                                        abundancePercent = 60,
+                                        abundanceCount = 15,
                                         speciesId = herbaceousSpeciesId2,
                                     ),
                                     BiomassQuadratSpeciesModel(
-                                        abundancePercent = 5,
+                                        abundanceCount = 1,
                                         speciesName = "Other herbaceous species",
                                     ),
                                 ),
@@ -97,7 +97,7 @@ class BiomassStoreInsertBiomassDetailsTest : BaseBiomassStoreTest() {
                             species =
                                 setOf(
                                     BiomassQuadratSpeciesModel(
-                                        abundancePercent = 90,
+                                        abundanceCount = 23,
                                         speciesId = herbaceousSpeciesId1,
                                     )
                                 ),
@@ -391,28 +391,28 @@ class BiomassStoreInsertBiomassDetailsTest : BaseBiomassStoreTest() {
                 observationId = observationId,
                 monitoringPlotId = plotId,
                 positionId = ObservationPlotPosition.NortheastCorner,
-                abundancePercent = 40,
+                abundanceCount = 10,
                 biomassSpeciesId = biomassHerbaceousSpeciesId1,
             ),
             ObservationBiomassQuadratSpeciesRecord(
                 observationId = observationId,
                 monitoringPlotId = plotId,
                 positionId = ObservationPlotPosition.NorthwestCorner,
-                abundancePercent = 60,
+                abundanceCount = 15,
                 biomassSpeciesId = biomassHerbaceousSpeciesId2,
             ),
             ObservationBiomassQuadratSpeciesRecord(
                 observationId = observationId,
                 monitoringPlotId = plotId,
                 positionId = ObservationPlotPosition.NorthwestCorner,
-                abundancePercent = 5,
+                abundanceCount = 1,
                 biomassSpeciesId = biomassHerbaceousSpeciesId3,
             ),
             ObservationBiomassQuadratSpeciesRecord(
                 observationId = observationId,
                 monitoringPlotId = plotId,
                 positionId = ObservationPlotPosition.SoutheastCorner,
-                abundancePercent = 90,
+                abundanceCount = 23,
                 biomassSpeciesId = biomassHerbaceousSpeciesId1,
             ),
         ),

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/biomassStore/BiomassStoreMergeOtherSpeciesTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/biomassStore/BiomassStoreMergeOtherSpeciesTest.kt
@@ -63,20 +63,20 @@ class BiomassStoreMergeOtherSpeciesTest : BaseBiomassStoreTest() {
                             species =
                                 setOf(
                                     BiomassQuadratSpeciesModel(
-                                        abundancePercent = 1,
+                                        abundanceCount = 1,
                                         speciesId = speciesId1,
                                     ),
                                     BiomassQuadratSpeciesModel(
-                                        abundancePercent = 2,
+                                        abundanceCount = 2,
                                         speciesId = speciesId2,
                                     ),
                                     // This will be merged with the speciesId1 entry
                                     BiomassQuadratSpeciesModel(
-                                        abundancePercent = 4,
+                                        abundanceCount = 4,
                                         speciesName = "Other 1",
                                     ),
                                     BiomassQuadratSpeciesModel(
-                                        abundancePercent = 8,
+                                        abundanceCount = 8,
                                         speciesName = "Other 2",
                                     ),
                                 ),
@@ -86,12 +86,12 @@ class BiomassStoreMergeOtherSpeciesTest : BaseBiomassStoreTest() {
                             species =
                                 setOf(
                                     BiomassQuadratSpeciesModel(
-                                        abundancePercent = 16,
+                                        abundanceCount = 16,
                                         speciesId = speciesId1,
                                     ),
                                     // This will be merged with the speciesId1 entry
                                     BiomassQuadratSpeciesModel(
-                                        abundancePercent = 32,
+                                        abundanceCount = 17,
                                         speciesName = "Other 1",
                                     ),
                                 ),
@@ -101,11 +101,11 @@ class BiomassStoreMergeOtherSpeciesTest : BaseBiomassStoreTest() {
                             species =
                                 setOf(
                                     BiomassQuadratSpeciesModel(
-                                        abundancePercent = 51,
+                                        abundanceCount = 18,
                                         speciesId = speciesId1,
                                     ),
                                     BiomassQuadratSpeciesModel(
-                                        abundancePercent = 52,
+                                        abundanceCount = 19,
                                         speciesName = "Other 2",
                                     ),
                                 ),
@@ -116,7 +116,7 @@ class BiomassStoreMergeOtherSpeciesTest : BaseBiomassStoreTest() {
                                 setOf(
                                     // This should turn into a speciesId1 entry
                                     BiomassQuadratSpeciesModel(
-                                        abundancePercent = 53,
+                                        abundanceCount = 20,
                                         speciesName = "Other 1",
                                     ),
                                 ),
@@ -225,19 +225,18 @@ class BiomassStoreMergeOtherSpeciesTest : BaseBiomassStoreTest() {
 
     assertTableEquals(
         setOf(
-            // Abundance percent is 5 because we are combining the original speciesId1 entry's 1
-            // with the "Other 1" entry's 4.
+            // Abundance count is 5 because we are combining the original speciesId1 entry's 1 with
+            // the "Other 1" entry's 4.
             quadratSpeciesRecord(ObservationPlotPosition.NortheastCorner, biomassSpeciesId1, 5),
             quadratSpeciesRecord(ObservationPlotPosition.NortheastCorner, biomassSpeciesId2, 2),
             quadratSpeciesRecord(ObservationPlotPosition.NortheastCorner, biomassOtherId2, 8),
-            // And this one combines entries with abundances of 16 and 32 (to test that we aren't
-            // combining the values from the wrong quadrats).
-            quadratSpeciesRecord(ObservationPlotPosition.NorthwestCorner, biomassSpeciesId1, 48),
-            // There's no "Other 1" in the southeast corner, so the abundance percent stays the same
-            quadratSpeciesRecord(ObservationPlotPosition.SoutheastCorner, biomassSpeciesId1, 51),
-            quadratSpeciesRecord(ObservationPlotPosition.SoutheastCorner, biomassOtherId2, 52),
+            // And this one combines entries with abundances of 16 and 17. It hits the cap of 25.
+            quadratSpeciesRecord(ObservationPlotPosition.NorthwestCorner, biomassSpeciesId1, 25),
+            // There's no "Other 1" in the southeast corner, so the abundance count stays the same
+            quadratSpeciesRecord(ObservationPlotPosition.SoutheastCorner, biomassSpeciesId1, 18),
+            quadratSpeciesRecord(ObservationPlotPosition.SoutheastCorner, biomassOtherId2, 19),
             // This started out as an "Other 1" entry.
-            quadratSpeciesRecord(ObservationPlotPosition.SouthwestCorner, biomassSpeciesId1, 53),
+            quadratSpeciesRecord(ObservationPlotPosition.SouthwestCorner, biomassSpeciesId1, 20),
         )
     )
 
@@ -288,7 +287,7 @@ class BiomassStoreMergeOtherSpeciesTest : BaseBiomassStoreTest() {
                             species =
                                 setOf(
                                     BiomassQuadratSpeciesModel(
-                                        abundancePercent = 1,
+                                        abundanceCount = 1,
                                         speciesName = "Other",
                                     )
                                 )
@@ -347,14 +346,14 @@ class BiomassStoreMergeOtherSpeciesTest : BaseBiomassStoreTest() {
   private fun quadratSpeciesRecord(
       position: ObservationPlotPosition,
       biomassSpeciesId: BiomassSpeciesId,
-      abundancePercent: Int,
+      abundanceCount: Int,
   ) =
       ObservationBiomassQuadratSpeciesRecord(
           observationId,
           monitoringPlotId,
           position,
           biomassSpeciesId,
-          abundancePercent,
+          abundanceCount,
       )
 
   private fun observationSpeciesRecord(

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/biomassStore/BiomassStoreUpdateBiomassQuadratSpeciesTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/biomassStore/BiomassStoreUpdateBiomassQuadratSpeciesTest.kt
@@ -25,7 +25,7 @@ class BiomassStoreUpdateBiomassQuadratSpeciesTest : BaseBiomassStoreTest() {
     insertObservationBiomassSpecies(speciesId = inserted.speciesId)
     insertObservationBiomassQuadratDetails(position = ObservationPlotPosition.SouthwestCorner)
     insertObservationBiomassQuadratSpecies(
-        abundancePercent = 1,
+        abundanceCount = 1,
         position = ObservationPlotPosition.SouthwestCorner,
     )
   }
@@ -44,7 +44,7 @@ class BiomassStoreUpdateBiomassQuadratSpeciesTest : BaseBiomassStoreTest() {
       it.copy(abundance = 2)
     }
 
-    val expected = before.copy().apply { abundancePercent = 2 }
+    val expected = before.copy().apply { abundanceCount = 2 }
 
     assertTableEquals(expected)
 


### PR DESCRIPTION
The database column for the square count for biomass observation quadrat species
was still named `abundance_percent` from the original spec where the value was a
percentage rather than a count.

Change it to `abundance_count` to reflect what it actually is, and change the
constraint on its value to reflect that it's a count of squares on a 5x5 grid.

This exposed an existing bug: merging an "Other" species into a known species on
a biomass observation could cause the abundance count to exceed 25. Introduce a
cap of 25 to protect against nonsense values.

The search API continues to expose an `abundancePercent` field, but it's now the
actual percentage (count muliplied by 4). A new `abundanceCount` search field
returns the actual count. This will fix the bug where CSV exports were labeling
the count as a percentage.