### PR TITLE
SW-7978 Reject future batch dates in CSVs

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/i18n/Messages.kt
+++ b/src/main/kotlin/com/terraformation/backend/i18n/Messages.kt
@@ -115,6 +115,8 @@ class Messages {
 
   fun csvRequiredFieldMissing() = getMessage("csvRequiredFieldMissing")
 
+  fun csvDateAddedInFuture() = getMessage("csvDateAddedInFuture")
+
   fun csvDateMalformed() = getMessage("csvDateMalformed")
 
   fun csvNameLineBreak() = getMessage("csvNameLineBreak")

--- a/src/main/kotlin/com/terraformation/backend/nursery/db/BatchCsvValidator.kt
+++ b/src/main/kotlin/com/terraformation/backend/nursery/db/BatchCsvValidator.kt
@@ -6,11 +6,15 @@ import com.terraformation.backend.i18n.Messages
 import com.terraformation.backend.i18n.currentLocale
 import com.terraformation.backend.i18n.toBigDecimal
 import com.terraformation.backend.importer.CsvValidator
+import java.time.LocalDate
+import java.time.format.DateTimeParseException
 
 class BatchCsvValidator(
     uploadId: UploadId,
     messages: Messages,
     private val subLocationNames: Set<String>,
+    /** Today's date in the nursery's time zone. */
+    private val today: LocalDate,
 ) : CsvValidator(uploadId, messages) {
   override val validators: List<((String?, String) -> Unit)?> =
       listOf(
@@ -19,12 +23,32 @@ class BatchCsvValidator(
           this::validateQuantity,
           this::validateQuantity,
           this::validateQuantity,
-          this::validateDate,
+          this::validateDateAdded,
           this::validateSubLocation,
       )
 
   override fun getColumnName(position: Int): String {
     return messages.batchCsvColumnName(position)
+  }
+
+  private fun validateDateAdded(value: String?, field: String) {
+    if (value == null) {
+      addError(
+          UploadProblemType.MissingRequiredValue,
+          field,
+          null,
+          messages.csvRequiredFieldMissing(),
+      )
+    } else {
+      try {
+        val date = LocalDate.parse(value)
+        if (date > today) {
+          addError(UploadProblemType.MalformedValue, field, value, messages.csvDateAddedInFuture())
+        }
+      } catch (_: DateTimeParseException) {
+        addError(UploadProblemType.MalformedValue, field, value, messages.csvDateMalformed())
+      }
+    }
   }
 
   private fun validateQuantity(value: String?, field: String) {

--- a/src/main/kotlin/com/terraformation/backend/nursery/db/BatchImporter.kt
+++ b/src/main/kotlin/com/terraformation/backend/nursery/db/BatchImporter.kt
@@ -28,6 +28,7 @@ import com.terraformation.backend.species.db.SpeciesStore
 import com.terraformation.backend.species.model.NewSpeciesModel
 import jakarta.inject.Named
 import java.io.InputStream
+import java.time.InstantSource
 import java.time.LocalDate
 import org.jobrunr.jobs.JobId
 import org.jobrunr.scheduling.JobScheduler
@@ -37,6 +38,7 @@ import org.springframework.context.annotation.Lazy
 @Named
 class BatchImporter(
     private val batchStore: BatchStore,
+    private val clock: InstantSource,
     dslContext: DSLContext,
     fileStore: FileStore,
     private val messages: Messages,
@@ -81,9 +83,15 @@ class BatchImporter(
 
   override fun getValidator(uploadsRow: UploadsRow): CsvValidator {
     val facilityId = uploadsRow.facilityId!!
+    val facilityTimeZone = parentStore.getEffectiveTimeZone(facilityId)
     val subLocationNames = subLocationsDao.fetchByFacilityId(facilityId).map { it.name!! }.toSet()
 
-    return BatchCsvValidator(uploadsRow.id!!, messages, subLocationNames)
+    return BatchCsvValidator(
+        uploadsRow.id!!,
+        messages,
+        subLocationNames,
+        LocalDate.ofInstant(clock.instant(), facilityTimeZone),
+    )
   }
 
   override fun doImportCsv(

--- a/src/main/resources/i18n/Messages_en.properties
+++ b/src/main/resources/i18n/Messages_en.properties
@@ -69,6 +69,7 @@ csvBooleanValues.false=false\nf\nFalse\nF\nFALSE\nno\nn\nNo\nN\nNO
 # appear in an uploaded spreadsheet file. The number of words doesn't have to be the same as in
 # English.
 csvBooleanValues.true=true\nt\nTrue\nT\nTRUE\nyes\ny\nYes\nY\nYES
+csvDateAddedInFuture=Date Added must be the current date or earlier. Future dates are not allowed.
 csvDateMalformed=Date must be in YYYY-MM-DD format
 csvNameLineBreak=Name may not contain line breaks
 csvRequiredFieldMissing=Missing required field

--- a/src/main/resources/i18n/Messages_es.properties
+++ b/src/main/resources/i18n/Messages_es.properties
@@ -115,6 +115,8 @@ csvBadHeader=Encabezados de columna incorrectos
 csvBooleanValues.false=falso\nf\nFalso\nF\nFALSO\nno\nn\nNo\nN\nNO
 # d7682931
 csvBooleanValues.true=verdadero\nv\nVerdadero\nV\nVERDADERO\nsí\ns\nS\nSí\nSÍ\nsi\nSi\nSI
+# 9e657d06
+csvDateAddedInFuture=La fecha de ingreso debe ser la actual o una anterior. No se permiten fechas futuras.
 # db6b739e
 csvDateMalformed=La fecha debe estar en formato AAAA-MM-DD.
 # 89a7406d

--- a/src/main/resources/i18n/Messages_fr.properties
+++ b/src/main/resources/i18n/Messages_fr.properties
@@ -115,6 +115,8 @@ csvBadHeader=En-têtes de colonnes incorrects
 csvBooleanValues.false=faux\nf\nFaux\nF\nFAUX\nnon\nn\nNon\nN\nNON
 # d7682931
 csvBooleanValues.true=vrai\nv\nVrai\nV\nVRAI\noui\no\nOui\nO\nOUI
+# 9e657d06
+csvDateAddedInFuture=La date d’ajout doit être la date actuelle ou une date antérieure. Les dates futures ne sont pas autorisées.
 # db6b739e
 csvDateMalformed=La date doit être au format AAAA-MM-JJ
 # 89a7406d

--- a/src/test/kotlin/com/terraformation/backend/nursery/db/BatchCsvValidatorTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/nursery/db/BatchCsvValidatorTest.kt
@@ -8,7 +8,8 @@ import com.terraformation.backend.i18n.Messages
 import com.terraformation.backend.i18n.toGibberish
 import com.terraformation.backend.i18n.use
 import java.io.InputStreamReader
-import org.junit.jupiter.api.Assertions.*
+import java.time.LocalDate
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 
 internal class BatchCsvValidatorTest {
@@ -88,7 +89,10 @@ internal class BatchCsvValidatorTest {
   @Test
   fun `rejects row with missing or invalid date`() {
     assertValidationResults(
-        "$header\nScientific name,,0,1,2,,\nScientific name,,0,1,2,Jan 18,",
+        "$header\n" +
+            "Scientific name,,0,1,2,,\n" +
+            "Scientific name,,0,1,2,Jan 18,\n" +
+            "Scientific name,,0,1,2,2023-01-02,",
         errors =
             setOf(
                 UploadProblemsRow(
@@ -107,6 +111,15 @@ internal class BatchCsvValidatorTest {
                     typeId = UploadProblemType.MalformedValue,
                     uploadId = uploadId,
                     value = "Jan 18",
+                ),
+                UploadProblemsRow(
+                    field = "Date Added",
+                    isError = true,
+                    message = messages.csvDateAddedInFuture(),
+                    position = 4,
+                    typeId = UploadProblemType.MalformedValue,
+                    uploadId = uploadId,
+                    value = "2023-01-02",
                 ),
             ),
     )
@@ -302,7 +315,12 @@ internal class BatchCsvValidatorTest {
       warnings: Set<UploadProblemsRow> = emptySet(),
   ) {
     val validator =
-        BatchCsvValidator(uploadId, messages, setOf("Valid Location", "Valid Location 2"))
+        BatchCsvValidator(
+            uploadId,
+            messages,
+            setOf("Valid Location", "Valid Location 2"),
+            LocalDate.of(2023, 1, 1),
+        )
     validator.validate(csv.byteInputStream())
 
     val expected = mapOf("errors" to errors, "warnings" to warnings)

--- a/src/test/kotlin/com/terraformation/backend/nursery/db/BatchImporterTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/nursery/db/BatchImporterTest.kt
@@ -19,6 +19,7 @@ import com.terraformation.backend.db.default_schema.UploadStatus
 import com.terraformation.backend.db.default_schema.UploadType
 import com.terraformation.backend.db.default_schema.tables.pojos.SpeciesRow
 import com.terraformation.backend.db.default_schema.tables.records.UploadProblemsRecord
+import com.terraformation.backend.db.default_schema.tables.references.FACILITIES
 import com.terraformation.backend.db.nursery.BatchId
 import com.terraformation.backend.db.nursery.tables.pojos.BatchSubLocationsRow
 import com.terraformation.backend.db.nursery.tables.pojos.BatchesRow
@@ -38,7 +39,9 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.slot
 import java.time.LocalDate
+import java.time.ZoneId
 import java.time.ZoneOffset
+import java.time.ZonedDateTime
 import java.util.Locale
 import java.util.UUID
 import org.jobrunr.jobs.JobId
@@ -94,6 +97,7 @@ internal class BatchImporterTest : DatabaseTest(), RunsAsUser {
   private val importer: BatchImporter by lazy {
     BatchImporter(
         batchStore,
+        clock,
         dslContext,
         fileStore,
         messages,
@@ -323,6 +327,40 @@ internal class BatchImporterTest : DatabaseTest(), RunsAsUser {
             typeId = UploadProblemType.MalformedValue,
             uploadId = uploadId,
             value = "ShortName",
+        )
+    )
+
+    assertStatus(UploadStatus.Invalid)
+  }
+
+  @Test
+  fun `uses nursery time zone to determine if added date is in the future`() {
+    // It's 2023-01-01 on the server but 2023-01-02 at the nursery.
+    dslContext.update(FACILITIES).set(FACILITIES.TIME_ZONE, ZoneId.of("Asia/Tokyo")).execute()
+
+    clock.instant = ZonedDateTime.of(2023, 1, 1, 19, 0, 0, 0, ZoneOffset.UTC).toInstant()
+
+    val uploadId =
+        insertBatchUpload(
+            headerAnd(
+                "Species name,,1,1,1,2023-01-01,\n" +
+                    "Species name,,1,1,1,2023-01-02,\n" +
+                    "Species name,,1,1,1,2023-01-03,\n"
+            ),
+            UploadStatus.AwaitingValidation,
+        )
+
+    importer.validateCsv(uploadId)
+
+    assertTableEquals(
+        UploadProblemsRecord(
+            isError = true,
+            field = "Date Added",
+            message = messages.csvDateAddedInFuture(),
+            position = 4,
+            typeId = UploadProblemType.MalformedValue,
+            uploadId = uploadId,
+            value = "2023-01-03",
         )
     )
 


### PR DESCRIPTION
Apply the same validation rule to seedling batch "Date Added" values in CSV
imports that we apply when adding batches in the UI: the date must be today
or earlier.