### PR TITLE
SW-8134 Remove duplicate species in site species for survival rate settings

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/tracking/db/T0Store.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/db/T0Store.kt
@@ -243,12 +243,14 @@ class T0Store(
       PlotSpeciesModel(
           monitoringPlotId = plotId as MonitoringPlotId,
           species =
-              records.map { record ->
-                OptionalSpeciesDensityModel(
-                    speciesId = record[speciesIdField] as SpeciesId,
-                    density = record[densityResultField] as BigDecimal?,
-                )
-              },
+              records
+                  .map { record ->
+                    OptionalSpeciesDensityModel(
+                        speciesId = record[speciesIdField] as SpeciesId,
+                        density = record[densityResultField] as BigDecimal?,
+                    )
+                  }
+                  .toSet(),
       )
     }
   }

--- a/src/main/kotlin/com/terraformation/backend/tracking/db/T0Store.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/db/T0Store.kt
@@ -190,7 +190,7 @@ class T0Store(
             .and(densityField.ge(BigDecimal.valueOf(0.05)))
 
     val observedNotWithdrawnSpecies =
-        DSL.select(
+        DSL.selectDistinct(
                 MONITORING_PLOTS.ID,
                 OBSERVED_PLOT_SPECIES_TOTALS.SPECIES_ID.`as`("species_id"),
                 DSL.castNull(SQLDataType.NUMERIC).`as`("density"),
@@ -243,14 +243,12 @@ class T0Store(
       PlotSpeciesModel(
           monitoringPlotId = plotId as MonitoringPlotId,
           species =
-              records
-                  .map { record ->
-                    OptionalSpeciesDensityModel(
-                        speciesId = record[speciesIdField] as SpeciesId,
-                        density = record[densityResultField] as BigDecimal?,
-                    )
-                  }
-                  .toSet(),
+              records.map { record ->
+                OptionalSpeciesDensityModel(
+                    speciesId = record[speciesIdField] as SpeciesId,
+                    density = record[densityResultField] as BigDecimal?,
+                )
+              },
       )
     }
   }

--- a/src/main/kotlin/com/terraformation/backend/tracking/model/T0DataModel.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/model/T0DataModel.kt
@@ -40,7 +40,7 @@ data class SiteT0DataModel(
 
 data class PlotSpeciesModel(
     val monitoringPlotId: MonitoringPlotId,
-    val species: List<OptionalSpeciesDensityModel> = emptyList(),
+    val species: Set<OptionalSpeciesDensityModel> = emptySet(),
 )
 
 data class PlotT0DataModel(

--- a/src/main/kotlin/com/terraformation/backend/tracking/model/T0DataModel.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/model/T0DataModel.kt
@@ -40,7 +40,7 @@ data class SiteT0DataModel(
 
 data class PlotSpeciesModel(
     val monitoringPlotId: MonitoringPlotId,
-    val species: Set<OptionalSpeciesDensityModel> = emptySet(),
+    val species: List<OptionalSpeciesDensityModel> = emptyList(),
 )
 
 data class PlotT0DataModel(

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/T0StoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/T0StoreTest.kt
@@ -578,11 +578,11 @@ internal class T0StoreTest : DatabaseTest(), RunsAsDatabaseUser {
           setOf(
               PlotSpeciesModel(
                   monitoringPlotId = monitoringPlotId,
-                  species = createSpeciesDensitySet(speciesId1 to null, speciesId2 to null),
+                  species = createSpeciesDensityList(speciesId1 to null, speciesId2 to null),
               ),
               PlotSpeciesModel(
                   monitoringPlotId = tempPlotId,
-                  species = createSpeciesDensitySet(speciesId1 to null),
+                  species = createSpeciesDensityList(speciesId1 to null),
               ),
           )
 
@@ -637,7 +637,7 @@ internal class T0StoreTest : DatabaseTest(), RunsAsDatabaseUser {
               PlotSpeciesModel(
                   monitoringPlotId = plot1,
                   species =
-                      createSpeciesDensitySet(
+                      createSpeciesDensityList(
                           speciesId1 to BigDecimal.valueOf(100.0),
                           speciesId2 to BigDecimal.valueOf(200.0),
                           speciesId4 to null,
@@ -646,7 +646,7 @@ internal class T0StoreTest : DatabaseTest(), RunsAsDatabaseUser {
               PlotSpeciesModel(
                   monitoringPlotId = plot2,
                   species =
-                      createSpeciesDensitySet(
+                      createSpeciesDensityList(
                           speciesId1 to BigDecimal.valueOf(100.0),
                           speciesId2 to BigDecimal.valueOf(200.0),
                           speciesId4 to null,
@@ -655,7 +655,7 @@ internal class T0StoreTest : DatabaseTest(), RunsAsDatabaseUser {
               PlotSpeciesModel(
                   monitoringPlotId = plot3,
                   species =
-                      createSpeciesDensitySet(
+                      createSpeciesDensityList(
                           speciesId1 to BigDecimal.valueOf(30.0),
                           speciesId2 to BigDecimal.valueOf(39.5), // this confirms correct rounding
                           speciesId3 to BigDecimal.valueOf(50.0),
@@ -664,7 +664,7 @@ internal class T0StoreTest : DatabaseTest(), RunsAsDatabaseUser {
               PlotSpeciesModel(
                   monitoringPlotId = plot4,
                   species =
-                      createSpeciesDensitySet(
+                      createSpeciesDensityList(
                           speciesId1 to BigDecimal.valueOf(30.0),
                           speciesId2 to BigDecimal.valueOf(39.5),
                           speciesId3 to BigDecimal.valueOf(50.0),
@@ -672,11 +672,11 @@ internal class T0StoreTest : DatabaseTest(), RunsAsDatabaseUser {
               ),
               PlotSpeciesModel(
                   monitoringPlotId = plot5,
-                  species = createSpeciesDensitySet(speciesId3 to BigDecimal.valueOf(120.0)),
+                  species = createSpeciesDensityList(speciesId3 to BigDecimal.valueOf(120.0)),
               ),
               PlotSpeciesModel(
                   monitoringPlotId = plot6,
-                  species = createSpeciesDensitySet(speciesId1 to BigDecimal.valueOf(0.2)),
+                  species = createSpeciesDensityList(speciesId1 to BigDecimal.valueOf(0.2)),
               ),
           )
 
@@ -1648,11 +1648,9 @@ internal class T0StoreTest : DatabaseTest(), RunsAsDatabaseUser {
   private fun plotDensityToHectare(density: Int): BigDecimal =
       density.toBigDecimal().toPlantsPerHectare()
 
-  private fun createSpeciesDensitySet(
+  private fun createSpeciesDensityList(
       vararg densities: Pair<SpeciesId, BigDecimal?>
-  ): Set<OptionalSpeciesDensityModel> {
-    return densities
-        .map { OptionalSpeciesDensityModel(speciesId = it.first, density = it.second) }
-        .toSet()
+  ): List<OptionalSpeciesDensityModel> {
+    return densities.map { OptionalSpeciesDensityModel(speciesId = it.first, density = it.second) }
   }
 }

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/T0StoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/T0StoreTest.kt
@@ -560,15 +560,29 @@ internal class T0StoreTest : DatabaseTest(), RunsAsDatabaseUser {
           totalLive = 1,
       )
 
+      // additional observations of the same plot should not cause the species to appear twice
+      insertObservation(
+          startDate = observationStartDate.plusDays(1),
+          completedTime = observationTime.plusSeconds(86400),
+      )
+      insertObservationPlot(
+          claimedTime = observationTime,
+          claimedBy = user.userId,
+          completedTime = observationTime,
+          completedBy = user.userId,
+          isPermanent = true,
+      )
+      insertObservedPlotSpeciesTotals(speciesId = speciesId1, totalLive = 2)
+
       val expected =
           setOf(
               PlotSpeciesModel(
                   monitoringPlotId = monitoringPlotId,
-                  species = createSpeciesDensityList(speciesId1 to null, speciesId2 to null),
+                  species = createSpeciesDensitySet(speciesId1 to null, speciesId2 to null),
               ),
               PlotSpeciesModel(
                   monitoringPlotId = tempPlotId,
-                  species = createSpeciesDensityList(speciesId1 to null),
+                  species = createSpeciesDensitySet(speciesId1 to null),
               ),
           )
 
@@ -623,7 +637,7 @@ internal class T0StoreTest : DatabaseTest(), RunsAsDatabaseUser {
               PlotSpeciesModel(
                   monitoringPlotId = plot1,
                   species =
-                      createSpeciesDensityList(
+                      createSpeciesDensitySet(
                           speciesId1 to BigDecimal.valueOf(100.0),
                           speciesId2 to BigDecimal.valueOf(200.0),
                           speciesId4 to null,
@@ -632,7 +646,7 @@ internal class T0StoreTest : DatabaseTest(), RunsAsDatabaseUser {
               PlotSpeciesModel(
                   monitoringPlotId = plot2,
                   species =
-                      createSpeciesDensityList(
+                      createSpeciesDensitySet(
                           speciesId1 to BigDecimal.valueOf(100.0),
                           speciesId2 to BigDecimal.valueOf(200.0),
                           speciesId4 to null,
@@ -641,7 +655,7 @@ internal class T0StoreTest : DatabaseTest(), RunsAsDatabaseUser {
               PlotSpeciesModel(
                   monitoringPlotId = plot3,
                   species =
-                      createSpeciesDensityList(
+                      createSpeciesDensitySet(
                           speciesId1 to BigDecimal.valueOf(30.0),
                           speciesId2 to BigDecimal.valueOf(39.5), // this confirms correct rounding
                           speciesId3 to BigDecimal.valueOf(50.0),
@@ -650,7 +664,7 @@ internal class T0StoreTest : DatabaseTest(), RunsAsDatabaseUser {
               PlotSpeciesModel(
                   monitoringPlotId = plot4,
                   species =
-                      createSpeciesDensityList(
+                      createSpeciesDensitySet(
                           speciesId1 to BigDecimal.valueOf(30.0),
                           speciesId2 to BigDecimal.valueOf(39.5),
                           speciesId3 to BigDecimal.valueOf(50.0),
@@ -658,11 +672,11 @@ internal class T0StoreTest : DatabaseTest(), RunsAsDatabaseUser {
               ),
               PlotSpeciesModel(
                   monitoringPlotId = plot5,
-                  species = createSpeciesDensityList(speciesId3 to BigDecimal.valueOf(120.0)),
+                  species = createSpeciesDensitySet(speciesId3 to BigDecimal.valueOf(120.0)),
               ),
               PlotSpeciesModel(
                   monitoringPlotId = plot6,
-                  species = createSpeciesDensityList(speciesId1 to BigDecimal.valueOf(0.2)),
+                  species = createSpeciesDensitySet(speciesId1 to BigDecimal.valueOf(0.2)),
               ),
           )
 
@@ -1634,9 +1648,11 @@ internal class T0StoreTest : DatabaseTest(), RunsAsDatabaseUser {
   private fun plotDensityToHectare(density: Int): BigDecimal =
       density.toBigDecimal().toPlantsPerHectare()
 
-  private fun createSpeciesDensityList(
+  private fun createSpeciesDensitySet(
       vararg densities: Pair<SpeciesId, BigDecimal?>
-  ): List<OptionalSpeciesDensityModel> {
-    return densities.map { OptionalSpeciesDensityModel(speciesId = it.first, density = it.second) }
+  ): Set<OptionalSpeciesDensityModel> {
+    return densities
+        .map { OptionalSpeciesDensityModel(speciesId = it.first, density = it.second) }
+        .toSet()
   }
 }


### PR DESCRIPTION
If a species is recorded in a plot in separate observations but it has not been withdrawn to that plot's substratum, it will show up multiple times in the list of species for manually providing plant density per species. Remove this duplication.