### PR TITLE
SW-5441 Preserve project ID across nursery transfers

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/nursery/db/BatchStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/nursery/db/BatchStore.kt
@@ -947,6 +947,7 @@ class BatchStore(
                     addedDate = withdrawal.withdrawnDate,
                     batchNumber = destinationBatchNumbersBySourceBatchId[batchWithdrawal.batchId],
                     facilityId = withdrawal.destinationFacilityId,
+                    projectId = sourceBatch.projectId,
                     germinatingQuantity = batchWithdrawal.germinatingQuantityWithdrawn,
                     hardeningOffQuantity = batchWithdrawal.hardeningOffQuantityWithdrawn,
                     initialBatchId = sourceBatch.id,

--- a/src/test/kotlin/com/terraformation/backend/nursery/db/batchStore/BatchStoreWithdrawTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/nursery/db/batchStore/BatchStoreWithdrawTest.kt
@@ -934,6 +934,60 @@ internal class BatchStoreWithdrawTest : BatchStoreTest() {
   }
 
   @Test
+  fun `nursery transfer retains original project associations`() {
+    insertFacility()
+    val projectId1 = insertProject()
+    val projectId2 = insertProject()
+
+    batchesDao.update(batchesDao.fetchOneById(species1Batch1Id)!!.copy(projectId = projectId1))
+    batchesDao.update(batchesDao.fetchOneById(species1Batch2Id)!!.copy(projectId = projectId2))
+
+    val destinationFacilityId = insertFacility(type = FacilityType.Nursery, facilityNumber = 2)
+
+    val withdrawnDate = LocalDate.of(2022, 10, 1)
+    clock.instant = withdrawnDate.plusDays(1).atStartOfDay(ZoneOffset.UTC).toInstant()
+
+    store.withdraw(
+        NewWithdrawalModel(
+            destinationFacilityId = destinationFacilityId,
+            facilityId = facilityId,
+            id = null,
+            notes = "Notes",
+            purpose = WithdrawalPurpose.NurseryTransfer,
+            withdrawnDate = withdrawnDate,
+            batchWithdrawals =
+                listOf(
+                    BatchWithdrawalModel(
+                        batchId = species1Batch1Id,
+                        germinatingQuantityWithdrawn = 0,
+                        activeGrowthQuantityWithdrawn = 0,
+                        readyQuantityWithdrawn = 1,
+                        hardeningOffQuantityWithdrawn = 0,
+                    ),
+                    BatchWithdrawalModel(
+                        batchId = species1Batch2Id,
+                        germinatingQuantityWithdrawn = 0,
+                        activeGrowthQuantityWithdrawn = 0,
+                        readyQuantityWithdrawn = 2,
+                        hardeningOffQuantityWithdrawn = 0,
+                    ),
+                ),
+        )
+    )
+
+    val newBatches =
+        batchesDao.fetchByFacilityId(destinationFacilityId).associate {
+          it.projectId to it.readyQuantity
+        }
+
+    assertEquals(
+        mapOf(projectId1 to 1, projectId2 to 2),
+        newBatches,
+        "Project IDs of new batches",
+    )
+  }
+
+  @Test
   fun `nursery transfer adds to existing batch if batch number already exists`() {
     val species1Batch1 = batchesDao.fetchOneById(species1Batch1Id)!!
 


### PR DESCRIPTION
If seedlings associated with a project are transferred from one nursery to
another, the most common case is that they're still part of the project, just
being moved to another of the project's nurseries. Associate the newly-created
batch with the same project as the original, if any.