### PR TITLE
SW-8128 Return baseline and endOfProjectTargets for indicators in reports

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/accelerator/db/ReportStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/db/ReportStore.kt
@@ -1618,6 +1618,7 @@ class ReportStore(
                       COMMON_INDICATORS.asterisk(),
                       REPORT_COMMON_INDICATORS.asterisk(),
                       REPORT_COMMON_INDICATOR_TARGETS.TARGET,
+                      COMMON_INDICATOR_TARGETS.asterisk(),
                   )
                   .from(COMMON_INDICATORS)
                   .leftJoin(REPORT_COMMON_INDICATORS)
@@ -1625,6 +1626,11 @@ class ReportStore(
                   .and(REPORTS.ID.eq(REPORT_COMMON_INDICATORS.REPORT_ID))
                   .leftJoin(REPORT_COMMON_INDICATOR_TARGETS)
                   .on(REPORT_COMMON_INDICATOR_TARGETS.COMMON_INDICATOR_ID.eq(COMMON_INDICATORS.ID))
+                  .leftJoin(COMMON_INDICATOR_TARGETS)
+                  .on(
+                      COMMON_INDICATOR_TARGETS.COMMON_INDICATOR_ID.eq(COMMON_INDICATORS.ID)
+                          .and(COMMON_INDICATOR_TARGETS.PROJECT_ID.eq(REPORTS.PROJECT_ID))
+                  )
                   .and(REPORT_COMMON_INDICATOR_TARGETS.PROJECT_ID.eq(REPORTS.PROJECT_ID))
                   .and(REPORT_COMMON_INDICATOR_TARGETS.YEAR.eq(DSL.year(REPORTS.END_DATE)))
                   .orderBy(COMMON_INDICATORS.REF_ID, COMMON_INDICATORS.ID)
@@ -1650,6 +1656,7 @@ class ReportStore(
                       PROJECT_INDICATORS.asterisk(),
                       REPORT_PROJECT_INDICATORS.asterisk(),
                       REPORT_PROJECT_INDICATOR_TARGETS.TARGET,
+                      PROJECT_INDICATOR_TARGETS.asterisk(),
                   )
                   .from(PROJECT_INDICATORS)
                   .leftJoin(REPORT_PROJECT_INDICATORS)
@@ -1660,6 +1667,11 @@ class ReportStore(
                       REPORT_PROJECT_INDICATOR_TARGETS.PROJECT_INDICATOR_ID.eq(
                           PROJECT_INDICATORS.ID
                       )
+                  )
+                  .leftJoin(PROJECT_INDICATOR_TARGETS)
+                  .on(
+                      PROJECT_INDICATOR_TARGETS.PROJECT_INDICATOR_ID.eq(PROJECT_INDICATORS.ID)
+                          .and(PROJECT_INDICATOR_TARGETS.PROJECT_ID.eq(REPORTS.PROJECT_ID))
                   )
                   .and(REPORT_PROJECT_INDICATOR_TARGETS.PROJECT_ID.eq(REPORTS.PROJECT_ID))
                   .and(REPORT_PROJECT_INDICATOR_TARGETS.YEAR.eq(DSL.year(REPORTS.END_DATE)))
@@ -1973,6 +1985,7 @@ class ReportStore(
                       REPORT_AUTO_CALCULATED_INDICATORS.asterisk(),
                       systemValueField,
                       REPORT_AUTO_CALCULATED_INDICATOR_TARGETS.TARGET,
+                      AUTO_CALCULATED_INDICATOR_TARGETS.asterisk(),
                   )
                   .from(AUTO_CALCULATED_INDICATORS)
                   .leftJoin(REPORT_AUTO_CALCULATED_INDICATORS)
@@ -1987,6 +2000,13 @@ class ReportStore(
                       REPORT_AUTO_CALCULATED_INDICATOR_TARGETS.AUTO_CALCULATED_INDICATOR_ID.eq(
                           AUTO_CALCULATED_INDICATORS.ID
                       )
+                  )
+                  .leftJoin(AUTO_CALCULATED_INDICATOR_TARGETS)
+                  .on(
+                      AUTO_CALCULATED_INDICATOR_TARGETS.AUTO_CALCULATED_INDICATOR_ID.eq(
+                              AUTO_CALCULATED_INDICATORS.ID
+                          )
+                          .and(AUTO_CALCULATED_INDICATOR_TARGETS.PROJECT_ID.eq(REPORTS.PROJECT_ID))
                   )
                   .and(REPORT_AUTO_CALCULATED_INDICATOR_TARGETS.PROJECT_ID.eq(REPORTS.PROJECT_ID))
                   .and(REPORT_AUTO_CALCULATED_INDICATOR_TARGETS.YEAR.eq(DSL.year(REPORTS.END_DATE)))

--- a/src/main/kotlin/com/terraformation/backend/accelerator/model/ReportIndicatorsModel.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/model/ReportIndicatorsModel.kt
@@ -4,6 +4,9 @@ import com.terraformation.backend.auth.currentUser
 import com.terraformation.backend.db.accelerator.AutoCalculatedIndicator
 import com.terraformation.backend.db.accelerator.ReportIndicatorStatus
 import com.terraformation.backend.db.accelerator.tables.references.AUTO_CALCULATED_INDICATORS
+import com.terraformation.backend.db.accelerator.tables.references.AUTO_CALCULATED_INDICATOR_TARGETS
+import com.terraformation.backend.db.accelerator.tables.references.COMMON_INDICATOR_TARGETS
+import com.terraformation.backend.db.accelerator.tables.references.PROJECT_INDICATOR_TARGETS
 import com.terraformation.backend.db.accelerator.tables.references.REPORT_AUTO_CALCULATED_INDICATORS
 import com.terraformation.backend.db.accelerator.tables.references.REPORT_AUTO_CALCULATED_INDICATOR_TARGETS
 import com.terraformation.backend.db.accelerator.tables.references.REPORT_COMMON_INDICATORS
@@ -12,29 +15,34 @@ import com.terraformation.backend.db.accelerator.tables.references.REPORT_PROJEC
 import com.terraformation.backend.db.accelerator.tables.references.REPORT_PROJECT_INDICATOR_TARGETS
 import com.terraformation.backend.db.asNonNullable
 import com.terraformation.backend.db.default_schema.UserId
+import java.math.BigDecimal
 import java.time.Instant
 import org.jooq.Field
 import org.jooq.Record
 
 data class ReportIndicatorEntryModel(
-    val target: Int? = null,
-    val value: Int? = null,
     val modifiedBy: UserId? = null,
     val modifiedTime: Instant? = null,
     val projectsComments: String? = null,
     val progressNotes: String? = null,
     val status: ReportIndicatorStatus? = null,
+    val target: Int? = null,
+    val value: Int? = null,
 )
 
 data class ReportCommonIndicatorModel(
     val indicator: ExistingCommonIndicatorModel,
     val entry: ReportIndicatorEntryModel,
+    val baseline: BigDecimal? = null,
+    val endOfProjectTarget: BigDecimal? = null,
 ) {
   companion object {
     fun of(record: Record): ReportCommonIndicatorModel {
       return ReportCommonIndicatorModel(
-          indicator = ExistingCommonIndicatorModel.of(record),
+          baseline = record[COMMON_INDICATOR_TARGETS.BASELINE],
+          endOfProjectTarget = record[COMMON_INDICATOR_TARGETS.END_TARGET],
           entry = entry(record),
+          indicator = ExistingCommonIndicatorModel.of(record),
       )
     }
 
@@ -62,12 +70,16 @@ data class ReportCommonIndicatorModel(
 data class ReportProjectIndicatorModel(
     val indicator: ExistingProjectIndicatorModel,
     val entry: ReportIndicatorEntryModel,
+    val baseline: BigDecimal? = null,
+    val endOfProjectTarget: BigDecimal? = null,
 ) {
   companion object {
     fun of(record: Record): ReportProjectIndicatorModel {
       return ReportProjectIndicatorModel(
-          indicator = ExistingProjectIndicatorModel.of(record),
+          baseline = record[PROJECT_INDICATOR_TARGETS.BASELINE],
+          endOfProjectTarget = record[PROJECT_INDICATOR_TARGETS.END_TARGET],
           entry = entry(record),
+          indicator = ExistingProjectIndicatorModel.of(record),
       )
     }
 
@@ -131,12 +143,16 @@ data class ReportAutoCalculatedIndicatorEntryModel(
 data class ReportAutoCalculatedIndicatorModel(
     val indicator: AutoCalculatedIndicator,
     val entry: ReportAutoCalculatedIndicatorEntryModel,
+    val baseline: BigDecimal? = null,
+    val endOfProjectTarget: BigDecimal? = null,
 ) {
   companion object {
     fun of(record: Record, systemValueField: Field<Int?>): ReportAutoCalculatedIndicatorModel {
       return ReportAutoCalculatedIndicatorModel(
-          indicator = record[AUTO_CALCULATED_INDICATORS.ID.asNonNullable()],
+          baseline = record[AUTO_CALCULATED_INDICATOR_TARGETS.BASELINE],
+          endOfProjectTarget = record[AUTO_CALCULATED_INDICATOR_TARGETS.END_TARGET],
           entry = ReportAutoCalculatedIndicatorEntryModel.of(record, systemValueField),
+          indicator = record[AUTO_CALCULATED_INDICATORS.ID.asNonNullable()],
       )
     }
   }

--- a/src/main/kotlin/com/terraformation/backend/accelerator/model/ReportModel.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/model/ReportModel.kt
@@ -59,7 +59,9 @@ data class ReportPhotoModel(
 data class ReportModel(
     val achievements: List<String> = emptyList(),
     val additionalComments: String? = null,
+    val autoCalculatedIndicators: List<ReportAutoCalculatedIndicatorModel> = emptyList(),
     val challenges: List<ReportChallengeModel> = emptyList(),
+    val commonIndicators: List<ReportCommonIndicatorModel> = emptyList(),
     val configId: ProjectReportConfigId,
     val createdBy: UserId,
     val createdByUser: SimpleUserModel,
@@ -78,13 +80,11 @@ data class ReportModel(
     val projectId: ProjectId,
     val projectIndicators: List<ReportProjectIndicatorModel> = emptyList(),
     val quarter: ReportQuarter?,
-    val commonIndicators: List<ReportCommonIndicatorModel> = emptyList(),
     val startDate: LocalDate,
     val status: ReportStatus,
     val submittedBy: UserId? = null,
     val submittedByUser: SimpleUserModel? = null,
     val submittedTime: Instant? = null,
-    val autoCalculatedIndicators: List<ReportAutoCalculatedIndicatorModel> = emptyList(),
 ) {
 
   /** Describes the reporting period of this report. For example "2025 Q1" or "2025 Annual" */

--- a/src/test/kotlin/com/terraformation/backend/accelerator/db/ReportStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/db/ReportStoreTest.kt
@@ -310,6 +310,7 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
           modifiedTime = Instant.ofEpochSecond(1500),
           modifiedBy = user.userId,
       )
+      insertProjectIndicatorBaselineTarget(baseline = 1, endTarget = 1000)
 
       val projectIndicators =
           listOf(
@@ -337,6 +338,8 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
                           modifiedTime = Instant.ofEpochSecond(1500),
                           modifiedBy = user.userId,
                       ),
+                  baseline = BigDecimal.ONE,
+                  endOfProjectTarget = BigDecimal("1000"),
               ),
           )
 
@@ -386,6 +389,10 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
           modifiedTime = Instant.ofEpochSecond(3000),
           modifiedBy = user.userId,
       )
+      insertCommonIndicatorBaselineTarget(
+          commonIndicatorId = commonIndicatorId1,
+          baseline = BigDecimal.TWO,
+      )
 
       insertReportCommonIndicatorTarget(
           commonIndicatorId = commonIndicatorId2,
@@ -398,6 +405,10 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
           status = ReportIndicatorStatus.Unlikely,
           modifiedTime = Instant.ofEpochSecond(1500),
           modifiedBy = user.userId,
+      )
+      insertCommonIndicatorBaselineTarget(
+          commonIndicatorId = commonIndicatorId2,
+          endTarget = BigDecimal("2000"),
       )
 
       val commonIndicators =
@@ -417,6 +428,8 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
                       ),
                   // all fields are null because no target/value have been set yet
                   entry = ReportIndicatorEntryModel(),
+                  baseline = null,
+                  endOfProjectTarget = null,
               ),
               ReportCommonIndicatorModel(
                   indicator =
@@ -443,6 +456,7 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
                           modifiedTime = Instant.ofEpochSecond(3000),
                           modifiedBy = user.userId,
                       ),
+                  baseline = BigDecimal.TWO,
               ),
               ReportCommonIndicatorModel(
                   indicator =
@@ -463,6 +477,7 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
                           modifiedTime = Instant.ofEpochSecond(1500),
                           modifiedBy = user.userId,
                       ),
+                  endOfProjectTarget = BigDecimal("2000"),
               ),
           )
 
@@ -491,6 +506,10 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
           modifiedTime = Instant.ofEpochSecond(500),
           modifiedBy = user.userId,
       )
+      insertAutoCalculatedIndicatorBaselineTarget(
+          indicator = AutoCalculatedIndicator.SeedsCollected,
+          baseline = BigDecimal.TEN,
+      )
 
       insertReportAutoCalculatedIndicatorTarget(
           indicator = AutoCalculatedIndicator.TreesPlanted,
@@ -507,6 +526,11 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
           modifiedTime = Instant.ofEpochSecond(700),
           modifiedBy = user.userId,
       )
+      insertAutoCalculatedIndicatorBaselineTarget(
+          indicator = AutoCalculatedIndicator.TreesPlanted,
+          baseline = BigDecimal("20"),
+          endTarget = BigDecimal("1500"),
+      )
 
       // These are ordered by reference.
       val autoCalculatedIndicators =
@@ -521,6 +545,7 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
                           modifiedTime = Instant.ofEpochSecond(500),
                           modifiedBy = user.userId,
                       ),
+                  baseline = BigDecimal.TEN,
               ),
               ReportAutoCalculatedIndicatorModel(
                   indicator = AutoCalculatedIndicator.HectaresPlanted,
@@ -551,6 +576,8 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
                           modifiedTime = Instant.ofEpochSecond(700),
                           modifiedBy = user.userId,
                       ),
+                  baseline = BigDecimal("20"),
+                  endOfProjectTarget = BigDecimal("1500"),
               ),
               ReportAutoCalculatedIndicatorModel(
                   indicator = AutoCalculatedIndicator.SpeciesPlanted,


### PR DESCRIPTION
In order to support cumulative progress calculations, return each indicator's `baseline` and `endOfProjectTarget` values for indicators in reports.