### PR TITLE
SW-8128 Add previous year's sum to report api

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/accelerator/db/ReportStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/db/ReportStore.kt
@@ -1615,7 +1615,7 @@ class ReportStore(
 
   private fun commonIndicatorsMultiset(): Field<List<ReportCommonIndicatorModel>> {
     val reportsForSum = REPORTS.`as`("reportsForSum")
-    val previousYearsSum =
+    val sumAtPreviousYearEnd =
         DSL.`when`(
             COMMON_INDICATORS.CLASS_ID.eq(IndicatorClass.Cumulative),
             DSL.select(DSL.sum(REPORT_COMMON_INDICATORS.VALUE))
@@ -1623,6 +1623,7 @@ class ReportStore(
                 .join(reportsForSum)
                 .on(reportsForSum.ID.eq(REPORT_COMMON_INDICATORS.REPORT_ID))
                 .where(DSL.year(reportsForSum.END_DATE).lt(DSL.year(REPORTS.END_DATE)))
+                .and(reportsForSum.PROJECT_ID.eq(REPORTS.PROJECT_ID))
                 .and(REPORT_COMMON_INDICATORS.COMMON_INDICATOR_ID.eq(COMMON_INDICATORS.ID)),
         )
 
@@ -1632,7 +1633,7 @@ class ReportStore(
                     REPORT_COMMON_INDICATORS.asterisk(),
                     REPORT_COMMON_INDICATOR_TARGETS.TARGET,
                     COMMON_INDICATOR_TARGETS.asterisk(),
-                    previousYearsSum,
+                    sumAtPreviousYearEnd,
                 )
                 .from(COMMON_INDICATORS)
                 .leftJoin(REPORT_COMMON_INDICATORS)
@@ -1650,7 +1651,7 @@ class ReportStore(
                 .orderBy(COMMON_INDICATORS.REF_ID, COMMON_INDICATORS.ID)
         )
         .convertFrom { results ->
-          results.map { ReportCommonIndicatorModel.of(it, previousYearsSum) }
+          results.map { ReportCommonIndicatorModel.of(it, sumAtPreviousYearEnd) }
         }
   }
 
@@ -1669,7 +1670,7 @@ class ReportStore(
 
   private fun projectIndicatorsMultiset(): Field<List<ReportProjectIndicatorModel>> {
     val reportsForSum = REPORTS.`as`("reportsForSum")
-    val previousYearSum =
+    val sumAtPreviousYearEnd =
         DSL.`when`(
             PROJECT_INDICATORS.CLASS_ID.eq(IndicatorClass.Cumulative),
             DSL.select(DSL.sum(REPORT_PROJECT_INDICATORS.VALUE))
@@ -1677,6 +1678,7 @@ class ReportStore(
                 .join(reportsForSum)
                 .on(reportsForSum.ID.eq(REPORT_PROJECT_INDICATORS.REPORT_ID))
                 .where(DSL.year(reportsForSum.END_DATE).lt(DSL.year(REPORTS.END_DATE)))
+                .and(reportsForSum.PROJECT_ID.eq(REPORTS.PROJECT_ID))
                 .and(REPORT_PROJECT_INDICATORS.PROJECT_INDICATOR_ID.eq(PROJECT_INDICATORS.ID)),
         )
 
@@ -1686,7 +1688,7 @@ class ReportStore(
                     REPORT_PROJECT_INDICATORS.asterisk(),
                     REPORT_PROJECT_INDICATOR_TARGETS.TARGET,
                     PROJECT_INDICATOR_TARGETS.asterisk(),
-                    previousYearSum,
+                    sumAtPreviousYearEnd,
                 )
                 .from(PROJECT_INDICATORS)
                 .leftJoin(REPORT_PROJECT_INDICATORS)
@@ -1705,7 +1707,7 @@ class ReportStore(
                 .orderBy(PROJECT_INDICATORS.REF_ID, PROJECT_INDICATORS.ID)
         )
         .convertFrom { results ->
-          results.map { ReportProjectIndicatorModel.of(it, previousYearSum) }
+          results.map { ReportProjectIndicatorModel.of(it, sumAtPreviousYearEnd) }
         }
   }
 
@@ -2009,7 +2011,7 @@ class ReportStore(
 
   private fun autoCalculatedIndicatorsMultiset(): Field<List<ReportAutoCalculatedIndicatorModel>> {
     val reportsForSum = REPORTS.`as`("reportsForSum")
-    val previousYearSum =
+    val sumAtPreviousYearEnd =
         DSL.`when`(
             AUTO_CALCULATED_INDICATORS.CLASS_ID.eq(IndicatorClass.Cumulative),
             DSL.select(
@@ -2024,6 +2026,7 @@ class ReportStore(
                 .join(reportsForSum)
                 .on(reportsForSum.ID.eq(REPORT_AUTO_CALCULATED_INDICATORS.REPORT_ID))
                 .where(DSL.year(reportsForSum.END_DATE).lt(DSL.year(REPORTS.END_DATE)))
+                .and(reportsForSum.PROJECT_ID.eq(REPORTS.PROJECT_ID))
                 .and(
                     REPORT_AUTO_CALCULATED_INDICATORS.AUTO_CALCULATED_INDICATOR_ID.eq(
                         AUTO_CALCULATED_INDICATORS.ID
@@ -2038,7 +2041,7 @@ class ReportStore(
                     systemValueField,
                     REPORT_AUTO_CALCULATED_INDICATOR_TARGETS.TARGET,
                     AUTO_CALCULATED_INDICATOR_TARGETS.asterisk(),
-                    previousYearSum,
+                    sumAtPreviousYearEnd,
                 )
                 .from(AUTO_CALCULATED_INDICATORS)
                 .leftJoin(REPORT_AUTO_CALCULATED_INDICATORS)
@@ -2067,7 +2070,7 @@ class ReportStore(
         )
         .convertFrom { results ->
           results.map {
-            ReportAutoCalculatedIndicatorModel.of(it, systemValueField, previousYearSum)
+            ReportAutoCalculatedIndicatorModel.of(it, systemValueField, sumAtPreviousYearEnd)
           }
         }
   }

--- a/src/main/kotlin/com/terraformation/backend/accelerator/db/ReportStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/db/ReportStore.kt
@@ -29,6 +29,7 @@ import com.terraformation.backend.db.ReportConfigNotFoundException
 import com.terraformation.backend.db.ReportNotFoundException
 import com.terraformation.backend.db.accelerator.AutoCalculatedIndicator
 import com.terraformation.backend.db.accelerator.CommonIndicatorId
+import com.terraformation.backend.db.accelerator.IndicatorClass
 import com.terraformation.backend.db.accelerator.ProjectIndicatorId
 import com.terraformation.backend.db.accelerator.ProjectReportConfigId
 import com.terraformation.backend.db.accelerator.ReportId
@@ -1093,7 +1094,7 @@ class ReportStore(
 
     val commonIndicatorsField =
         if (includeIndicators) {
-          commonIndicatorsMultiset
+          commonIndicatorsMultiset()
         } else {
           null
         }
@@ -1612,30 +1613,45 @@ class ReportStore(
           )
           .convertFrom { results -> results.map { ReportChallengeModel.of(it) } }
 
-  private val commonIndicatorsMultiset: Field<List<ReportCommonIndicatorModel>> =
-      DSL.multiset(
-              DSL.select(
-                      COMMON_INDICATORS.asterisk(),
-                      REPORT_COMMON_INDICATORS.asterisk(),
-                      REPORT_COMMON_INDICATOR_TARGETS.TARGET,
-                      COMMON_INDICATOR_TARGETS.asterisk(),
-                  )
-                  .from(COMMON_INDICATORS)
-                  .leftJoin(REPORT_COMMON_INDICATORS)
-                  .on(COMMON_INDICATORS.ID.eq(REPORT_COMMON_INDICATORS.COMMON_INDICATOR_ID))
-                  .and(REPORTS.ID.eq(REPORT_COMMON_INDICATORS.REPORT_ID))
-                  .leftJoin(REPORT_COMMON_INDICATOR_TARGETS)
-                  .on(REPORT_COMMON_INDICATOR_TARGETS.COMMON_INDICATOR_ID.eq(COMMON_INDICATORS.ID))
-                  .leftJoin(COMMON_INDICATOR_TARGETS)
-                  .on(
-                      COMMON_INDICATOR_TARGETS.COMMON_INDICATOR_ID.eq(COMMON_INDICATORS.ID)
-                          .and(COMMON_INDICATOR_TARGETS.PROJECT_ID.eq(REPORTS.PROJECT_ID))
-                  )
-                  .and(REPORT_COMMON_INDICATOR_TARGETS.PROJECT_ID.eq(REPORTS.PROJECT_ID))
-                  .and(REPORT_COMMON_INDICATOR_TARGETS.YEAR.eq(DSL.year(REPORTS.END_DATE)))
-                  .orderBy(COMMON_INDICATORS.REF_ID, COMMON_INDICATORS.ID)
-          )
-          .convertFrom { results -> results.map { ReportCommonIndicatorModel.of(it) } }
+  private fun commonIndicatorsMultiset(): Field<List<ReportCommonIndicatorModel>> {
+    val reportsForSum = REPORTS.`as`("reportsForSum")
+    val previousYearsSum =
+        DSL.`when`(
+            COMMON_INDICATORS.CLASS_ID.eq(IndicatorClass.Cumulative),
+            DSL.select(DSL.sum(REPORT_COMMON_INDICATORS.VALUE))
+                .from(REPORT_COMMON_INDICATORS)
+                .join(reportsForSum)
+                .on(reportsForSum.ID.eq(REPORT_COMMON_INDICATORS.REPORT_ID))
+                .where(DSL.year(reportsForSum.END_DATE).lt(DSL.year(REPORTS.END_DATE))),
+        )
+
+    return DSL.multiset(
+            DSL.select(
+                    COMMON_INDICATORS.asterisk(),
+                    REPORT_COMMON_INDICATORS.asterisk(),
+                    REPORT_COMMON_INDICATOR_TARGETS.TARGET,
+                    COMMON_INDICATOR_TARGETS.asterisk(),
+                    previousYearsSum,
+                )
+                .from(COMMON_INDICATORS)
+                .leftJoin(REPORT_COMMON_INDICATORS)
+                .on(COMMON_INDICATORS.ID.eq(REPORT_COMMON_INDICATORS.COMMON_INDICATOR_ID))
+                .and(REPORTS.ID.eq(REPORT_COMMON_INDICATORS.REPORT_ID))
+                .leftJoin(REPORT_COMMON_INDICATOR_TARGETS)
+                .on(REPORT_COMMON_INDICATOR_TARGETS.COMMON_INDICATOR_ID.eq(COMMON_INDICATORS.ID))
+                .leftJoin(COMMON_INDICATOR_TARGETS)
+                .on(
+                    COMMON_INDICATOR_TARGETS.COMMON_INDICATOR_ID.eq(COMMON_INDICATORS.ID)
+                        .and(COMMON_INDICATOR_TARGETS.PROJECT_ID.eq(REPORTS.PROJECT_ID))
+                )
+                .and(REPORT_COMMON_INDICATOR_TARGETS.PROJECT_ID.eq(REPORTS.PROJECT_ID))
+                .and(REPORT_COMMON_INDICATOR_TARGETS.YEAR.eq(DSL.year(REPORTS.END_DATE)))
+                .orderBy(COMMON_INDICATORS.REF_ID, COMMON_INDICATORS.ID)
+        )
+        .convertFrom { results ->
+          results.map { ReportCommonIndicatorModel.of(it, previousYearsSum) }
+        }
+  }
 
   private val photosMultiset: Field<List<ReportPhotoModel>> =
       DSL.multiset(

--- a/src/main/kotlin/com/terraformation/backend/accelerator/db/ReportStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/db/ReportStore.kt
@@ -1087,7 +1087,7 @@ class ReportStore(
   ): List<ReportModel> {
     val projectIndicatorsField =
         if (includeIndicators) {
-          projectIndicatorsMultiset
+          projectIndicatorsMultiset()
         } else {
           null
         }
@@ -1101,7 +1101,7 @@ class ReportStore(
 
     val autoCalculatedIndicatorsField =
         if (includeIndicators) {
-          autoCalculatedIndicatorsMultiset
+          autoCalculatedIndicatorsMultiset()
         } else {
           null
         }
@@ -1622,7 +1622,8 @@ class ReportStore(
                 .from(REPORT_COMMON_INDICATORS)
                 .join(reportsForSum)
                 .on(reportsForSum.ID.eq(REPORT_COMMON_INDICATORS.REPORT_ID))
-                .where(DSL.year(reportsForSum.END_DATE).lt(DSL.year(REPORTS.END_DATE))),
+                .where(DSL.year(reportsForSum.END_DATE).lt(DSL.year(REPORTS.END_DATE)))
+                .and(REPORT_COMMON_INDICATORS.COMMON_INDICATOR_ID.eq(COMMON_INDICATORS.ID)),
         )
 
     return DSL.multiset(
@@ -1666,35 +1667,47 @@ class ReportStore(
           )
           .convertFrom { results -> results.map { ReportPhotoModel.of(it) } }
 
-  private val projectIndicatorsMultiset: Field<List<ReportProjectIndicatorModel>> =
-      DSL.multiset(
-              DSL.select(
-                      PROJECT_INDICATORS.asterisk(),
-                      REPORT_PROJECT_INDICATORS.asterisk(),
-                      REPORT_PROJECT_INDICATOR_TARGETS.TARGET,
-                      PROJECT_INDICATOR_TARGETS.asterisk(),
-                  )
-                  .from(PROJECT_INDICATORS)
-                  .leftJoin(REPORT_PROJECT_INDICATORS)
-                  .on(PROJECT_INDICATORS.ID.eq(REPORT_PROJECT_INDICATORS.PROJECT_INDICATOR_ID))
-                  .and(REPORTS.ID.eq(REPORT_PROJECT_INDICATORS.REPORT_ID))
-                  .leftJoin(REPORT_PROJECT_INDICATOR_TARGETS)
-                  .on(
-                      REPORT_PROJECT_INDICATOR_TARGETS.PROJECT_INDICATOR_ID.eq(
-                          PROJECT_INDICATORS.ID
-                      )
-                  )
-                  .leftJoin(PROJECT_INDICATOR_TARGETS)
-                  .on(
-                      PROJECT_INDICATOR_TARGETS.PROJECT_INDICATOR_ID.eq(PROJECT_INDICATORS.ID)
-                          .and(PROJECT_INDICATOR_TARGETS.PROJECT_ID.eq(REPORTS.PROJECT_ID))
-                  )
-                  .and(REPORT_PROJECT_INDICATOR_TARGETS.PROJECT_ID.eq(REPORTS.PROJECT_ID))
-                  .and(REPORT_PROJECT_INDICATOR_TARGETS.YEAR.eq(DSL.year(REPORTS.END_DATE)))
-                  .where(PROJECT_INDICATORS.PROJECT_ID.eq(REPORTS.PROJECT_ID))
-                  .orderBy(PROJECT_INDICATORS.REF_ID, PROJECT_INDICATORS.ID)
-          )
-          .convertFrom { results -> results.map { ReportProjectIndicatorModel.of(it) } }
+  private fun projectIndicatorsMultiset(): Field<List<ReportProjectIndicatorModel>> {
+    val reportsForSum = REPORTS.`as`("reportsForSum")
+    val previousYearSum =
+        DSL.`when`(
+            PROJECT_INDICATORS.CLASS_ID.eq(IndicatorClass.Cumulative),
+            DSL.select(DSL.sum(REPORT_PROJECT_INDICATORS.VALUE))
+                .from(REPORT_PROJECT_INDICATORS)
+                .join(reportsForSum)
+                .on(reportsForSum.ID.eq(REPORT_PROJECT_INDICATORS.REPORT_ID))
+                .where(DSL.year(reportsForSum.END_DATE).lt(DSL.year(REPORTS.END_DATE)))
+                .and(REPORT_PROJECT_INDICATORS.PROJECT_INDICATOR_ID.eq(PROJECT_INDICATORS.ID)),
+        )
+
+    return DSL.multiset(
+            DSL.select(
+                    PROJECT_INDICATORS.asterisk(),
+                    REPORT_PROJECT_INDICATORS.asterisk(),
+                    REPORT_PROJECT_INDICATOR_TARGETS.TARGET,
+                    PROJECT_INDICATOR_TARGETS.asterisk(),
+                    previousYearSum,
+                )
+                .from(PROJECT_INDICATORS)
+                .leftJoin(REPORT_PROJECT_INDICATORS)
+                .on(PROJECT_INDICATORS.ID.eq(REPORT_PROJECT_INDICATORS.PROJECT_INDICATOR_ID))
+                .and(REPORTS.ID.eq(REPORT_PROJECT_INDICATORS.REPORT_ID))
+                .leftJoin(REPORT_PROJECT_INDICATOR_TARGETS)
+                .on(REPORT_PROJECT_INDICATOR_TARGETS.PROJECT_INDICATOR_ID.eq(PROJECT_INDICATORS.ID))
+                .leftJoin(PROJECT_INDICATOR_TARGETS)
+                .on(
+                    PROJECT_INDICATOR_TARGETS.PROJECT_INDICATOR_ID.eq(PROJECT_INDICATORS.ID)
+                        .and(PROJECT_INDICATOR_TARGETS.PROJECT_ID.eq(REPORTS.PROJECT_ID))
+                )
+                .and(REPORT_PROJECT_INDICATOR_TARGETS.PROJECT_ID.eq(REPORTS.PROJECT_ID))
+                .and(REPORT_PROJECT_INDICATOR_TARGETS.YEAR.eq(DSL.year(REPORTS.END_DATE)))
+                .where(PROJECT_INDICATORS.PROJECT_ID.eq(REPORTS.PROJECT_ID))
+                .orderBy(PROJECT_INDICATORS.REF_ID, PROJECT_INDICATORS.ID)
+        )
+        .convertFrom { results ->
+          results.map { ReportProjectIndicatorModel.of(it, previousYearSum) }
+        }
+  }
 
   private fun userIsInSameOrg() =
       with(ORGANIZATION_USERS) {
@@ -1994,41 +2007,68 @@ class ReportStore(
           .`when`(REPORT_AUTO_CALCULATED_INDICATORS.SYSTEM_TIME.isNull(), systemTerrawareValueField)
           .else_(REPORT_AUTO_CALCULATED_INDICATORS.SYSTEM_VALUE)
 
-  private val autoCalculatedIndicatorsMultiset: Field<List<ReportAutoCalculatedIndicatorModel>> =
-      DSL.multiset(
-              DSL.select(
-                      AUTO_CALCULATED_INDICATORS.ID,
-                      REPORT_AUTO_CALCULATED_INDICATORS.asterisk(),
-                      systemValueField,
-                      REPORT_AUTO_CALCULATED_INDICATOR_TARGETS.TARGET,
-                      AUTO_CALCULATED_INDICATOR_TARGETS.asterisk(),
-                  )
-                  .from(AUTO_CALCULATED_INDICATORS)
-                  .leftJoin(REPORT_AUTO_CALCULATED_INDICATORS)
-                  .on(
-                      AUTO_CALCULATED_INDICATORS.ID.eq(
-                          REPORT_AUTO_CALCULATED_INDICATORS.AUTO_CALCULATED_INDICATOR_ID
-                      )
-                  )
-                  .and(REPORTS.ID.eq(REPORT_AUTO_CALCULATED_INDICATORS.REPORT_ID))
-                  .leftJoin(REPORT_AUTO_CALCULATED_INDICATOR_TARGETS)
-                  .on(
-                      REPORT_AUTO_CALCULATED_INDICATOR_TARGETS.AUTO_CALCULATED_INDICATOR_ID.eq(
-                          AUTO_CALCULATED_INDICATORS.ID
-                      )
-                  )
-                  .leftJoin(AUTO_CALCULATED_INDICATOR_TARGETS)
-                  .on(
-                      AUTO_CALCULATED_INDICATOR_TARGETS.AUTO_CALCULATED_INDICATOR_ID.eq(
-                              AUTO_CALCULATED_INDICATORS.ID
-                          )
-                          .and(AUTO_CALCULATED_INDICATOR_TARGETS.PROJECT_ID.eq(REPORTS.PROJECT_ID))
-                  )
-                  .and(REPORT_AUTO_CALCULATED_INDICATOR_TARGETS.PROJECT_ID.eq(REPORTS.PROJECT_ID))
-                  .and(REPORT_AUTO_CALCULATED_INDICATOR_TARGETS.YEAR.eq(DSL.year(REPORTS.END_DATE)))
-                  .orderBy(AUTO_CALCULATED_INDICATORS.REF_ID, AUTO_CALCULATED_INDICATORS.ID)
-          )
-          .convertFrom { results ->
-            results.map { ReportAutoCalculatedIndicatorModel.of(it, systemValueField) }
+  private fun autoCalculatedIndicatorsMultiset(): Field<List<ReportAutoCalculatedIndicatorModel>> {
+    val reportsForSum = REPORTS.`as`("reportsForSum")
+    val previousYearSum =
+        DSL.`when`(
+            AUTO_CALCULATED_INDICATORS.CLASS_ID.eq(IndicatorClass.Cumulative),
+            DSL.select(
+                    DSL.sum(
+                        DSL.coalesce(
+                            REPORT_AUTO_CALCULATED_INDICATORS.OVERRIDE_VALUE,
+                            REPORT_AUTO_CALCULATED_INDICATORS.SYSTEM_VALUE,
+                        )
+                    )
+                )
+                .from(REPORT_AUTO_CALCULATED_INDICATORS)
+                .join(reportsForSum)
+                .on(reportsForSum.ID.eq(REPORT_AUTO_CALCULATED_INDICATORS.REPORT_ID))
+                .where(DSL.year(reportsForSum.END_DATE).lt(DSL.year(REPORTS.END_DATE)))
+                .and(
+                    REPORT_AUTO_CALCULATED_INDICATORS.AUTO_CALCULATED_INDICATOR_ID.eq(
+                        AUTO_CALCULATED_INDICATORS.ID
+                    )
+                ),
+        )
+
+    return DSL.multiset(
+            DSL.select(
+                    AUTO_CALCULATED_INDICATORS.ID,
+                    REPORT_AUTO_CALCULATED_INDICATORS.asterisk(),
+                    systemValueField,
+                    REPORT_AUTO_CALCULATED_INDICATOR_TARGETS.TARGET,
+                    AUTO_CALCULATED_INDICATOR_TARGETS.asterisk(),
+                    previousYearSum,
+                )
+                .from(AUTO_CALCULATED_INDICATORS)
+                .leftJoin(REPORT_AUTO_CALCULATED_INDICATORS)
+                .on(
+                    AUTO_CALCULATED_INDICATORS.ID.eq(
+                        REPORT_AUTO_CALCULATED_INDICATORS.AUTO_CALCULATED_INDICATOR_ID
+                    )
+                )
+                .and(REPORTS.ID.eq(REPORT_AUTO_CALCULATED_INDICATORS.REPORT_ID))
+                .leftJoin(REPORT_AUTO_CALCULATED_INDICATOR_TARGETS)
+                .on(
+                    REPORT_AUTO_CALCULATED_INDICATOR_TARGETS.AUTO_CALCULATED_INDICATOR_ID.eq(
+                        AUTO_CALCULATED_INDICATORS.ID
+                    )
+                )
+                .leftJoin(AUTO_CALCULATED_INDICATOR_TARGETS)
+                .on(
+                    AUTO_CALCULATED_INDICATOR_TARGETS.AUTO_CALCULATED_INDICATOR_ID.eq(
+                            AUTO_CALCULATED_INDICATORS.ID
+                        )
+                        .and(AUTO_CALCULATED_INDICATOR_TARGETS.PROJECT_ID.eq(REPORTS.PROJECT_ID))
+                )
+                .and(REPORT_AUTO_CALCULATED_INDICATOR_TARGETS.PROJECT_ID.eq(REPORTS.PROJECT_ID))
+                .and(REPORT_AUTO_CALCULATED_INDICATOR_TARGETS.YEAR.eq(DSL.year(REPORTS.END_DATE)))
+                .orderBy(AUTO_CALCULATED_INDICATORS.REF_ID, AUTO_CALCULATED_INDICATORS.ID)
+        )
+        .convertFrom { results ->
+          results.map {
+            ReportAutoCalculatedIndicatorModel.of(it, systemValueField, previousYearSum)
           }
+        }
+  }
 }

--- a/src/main/kotlin/com/terraformation/backend/accelerator/model/ReportIndicatorsModel.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/model/ReportIndicatorsModel.kt
@@ -3,6 +3,7 @@ package com.terraformation.backend.accelerator.model
 import com.terraformation.backend.auth.currentUser
 import com.terraformation.backend.db.accelerator.AutoCalculatedIndicator
 import com.terraformation.backend.db.accelerator.ReportIndicatorStatus
+import com.terraformation.backend.db.accelerator.ReportQuarter
 import com.terraformation.backend.db.accelerator.tables.references.AUTO_CALCULATED_INDICATORS
 import com.terraformation.backend.db.accelerator.tables.references.AUTO_CALCULATED_INDICATOR_TARGETS
 import com.terraformation.backend.db.accelerator.tables.references.COMMON_INDICATOR_TARGETS
@@ -20,6 +21,11 @@ import java.time.Instant
 import org.jooq.Field
 import org.jooq.Record
 
+data class CumulativeIndicatorProgressModel(
+    val quarter: ReportQuarter,
+    val value: Int,
+)
+
 data class ReportIndicatorEntryModel(
     val modifiedBy: UserId? = null,
     val modifiedTime: Instant? = null,
@@ -35,14 +41,22 @@ data class ReportCommonIndicatorModel(
     val entry: ReportIndicatorEntryModel,
     val baseline: BigDecimal? = null,
     val endOfProjectTarget: BigDecimal? = null,
+    /**
+     * If the indicator is cumulative, the list of actual values for all quarters in the report's
+     * year
+     */
+    val currentYearProgress: List<CumulativeIndicatorProgressModel>? = null,
+    /** If the indicator is cumulative, the cumulative total and the end of the previous year */
+    val previousYearCumulativeTotal: BigDecimal? = null,
 ) {
   companion object {
-    fun of(record: Record): ReportCommonIndicatorModel {
+    fun of(record: Record, previousYearTotalField: Field<BigDecimal?>): ReportCommonIndicatorModel {
       return ReportCommonIndicatorModel(
           baseline = record[COMMON_INDICATOR_TARGETS.BASELINE],
           endOfProjectTarget = record[COMMON_INDICATOR_TARGETS.END_TARGET],
           entry = entry(record),
           indicator = ExistingCommonIndicatorModel.of(record),
+          previousYearCumulativeTotal = record[previousYearTotalField],
       )
     }
 
@@ -72,6 +86,13 @@ data class ReportProjectIndicatorModel(
     val entry: ReportIndicatorEntryModel,
     val baseline: BigDecimal? = null,
     val endOfProjectTarget: BigDecimal? = null,
+    /**
+     * If the indicator is cumulative, the list of actual values for all quarters in the report's
+     * year
+     */
+    val currentYearProgress: List<CumulativeIndicatorProgressModel>? = null,
+    /** If the indicator is cumulative, the cumulative total and the end of the previous year */
+    val previousYearCumulativeTotal: BigDecimal? = null,
 ) {
   companion object {
     fun of(record: Record): ReportProjectIndicatorModel {
@@ -145,6 +166,13 @@ data class ReportAutoCalculatedIndicatorModel(
     val entry: ReportAutoCalculatedIndicatorEntryModel,
     val baseline: BigDecimal? = null,
     val endOfProjectTarget: BigDecimal? = null,
+    /**
+     * If the indicator is cumulative, the list of actual values for all quarters in the report's
+     * year
+     */
+    val currentYearProgress: List<CumulativeIndicatorProgressModel>? = null,
+    /** If the indicator is cumulative, the cumulative total and the end of the previous year */
+    val previousYearCumulativeTotal: BigDecimal? = null,
 ) {
   companion object {
     fun of(record: Record, systemValueField: Field<Int?>): ReportAutoCalculatedIndicatorModel {

--- a/src/main/kotlin/com/terraformation/backend/accelerator/model/ReportIndicatorsModel.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/model/ReportIndicatorsModel.kt
@@ -95,12 +95,16 @@ data class ReportProjectIndicatorModel(
     val previousYearCumulativeTotal: BigDecimal? = null,
 ) {
   companion object {
-    fun of(record: Record): ReportProjectIndicatorModel {
+    fun of(
+        record: Record,
+        previousYearTotalField: Field<BigDecimal?>,
+    ): ReportProjectIndicatorModel {
       return ReportProjectIndicatorModel(
           baseline = record[PROJECT_INDICATOR_TARGETS.BASELINE],
           endOfProjectTarget = record[PROJECT_INDICATOR_TARGETS.END_TARGET],
           entry = entry(record),
           indicator = ExistingProjectIndicatorModel.of(record),
+          previousYearCumulativeTotal = record[previousYearTotalField],
       )
     }
 
@@ -175,12 +179,17 @@ data class ReportAutoCalculatedIndicatorModel(
     val previousYearCumulativeTotal: BigDecimal? = null,
 ) {
   companion object {
-    fun of(record: Record, systemValueField: Field<Int?>): ReportAutoCalculatedIndicatorModel {
+    fun of(
+        record: Record,
+        systemValueField: Field<Int?>,
+        previousYearTotalField: Field<BigDecimal?>,
+    ): ReportAutoCalculatedIndicatorModel {
       return ReportAutoCalculatedIndicatorModel(
           baseline = record[AUTO_CALCULATED_INDICATOR_TARGETS.BASELINE],
           endOfProjectTarget = record[AUTO_CALCULATED_INDICATOR_TARGETS.END_TARGET],
           entry = ReportAutoCalculatedIndicatorEntryModel.of(record, systemValueField),
           indicator = record[AUTO_CALCULATED_INDICATORS.ID.asNonNullable()],
+          previousYearCumulativeTotal = record[previousYearTotalField],
       )
     }
   }

--- a/src/test/kotlin/com/terraformation/backend/accelerator/db/ReportStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/db/ReportStoreTest.kt
@@ -620,31 +620,76 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
     fun `cumulative indicators contain previous year total`() {
       val configId = insertProjectReportConfig()
 
-      val projectIndicatorId =
+      // multiple indicators should not interfere with each other's totals
+      val projectIndicatorId1 =
           insertProjectIndicator(
               classId = IndicatorClass.Cumulative,
-              name = "Project Indicator Name",
+              name = "Project Indicator Name 1",
           )
-      val commonIndicatorId =
-          insertCommonIndicator(name = "Common Indicator Name", classId = IndicatorClass.Cumulative)
+      val projectIndicatorId2 =
+          insertProjectIndicator(
+              classId = IndicatorClass.Cumulative,
+              name = "Project Indicator Name 2",
+          )
+      val commonIndicatorId1 =
+          insertCommonIndicator(
+              name = "Common Indicator Name 1",
+              classId = IndicatorClass.Cumulative,
+          )
+      val commonIndicatorId2 =
+          insertCommonIndicator(
+              name = "Common Indicator Name 2",
+              classId = IndicatorClass.Cumulative,
+          )
 
       // oldReport1
       insertReport(endDate = LocalDate.of(2024, 9, 30))
-      insertReportProjectIndicator(value = 10)
-      insertReportCommonIndicator(value = 20)
-      insertReportAutoCalculatedIndicator(systemValue = 30)
+      insertReportProjectIndicator(indicatorId = projectIndicatorId1, value = 10)
+      insertReportProjectIndicator(indicatorId = projectIndicatorId2, value = 11)
+      insertReportCommonIndicator(indicatorId = commonIndicatorId1, value = 20)
+      insertReportCommonIndicator(indicatorId = commonIndicatorId2, value = 21)
+      insertReportAutoCalculatedIndicator(
+          indicator = AutoCalculatedIndicator.SeedsCollected,
+          systemValue = 30,
+      )
+      insertReportAutoCalculatedIndicator(
+          indicator = AutoCalculatedIndicator.HectaresPlanted,
+          systemValue = 29,
+          overrideValue = 31, // overrideValue takes precedence
+      )
 
       // oldReport2
       insertReport(endDate = LocalDate.of(2024, 12, 31))
-      insertReportProjectIndicator(value = 100)
-      insertReportCommonIndicator(value = 200)
-      insertReportAutoCalculatedIndicator(systemValue = 300)
+      insertReportProjectIndicator(indicatorId = projectIndicatorId1, value = 100)
+      insertReportProjectIndicator(indicatorId = projectIndicatorId2, value = 101)
+      insertReportCommonIndicator(indicatorId = commonIndicatorId1, value = 200)
+      insertReportCommonIndicator(indicatorId = commonIndicatorId2, value = 201)
+
+      insertReportAutoCalculatedIndicator(
+          indicator = AutoCalculatedIndicator.SeedsCollected,
+          systemValue = 300,
+          overrideValue = 301, // overrideValue takes precedence
+      )
+      insertReportAutoCalculatedIndicator(
+          indicator = AutoCalculatedIndicator.HectaresPlanted,
+          systemValue = 299,
+          overrideValue = 302,
+      )
 
       val reportId =
           insertReport(startDate = LocalDate.of(2025, 1, 1), endDate = LocalDate.of(2025, 3, 31))
-      insertReportProjectIndicator()
-      insertReportCommonIndicator()
-      insertReportAutoCalculatedIndicator(systemValue = 3000)
+      insertReportProjectIndicator(indicatorId = projectIndicatorId1)
+      insertReportProjectIndicator(indicatorId = projectIndicatorId2)
+      insertReportCommonIndicator(indicatorId = commonIndicatorId1)
+      insertReportCommonIndicator(indicatorId = commonIndicatorId2)
+      insertReportAutoCalculatedIndicator(
+          indicator = AutoCalculatedIndicator.SeedsCollected,
+          systemValue = 3000,
+      )
+      insertReportAutoCalculatedIndicator(
+          indicator = AutoCalculatedIndicator.HectaresPlanted,
+          systemValue = 4000,
+      )
 
       val projectIndicators =
           listOf(
@@ -654,10 +699,10 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
                           category = IndicatorCategory.ProjectObjectives,
                           classId = IndicatorClass.Cumulative,
                           description = null,
-                          id = projectIndicatorId,
+                          id = projectIndicatorId1,
                           isPublishable = true,
                           level = IndicatorLevel.Impact,
-                          name = "Project Indicator Name",
+                          name = "Project Indicator Name 1",
                           projectId = projectId,
                           refId = "1.1",
                           tfOwner = "Carbon",
@@ -667,8 +712,29 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
                           modifiedBy = user.userId,
                           modifiedTime = Instant.EPOCH,
                       ),
-                  //                  previousYearCumulativeTotal = BigDecimal("110"),
-              )
+                  previousYearCumulativeTotal = BigDecimal("110"),
+              ),
+              ReportProjectIndicatorModel(
+                  indicator =
+                      ProjectIndicatorModel(
+                          category = IndicatorCategory.ProjectObjectives,
+                          classId = IndicatorClass.Cumulative,
+                          description = null,
+                          id = projectIndicatorId2,
+                          isPublishable = true,
+                          level = IndicatorLevel.Impact,
+                          name = "Project Indicator Name 2",
+                          projectId = projectId,
+                          refId = "1.1",
+                          tfOwner = "Carbon",
+                      ),
+                  entry =
+                      ReportIndicatorEntryModel(
+                          modifiedBy = user.userId,
+                          modifiedTime = Instant.EPOCH,
+                      ),
+                  previousYearCumulativeTotal = BigDecimal("112"),
+              ),
           )
       val commonIndicators =
           listOf(
@@ -678,10 +744,10 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
                           category = IndicatorCategory.ProjectObjectives,
                           classId = IndicatorClass.Cumulative,
                           description = null,
-                          id = commonIndicatorId,
+                          id = commonIndicatorId1,
                           isPublishable = true,
                           level = IndicatorLevel.Impact,
-                          name = "Common Indicator Name",
+                          name = "Common Indicator Name 1",
                           refId = "1.1",
                           tfOwner = "Carbon",
                       ),
@@ -691,7 +757,27 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
                           modifiedTime = Instant.EPOCH,
                       ),
                   previousYearCumulativeTotal = BigDecimal("220"),
-              )
+              ),
+              ReportCommonIndicatorModel(
+                  indicator =
+                      CommonIndicatorModel(
+                          category = IndicatorCategory.ProjectObjectives,
+                          classId = IndicatorClass.Cumulative,
+                          description = null,
+                          id = commonIndicatorId2,
+                          isPublishable = true,
+                          level = IndicatorLevel.Impact,
+                          name = "Common Indicator Name 2",
+                          refId = "1.1",
+                          tfOwner = "Carbon",
+                      ),
+                  entry =
+                      ReportIndicatorEntryModel(
+                          modifiedBy = user.userId,
+                          modifiedTime = Instant.EPOCH,
+                      ),
+                  previousYearCumulativeTotal = BigDecimal("222"),
+              ),
           )
       val autoCalculatedIndicators =
           listOf(
@@ -704,11 +790,18 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
                           systemValue = 3000,
                           systemTime = Instant.EPOCH,
                       ),
-                  //                  previousYearCumulativeTotal = BigDecimal("330"),
+                  previousYearCumulativeTotal = BigDecimal("331"),
               ),
               ReportAutoCalculatedIndicatorModel(
                   indicator = AutoCalculatedIndicator.HectaresPlanted,
-                  entry = ReportAutoCalculatedIndicatorEntryModel(systemValue = 0),
+                  entry =
+                      ReportAutoCalculatedIndicatorEntryModel(
+                          modifiedBy = user.userId,
+                          modifiedTime = Instant.EPOCH,
+                          systemValue = 4000,
+                          systemTime = Instant.EPOCH,
+                      ),
+                  previousYearCumulativeTotal = BigDecimal("333"),
               ),
               ReportAutoCalculatedIndicatorModel(
                   indicator = AutoCalculatedIndicator.Seedlings,

--- a/src/test/kotlin/com/terraformation/backend/accelerator/db/ReportStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/db/ReportStoreTest.kt
@@ -617,6 +617,147 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
     }
 
     @Test
+    fun `cumulative indicators contain previous year total`() {
+      val configId = insertProjectReportConfig()
+
+      val projectIndicatorId =
+          insertProjectIndicator(
+              classId = IndicatorClass.Cumulative,
+              name = "Project Indicator Name",
+          )
+      val commonIndicatorId =
+          insertCommonIndicator(name = "Common Indicator Name", classId = IndicatorClass.Cumulative)
+
+      // oldReport1
+      insertReport(endDate = LocalDate.of(2024, 9, 30))
+      insertReportProjectIndicator(value = 10)
+      insertReportCommonIndicator(value = 20)
+      insertReportAutoCalculatedIndicator(systemValue = 30)
+
+      // oldReport2
+      insertReport(endDate = LocalDate.of(2024, 12, 31))
+      insertReportProjectIndicator(value = 100)
+      insertReportCommonIndicator(value = 200)
+      insertReportAutoCalculatedIndicator(systemValue = 300)
+
+      val reportId =
+          insertReport(startDate = LocalDate.of(2025, 1, 1), endDate = LocalDate.of(2025, 3, 31))
+      insertReportProjectIndicator()
+      insertReportCommonIndicator()
+      insertReportAutoCalculatedIndicator(systemValue = 3000)
+
+      val projectIndicators =
+          listOf(
+              ReportProjectIndicatorModel(
+                  indicator =
+                      ProjectIndicatorModel(
+                          category = IndicatorCategory.ProjectObjectives,
+                          classId = IndicatorClass.Cumulative,
+                          description = null,
+                          id = projectIndicatorId,
+                          isPublishable = true,
+                          level = IndicatorLevel.Impact,
+                          name = "Project Indicator Name",
+                          projectId = projectId,
+                          refId = "1.1",
+                          tfOwner = "Carbon",
+                      ),
+                  entry =
+                      ReportIndicatorEntryModel(
+                          modifiedBy = user.userId,
+                          modifiedTime = Instant.EPOCH,
+                      ),
+                  //                  previousYearCumulativeTotal = BigDecimal("110"),
+              )
+          )
+      val commonIndicators =
+          listOf(
+              ReportCommonIndicatorModel(
+                  indicator =
+                      CommonIndicatorModel(
+                          category = IndicatorCategory.ProjectObjectives,
+                          classId = IndicatorClass.Cumulative,
+                          description = null,
+                          id = commonIndicatorId,
+                          isPublishable = true,
+                          level = IndicatorLevel.Impact,
+                          name = "Common Indicator Name",
+                          refId = "1.1",
+                          tfOwner = "Carbon",
+                      ),
+                  entry =
+                      ReportIndicatorEntryModel(
+                          modifiedBy = user.userId,
+                          modifiedTime = Instant.EPOCH,
+                      ),
+                  previousYearCumulativeTotal = BigDecimal("220"),
+              )
+          )
+      val autoCalculatedIndicators =
+          listOf(
+              ReportAutoCalculatedIndicatorModel(
+                  indicator = AutoCalculatedIndicator.SeedsCollected,
+                  entry =
+                      ReportAutoCalculatedIndicatorEntryModel(
+                          modifiedBy = user.userId,
+                          modifiedTime = Instant.EPOCH,
+                          systemValue = 3000,
+                          systemTime = Instant.EPOCH,
+                      ),
+                  //                  previousYearCumulativeTotal = BigDecimal("330"),
+              ),
+              ReportAutoCalculatedIndicatorModel(
+                  indicator = AutoCalculatedIndicator.HectaresPlanted,
+                  entry = ReportAutoCalculatedIndicatorEntryModel(systemValue = 0),
+              ),
+              ReportAutoCalculatedIndicatorModel(
+                  indicator = AutoCalculatedIndicator.Seedlings,
+                  entry = ReportAutoCalculatedIndicatorEntryModel(systemValue = 0),
+              ),
+              ReportAutoCalculatedIndicatorModel(
+                  indicator = AutoCalculatedIndicator.TreesPlanted,
+                  entry = ReportAutoCalculatedIndicatorEntryModel(systemValue = 0),
+              ),
+              ReportAutoCalculatedIndicatorModel(
+                  indicator = AutoCalculatedIndicator.SpeciesPlanted,
+                  entry = ReportAutoCalculatedIndicatorEntryModel(systemValue = 0),
+              ),
+              ReportAutoCalculatedIndicatorModel(
+                  indicator = AutoCalculatedIndicator.SurvivalRate,
+                  entry = ReportAutoCalculatedIndicatorEntryModel(systemValue = null),
+              ),
+          )
+
+      val reportModel =
+          ReportModel(
+              id = reportId,
+              configId = configId,
+              projectId = projectId,
+              projectDealName = "DEAL_Report Project",
+              quarter = ReportQuarter.Q1,
+              status = ReportStatus.NotSubmitted,
+              startDate = LocalDate.of(2025, 1, 1),
+              endDate = LocalDate.of(2025, 3, 31),
+              createdBy = user.userId,
+              createdByUser = SimpleUserModel(user.userId, "First Last"),
+              createdTime = Instant.EPOCH,
+              modifiedBy = user.userId,
+              modifiedByUser = SimpleUserModel(user.userId, "First Last"),
+              modifiedTime = Instant.EPOCH,
+              projectIndicators = projectIndicators,
+              commonIndicators = commonIndicators,
+              autoCalculatedIndicators = autoCalculatedIndicators,
+          )
+
+      clock.instant = LocalDate.of(2025, 3, 20).atStartOfDay().toInstant(ZoneOffset.UTC)
+      assertEquals(
+          reportModel,
+          store.fetchOne(reportId = reportId, includeIndicators = true),
+          "Indicators should have previous year cumulative totals",
+      )
+    }
+
+    @Test
     fun `queries Terraware data for auto calculated indicator`() {
       insertProjectReportConfig()
       insertReport(

--- a/src/test/kotlin/com/terraformation/backend/accelerator/db/ReportStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/db/ReportStoreTest.kt
@@ -124,6 +124,7 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
   }
 
   private lateinit var organizationId: OrganizationId
+  private lateinit var otherProjectId: ProjectId
   private lateinit var projectId: ProjectId
 
   private val sitesLiveSum = 6 + 11 + 6 + 7
@@ -134,6 +135,7 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
   @BeforeEach
   fun setup() {
     organizationId = insertOrganization(timeZone = ZoneOffset.UTC)
+    otherProjectId = insertProject()
     projectId = insertProject()
     insertProjectAcceleratorDetails(dealName = "DEAL_Report Project")
     insertOrganizationUser(role = Role.Admin)
@@ -617,240 +619,6 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
     }
 
     @Test
-    fun `cumulative indicators contain previous year total`() {
-      val configId = insertProjectReportConfig()
-
-      // multiple indicators should not interfere with each other's totals
-      val projectIndicatorId1 =
-          insertProjectIndicator(
-              classId = IndicatorClass.Cumulative,
-              name = "Project Indicator Name 1",
-          )
-      val projectIndicatorId2 =
-          insertProjectIndicator(
-              classId = IndicatorClass.Cumulative,
-              name = "Project Indicator Name 2",
-          )
-      val commonIndicatorId1 =
-          insertCommonIndicator(
-              name = "Common Indicator Name 1",
-              classId = IndicatorClass.Cumulative,
-          )
-      val commonIndicatorId2 =
-          insertCommonIndicator(
-              name = "Common Indicator Name 2",
-              classId = IndicatorClass.Cumulative,
-          )
-
-      // oldReport1
-      insertReport(endDate = LocalDate.of(2024, 9, 30))
-      insertReportProjectIndicator(indicatorId = projectIndicatorId1, value = 10)
-      insertReportProjectIndicator(indicatorId = projectIndicatorId2, value = 11)
-      insertReportCommonIndicator(indicatorId = commonIndicatorId1, value = 20)
-      insertReportCommonIndicator(indicatorId = commonIndicatorId2, value = 21)
-      insertReportAutoCalculatedIndicator(
-          indicator = AutoCalculatedIndicator.SeedsCollected,
-          systemValue = 30,
-      )
-      insertReportAutoCalculatedIndicator(
-          indicator = AutoCalculatedIndicator.HectaresPlanted,
-          systemValue = 29,
-          overrideValue = 31, // overrideValue takes precedence
-      )
-
-      // oldReport2
-      insertReport(endDate = LocalDate.of(2024, 12, 31))
-      insertReportProjectIndicator(indicatorId = projectIndicatorId1, value = 100)
-      insertReportProjectIndicator(indicatorId = projectIndicatorId2, value = 101)
-      insertReportCommonIndicator(indicatorId = commonIndicatorId1, value = 200)
-      insertReportCommonIndicator(indicatorId = commonIndicatorId2, value = 201)
-
-      insertReportAutoCalculatedIndicator(
-          indicator = AutoCalculatedIndicator.SeedsCollected,
-          systemValue = 300,
-          overrideValue = 301, // overrideValue takes precedence
-      )
-      insertReportAutoCalculatedIndicator(
-          indicator = AutoCalculatedIndicator.HectaresPlanted,
-          systemValue = 299,
-          overrideValue = 302,
-      )
-
-      val reportId =
-          insertReport(startDate = LocalDate.of(2025, 1, 1), endDate = LocalDate.of(2025, 3, 31))
-      insertReportProjectIndicator(indicatorId = projectIndicatorId1)
-      insertReportProjectIndicator(indicatorId = projectIndicatorId2)
-      insertReportCommonIndicator(indicatorId = commonIndicatorId1)
-      insertReportCommonIndicator(indicatorId = commonIndicatorId2)
-      insertReportAutoCalculatedIndicator(
-          indicator = AutoCalculatedIndicator.SeedsCollected,
-          systemValue = 3000,
-      )
-      insertReportAutoCalculatedIndicator(
-          indicator = AutoCalculatedIndicator.HectaresPlanted,
-          systemValue = 4000,
-      )
-
-      val projectIndicators =
-          listOf(
-              ReportProjectIndicatorModel(
-                  indicator =
-                      ProjectIndicatorModel(
-                          category = IndicatorCategory.ProjectObjectives,
-                          classId = IndicatorClass.Cumulative,
-                          description = null,
-                          id = projectIndicatorId1,
-                          isPublishable = true,
-                          level = IndicatorLevel.Impact,
-                          name = "Project Indicator Name 1",
-                          projectId = projectId,
-                          refId = "1.1",
-                          tfOwner = "Carbon",
-                      ),
-                  entry =
-                      ReportIndicatorEntryModel(
-                          modifiedBy = user.userId,
-                          modifiedTime = Instant.EPOCH,
-                      ),
-                  previousYearCumulativeTotal = BigDecimal("110"),
-              ),
-              ReportProjectIndicatorModel(
-                  indicator =
-                      ProjectIndicatorModel(
-                          category = IndicatorCategory.ProjectObjectives,
-                          classId = IndicatorClass.Cumulative,
-                          description = null,
-                          id = projectIndicatorId2,
-                          isPublishable = true,
-                          level = IndicatorLevel.Impact,
-                          name = "Project Indicator Name 2",
-                          projectId = projectId,
-                          refId = "1.1",
-                          tfOwner = "Carbon",
-                      ),
-                  entry =
-                      ReportIndicatorEntryModel(
-                          modifiedBy = user.userId,
-                          modifiedTime = Instant.EPOCH,
-                      ),
-                  previousYearCumulativeTotal = BigDecimal("112"),
-              ),
-          )
-      val commonIndicators =
-          listOf(
-              ReportCommonIndicatorModel(
-                  indicator =
-                      CommonIndicatorModel(
-                          category = IndicatorCategory.ProjectObjectives,
-                          classId = IndicatorClass.Cumulative,
-                          description = null,
-                          id = commonIndicatorId1,
-                          isPublishable = true,
-                          level = IndicatorLevel.Impact,
-                          name = "Common Indicator Name 1",
-                          refId = "1.1",
-                          tfOwner = "Carbon",
-                      ),
-                  entry =
-                      ReportIndicatorEntryModel(
-                          modifiedBy = user.userId,
-                          modifiedTime = Instant.EPOCH,
-                      ),
-                  previousYearCumulativeTotal = BigDecimal("220"),
-              ),
-              ReportCommonIndicatorModel(
-                  indicator =
-                      CommonIndicatorModel(
-                          category = IndicatorCategory.ProjectObjectives,
-                          classId = IndicatorClass.Cumulative,
-                          description = null,
-                          id = commonIndicatorId2,
-                          isPublishable = true,
-                          level = IndicatorLevel.Impact,
-                          name = "Common Indicator Name 2",
-                          refId = "1.1",
-                          tfOwner = "Carbon",
-                      ),
-                  entry =
-                      ReportIndicatorEntryModel(
-                          modifiedBy = user.userId,
-                          modifiedTime = Instant.EPOCH,
-                      ),
-                  previousYearCumulativeTotal = BigDecimal("222"),
-              ),
-          )
-      val autoCalculatedIndicators =
-          listOf(
-              ReportAutoCalculatedIndicatorModel(
-                  indicator = AutoCalculatedIndicator.SeedsCollected,
-                  entry =
-                      ReportAutoCalculatedIndicatorEntryModel(
-                          modifiedBy = user.userId,
-                          modifiedTime = Instant.EPOCH,
-                          systemValue = 3000,
-                          systemTime = Instant.EPOCH,
-                      ),
-                  previousYearCumulativeTotal = BigDecimal("331"),
-              ),
-              ReportAutoCalculatedIndicatorModel(
-                  indicator = AutoCalculatedIndicator.HectaresPlanted,
-                  entry =
-                      ReportAutoCalculatedIndicatorEntryModel(
-                          modifiedBy = user.userId,
-                          modifiedTime = Instant.EPOCH,
-                          systemValue = 4000,
-                          systemTime = Instant.EPOCH,
-                      ),
-                  previousYearCumulativeTotal = BigDecimal("333"),
-              ),
-              ReportAutoCalculatedIndicatorModel(
-                  indicator = AutoCalculatedIndicator.Seedlings,
-                  entry = ReportAutoCalculatedIndicatorEntryModel(systemValue = 0),
-              ),
-              ReportAutoCalculatedIndicatorModel(
-                  indicator = AutoCalculatedIndicator.TreesPlanted,
-                  entry = ReportAutoCalculatedIndicatorEntryModel(systemValue = 0),
-              ),
-              ReportAutoCalculatedIndicatorModel(
-                  indicator = AutoCalculatedIndicator.SpeciesPlanted,
-                  entry = ReportAutoCalculatedIndicatorEntryModel(systemValue = 0),
-              ),
-              ReportAutoCalculatedIndicatorModel(
-                  indicator = AutoCalculatedIndicator.SurvivalRate,
-                  entry = ReportAutoCalculatedIndicatorEntryModel(systemValue = null),
-              ),
-          )
-
-      val reportModel =
-          ReportModel(
-              id = reportId,
-              configId = configId,
-              projectId = projectId,
-              projectDealName = "DEAL_Report Project",
-              quarter = ReportQuarter.Q1,
-              status = ReportStatus.NotSubmitted,
-              startDate = LocalDate.of(2025, 1, 1),
-              endDate = LocalDate.of(2025, 3, 31),
-              createdBy = user.userId,
-              createdByUser = SimpleUserModel(user.userId, "First Last"),
-              createdTime = Instant.EPOCH,
-              modifiedBy = user.userId,
-              modifiedByUser = SimpleUserModel(user.userId, "First Last"),
-              modifiedTime = Instant.EPOCH,
-              projectIndicators = projectIndicators,
-              commonIndicators = commonIndicators,
-              autoCalculatedIndicators = autoCalculatedIndicators,
-          )
-
-      clock.instant = LocalDate.of(2025, 3, 20).atStartOfDay().toInstant(ZoneOffset.UTC)
-      assertEquals(
-          reportModel,
-          store.fetchOne(reportId = reportId, includeIndicators = true),
-          "Indicators should have previous year cumulative totals",
-      )
-    }
-
-    @Test
     fun `queries Terraware data for auto calculated indicator`() {
       insertProjectReportConfig()
       insertReport(
@@ -1309,6 +1077,260 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
       deleteOrganizationUser(organizationId = organizationId)
       insertUserGlobalRole(role = GlobalRole.ReadOnly)
       assertDoesNotThrow(message = "Read-only global user") { store.fetchOne(reportId) }
+    }
+
+    @Test
+    fun `cumulative indicators contain previous year total`() {
+      val otherProjectConfigId = insertProjectReportConfig(projectId = otherProjectId)
+      val configId = insertProjectReportConfig()
+
+      // multiple indicators should not interfere with each other's totals
+      val projectIndicatorId1 =
+          insertProjectIndicator(
+              classId = IndicatorClass.Cumulative,
+              name = "Project Indicator Name 1",
+          )
+      val projectIndicatorId2 =
+          insertProjectIndicator(
+              classId = IndicatorClass.Cumulative,
+              name = "Project Indicator Name 2",
+          )
+      val otherProjectIndicatorId =
+          insertProjectIndicator(
+              projectId = otherProjectId,
+              classId = IndicatorClass.Cumulative,
+              name = "Other Project's Indicator",
+          )
+      val commonIndicatorId1 =
+          insertCommonIndicator(
+              name = "Common Indicator Name 1",
+              classId = IndicatorClass.Cumulative,
+          )
+      val commonIndicatorId2 =
+          insertCommonIndicator(
+              name = "Common Indicator Name 2",
+              classId = IndicatorClass.Cumulative,
+          )
+
+      // other project's indicators shouldn't affect total
+      insertReport(
+          projectId = otherProjectId,
+          endDate = LocalDate.of(2024, 6, 30),
+          configId = otherProjectConfigId,
+      )
+      insertReportProjectIndicator(indicatorId = otherProjectIndicatorId, value = 10_000)
+      insertReportCommonIndicator(indicatorId = commonIndicatorId1, value = 20_000)
+      insertReportAutoCalculatedIndicator(
+          indicator = AutoCalculatedIndicator.SeedsCollected,
+          systemValue = 30_000,
+      )
+
+      // oldReport1
+      insertReport(endDate = LocalDate.of(2024, 9, 30))
+      insertReportProjectIndicator(indicatorId = projectIndicatorId1, value = 10)
+      insertReportProjectIndicator(indicatorId = projectIndicatorId2, value = 11)
+      insertReportCommonIndicator(indicatorId = commonIndicatorId1, value = 20)
+      insertReportCommonIndicator(indicatorId = commonIndicatorId2, value = 21)
+      insertReportAutoCalculatedIndicator(
+          indicator = AutoCalculatedIndicator.SeedsCollected,
+          systemValue = 30,
+      )
+      insertReportAutoCalculatedIndicator(
+          indicator = AutoCalculatedIndicator.HectaresPlanted,
+          systemValue = 29,
+          overrideValue = 31, // overrideValue takes precedence
+      )
+
+      // oldReport2
+      insertReport(endDate = LocalDate.of(2024, 12, 31))
+      insertReportProjectIndicator(indicatorId = projectIndicatorId1, value = 100)
+      insertReportProjectIndicator(indicatorId = projectIndicatorId2, value = 101)
+      insertReportCommonIndicator(indicatorId = commonIndicatorId1, value = 200)
+      insertReportCommonIndicator(indicatorId = commonIndicatorId2, value = 201)
+
+      insertReportAutoCalculatedIndicator(
+          indicator = AutoCalculatedIndicator.SeedsCollected,
+          systemValue = 300,
+          overrideValue = 301, // overrideValue takes precedence
+      )
+      insertReportAutoCalculatedIndicator(
+          indicator = AutoCalculatedIndicator.HectaresPlanted,
+          systemValue = 299,
+          overrideValue = 302, // overrideValue takes precedence
+      )
+
+      val reportId =
+          insertReport(startDate = LocalDate.of(2025, 1, 1), endDate = LocalDate.of(2025, 3, 31))
+      insertReportProjectIndicator(indicatorId = projectIndicatorId1)
+      insertReportProjectIndicator(indicatorId = projectIndicatorId2)
+      insertReportCommonIndicator(indicatorId = commonIndicatorId1)
+      insertReportCommonIndicator(indicatorId = commonIndicatorId2)
+      insertReportAutoCalculatedIndicator(
+          indicator = AutoCalculatedIndicator.SeedsCollected,
+          systemValue = 3000,
+      )
+      insertReportAutoCalculatedIndicator(
+          indicator = AutoCalculatedIndicator.HectaresPlanted,
+          systemValue = 4000,
+      )
+
+      val projectIndicators =
+          listOf(
+              ReportProjectIndicatorModel(
+                  indicator =
+                      ProjectIndicatorModel(
+                          category = IndicatorCategory.ProjectObjectives,
+                          classId = IndicatorClass.Cumulative,
+                          description = null,
+                          id = projectIndicatorId1,
+                          isPublishable = true,
+                          level = IndicatorLevel.Impact,
+                          name = "Project Indicator Name 1",
+                          projectId = projectId,
+                          refId = "1.1",
+                          tfOwner = "Carbon",
+                      ),
+                  entry =
+                      ReportIndicatorEntryModel(
+                          modifiedBy = user.userId,
+                          modifiedTime = Instant.EPOCH,
+                      ),
+                  previousYearCumulativeTotal = BigDecimal("110"),
+              ),
+              ReportProjectIndicatorModel(
+                  indicator =
+                      ProjectIndicatorModel(
+                          category = IndicatorCategory.ProjectObjectives,
+                          classId = IndicatorClass.Cumulative,
+                          description = null,
+                          id = projectIndicatorId2,
+                          isPublishable = true,
+                          level = IndicatorLevel.Impact,
+                          name = "Project Indicator Name 2",
+                          projectId = projectId,
+                          refId = "1.1",
+                          tfOwner = "Carbon",
+                      ),
+                  entry =
+                      ReportIndicatorEntryModel(
+                          modifiedBy = user.userId,
+                          modifiedTime = Instant.EPOCH,
+                      ),
+                  previousYearCumulativeTotal = BigDecimal("112"),
+              ),
+          )
+      val commonIndicators =
+          listOf(
+              ReportCommonIndicatorModel(
+                  indicator =
+                      CommonIndicatorModel(
+                          category = IndicatorCategory.ProjectObjectives,
+                          classId = IndicatorClass.Cumulative,
+                          description = null,
+                          id = commonIndicatorId1,
+                          isPublishable = true,
+                          level = IndicatorLevel.Impact,
+                          name = "Common Indicator Name 1",
+                          refId = "1.1",
+                          tfOwner = "Carbon",
+                      ),
+                  entry =
+                      ReportIndicatorEntryModel(
+                          modifiedBy = user.userId,
+                          modifiedTime = Instant.EPOCH,
+                      ),
+                  previousYearCumulativeTotal = BigDecimal("220"),
+              ),
+              ReportCommonIndicatorModel(
+                  indicator =
+                      CommonIndicatorModel(
+                          category = IndicatorCategory.ProjectObjectives,
+                          classId = IndicatorClass.Cumulative,
+                          description = null,
+                          id = commonIndicatorId2,
+                          isPublishable = true,
+                          level = IndicatorLevel.Impact,
+                          name = "Common Indicator Name 2",
+                          refId = "1.1",
+                          tfOwner = "Carbon",
+                      ),
+                  entry =
+                      ReportIndicatorEntryModel(
+                          modifiedBy = user.userId,
+                          modifiedTime = Instant.EPOCH,
+                      ),
+                  previousYearCumulativeTotal = BigDecimal("222"),
+              ),
+          )
+      val autoCalculatedIndicators =
+          listOf(
+              ReportAutoCalculatedIndicatorModel(
+                  indicator = AutoCalculatedIndicator.SeedsCollected,
+                  entry =
+                      ReportAutoCalculatedIndicatorEntryModel(
+                          modifiedBy = user.userId,
+                          modifiedTime = Instant.EPOCH,
+                          systemValue = 3000,
+                          systemTime = Instant.EPOCH,
+                      ),
+                  previousYearCumulativeTotal = BigDecimal("331"),
+              ),
+              ReportAutoCalculatedIndicatorModel(
+                  indicator = AutoCalculatedIndicator.HectaresPlanted,
+                  entry =
+                      ReportAutoCalculatedIndicatorEntryModel(
+                          modifiedBy = user.userId,
+                          modifiedTime = Instant.EPOCH,
+                          systemValue = 4000,
+                          systemTime = Instant.EPOCH,
+                      ),
+                  previousYearCumulativeTotal = BigDecimal("333"),
+              ),
+              ReportAutoCalculatedIndicatorModel(
+                  indicator = AutoCalculatedIndicator.Seedlings,
+                  entry = ReportAutoCalculatedIndicatorEntryModel(systemValue = 0),
+              ),
+              ReportAutoCalculatedIndicatorModel(
+                  indicator = AutoCalculatedIndicator.TreesPlanted,
+                  entry = ReportAutoCalculatedIndicatorEntryModel(systemValue = 0),
+              ),
+              ReportAutoCalculatedIndicatorModel(
+                  indicator = AutoCalculatedIndicator.SpeciesPlanted,
+                  entry = ReportAutoCalculatedIndicatorEntryModel(systemValue = 0),
+              ),
+              ReportAutoCalculatedIndicatorModel(
+                  indicator = AutoCalculatedIndicator.SurvivalRate,
+                  entry = ReportAutoCalculatedIndicatorEntryModel(systemValue = null),
+              ),
+          )
+
+      val reportModel =
+          ReportModel(
+              id = reportId,
+              configId = configId,
+              projectId = projectId,
+              projectDealName = "DEAL_Report Project",
+              quarter = ReportQuarter.Q1,
+              status = ReportStatus.NotSubmitted,
+              startDate = LocalDate.of(2025, 1, 1),
+              endDate = LocalDate.of(2025, 3, 31),
+              createdBy = user.userId,
+              createdByUser = SimpleUserModel(user.userId, "First Last"),
+              createdTime = Instant.EPOCH,
+              modifiedBy = user.userId,
+              modifiedByUser = SimpleUserModel(user.userId, "First Last"),
+              modifiedTime = Instant.EPOCH,
+              projectIndicators = projectIndicators,
+              commonIndicators = commonIndicators,
+              autoCalculatedIndicators = autoCalculatedIndicators,
+          )
+
+      clock.instant = LocalDate.of(2025, 3, 20).atStartOfDay().toInstant(ZoneOffset.UTC)
+      assertEquals(
+          reportModel,
+          store.fetchOne(reportId = reportId, includeIndicators = true),
+          "Indicators should have previous year cumulative totals",
+      )
     }
 
     @Test


### PR DESCRIPTION
In order to display the new progress bar in reports, cumulative indicators will be showing a value for the following:

- previous year's sum
- all quarters' actuals in the current year
- year target

Cumulative indicators are basically summed up for each quarter, and we aren't storing the sums anywhere, so it needs to be calculated when reports are returned.

For each cumulative indicator returned, include the previous year's sum (if it exists).