### PR TITLE
SW-5441 Add destination batch project ID search field

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/search/table/BatchWithdrawalsTable.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/table/BatchWithdrawalsTable.kt
@@ -1,5 +1,6 @@
 package com.terraformation.backend.search.table
 
+import com.terraformation.backend.db.default_schema.tables.references.PROJECTS
 import com.terraformation.backend.db.nursery.tables.references.BATCHES
 import com.terraformation.backend.db.nursery.tables.references.BATCH_WITHDRAWALS
 import com.terraformation.backend.db.nursery.tables.references.WITHDRAWAL_SUMMARIES
@@ -10,6 +11,7 @@ import org.jooq.OrderField
 import org.jooq.Record
 import org.jooq.SelectJoinStep
 import org.jooq.TableField
+import org.jooq.impl.DSL
 
 class BatchWithdrawalsTable(private val tables: SearchTables) : SearchTable() {
   override val primaryKey: TableField<out Record, out Any?>
@@ -37,6 +39,16 @@ class BatchWithdrawalsTable(private val tables: SearchTables) : SearchTable() {
         integerField(
             "activeGrowthQuantityWithdrawn",
             BATCH_WITHDRAWALS.ACTIVE_GROWTH_QUANTITY_WITHDRAWN,
+        ),
+        textField(
+            "destinationBatchProjectName",
+            DSL.field(
+                DSL.select(PROJECTS.NAME)
+                    .from(BATCHES)
+                    .leftJoin(PROJECTS)
+                    .on(BATCHES.PROJECT_ID.eq(PROJECTS.ID))
+                    .where(BATCHES.ID.eq(BATCH_WITHDRAWALS.DESTINATION_BATCH_ID))
+            ),
         ),
         integerField(
             "germinatingQuantityWithdrawn",

--- a/src/main/resources/i18n/Messages_en.properties
+++ b/src/main/resources/i18n/Messages_en.properties
@@ -569,6 +569,7 @@ search.applications.id=Application ID
 search.applications.status=Application status
 search.bags.number=Bag number
 search.batchWithdrawals.activeGrowthQuantityWithdrawn=Active growth quantity withdrawn
+search.batchWithdrawals.destinationBatchProjectName=Destination batch project name
 search.batchWithdrawals.germinatingQuantityWithdrawn=Germinating quantity withdrawn
 search.batchWithdrawals.hardeningOffQuantityWithdrawn=Hardening off quantity withdrawn
 search.batchWithdrawals.notReadyQuantityWithdrawn=Active growth quantity withdrawn

--- a/src/main/resources/i18n/Messages_es.properties
+++ b/src/main/resources/i18n/Messages_es.properties
@@ -1005,6 +1005,8 @@ search.batches.treatmentNotes=Notas del tratamiento
 search.batches.version=Versión por lotes
 # 84d3c3af
 search.batchWithdrawals.activeGrowthQuantityWithdrawn=Cantidad de crecimiento activo retirada
+# 7cd53005
+search.batchWithdrawals.destinationBatchProjectName=Nombre del proyecto del lote de destino
 # dc94da45
 search.batchWithdrawals.germinatingQuantityWithdrawn=Cantidad germinada retirada
 # d9e5e865

--- a/src/main/resources/i18n/Messages_fr.properties
+++ b/src/main/resources/i18n/Messages_fr.properties
@@ -1005,6 +1005,8 @@ search.batches.treatmentNotes=Notes sur le traitement
 search.batches.version=Version du lot
 # 84d3c3af
 search.batchWithdrawals.activeGrowthQuantityWithdrawn=Quantité de croissance active retirée
+# 7cd53005
+search.batchWithdrawals.destinationBatchProjectName=Nom du projet du lot de destination
 # dc94da45
 search.batchWithdrawals.germinatingQuantityWithdrawn=Quantité de germination prélevée
 # d9e5e865

--- a/src/test/kotlin/com/terraformation/backend/nursery/NurserySearchTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/nursery/NurserySearchTest.kt
@@ -18,6 +18,7 @@ import com.terraformation.backend.mockUser
 import com.terraformation.backend.search.AndNode
 import com.terraformation.backend.search.FieldNode
 import com.terraformation.backend.search.NoConditionNode
+import com.terraformation.backend.search.OrNode
 import com.terraformation.backend.search.SearchFieldPrefix
 import com.terraformation.backend.search.SearchResults
 import com.terraformation.backend.search.SearchService
@@ -507,6 +508,91 @@ internal class NurserySearchTest : DatabaseTest(), RunsAsUser {
           ),
           results,
       )
+    }
+
+    @Test
+    fun `can search for both source and destination batch projects`() {
+      val projectId1 = insertProject(name = "Project 1")
+      val projectId2 = insertProject(name = "Project 2")
+      val projectId3 = insertProject(name = "Project 3")
+      val project1Batch =
+          insertBatch(
+              facilityId = facilityId,
+              germinatingQuantity = 1,
+              speciesId = speciesId1,
+              projectId = projectId1,
+          )
+      val project2Batch =
+          insertBatch(
+              facilityId = facilityId2,
+              germinatingQuantity = 1,
+              speciesId = speciesId1,
+              projectId = projectId2,
+          )
+      insertBatch(
+          facilityId = facilityId,
+          germinatingQuantity = 1,
+          speciesId = speciesId1,
+          projectId = projectId3,
+      )
+      val withdrawalId =
+          insertNurseryWithdrawal(
+              facilityId = facilityId,
+              purpose = WithdrawalPurpose.NurseryTransfer,
+              destinationFacilityId = facilityId2,
+              withdrawnDate = LocalDate.of(2021, 1, 1),
+          )
+      insertBatchWithdrawal(
+          batchId = project1Batch,
+          destinationBatchId = project2Batch,
+          germinatingQuantityWithdrawn = 1,
+      )
+
+      val prefix = SearchFieldPrefix(root = searchTables.nurseryWithdrawals)
+      val fields =
+          listOf(
+                  "id",
+                  "batchWithdrawals.batch_project_name",
+                  "batchWithdrawals.destinationBatchProjectName",
+              )
+              .map { prefix.resolve(it) }
+
+      listOf("Project 1", "Project 2").forEach { projectName ->
+        val filter =
+            OrNode(
+                listOf(
+                    FieldNode(
+                        prefix.resolve("batchWithdrawals.batch_project_name"),
+                        listOf(projectName),
+                    ),
+                    FieldNode(
+                        prefix.resolve("batchWithdrawals.destinationBatchProjectName"),
+                        listOf(projectName),
+                    ),
+                )
+            )
+        val orderBy = listOf(SearchSortField(prefix.resolve("id")))
+
+        val expected =
+            SearchResults(
+                listOf(
+                    mapOf(
+                        "id" to "$withdrawalId",
+                        "batchWithdrawals" to
+                            listOf(
+                                mapOf(
+                                    "batch_project_name" to "Project 1",
+                                    "destinationBatchProjectName" to "Project 2",
+                                ),
+                            ),
+                    ),
+                )
+            )
+
+        val actual = searchService.search(prefix, fields, mapOf(prefix to filter), orderBy)
+
+        assertJsonEquals(expected, actual)
+      }
     }
 
     @Test


### PR DESCRIPTION
In the withdrawal history in the UI, for nursery transfers where the destination
batch is set to a different project than the originating batch, we want to show
both project names rather than just the originating batch's project name.

Ideally this would be purely a client-side change: add the search field for the
destination batch's project name to the query. But that doesn't work because it
would cause the query to reference the `batches` search table twice with different
join criteria, which the search API doesn't currently support.

Instead, solve it by adding a use-case-specific field to the `batchWithdrawals`
search table that fetches the destination batch's project name using a subquery.
The frontend code can then add the new field to its query without causing a
double join.