### PR TITLE
SW-8125 Publish baseline and end-of-project target when reports are published

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/accelerator/db/ReportStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/db/ReportStore.kt
@@ -66,8 +66,11 @@ import com.terraformation.backend.db.default_schema.UserIdConverter
 import com.terraformation.backend.db.default_schema.tables.references.ORGANIZATIONS
 import com.terraformation.backend.db.default_schema.tables.references.ORGANIZATION_USERS
 import com.terraformation.backend.db.default_schema.tables.references.USERS
+import com.terraformation.backend.db.funder.tables.references.PUBLISHED_AUTO_CALCULATED_INDICATOR_BASELINES
 import com.terraformation.backend.db.funder.tables.references.PUBLISHED_AUTO_CALCULATED_INDICATOR_TARGETS
+import com.terraformation.backend.db.funder.tables.references.PUBLISHED_COMMON_INDICATOR_BASELINES
 import com.terraformation.backend.db.funder.tables.references.PUBLISHED_COMMON_INDICATOR_TARGETS
+import com.terraformation.backend.db.funder.tables.references.PUBLISHED_PROJECT_INDICATOR_BASELINES
 import com.terraformation.backend.db.funder.tables.references.PUBLISHED_PROJECT_INDICATOR_TARGETS
 import com.terraformation.backend.db.funder.tables.references.PUBLISHED_REPORTS
 import com.terraformation.backend.db.funder.tables.references.PUBLISHED_REPORT_ACHIEVEMENTS
@@ -680,6 +683,26 @@ class ReportStore(
           reportId,
           PUBLISHED_REPORT_PROJECT_INDICATORS.PROJECT_INDICATOR_ID,
           publishableProjectIndicators,
+      )
+
+      // Publish indicator baseline and end-of-project targets
+      publishIndicatorBaselineTargets(
+          report.projectId,
+          PUBLISHED_PROJECT_INDICATOR_BASELINES.PROJECT_INDICATOR_ID,
+          PROJECT_INDICATOR_TARGETS.PROJECT_INDICATOR_ID,
+          PROJECT_INDICATORS.ID,
+      )
+      publishIndicatorBaselineTargets(
+          report.projectId,
+          PUBLISHED_COMMON_INDICATOR_BASELINES.COMMON_INDICATOR_ID,
+          COMMON_INDICATOR_TARGETS.COMMON_INDICATOR_ID,
+          COMMON_INDICATORS.ID,
+      )
+      publishIndicatorBaselineTargets(
+          report.projectId,
+          PUBLISHED_AUTO_CALCULATED_INDICATOR_BASELINES.AUTO_CALCULATED_INDICATOR_ID,
+          AUTO_CALCULATED_INDICATOR_TARGETS.AUTO_CALCULATED_INDICATOR_ID,
+          AUTO_CALCULATED_INDICATORS.ID,
       )
 
       // Publish indicator targets for the report year
@@ -1375,6 +1398,52 @@ class ReportStore(
           .deleteFrom(table)
           .where(reportIdField.eq(reportId))
           .and(indicatorIdField.notIn(entries.keys))
+          .execute()
+    }
+  }
+
+  private fun <ID : Any> publishIndicatorBaselineTargets(
+      projectId: ProjectId,
+      publishedIndicatorIdField: TableField<*, ID?>,
+      unpublishedIndicatorIdField: TableField<*, ID?>,
+      indicatorIdField: TableField<*, ID?>,
+  ) {
+    val publishedTable = publishedIndicatorIdField.table!!
+    val publishedProjectIdField =
+        publishedTable.field(
+            "project_id",
+            SQLDataType.BIGINT.asConvertedDataType(ProjectIdConverter()),
+        )!!
+    val unpublishedTable = unpublishedIndicatorIdField.table!!
+    val unpublishedProjectIdField =
+        unpublishedTable.field(
+            "project_id",
+            SQLDataType.BIGINT.asConvertedDataType(ProjectIdConverter()),
+        )!!
+    val unpublishedBaselineField = unpublishedTable.field("baseline", SQLDataType.NUMERIC)!!
+    val unpublishedEndTargetField = unpublishedTable.field("end_target", SQLDataType.NUMERIC)!!
+    val indicatorTable = indicatorIdField.table!!
+    val isPublishableField = indicatorTable.field("is_publishable", Boolean::class.java)!!
+
+    dslContext.transaction { _ ->
+      dslContext
+          .insertInto(publishedTable)
+          .select(
+              DSL.select(
+                      unpublishedProjectIdField,
+                      unpublishedIndicatorIdField,
+                      unpublishedBaselineField,
+                      unpublishedEndTargetField,
+                  )
+                  .from(unpublishedTable)
+                  .join(indicatorTable)
+                  .on(indicatorIdField.eq(unpublishedIndicatorIdField))
+                  .where(unpublishedProjectIdField.eq(projectId))
+                  .and(isPublishableField.isTrue),
+          )
+          .onConflict(publishedProjectIdField, publishedIndicatorIdField)
+          .doUpdate()
+          .setAllToExcluded()
           .execute()
     }
   }

--- a/src/test/kotlin/com/terraformation/backend/accelerator/db/ReportStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/db/ReportStoreTest.kt
@@ -60,8 +60,11 @@ import com.terraformation.backend.db.default_schema.OrganizationId
 import com.terraformation.backend.db.default_schema.ProjectId
 import com.terraformation.backend.db.default_schema.Role
 import com.terraformation.backend.db.default_schema.UserId
+import com.terraformation.backend.db.funder.tables.records.PublishedAutoCalculatedIndicatorBaselinesRecord
 import com.terraformation.backend.db.funder.tables.records.PublishedAutoCalculatedIndicatorTargetsRecord
+import com.terraformation.backend.db.funder.tables.records.PublishedCommonIndicatorBaselinesRecord
 import com.terraformation.backend.db.funder.tables.records.PublishedCommonIndicatorTargetsRecord
+import com.terraformation.backend.db.funder.tables.records.PublishedProjectIndicatorBaselinesRecord
 import com.terraformation.backend.db.funder.tables.records.PublishedProjectIndicatorTargetsRecord
 import com.terraformation.backend.db.funder.tables.records.PublishedReportAchievementsRecord
 import com.terraformation.backend.db.funder.tables.records.PublishedReportAutoCalculatedIndicatorsRecord
@@ -4380,6 +4383,39 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
           status = ReportIndicatorStatus.Unlikely,
           systemValue = 51,
       )
+
+      // Baseline and end-of-project targets
+      insertProjectIndicatorBaselineTarget(
+          projectIndicatorId = projectIndicatorId1,
+          baseline = 10,
+          endTarget = 100,
+      )
+      insertProjectIndicatorBaselineTarget(
+          projectIndicatorId = projectIndicatorId2,
+          baseline = 20,
+          endTarget = 200,
+      )
+      insertProjectIndicatorBaselineTarget(
+          projectIndicatorId = projectIndicatorNotPublishableId,
+          baseline = 30,
+          endTarget = 300,
+          // Not expected to be published because the indicator is not publishable
+      )
+      insertCommonIndicatorBaselineTarget(
+          commonIndicatorId = commonIndicatorId1,
+          baseline = 5,
+          endTarget = 50,
+      )
+      insertCommonIndicatorBaselineTarget(
+          commonIndicatorId = commonIndicatorNullValueId,
+          baseline = null,
+          endTarget = 15,
+      )
+      insertAutoCalculatedIndicatorBaselineTarget(
+          indicator = AutoCalculatedIndicator.Seedlings,
+          baseline = 25,
+          endTarget = 250,
+      )
     }
 
     @Test
@@ -4464,12 +4500,10 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
           progressNotes = "Existing progress notes",
           projectsComments = "Existing underperformance justification",
       )
-
       insertPublishedReportCommonIndicator(
           indicatorId = commonIndicatorNullValueId,
           value = 100,
       )
-
       insertPublishedReportCommonIndicator(
           indicatorId = commonIndicatorNotPublishableId,
           value = 100,
@@ -4481,13 +4515,11 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
           progressNotes = "Existing progress notes",
           projectsComments = "Existing underperformance justification",
       )
-
       insertPublishedReportProjectIndicator(
           indicatorId = projectIndicatorId2,
           value = 100,
           projectsComments = "Existing underperformance justification",
       )
-
       insertPublishedReportProjectIndicator(
           indicatorId = projectIndicatorNotPublishableId,
           value = 100,
@@ -4497,18 +4529,32 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
           indicator = AutoCalculatedIndicator.SeedsCollected,
           value = 100,
       )
-
       insertPublishedReportAutoCalculatedIndicator(
           indicator = AutoCalculatedIndicator.Seedlings,
           value = 100,
           progressNotes = "Existing progress notes",
           projectsComments = "Existing underperformance justification",
       )
-
       insertPublishedReportAutoCalculatedIndicator(
           indicator = AutoCalculatedIndicator.TreesPlanted,
           value = 100,
           projectsComments = "Existing underperformance justification",
+      )
+
+      insertPublishedProjectIndicatorBaseline(
+          projectIndicatorId = projectIndicatorId1,
+          baseline = 999,
+          endTarget = 9999,
+      )
+      insertPublishedCommonIndicatorBaseline(
+          commonIndicatorId = commonIndicatorId1,
+          baseline = 999,
+          endTarget = 9999,
+      )
+      insertPublishedAutoCalculatedIndicatorBaseline(
+          indicator = AutoCalculatedIndicator.Seedlings,
+          baseline = 999,
+          endTarget = 9999,
       )
 
       insertPublishedReportPhoto(
@@ -4761,6 +4807,54 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
               ),
           ),
           "Published auto calculated indicator targets table",
+      )
+
+      assertTableEquals(
+          listOf(
+              PublishedProjectIndicatorBaselinesRecord(
+                  projectId = projectId,
+                  projectIndicatorId = projectIndicatorId1,
+                  baseline = BigDecimal(10),
+                  endTarget = BigDecimal(100),
+              ),
+              PublishedProjectIndicatorBaselinesRecord(
+                  projectId = projectId,
+                  projectIndicatorId = projectIndicatorId2,
+                  baseline = BigDecimal(20),
+                  endTarget = BigDecimal(200),
+              ),
+          ),
+          "Published project indicator baselines table",
+      )
+
+      assertTableEquals(
+          listOf(
+              PublishedCommonIndicatorBaselinesRecord(
+                  projectId = projectId,
+                  commonIndicatorId = commonIndicatorId1,
+                  baseline = BigDecimal(5),
+                  endTarget = BigDecimal(50),
+              ),
+              PublishedCommonIndicatorBaselinesRecord(
+                  projectId = projectId,
+                  commonIndicatorId = commonIndicatorNullValueId,
+                  baseline = null,
+                  endTarget = BigDecimal(15),
+              ),
+          ),
+          "Published common indicator baselines table",
+      )
+
+      assertTableEquals(
+          listOf(
+              PublishedAutoCalculatedIndicatorBaselinesRecord(
+                  projectId = projectId,
+                  autoCalculatedIndicatorId = AutoCalculatedIndicator.Seedlings,
+                  baseline = BigDecimal(25),
+                  endTarget = BigDecimal(250),
+              ),
+          ),
+          "Published auto calculated indicator baselines table",
       )
     }
   }

--- a/src/test/kotlin/com/terraformation/backend/db/DatabaseBackedTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/db/DatabaseBackedTest.kt
@@ -318,10 +318,13 @@ import com.terraformation.backend.db.funder.tables.daos.FundingEntityProjectsDao
 import com.terraformation.backend.db.funder.tables.daos.FundingEntityUsersDao
 import com.terraformation.backend.db.funder.tables.daos.PublishedActivitiesDao
 import com.terraformation.backend.db.funder.tables.daos.PublishedActivityMediaFilesDao
+import com.terraformation.backend.db.funder.tables.daos.PublishedAutoCalculatedIndicatorBaselinesDao
 import com.terraformation.backend.db.funder.tables.daos.PublishedAutoCalculatedIndicatorTargetsDao
+import com.terraformation.backend.db.funder.tables.daos.PublishedCommonIndicatorBaselinesDao
 import com.terraformation.backend.db.funder.tables.daos.PublishedCommonIndicatorTargetsDao
 import com.terraformation.backend.db.funder.tables.daos.PublishedProjectCarbonCertsDao
 import com.terraformation.backend.db.funder.tables.daos.PublishedProjectDetailsDao
+import com.terraformation.backend.db.funder.tables.daos.PublishedProjectIndicatorBaselinesDao
 import com.terraformation.backend.db.funder.tables.daos.PublishedProjectIndicatorTargetsDao
 import com.terraformation.backend.db.funder.tables.daos.PublishedProjectLandUseDao
 import com.terraformation.backend.db.funder.tables.daos.PublishedProjectSdgDao
@@ -334,10 +337,13 @@ import com.terraformation.backend.db.funder.tables.pojos.FundingEntityProjectsRo
 import com.terraformation.backend.db.funder.tables.pojos.FundingEntityUsersRow
 import com.terraformation.backend.db.funder.tables.pojos.PublishedActivitiesRow
 import com.terraformation.backend.db.funder.tables.pojos.PublishedActivityMediaFilesRow
+import com.terraformation.backend.db.funder.tables.pojos.PublishedAutoCalculatedIndicatorBaselinesRow
 import com.terraformation.backend.db.funder.tables.pojos.PublishedAutoCalculatedIndicatorTargetsRow
+import com.terraformation.backend.db.funder.tables.pojos.PublishedCommonIndicatorBaselinesRow
 import com.terraformation.backend.db.funder.tables.pojos.PublishedCommonIndicatorTargetsRow
 import com.terraformation.backend.db.funder.tables.pojos.PublishedProjectCarbonCertsRow
 import com.terraformation.backend.db.funder.tables.pojos.PublishedProjectDetailsRow
+import com.terraformation.backend.db.funder.tables.pojos.PublishedProjectIndicatorBaselinesRow
 import com.terraformation.backend.db.funder.tables.pojos.PublishedProjectIndicatorTargetsRow
 import com.terraformation.backend.db.funder.tables.pojos.PublishedProjectLandUseRow
 import com.terraformation.backend.db.funder.tables.pojos.PublishedProjectSdgRow
@@ -707,12 +713,19 @@ abstract class DatabaseBackedTest {
   protected val projectVotesDao: ProjectVotesDao by lazyDao()
   protected val publishedActivitiesDao: PublishedActivitiesDao by lazyDao()
   protected val publishedActivityMediaFilesDao: PublishedActivityMediaFilesDao by lazyDao()
+  protected val publishedAutoCalculatedIndicatorBaselinesDao:
+      PublishedAutoCalculatedIndicatorBaselinesDao by
+      lazyDao()
   protected val publishedAutoCalculatedIndicatorTargetsDao:
       PublishedAutoCalculatedIndicatorTargetsDao by
+      lazyDao()
+  protected val publishedCommonIndicatorBaselinesDao: PublishedCommonIndicatorBaselinesDao by
       lazyDao()
   protected val publishedCommonIndicatorTargetsDao: PublishedCommonIndicatorTargetsDao by lazyDao()
   protected val publishedProjectCarbonCertsDao: PublishedProjectCarbonCertsDao by lazyDao()
   protected val publishedProjectDetailsDao: PublishedProjectDetailsDao by lazyDao()
+  protected val publishedProjectIndicatorBaselinesDao: PublishedProjectIndicatorBaselinesDao by
+      lazyDao()
   protected val publishedProjectLandUseDao: PublishedProjectLandUseDao by lazyDao()
   protected val publishedProjectSdgDao: PublishedProjectSdgDao by lazyDao()
   protected val publishedReportAutoCalculatedIndicatorsDao:
@@ -3904,6 +3917,63 @@ abstract class DatabaseBackedTest {
         )
 
     autoCalculatedIndicatorTargetsDao.insert(rowWithDefaults)
+  }
+
+  protected fun insertPublishedProjectIndicatorBaseline(
+      row: PublishedProjectIndicatorBaselinesRow = PublishedProjectIndicatorBaselinesRow(),
+      projectId: ProjectId = row.projectId ?: inserted.projectId,
+      projectIndicatorId: ProjectIndicatorId =
+          row.projectIndicatorId ?: inserted.projectIndicatorId,
+      baseline: Number? = row.baseline,
+      endTarget: Number? = row.endTarget,
+  ) {
+    val rowWithDefaults =
+        row.copy(
+            projectId = projectId,
+            projectIndicatorId = projectIndicatorId,
+            baseline = baseline?.toBigDecimal(),
+            endTarget = endTarget?.toBigDecimal(),
+        )
+
+    publishedProjectIndicatorBaselinesDao.insert(rowWithDefaults)
+  }
+
+  protected fun insertPublishedCommonIndicatorBaseline(
+      row: PublishedCommonIndicatorBaselinesRow = PublishedCommonIndicatorBaselinesRow(),
+      projectId: ProjectId = row.projectId ?: inserted.projectId,
+      commonIndicatorId: CommonIndicatorId = row.commonIndicatorId ?: inserted.commonIndicatorId,
+      baseline: Number? = row.baseline,
+      endTarget: Number? = row.endTarget,
+  ) {
+    val rowWithDefaults =
+        row.copy(
+            projectId = projectId,
+            commonIndicatorId = commonIndicatorId,
+            baseline = baseline?.toBigDecimal(),
+            endTarget = endTarget?.toBigDecimal(),
+        )
+
+    publishedCommonIndicatorBaselinesDao.insert(rowWithDefaults)
+  }
+
+  protected fun insertPublishedAutoCalculatedIndicatorBaseline(
+      row: PublishedAutoCalculatedIndicatorBaselinesRow =
+          PublishedAutoCalculatedIndicatorBaselinesRow(),
+      projectId: ProjectId = row.projectId ?: inserted.projectId,
+      indicator: AutoCalculatedIndicator =
+          row.autoCalculatedIndicatorId ?: AutoCalculatedIndicator.SeedsCollected,
+      baseline: Number? = row.baseline,
+      endTarget: Number? = row.endTarget,
+  ) {
+    val rowWithDefaults =
+        row.copy(
+            projectId = projectId,
+            autoCalculatedIndicatorId = indicator,
+            baseline = baseline?.toBigDecimal(),
+            endTarget = endTarget?.toBigDecimal(),
+        )
+
+    publishedAutoCalculatedIndicatorBaselinesDao.insert(rowWithDefaults)
   }
 
   protected fun insertPublishedReport(


### PR DESCRIPTION
Baseline and End-of-Project Target values are per-project and publishable, but there won't be a separate interaction for publishing these. Instead, publish these values anytime a report is published for that project.