### PR TITLE
SW-8093 Retrieve previous year cumulative totals for published reports

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/funder/api/FunderReportsController.kt
+++ b/src/main/kotlin/com/terraformation/backend/funder/api/FunderReportsController.kt
@@ -124,6 +124,11 @@ data class PublishedReportIndicatorPayload(
     val endOfProjectTarget: BigDecimal?,
     val level: IndicatorLevel,
     val name: String,
+    @Schema(
+        description =
+            "If the indicator is cumulative, the cumulative total at the end of the previous year"
+    )
+    val previousYearCumulativeTotal: BigDecimal?,
     val progressNotes: String?,
     val projectsComments: String?,
     val refId: String,
@@ -142,6 +147,7 @@ data class PublishedReportIndicatorPayload(
       endOfProjectTarget = model.endOfProjectTarget,
       level = model.level,
       name = model.name,
+      previousYearCumulativeTotal = model.previousYearCumulativeTotal,
       progressNotes = model.progressNotes,
       projectsComments = model.projectsComments,
       refId = model.refId,

--- a/src/main/kotlin/com/terraformation/backend/funder/db/PublishedReportStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/funder/db/PublishedReportStore.kt
@@ -4,6 +4,7 @@ import com.terraformation.backend.accelerator.model.ReportChallengeModel
 import com.terraformation.backend.accelerator.model.ReportPhotoModel
 import com.terraformation.backend.customer.model.requirePermissions
 import com.terraformation.backend.db.accelerator.IndicatorCategoryConverter
+import com.terraformation.backend.db.accelerator.IndicatorClass
 import com.terraformation.backend.db.accelerator.IndicatorClassConverter
 import com.terraformation.backend.db.accelerator.IndicatorLevelConverter
 import com.terraformation.backend.db.accelerator.ReportIdConverter
@@ -12,6 +13,10 @@ import com.terraformation.backend.db.accelerator.tables.references.AUTO_CALCULAT
 import com.terraformation.backend.db.accelerator.tables.references.COMMON_INDICATORS
 import com.terraformation.backend.db.accelerator.tables.references.PROJECT_ACCELERATOR_DETAILS
 import com.terraformation.backend.db.accelerator.tables.references.PROJECT_INDICATORS
+import com.terraformation.backend.db.accelerator.tables.references.REPORTS
+import com.terraformation.backend.db.accelerator.tables.references.REPORT_AUTO_CALCULATED_INDICATORS
+import com.terraformation.backend.db.accelerator.tables.references.REPORT_COMMON_INDICATORS
+import com.terraformation.backend.db.accelerator.tables.references.REPORT_PROJECT_INDICATORS
 import com.terraformation.backend.db.asNonNullable
 import com.terraformation.backend.db.default_schema.ProjectId
 import com.terraformation.backend.db.default_schema.ProjectIdConverter
@@ -122,6 +127,7 @@ class PublishedReportStore(
       publishedIndicatorIdField: TableField<*, ID?>,
       targetTableIndicatorIdField: TableField<*, ID?>,
       baselineTableIndicatorIdField: TableField<*, ID?>,
+      reportTableIndicatorIdField: TableField<*, ID?>,
   ): Field<List<PublishedReportIndicatorModel<ID>>> {
     val publishedIndicatorTable = publishedIndicatorIdField.table!!
     val reportIdField =
@@ -158,6 +164,11 @@ class PublishedReportStore(
     val endTargetField = baselineTable.field("end_target", BigDecimal::class.java)!!
 
     val indicatorTable = indicatorTableIdField.table!!
+    val indicatorClassIdField =
+        indicatorTable.field(
+            "class_id",
+            SQLDataType.INTEGER.asConvertedDataType(IndicatorClassConverter()),
+        )!!
     val indicatorCategoryField =
         indicatorTable.field(
             "category_id",
@@ -178,6 +189,31 @@ class PublishedReportStore(
         )!!
     val unitField = indicatorTable.field("unit", String::class.java) ?: DSL.value(null as String?)
 
+    val reportIndicatorTable = reportTableIndicatorIdField.table!!
+    val reportIndicatorReportField =
+        reportIndicatorTable.field(
+            "report_id",
+            SQLDataType.BIGINT.asConvertedDataType(ReportIdConverter()),
+        )!!
+    val reportValueField =
+        reportIndicatorTable.field("value", Int::class.java)
+            ?: DSL.coalesce(
+                reportIndicatorTable.field("override_value", Int::class.java)!!,
+                reportIndicatorTable.field("system_value", Int::class.java)!!,
+            )
+    val reportsForSum = REPORTS.`as`("reportsForSum")
+    val sumAtPreviousYearEnd =
+        DSL.`when`(
+            indicatorClassIdField.eq(IndicatorClass.Cumulative),
+            DSL.select(DSL.sum(reportValueField))
+                .from(reportIndicatorTable)
+                .join(reportsForSum)
+                .on(reportsForSum.ID.eq(reportIndicatorReportField))
+                .where(DSL.year(reportsForSum.END_DATE).lt(DSL.year(PUBLISHED_REPORTS.END_DATE)))
+                .and(reportsForSum.PROJECT_ID.eq(PUBLISHED_REPORTS.PROJECT_ID))
+                .and(reportTableIndicatorIdField.eq(indicatorTableIdField)),
+        )
+
     return DSL.multiset(
             DSL.select(
                     progressNotesField,
@@ -195,6 +231,7 @@ class PublishedReportStore(
                     unitField,
                     baselineField,
                     endTargetField,
+                    sumAtPreviousYearEnd,
                 )
                 .from(publishedIndicatorTable)
                 .join(indicatorTable)
@@ -220,6 +257,7 @@ class PublishedReportStore(
                 indicatorId = it[publishedIndicatorIdField.asNonNullable()],
                 level = it[indicatorTypeField],
                 name = it[indicatorNameField],
+                previousYearCumulativeTotal = it[sumAtPreviousYearEnd],
                 progressNotes = it[progressNotesField],
                 projectsComments = it[projectsCommentsField],
                 refId = it[indicatorReferenceField],
@@ -250,6 +288,7 @@ class PublishedReportStore(
           PUBLISHED_REPORT_PROJECT_INDICATORS.PROJECT_INDICATOR_ID,
           PUBLISHED_PROJECT_INDICATOR_TARGETS.PROJECT_INDICATOR_ID,
           PUBLISHED_PROJECT_INDICATOR_BASELINES.PROJECT_INDICATOR_ID,
+          REPORT_PROJECT_INDICATORS.PROJECT_INDICATOR_ID,
       )
 
   private val commonIndicatorsMultiset =
@@ -258,6 +297,7 @@ class PublishedReportStore(
           PUBLISHED_REPORT_COMMON_INDICATORS.COMMON_INDICATOR_ID,
           PUBLISHED_COMMON_INDICATOR_TARGETS.COMMON_INDICATOR_ID,
           PUBLISHED_COMMON_INDICATOR_BASELINES.COMMON_INDICATOR_ID,
+          REPORT_COMMON_INDICATORS.COMMON_INDICATOR_ID,
       )
 
   private val autoCalculatedIndicatorsMultiset =
@@ -266,5 +306,6 @@ class PublishedReportStore(
           PUBLISHED_REPORT_AUTO_CALCULATED_INDICATORS.AUTO_CALCULATED_INDICATOR_ID,
           PUBLISHED_AUTO_CALCULATED_INDICATOR_TARGETS.AUTO_CALCULATED_INDICATOR_ID,
           PUBLISHED_AUTO_CALCULATED_INDICATOR_BASELINES.AUTO_CALCULATED_INDICATOR_ID,
+          REPORT_AUTO_CALCULATED_INDICATORS.AUTO_CALCULATED_INDICATOR_ID,
       )
 }

--- a/src/main/kotlin/com/terraformation/backend/funder/db/PublishedReportStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/funder/db/PublishedReportStore.kt
@@ -164,11 +164,6 @@ class PublishedReportStore(
     val endTargetField = baselineTable.field("end_target", BigDecimal::class.java)!!
 
     val indicatorTable = indicatorTableIdField.table!!
-    val indicatorClassIdField =
-        indicatorTable.field(
-            "class_id",
-            SQLDataType.INTEGER.asConvertedDataType(IndicatorClassConverter()),
-        )!!
     val indicatorCategoryField =
         indicatorTable.field(
             "category_id",
@@ -204,7 +199,7 @@ class PublishedReportStore(
     val reportsForSum = REPORTS.`as`("reportsForSum")
     val sumAtPreviousYearEnd =
         DSL.`when`(
-            indicatorClassIdField.eq(IndicatorClass.Cumulative),
+            indicatorClassField.eq(IndicatorClass.Cumulative),
             DSL.select(DSL.sum(reportValueField))
                 .from(reportIndicatorTable)
                 .join(reportsForSum)

--- a/src/main/kotlin/com/terraformation/backend/funder/model/PublishedReportIndicatorModel.kt
+++ b/src/main/kotlin/com/terraformation/backend/funder/model/PublishedReportIndicatorModel.kt
@@ -15,6 +15,7 @@ data class PublishedReportIndicatorModel<ID : Any>(
     val indicatorId: ID,
     val level: IndicatorLevel,
     val name: String,
+    val previousYearCumulativeTotal: BigDecimal? = null,
     val progressNotes: String?,
     val projectsComments: String?,
     val refId: String,

--- a/src/test/kotlin/com/terraformation/backend/funder/db/PublishedReportStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/funder/db/PublishedReportStoreTest.kt
@@ -95,6 +95,29 @@ class PublishedReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
       insertProjectAcceleratorDetails(dealName = dealName)
       insertProjectReportConfig()
 
+      // oldReport1
+      insertReport(endDate = LocalDate.of(2024, 9, 30))
+      insertReportProjectIndicator(indicatorId = projectIndicatorId1, value = 10)
+      insertReportProjectIndicator(indicatorId = projectIndicatorId2, value = 11)
+      insertReportCommonIndicator(indicatorId = commonIndicatorId1, value = 20)
+      insertReportCommonIndicator(indicatorId = commonIndicatorId2, value = 21)
+      insertReportAutoCalculatedIndicator(
+          indicator = AutoCalculatedIndicator.SeedsCollected,
+          systemValue = 30,
+      )
+
+      // oldReport2
+      insertReport(endDate = LocalDate.of(2024, 12, 31))
+      insertReportProjectIndicator(indicatorId = projectIndicatorId1, value = 100)
+      insertReportProjectIndicator(indicatorId = projectIndicatorId2, value = 101)
+      insertReportCommonIndicator(indicatorId = commonIndicatorId1, value = 200)
+      insertReportCommonIndicator(indicatorId = commonIndicatorId2, value = 201)
+      insertReportAutoCalculatedIndicator(
+          indicator = AutoCalculatedIndicator.SeedsCollected,
+          systemValue = 29,
+          overrideValue = 31,
+      )
+
       val reportId1 =
           insertReport(
               startDate = LocalDate.of(2025, 1, 1),
@@ -264,10 +287,11 @@ class PublishedReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
                               level = AutoCalculatedIndicator.SeedsCollected.levelId,
                               name = AutoCalculatedIndicator.SeedsCollected.jsonValue,
                               refId = AutoCalculatedIndicator.SeedsCollected.refId,
-                              status = ReportIndicatorStatus.OffTrack,
-                              target = 6,
+                              previousYearCumulativeTotal = BigDecimal("61"),
                               progressNotes = null,
                               projectsComments = null,
+                              status = ReportIndicatorStatus.OffTrack,
+                              target = 6,
                               unit = "Seeds",
                               value = 6,
                           ),
@@ -288,13 +312,14 @@ class PublishedReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
                               indicatorId = commonIndicatorId2,
                               level = IndicatorLevel.Outcome,
                               name = "Common Indicator 2",
-                              refId = "1.1.1",
-                              target = 200,
-                              value = 180,
+                              previousYearCumulativeTotal = BigDecimal("222"),
                               progressNotes = "progress notes 2",
                               projectsComments = "Underperformance justification 2",
+                              refId = "1.1.1",
                               status = ReportIndicatorStatus.Unlikely,
+                              target = 200,
                               unit = null,
+                              value = 180,
                           ),
                           PublishedReportIndicatorModel(
                               category = IndicatorCategory.Climate,
@@ -304,11 +329,12 @@ class PublishedReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
                               indicatorId = commonIndicatorId1,
                               level = IndicatorLevel.Output,
                               name = "Common Indicator 1",
-                              status = ReportIndicatorStatus.Achieved,
-                              refId = "1.1.2",
-                              target = 100,
+                              previousYearCumulativeTotal = BigDecimal("220"),
                               progressNotes = null,
                               projectsComments = null,
+                              refId = "1.1.2",
+                              status = ReportIndicatorStatus.Achieved,
+                              target = 100,
                               unit = null,
                               value = 120,
                           ),
@@ -333,11 +359,12 @@ class PublishedReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
                               indicatorId = projectIndicatorId1,
                               level = IndicatorLevel.Output,
                               name = "Project Indicator 1",
+                              previousYearCumulativeTotal = BigDecimal("110"),
+                              progressNotes = "progress notes 1",
+                              projectsComments = null,
                               refId = "1.2.1",
                               status = ReportIndicatorStatus.OnTrack,
                               target = null,
-                              progressNotes = "progress notes 1",
-                              projectsComments = null,
                               unit = "%",
                               value = 40,
                           ),
@@ -350,11 +377,12 @@ class PublishedReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
                               indicatorId = projectIndicatorId2,
                               level = IndicatorLevel.Outcome,
                               name = "Project Indicator 2",
+                              previousYearCumulativeTotal = BigDecimal("112"),
+                              progressNotes = null,
+                              projectsComments = null,
                               refId = "1.2.11",
                               status = null,
                               target = null,
-                              progressNotes = null,
-                              projectsComments = null,
                               unit = "USD",
                               value = null,
                           ),

--- a/src/test/kotlin/com/terraformation/backend/funder/db/PublishedReportStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/funder/db/PublishedReportStoreTest.kt
@@ -52,7 +52,7 @@ class PublishedReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
       val commonIndicatorId1 =
           insertCommonIndicator(
               category = IndicatorCategory.Climate,
-              classId = IndicatorClass.Level,
+              classId = IndicatorClass.Cumulative,
               description = "Common Indicator Description 1",
               name = "Common Indicator 1",
               refId = "1.1.2",
@@ -72,7 +72,7 @@ class PublishedReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
       val projectIndicatorId1 =
           insertProjectIndicator(
               category = IndicatorCategory.Biodiversity,
-              classId = IndicatorClass.Level,
+              classId = IndicatorClass.Cumulative,
               description = "Project Indicator Description 1",
               name = "Project Indicator 1",
               refId = "1.2.1",
@@ -323,7 +323,7 @@ class PublishedReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
                           ),
                           PublishedReportIndicatorModel(
                               category = IndicatorCategory.Climate,
-                              classId = IndicatorClass.Level,
+                              classId = IndicatorClass.Cumulative,
                               description = "Common Indicator Description 1",
                               endOfProjectTarget = null,
                               indicatorId = commonIndicatorId1,
@@ -353,7 +353,7 @@ class PublishedReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
                           PublishedReportIndicatorModel(
                               baseline = null,
                               category = IndicatorCategory.Biodiversity,
-                              classId = IndicatorClass.Level,
+                              classId = IndicatorClass.Cumulative,
                               description = "Project Indicator Description 1",
                               endOfProjectTarget = null,
                               indicatorId = projectIndicatorId1,


### PR DESCRIPTION
Cumulative indicators in published reports will use un-published numbers for values from previous quarters. This is because a report could have been published, then updated, then a later quarter's report published. In the later report we want it to include the most accurate data, so will use the unpublished value instead. Ideally reports will always re-publish after making changes, but that is a separate issue and not required. 

Add the previous year sum by summing all quarters' (unpublished) actuals prior to the current report's quarter. The unpublished values may or may not match their published counterparts.