### PR TITLE
SW-8022 Always assign new plot to replace permanent one

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/tracking/ObservationService.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/ObservationService.kt
@@ -534,72 +534,84 @@ class ObservationService(
       log.info("Replacing monitoring plot $monitoringPlotId in observation $observationId")
 
       if (observationPlot.model.isPermanent) {
-        val isFirstObservation =
-            observationStore.fetchObservationsByPlantingSite(observation.plantingSiteId).none {
-              it.state == ObservationState.Completed
-            }
-        val observationHasResults = observationPlots.any { it.model.completedTime != null }
-
-        if (isFirstObservation && !observationHasResults) {
-          val replacementResult = plantingSiteStore.replacePermanentIndex(monitoringPlotId)
-
-          if (duration == ReplacementDuration.LongTerm) {
-            plantingSiteStore.makePlotUnavailable(monitoringPlotId)
-          }
-
-          // At this point we will usually have replaced the plot with a new one in a random place
-          // in the stratum that hasn't been used in an observation yet.
-          //
-          // If this is the first observation, there's a good chance that there are still substrata
-          // that haven't completed planting, and a chance that the replacement plot be in one of
-          // the incomplete substrata. In that case, we want the same behavior as during initial
-          // permanent plot selection: the plot is excluded from the observation even if that means
-          // the observation has fewer than the configured number of permanent plots.
-          val addedPlotsInRequestedSubstrata =
-              if (replacementResult.addedMonitoringPlotIds.isNotEmpty()) {
-                val substrata =
-                    stratum.substrata.filter { substratum ->
-                      substratum.monitoringPlots.any {
-                        it.id in replacementResult.addedMonitoringPlotIds
-                      }
-                    }
-                if (substrata.all { it.id in observation.requestedSubstratumIds }) {
-                  log.info(
-                      "Replacement permanent plot is in a substratum that has completed planting; " +
-                          "including the plot in this observation."
-                  )
-                  replacementResult.addedMonitoringPlotIds
-                } else {
-                  log.info(
-                      "Replacement permanent plot is in a substratum that has not completed " +
-                          "planting; not including it in this observation."
-                  )
-                  emptySet()
-                }
-              } else {
-                emptySet()
-              }
-
-          observationStore.removePlotsFromObservation(
-              observationId,
-              replacementResult.removedMonitoringPlotIds,
-          )
-          removedPlotIds.addAll(replacementResult.removedMonitoringPlotIds)
-
-          if (addedPlotsInRequestedSubstrata.isNotEmpty()) {
-            observationStore.addPlotsToObservation(
-                observationId,
-                addedPlotsInRequestedSubstrata,
-                isPermanent = true,
+        when (duration) {
+          ReplacementDuration.LongTerm -> {
+            log.info(
+                "Permanent plot being replaced long-term; assigning a new permanent plot and " +
+                    "removing the original from the available pool."
             )
-            addedPlotIds.addAll(addedPlotsInRequestedSubstrata)
+
+            // replacePermanentIndex must be called before removing the plot from the observation
+            // so that it still appears as "previously used" in the DB query that selects an
+            // unused permanent index.
+            val replacementResult = plantingSiteStore.replacePermanentIndex(monitoringPlotId)
+
+            observationStore.removePlotsFromObservation(observationId, listOf(monitoringPlotId))
+
+            plantingSiteStore.makePlotUnavailable(monitoringPlotId)
+
+            if (replacementResult.addedMonitoringPlotIds.isNotEmpty()) {
+              val substrata =
+                  stratum.substrata.filter { substratum ->
+                    substratum.monitoringPlots.any {
+                      it.id in replacementResult.addedMonitoringPlotIds
+                    }
+                  }
+              if (substrata.all { it.id in observation.requestedSubstratumIds }) {
+                log.info(
+                    "Replacement permanent plot is in a requested substratum; " +
+                        "including it in this observation."
+                )
+                observationStore.addPlotsToObservation(
+                    observationId,
+                    replacementResult.addedMonitoringPlotIds,
+                    isPermanent = true,
+                )
+                addedPlotIds.addAll(replacementResult.addedMonitoringPlotIds)
+              } else {
+                log.info(
+                    "Replacement permanent plot is not in a requested substratum; " +
+                        "not including it in this observation."
+                )
+              }
+            }
           }
-        } else {
-          log.info(
-              "Permanent plot at a site that already has observation data; removing it from this " +
-                  "observation but it may be included in future ones."
-          )
-          observationStore.removePlotsFromObservation(observationId, listOf(monitoringPlotId))
+          ReplacementDuration.Temporary -> {
+            log.info(
+                "Permanent plot being replaced temporarily; assigning a temporary substitute " +
+                    "for this observation. The permanent plot remains available for future observations."
+            )
+            observationStore.removePlotsFromObservation(observationId, listOf(monitoringPlotId))
+
+            val replacementPlotBoundary =
+                stratum
+                    .findUnusedSquares(
+                        count = 1,
+                        excludePlotIds = observationPlotIds,
+                        exclusion = plantingSite.exclusion,
+                        gridOrigin = gridOrigin,
+                        searchBoundary = substratum.boundary,
+                    )
+                    .firstOrNull()
+
+            if (replacementPlotBoundary != null) {
+              val replacementPlotId =
+                  plantingSiteStore.createTemporaryPlot(
+                      plantingSite.id,
+                      stratum.id,
+                      replacementPlotBoundary,
+                  )
+              log.info("Adding temporary replacement plot $replacementPlotId")
+              addedPlotIds.add(replacementPlotId)
+              observationStore.addPlotsToObservation(
+                  observationId,
+                  listOf(replacementPlotId),
+                  isPermanent = false,
+              )
+            } else {
+              log.info("No temporary plots available in substratum for replacement")
+            }
+          }
         }
       } else {
         observationStore.removePlotsFromObservation(observationId, listOf(monitoringPlotId))

--- a/src/main/kotlin/com/terraformation/backend/tracking/ObservationService.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/ObservationService.kt
@@ -550,9 +550,14 @@ class ObservationService(
 
             plantingSiteStore.makePlotUnavailable(monitoringPlotId)
 
+            val plantingSiteWithReplacedPlot =
+                plantingSiteStore.fetchSiteById(observation.plantingSiteId, PlantingSiteDepth.Plot)
+            val stratumWithReplacedPlot =
+                plantingSiteWithReplacedPlot.strata.first { it.id == stratum.id }
+
             if (replacementResult.addedMonitoringPlotIds.isNotEmpty()) {
               val substrata =
-                  stratum.substrata.filter { substratum ->
+                  stratumWithReplacedPlot.substrata.filter { substratum ->
                     substratum.monitoringPlots.any {
                       it.id in replacementResult.addedMonitoringPlotIds
                     }

--- a/src/test/kotlin/com/terraformation/backend/tracking/ObservationServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/ObservationServiceTest.kt
@@ -2147,6 +2147,40 @@ class ObservationServiceTest : DatabaseTest(), RunsAsDatabaseUser {
     }
 
     @Test
+    fun `does not include newly-created plot in observation if it is in an unrequested substratum`() {
+      insertStratum(numPermanentPlots = 2, width = 1, height = 2)
+      insertSubstratum(width = 1, height = 1)
+      insertObservationRequestedSubstratum()
+      val plotId1 = insertPermanentPlot(1, isPermanent = true)
+      val plotId2 = insertPermanentPlot(2, isPermanent = true)
+
+      insertSubstratum(y = 1, width = 1, height = 1)
+
+      val result =
+          service.replaceMonitoringPlot(
+              observationId,
+              plotId1,
+              "why not",
+              ReplacementDuration.LongTerm,
+          )
+
+      assertEquals(
+          ReplacementResult(
+              addedMonitoringPlotIds = emptySet(),
+              removedMonitoringPlotIds = setOf(plotId1),
+          ),
+          result,
+      )
+
+      assertEquals(1, observationPlotsDao.findAll().size, "Number of plots in observation")
+      assertEquals(
+          2,
+          monitoringPlotsDao.fetchOneById(plotId2)!!.permanentIndex,
+          "Plot $plotId2 index should not have changed",
+      )
+    }
+
+    @Test
     fun `creates a new plot to replace permanent plot if duration is long-term`() {
       val plotId1 = insertPermanentPlot(1, isPermanent = true)
 

--- a/src/test/kotlin/com/terraformation/backend/tracking/ObservationServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/ObservationServiceTest.kt
@@ -2073,7 +2073,7 @@ class ObservationServiceTest : DatabaseTest(), RunsAsDatabaseUser {
     }
 
     @Test
-    fun `replaces permanent plot if this is the first observation and there are no completed plots`() {
+    fun `can reuse existing temporary plot as replacement permanent plot`() {
       insertStratum(numPermanentPlots = 1, width = 2, height = 4)
       insertSubstratum(width = 2, height = 4)
       insertObservationRequestedSubstratum()
@@ -2085,7 +2085,7 @@ class ObservationServiceTest : DatabaseTest(), RunsAsDatabaseUser {
               observationId,
               plotId1,
               "why not",
-              ReplacementDuration.Temporary,
+              ReplacementDuration.LongTerm,
           )
 
       assertEquals(
@@ -2096,15 +2096,15 @@ class ObservationServiceTest : DatabaseTest(), RunsAsDatabaseUser {
           result,
       )
 
+      val plot1Row = monitoringPlotsDao.fetchOneById(plotId1)!!
+
+      assertNull(plot1Row.permanentIndex, "Plot $plotId1 index")
+      assertFalse(plot1Row.isAvailable!!, "Plot $plotId1 available")
+
       assertEquals(
           1,
           monitoringPlotsDao.fetchOneById(plotId2)!!.permanentIndex,
           "Should have moved second permanent plot to first place",
-      )
-      assertNotEquals(
-          1,
-          monitoringPlotsDao.fetchOneById(plotId1)!!.permanentIndex,
-          "Plot $plotId1 index",
       )
     }
 
@@ -2123,7 +2123,7 @@ class ObservationServiceTest : DatabaseTest(), RunsAsDatabaseUser {
               observationId,
               plotId1,
               "why not",
-              ReplacementDuration.Temporary,
+              ReplacementDuration.LongTerm,
           )
 
       assertEquals(
@@ -2147,22 +2147,9 @@ class ObservationServiceTest : DatabaseTest(), RunsAsDatabaseUser {
     }
 
     @Test
-    fun `marks permanent plot as unavailable and swaps in a new one if this is the first observation and duration is long-term`() {
-      val plotId1 = insertPermanentPlot(1, isPermanent = true)
-      insertPermanentPlot(2)
-      insertPermanentPlot(3)
-
-      testPermanentPlotReplacement(plotId1)
-    }
-
-    @Test
-    fun `creates a new plot to replace permanent plot if this is the first observation and duration is long-term`() {
+    fun `creates a new plot to replace permanent plot if duration is long-term`() {
       val plotId1 = insertPermanentPlot(1, isPermanent = true)
 
-      testPermanentPlotReplacement(plotId1)
-    }
-
-    private fun testPermanentPlotReplacement(plotId1: MonitoringPlotId) {
       val result =
           service.replaceMonitoringPlot(
               observationId,
@@ -2192,44 +2179,7 @@ class ObservationServiceTest : DatabaseTest(), RunsAsDatabaseUser {
     }
 
     @Test
-    fun `removes permanent plot but keeps it available if this is the first observation and there are already completed plots`() {
-      val plotId1 = insertPermanentPlot(1)
-      val plotId2 = insertPermanentPlot(2)
-      insertObservationPlot(monitoringPlotId = plotId1, isPermanent = true)
-      insertObservationPlot(
-          monitoringPlotId = plotId2,
-          isPermanent = true,
-          claimedBy = user.userId,
-          claimedTime = Instant.EPOCH,
-          completedBy = user.userId,
-          completedTime = Instant.EPOCH,
-      )
-
-      val result =
-          service.replaceMonitoringPlot(
-              observationId,
-              plotId1,
-              "forest fire",
-              ReplacementDuration.LongTerm,
-          )
-
-      assertEquals(
-          ReplacementResult(
-              addedMonitoringPlotIds = emptySet(),
-              removedMonitoringPlotIds = setOf(plotId1),
-          ),
-          result,
-      )
-
-      assertEquals(
-          true,
-          monitoringPlotsDao.fetchOneById(plotId1)!!.isAvailable,
-          "Monitoring plot should remain available",
-      )
-    }
-
-    @Test
-    fun `removes permanent plot but keeps it available if this is not the first observation`() {
+    fun `assigns temporary replacement for permanent plot if duration is temporary`() {
       observationsDao.update(
           observationsDao
               .fetchOneById(inserted.observationId)!!
@@ -2237,6 +2187,7 @@ class ObservationServiceTest : DatabaseTest(), RunsAsDatabaseUser {
       )
 
       val newObservationId = insertObservation()
+      insertObservationRequestedSubstratum()
 
       val plotId1 = insertPermanentPlot(1, isPermanent = true)
 
@@ -2245,21 +2196,27 @@ class ObservationServiceTest : DatabaseTest(), RunsAsDatabaseUser {
               newObservationId,
               plotId1,
               "forest fire",
-              ReplacementDuration.LongTerm,
+              ReplacementDuration.Temporary,
           )
 
-      assertEquals(
-          ReplacementResult(
-              addedMonitoringPlotIds = emptySet(),
-              removedMonitoringPlotIds = setOf(plotId1),
-          ),
-          result,
+      assertSetEquals(setOf(plotId1), result.removedMonitoringPlotIds, "Removed plot IDs")
+      assertEquals(1, result.addedMonitoringPlotIds.size, "Number of replacement plot IDs added")
+
+      val plotId1Row = monitoringPlotsDao.fetchOneById(plotId1)!!
+      assertEquals(true, plotId1Row.isAvailable, "Original permanent plot should remain available")
+      assertEquals(1, plotId1Row.permanentIndex, "Permanent index should be unchanged")
+
+      val replacementId = result.addedMonitoringPlotIds.first()
+      assertNull(
+          monitoringPlotsDao.fetchOneById(replacementId)!!.permanentIndex,
+          "Replacement plot should not have a permanent index",
       )
 
-      assertEquals(
-          true,
-          monitoringPlotsDao.fetchOneById(plotId1)!!.isAvailable,
-          "Monitoring plot should remain available",
+      val allObsPlots = observationPlotsDao.findAll().associateBy { it.monitoringPlotId }
+      assertFalse(plotId1 in allObsPlots, "Original plot should not be in observation")
+      assertFalse(
+          allObsPlots[replacementId]!!.isPermanent!!,
+          "Replacement observation plot should not be marked as permanent",
       )
     }
 


### PR DESCRIPTION
Previously, if a user requested replacement of a permanent monitoring plot in an
observation, the system's behavior would differ depending on whether or not there
had been previous observations and whether or not the current observation already
had completed plots, and in some cases it would (by design) just remove the
requested plot without replacing it with anything.

We want to maintain the correct number of permanent plots even in the face of
replacements.

Simplify the implementation so that the old "first observation, no completed
plots" behavior always happens: the plot will be replaced with a new one and
the new plot will be added to the current observation.