### PR TITLE
SW-8093 Add current year progress to published report model and api

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/funder/api/FunderReportsController.kt
+++ b/src/main/kotlin/com/terraformation/backend/funder/api/FunderReportsController.kt
@@ -135,7 +135,7 @@ data class PublishedReportIndicatorPayload(
     val classId: IndicatorClass?,
     @Schema(
         description =
-            "If the indicator is cumulative, the list of actual values for all quarters in the" +
+            "If the indicator is cumulative, the list of actual values for all quarters in the " +
                 "report's year. Note that only the report's quarter will be a published value, the " +
                 "rest will be current values whether or not they are the same as their published " +
                 "counterparts."

--- a/src/main/kotlin/com/terraformation/backend/funder/api/FunderReportsController.kt
+++ b/src/main/kotlin/com/terraformation/backend/funder/api/FunderReportsController.kt
@@ -21,6 +21,7 @@ import com.terraformation.backend.db.default_schema.ProjectId
 import com.terraformation.backend.db.default_schema.UserId
 import com.terraformation.backend.funder.PublishedReportService
 import com.terraformation.backend.funder.db.PublishedReportStore
+import com.terraformation.backend.funder.model.PublishedCumulativeIndicatorProgressModel
 import com.terraformation.backend.funder.model.PublishedReportIndicatorModel
 import com.terraformation.backend.funder.model.PublishedReportModel
 import io.swagger.v3.oas.annotations.Operation
@@ -85,6 +86,18 @@ data class ReportChallengePayload(
     val mitigationPlan: String,
 )
 
+data class PublishedCumulativeIndicatorProgressPayload(
+    val quarter: ReportQuarter,
+    val value: Int,
+) {
+  constructor(
+      model: PublishedCumulativeIndicatorProgressModel
+  ) : this(
+      quarter = model.quarter,
+      value = model.value,
+  )
+}
+
 @Schema(description = "Use PublishedReportIndicatorPayload instead", deprecated = true)
 data class PublishedReportMetricPayload(
     val component: IndicatorCategory,
@@ -120,6 +133,14 @@ data class PublishedReportIndicatorPayload(
     val baseline: BigDecimal?,
     val category: IndicatorCategory,
     val classId: IndicatorClass?,
+    @Schema(
+        description =
+            "If the indicator is cumulative, the list of actual values for all quarters in the" +
+                "report's year. Note that only the report's quarter will be a published value, the " +
+                "rest will be current values whether or not they are the same as their published " +
+                "counterparts."
+    )
+    val currentYearProgress: List<PublishedCumulativeIndicatorProgressPayload>?,
     val description: String?,
     val endOfProjectTarget: BigDecimal?,
     val level: IndicatorLevel,
@@ -143,6 +164,8 @@ data class PublishedReportIndicatorPayload(
       baseline = model.baseline,
       category = model.category,
       classId = model.classId,
+      currentYearProgress =
+          model.currentYearProgress?.map { PublishedCumulativeIndicatorProgressPayload(it) },
       description = model.description,
       endOfProjectTarget = model.endOfProjectTarget,
       level = model.level,

--- a/src/main/kotlin/com/terraformation/backend/funder/db/PublishedReportStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/funder/db/PublishedReportStore.kt
@@ -219,18 +219,45 @@ class PublishedReportStore(
                 reportIndicatorsForProgress.field("override_value", Int::class.java)!!,
                 reportIndicatorsForProgress.field("system_value", Int::class.java)!!,
             )
+    val reportIdProgressField =
+        reportIndicatorsForProgress.field(
+            "report_id",
+            SQLDataType.BIGINT.asConvertedDataType(ReportIdConverter()),
+        )!!
+    val publishedIndicatorForProgress =
+        publishedIndicatorTable.`as`("publishedIndicatorForProgress")
+    val publishedReportIdForProgressField =
+        publishedIndicatorForProgress.field(
+            "report_id",
+            SQLDataType.BIGINT.asConvertedDataType(ReportIdConverter()),
+        )!!
+    val publishedIndicatorIdForProgress =
+        publishedIndicatorForProgress.field(publishedIndicatorIdField)!!
+    val publishedValueForProgress = publishedIndicatorForProgress.field("value", Int::class.java)!!
+    // For previous quarters, use the report value directly. For the current quarter, use the
+    // published value only (null if no published entry, which excludes it from the result).
+    val progressValue =
+        DSL.if_(
+            reportsForProgress.REPORT_QUARTER_ID.eq(PUBLISHED_REPORTS.REPORT_QUARTER_ID),
+            publishedValueForProgress,
+            indicatorValueProgressField,
+        )
+
     val currentYearProgressField: Field<List<PublishedCumulativeIndicatorProgressModel>> =
         DSL.multiset(
-                DSL.select(reportsForProgress.REPORT_QUARTER_ID, indicatorValueProgressField)
+                DSL.select(
+                        reportsForProgress.REPORT_QUARTER_ID,
+                        progressValue.`as`("progress_value"),
+                    )
                     .from(reportIndicatorsForProgress)
                     .join(reportsForProgress)
+                    .on(reportsForProgress.ID.eq(reportIdProgressField))
+                    .leftJoin(publishedIndicatorForProgress)
                     .on(
-                        reportsForProgress.ID.eq(
-                            reportIndicatorsForProgress.field(
-                                "report_id",
-                                SQLDataType.BIGINT.asConvertedDataType(ReportIdConverter()),
-                            )
-                        )
+                        publishedReportIdForProgressField
+                            .eq(reportIdProgressField)
+                            .and(publishedIndicatorIdForProgress.eq(indicatorTableIdField))
+                            .and(publishedReportIdForProgressField.eq(PUBLISHED_REPORTS.REPORT_ID))
                     )
                     .where(
                         DSL.year(reportsForProgress.END_DATE)
@@ -238,7 +265,7 @@ class PublishedReportStore(
                     )
                     .and(reportsForProgress.PROJECT_ID.eq(PUBLISHED_REPORTS.PROJECT_ID))
                     .and(indicatorIdForProgress.eq(indicatorTableIdField))
-                    .and(indicatorValueProgressField.isNotNull)
+                    .and(progressValue.isNotNull)
                     .and(
                         reportsForProgress.REPORT_QUARTER_ID.le(PUBLISHED_REPORTS.REPORT_QUARTER_ID)
                     )
@@ -248,16 +275,24 @@ class PublishedReportStore(
               results.map { record ->
                 PublishedCumulativeIndicatorProgressModel(
                     quarter = record[reportsForProgress.REPORT_QUARTER_ID]!!,
-                    value = record[indicatorValueProgressField]!!,
+                    value = record[DSL.field("progress_value", SQLDataType.INTEGER)]!!,
                 )
               }
             }
+
+    val reportIndicatorForReport = reportIndicatorTable.`as`("reportIndicatorForReport")
+    val repIndicatorIdForReport = reportIndicatorForReport.field(reportTableIndicatorIdField)!!
+    val repReportIdForReport =
+        reportIndicatorForReport.field(
+            "report_id",
+            SQLDataType.BIGINT.asConvertedDataType(ReportIdConverter()),
+        )!!
 
     return DSL.multiset(
             DSL.select(
                     progressNotesField,
                     projectsCommentsField,
-                    publishedIndicatorIdField,
+                    indicatorTableIdField,
                     indicatorCategoryField,
                     indicatorClassField,
                     indicatorDescriptionField,
@@ -273,17 +308,33 @@ class PublishedReportStore(
                     sumAtPreviousYearEnd,
                     currentYearProgressField,
                 )
-                .from(publishedIndicatorTable)
-                .join(indicatorTable)
-                .on(indicatorTableIdField.eq(publishedIndicatorIdField))
+                .from(indicatorTable)
+                .leftJoin(publishedIndicatorTable)
+                .on(
+                    publishedIndicatorIdField
+                        .eq(indicatorTableIdField)
+                        .and(reportIdField.eq(PUBLISHED_REPORTS.REPORT_ID))
+                )
+                .leftJoin(reportIndicatorForReport)
+                .on(
+                    repIndicatorIdForReport
+                        .eq(indicatorTableIdField)
+                        .and(repReportIdForReport.eq(PUBLISHED_REPORTS.REPORT_ID))
+                )
                 .leftJoin(targetTable)
-                .on(targetTableIndicatorIdField.eq(indicatorTableIdField))
-                .and(targetProjectIdField.eq(PUBLISHED_REPORTS.PROJECT_ID))
-                .and(targetYearField.eq(DSL.year(PUBLISHED_REPORTS.END_DATE)))
+                .on(
+                    targetTableIndicatorIdField
+                        .eq(indicatorTableIdField)
+                        .and(targetProjectIdField.eq(PUBLISHED_REPORTS.PROJECT_ID))
+                        .and(targetYearField.eq(DSL.year(PUBLISHED_REPORTS.END_DATE)))
+                )
                 .leftJoin(baselineTable)
-                .on(baselineTableIndicatorIdField.eq(indicatorTableIdField))
-                .and(baselineProjectIdField.eq(PUBLISHED_REPORTS.PROJECT_ID))
-                .where(reportIdField.eq(PUBLISHED_REPORTS.REPORT_ID))
+                .on(
+                    baselineTableIndicatorIdField
+                        .eq(indicatorTableIdField)
+                        .and(baselineProjectIdField.eq(PUBLISHED_REPORTS.PROJECT_ID))
+                )
+                .where(publishedIndicatorIdField.isNotNull.or(repIndicatorIdForReport.isNotNull))
                 .orderBy(indicatorReferenceField)
         )
         .convertFrom { result ->
@@ -295,7 +346,7 @@ class PublishedReportStore(
                 currentYearProgress = it[currentYearProgressField],
                 description = it[indicatorDescriptionField],
                 endOfProjectTarget = it[endTargetField],
-                indicatorId = it[publishedIndicatorIdField.asNonNullable()],
+                indicatorId = it[indicatorTableIdField.asNonNullable()],
                 level = it[indicatorTypeField],
                 name = it[indicatorNameField],
                 previousYearCumulativeTotal = it[sumAtPreviousYearEnd],

--- a/src/main/kotlin/com/terraformation/backend/funder/db/PublishedReportStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/funder/db/PublishedReportStore.kt
@@ -34,6 +34,7 @@ import com.terraformation.backend.db.funder.tables.references.PUBLISHED_REPORT_C
 import com.terraformation.backend.db.funder.tables.references.PUBLISHED_REPORT_COMMON_INDICATORS
 import com.terraformation.backend.db.funder.tables.references.PUBLISHED_REPORT_PHOTOS
 import com.terraformation.backend.db.funder.tables.references.PUBLISHED_REPORT_PROJECT_INDICATORS
+import com.terraformation.backend.funder.model.PublishedCumulativeIndicatorProgressModel
 import com.terraformation.backend.funder.model.PublishedReportIndicatorModel
 import com.terraformation.backend.funder.model.PublishedReportModel
 import jakarta.inject.Named
@@ -209,6 +210,46 @@ class PublishedReportStore(
                 .and(reportTableIndicatorIdField.eq(indicatorTableIdField)),
         )
 
+    val reportsForProgress = REPORTS.`as`("reportsForProgress")
+    val reportIndicatorsForProgress = reportIndicatorTable.`as`("reportIndicatorsForProgress")
+    val indicatorIdForProgress = reportIndicatorsForProgress.field(reportTableIndicatorIdField)!!
+    val indicatorValueProgressField =
+        reportIndicatorsForProgress.field("value", Int::class.java)
+            ?: DSL.coalesce(
+                reportIndicatorsForProgress.field("override_value", Int::class.java)!!,
+                reportIndicatorsForProgress.field("system_value", Int::class.java)!!,
+            )
+    val currentYearProgressField: Field<List<PublishedCumulativeIndicatorProgressModel>> =
+        DSL.multiset(
+                DSL.select(reportsForProgress.REPORT_QUARTER_ID, indicatorValueProgressField)
+                    .from(reportIndicatorsForProgress)
+                    .join(reportsForProgress)
+                    .on(
+                        reportsForProgress.ID.eq(
+                            reportIndicatorsForProgress.field(
+                                "report_id",
+                                SQLDataType.BIGINT.asConvertedDataType(ReportIdConverter()),
+                            )
+                        )
+                    )
+                    .where(
+                        DSL.year(reportsForProgress.END_DATE)
+                            .eq(DSL.year(PUBLISHED_REPORTS.END_DATE))
+                    )
+                    .and(reportsForProgress.PROJECT_ID.eq(PUBLISHED_REPORTS.PROJECT_ID))
+                    .and(indicatorIdForProgress.eq(indicatorTableIdField))
+                    .and(indicatorValueProgressField.isNotNull)
+                    .orderBy(reportsForProgress.REPORT_QUARTER_ID)
+            )
+            .convertFrom { results ->
+              results.map { record ->
+                PublishedCumulativeIndicatorProgressModel(
+                    quarter = record[reportsForProgress.REPORT_QUARTER_ID]!!,
+                    value = record[indicatorValueProgressField]!!,
+                )
+              }
+            }
+
     return DSL.multiset(
             DSL.select(
                     progressNotesField,
@@ -227,6 +268,7 @@ class PublishedReportStore(
                     baselineField,
                     endTargetField,
                     sumAtPreviousYearEnd,
+                    currentYearProgressField,
                 )
                 .from(publishedIndicatorTable)
                 .join(indicatorTable)
@@ -247,6 +289,7 @@ class PublishedReportStore(
                 baseline = it[baselineField],
                 category = it[indicatorCategoryField],
                 classId = it[indicatorClassField],
+                currentYearProgress = it[currentYearProgressField],
                 description = it[indicatorDescriptionField],
                 endOfProjectTarget = it[endTargetField],
                 indicatorId = it[publishedIndicatorIdField.asNonNullable()],

--- a/src/main/kotlin/com/terraformation/backend/funder/db/PublishedReportStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/funder/db/PublishedReportStore.kt
@@ -239,6 +239,9 @@ class PublishedReportStore(
                     .and(reportsForProgress.PROJECT_ID.eq(PUBLISHED_REPORTS.PROJECT_ID))
                     .and(indicatorIdForProgress.eq(indicatorTableIdField))
                     .and(indicatorValueProgressField.isNotNull)
+                    .and(
+                        reportsForProgress.REPORT_QUARTER_ID.le(PUBLISHED_REPORTS.REPORT_QUARTER_ID)
+                    )
                     .orderBy(reportsForProgress.REPORT_QUARTER_ID)
             )
             .convertFrom { results ->

--- a/src/main/kotlin/com/terraformation/backend/funder/model/PublishedReportIndicatorModel.kt
+++ b/src/main/kotlin/com/terraformation/backend/funder/model/PublishedReportIndicatorModel.kt
@@ -4,12 +4,19 @@ import com.terraformation.backend.db.accelerator.IndicatorCategory
 import com.terraformation.backend.db.accelerator.IndicatorClass
 import com.terraformation.backend.db.accelerator.IndicatorLevel
 import com.terraformation.backend.db.accelerator.ReportIndicatorStatus
+import com.terraformation.backend.db.accelerator.ReportQuarter
 import java.math.BigDecimal
+
+data class PublishedCumulativeIndicatorProgressModel(
+    val quarter: ReportQuarter,
+    val value: Int,
+)
 
 data class PublishedReportIndicatorModel<ID : Any>(
     val baseline: BigDecimal? = null,
     val category: IndicatorCategory,
     val classId: IndicatorClass?,
+    val currentYearProgress: List<PublishedCumulativeIndicatorProgressModel>? = null,
     val description: String?,
     val endOfProjectTarget: BigDecimal? = null,
     val indicatorId: ID,

--- a/src/test/kotlin/com/terraformation/backend/funder/db/PublishedReportStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/funder/db/PublishedReportStoreTest.kt
@@ -14,6 +14,7 @@ import com.terraformation.backend.db.accelerator.ReportIndicatorStatus
 import com.terraformation.backend.db.accelerator.ReportQuarter
 import com.terraformation.backend.db.default_schema.ProjectId
 import com.terraformation.backend.db.default_schema.UserType
+import com.terraformation.backend.funder.model.PublishedCumulativeIndicatorProgressModel
 import com.terraformation.backend.funder.model.PublishedReportIndicatorModel
 import com.terraformation.backend.funder.model.PublishedReportModel
 import java.math.BigDecimal
@@ -281,6 +282,7 @@ class PublishedReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
                               baseline = BigDecimal.valueOf(300),
                               classId = IndicatorClass.Cumulative,
                               category = AutoCalculatedIndicator.SeedsCollected.categoryId,
+                              currentYearProgress = emptyList(),
                               description = AutoCalculatedIndicator.SeedsCollected.description,
                               endOfProjectTarget = BigDecimal.valueOf(400),
                               indicatorId = AutoCalculatedIndicator.SeedsCollected,
@@ -307,6 +309,7 @@ class PublishedReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
                               baseline = BigDecimal.valueOf(200),
                               category = IndicatorCategory.Community,
                               classId = IndicatorClass.Cumulative,
+                              currentYearProgress = emptyList(),
                               description = "Common Indicator Description 2",
                               endOfProjectTarget = BigDecimal.valueOf(250),
                               indicatorId = commonIndicatorId2,
@@ -324,6 +327,7 @@ class PublishedReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
                           PublishedReportIndicatorModel(
                               category = IndicatorCategory.Climate,
                               classId = IndicatorClass.Cumulative,
+                              currentYearProgress = emptyList(),
                               description = "Common Indicator Description 1",
                               endOfProjectTarget = null,
                               indicatorId = commonIndicatorId1,
@@ -354,6 +358,7 @@ class PublishedReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
                               baseline = null,
                               category = IndicatorCategory.Biodiversity,
                               classId = IndicatorClass.Cumulative,
+                              currentYearProgress = emptyList(),
                               description = "Project Indicator Description 1",
                               endOfProjectTarget = null,
                               indicatorId = projectIndicatorId1,
@@ -372,6 +377,7 @@ class PublishedReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
                               baseline = BigDecimal.valueOf(210),
                               category = IndicatorCategory.ProjectObjectives,
                               classId = IndicatorClass.Cumulative,
+                              currentYearProgress = emptyList(),
                               description = "Project Indicator Description 2",
                               endOfProjectTarget = BigDecimal.valueOf(220),
                               indicatorId = projectIndicatorId2,
@@ -457,6 +463,7 @@ class PublishedReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
           PublishedReportIndicatorModel(
               category = IndicatorCategory.Biodiversity,
               classId = IndicatorClass.Level,
+              currentYearProgress = emptyList(),
               description = "Project Indicator Description",
               indicatorId = projectIndicatorId,
               level = IndicatorLevel.Output,
@@ -534,6 +541,7 @@ class PublishedReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
           PublishedReportIndicatorModel(
               category = IndicatorCategory.Climate,
               classId = IndicatorClass.Cumulative,
+              currentYearProgress = emptyList(),
               description = "Common Indicator Description",
               indicatorId = commonIndicatorId,
               level = IndicatorLevel.Output,
@@ -601,6 +609,7 @@ class PublishedReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
           PublishedReportIndicatorModel(
               category = AutoCalculatedIndicator.SurvivalRate.categoryId,
               classId = IndicatorClass.Level,
+              currentYearProgress = emptyList(),
               description = AutoCalculatedIndicator.SurvivalRate.description,
               indicatorId = AutoCalculatedIndicator.SurvivalRate,
               level = AutoCalculatedIndicator.SurvivalRate.levelId,
@@ -617,6 +626,236 @@ class PublishedReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
           listOf(expected),
           reports.single().autoCalculatedIndicators,
           "Other years and projects don't affect auto-calculated indicators",
+      )
+    }
+
+    @Test
+    fun `currentYearProgress contains only same-year quarters with non-null values`() {
+      insertFundingEntityProject()
+      insertProjectReportConfig()
+
+      val commonIndicatorId =
+          insertCommonIndicator(
+              category = IndicatorCategory.Climate,
+              classId = IndicatorClass.Cumulative,
+              description = "Cumulative Indicator Description",
+              name = "Cumulative Indicator",
+              refId = "1.1.1",
+              level = IndicatorLevel.Output,
+          )
+
+      // Prior year report — must NOT appear in currentYearProgress
+      val priorYearReportId =
+          insertReport(
+              startDate = LocalDate.of(2024, 10, 1),
+              endDate = LocalDate.of(2024, 12, 31),
+              quarter = ReportQuarter.Q4,
+          )
+      insertReportCommonIndicator(
+          reportId = priorYearReportId,
+          indicatorId = commonIndicatorId,
+          value = 999,
+      )
+
+      val q1ReportId =
+          insertReport(
+              startDate = LocalDate.of(2025, 1, 1),
+              endDate = LocalDate.of(2025, 3, 31),
+              quarter = ReportQuarter.Q1,
+          )
+      insertReportCommonIndicator(
+          reportId = q1ReportId,
+          indicatorId = commonIndicatorId,
+          value = 10,
+      )
+
+      val q2ReportId =
+          insertReport(
+              startDate = LocalDate.of(2025, 4, 1),
+              endDate = LocalDate.of(2025, 6, 30),
+              quarter = ReportQuarter.Q2,
+          )
+      insertReportCommonIndicator(
+          reportId = q2ReportId,
+          indicatorId = commonIndicatorId,
+          value = 20,
+      )
+
+      val q3ReportId =
+          insertReport(
+              startDate = LocalDate.of(2025, 7, 1),
+              endDate = LocalDate.of(2025, 9, 30),
+              quarter = ReportQuarter.Q3,
+          )
+      insertReportCommonIndicator(
+          reportId = q3ReportId,
+          indicatorId = commonIndicatorId,
+          value = 30,
+      )
+
+      insertPublishedReport(
+          reportId = q3ReportId,
+          startDate = LocalDate.of(2025, 7, 1),
+          endDate = LocalDate.of(2025, 9, 30),
+          quarter = ReportQuarter.Q3,
+      )
+      insertPublishedReportCommonIndicator(
+          reportId = q3ReportId,
+          indicatorId = commonIndicatorId,
+          value = 30,
+          status = ReportIndicatorStatus.OnTrack,
+      )
+
+      val reports = store.fetchPublishedReports(projectId)
+      val indicator = reports.single().commonIndicators.single()
+
+      assertEquals(
+          listOf(
+              PublishedCumulativeIndicatorProgressModel(quarter = ReportQuarter.Q1, value = 10),
+              PublishedCumulativeIndicatorProgressModel(quarter = ReportQuarter.Q2, value = 20),
+              PublishedCumulativeIndicatorProgressModel(quarter = ReportQuarter.Q3, value = 30),
+          ),
+          indicator.currentYearProgress,
+      )
+    }
+
+    @Test
+    fun `currentYearProgress excludes quarters where the indicator value is null`() {
+      insertFundingEntityProject()
+      insertProjectReportConfig()
+
+      val commonIndicatorId =
+          insertCommonIndicator(
+              category = IndicatorCategory.Climate,
+              classId = IndicatorClass.Cumulative,
+              description = "Cumulative Indicator Description",
+              name = "Cumulative Indicator",
+              refId = "1.1.1",
+              level = IndicatorLevel.Output,
+          )
+
+      val q1ReportId =
+          insertReport(
+              startDate = LocalDate.of(2025, 1, 1),
+              endDate = LocalDate.of(2025, 3, 31),
+              quarter = ReportQuarter.Q1,
+          )
+      insertReportCommonIndicator(
+          reportId = q1ReportId,
+          indicatorId = commonIndicatorId,
+          value = 10,
+      )
+
+      // Q2 has a null value for this indicator — must be excluded
+      val q2ReportId =
+          insertReport(
+              startDate = LocalDate.of(2025, 4, 1),
+              endDate = LocalDate.of(2025, 6, 30),
+              quarter = ReportQuarter.Q2,
+          )
+      insertReportCommonIndicator(
+          reportId = q2ReportId,
+          indicatorId = commonIndicatorId,
+          value = null,
+      )
+
+      val q3ReportId =
+          insertReport(
+              startDate = LocalDate.of(2025, 7, 1),
+              endDate = LocalDate.of(2025, 9, 30),
+              quarter = ReportQuarter.Q3,
+          )
+      insertReportCommonIndicator(
+          reportId = q3ReportId,
+          indicatorId = commonIndicatorId,
+          value = 30,
+      )
+
+      insertPublishedReport(
+          reportId = q3ReportId,
+          startDate = LocalDate.of(2025, 7, 1),
+          endDate = LocalDate.of(2025, 9, 30),
+          quarter = ReportQuarter.Q3,
+      )
+      insertPublishedReportCommonIndicator(
+          reportId = q3ReportId,
+          indicatorId = commonIndicatorId,
+          value = 30,
+          status = ReportIndicatorStatus.OnTrack,
+      )
+
+      val reports = store.fetchPublishedReports(projectId)
+      val indicator = reports.single().commonIndicators.single()
+
+      assertEquals(
+          listOf(
+              PublishedCumulativeIndicatorProgressModel(quarter = ReportQuarter.Q1, value = 10),
+              PublishedCumulativeIndicatorProgressModel(quarter = ReportQuarter.Q3, value = 30),
+          ),
+          indicator.currentYearProgress,
+          "Quarters with null indicator values must be excluded from currentYearProgress",
+      )
+    }
+
+    @Test
+    fun `currentYearProgress is empty for a non-cumulative indicator`() {
+      insertFundingEntityProject()
+      insertProjectReportConfig()
+
+      val levelIndicatorId =
+          insertCommonIndicator(
+              category = IndicatorCategory.Climate,
+              classId = IndicatorClass.Level,
+              description = "Level Indicator Description",
+              name = "Level Indicator",
+              refId = "1.1.1",
+              level = IndicatorLevel.Output,
+          )
+
+      val q1ReportId =
+          insertReport(
+              startDate = LocalDate.of(2025, 1, 1),
+              endDate = LocalDate.of(2025, 3, 31),
+              quarter = ReportQuarter.Q1,
+          )
+      insertReportCommonIndicator(reportId = q1ReportId, indicatorId = levelIndicatorId, value = 50)
+
+      val q2ReportId =
+          insertReport(
+              startDate = LocalDate.of(2025, 4, 1),
+              endDate = LocalDate.of(2025, 6, 30),
+              quarter = ReportQuarter.Q2,
+          )
+      insertReportCommonIndicator(reportId = q2ReportId, indicatorId = levelIndicatorId, value = 60)
+
+      insertPublishedReport(
+          reportId = q2ReportId,
+          startDate = LocalDate.of(2025, 4, 1),
+          endDate = LocalDate.of(2025, 6, 30),
+          quarter = ReportQuarter.Q2,
+      )
+      insertPublishedReportCommonIndicator(
+          reportId = q2ReportId,
+          indicatorId = levelIndicatorId,
+          value = 60,
+          status = ReportIndicatorStatus.OnTrack,
+      )
+
+      val reports = store.fetchPublishedReports(projectId)
+      val indicator = reports.single().commonIndicators.single()
+
+      assertEquals(
+          IndicatorClass.Level,
+          indicator.classId,
+          "Indicator class should be Level for this test",
+      )
+      assertEquals(
+          listOf(
+              PublishedCumulativeIndicatorProgressModel(quarter = ReportQuarter.Q1, value = 50),
+              PublishedCumulativeIndicatorProgressModel(quarter = ReportQuarter.Q2, value = 60),
+          ),
+          indicator.currentYearProgress,
+          "currentYearProgress is populated regardless of indicator class; consumers decide whether to use it",
       )
     }
 

--- a/src/test/kotlin/com/terraformation/backend/funder/db/PublishedReportStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/funder/db/PublishedReportStoreTest.kt
@@ -706,6 +706,19 @@ class PublishedReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
           status = ReportIndicatorStatus.OnTrack,
       )
 
+      // Q4 report (future quarter relative to the published Q3 report - should be excluded)
+      val q4ReportId =
+          insertReport(
+              startDate = LocalDate.of(2025, 10, 1),
+              endDate = LocalDate.of(2025, 12, 31),
+              quarter = ReportQuarter.Q4,
+          )
+      insertReportCommonIndicator(
+          reportId = q4ReportId,
+          indicatorId = commonIndicatorId,
+          value = 40,
+      )
+
       val reports = store.fetchPublishedReports(projectId)
       val indicator = reports.single().commonIndicators.single()
 
@@ -716,6 +729,7 @@ class PublishedReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
               PublishedCumulativeIndicatorProgressModel(quarter = ReportQuarter.Q3, value = 30),
           ),
           indicator.currentYearProgress,
+          "currentYearProgress must not include quarters after the published report's quarter",
       )
     }
 

--- a/src/test/kotlin/com/terraformation/backend/funder/db/PublishedReportStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/funder/db/PublishedReportStoreTest.kt
@@ -690,7 +690,8 @@ class PublishedReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
       insertReportCommonIndicator(
           reportId = q3ReportId,
           indicatorId = commonIndicatorId,
-          value = 30,
+          // current quarter value is ignored, only published value is used for the current quarter
+          value = 29,
       )
 
       insertPublishedReport(
@@ -729,12 +730,12 @@ class PublishedReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
               PublishedCumulativeIndicatorProgressModel(quarter = ReportQuarter.Q3, value = 30),
           ),
           indicator.currentYearProgress,
-          "currentYearProgress must not include quarters after the published report's quarter",
+          "currentYearProgress contains all quarters in the current year, excluding future quarters",
       )
     }
 
     @Test
-    fun `currentYearProgress excludes quarters where the indicator value is null`() {
+    fun `currentYearProgress excludes quarters where the indicator value is null and excludes current quarter if unpublished`() {
       insertFundingEntityProject()
       insertProjectReportConfig()
 
@@ -791,12 +792,6 @@ class PublishedReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
           endDate = LocalDate.of(2025, 9, 30),
           quarter = ReportQuarter.Q3,
       )
-      insertPublishedReportCommonIndicator(
-          reportId = q3ReportId,
-          indicatorId = commonIndicatorId,
-          value = 30,
-          status = ReportIndicatorStatus.OnTrack,
-      )
 
       val reports = store.fetchPublishedReports(projectId)
       val indicator = reports.single().commonIndicators.single()
@@ -804,10 +799,11 @@ class PublishedReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
       assertEquals(
           listOf(
               PublishedCumulativeIndicatorProgressModel(quarter = ReportQuarter.Q1, value = 10),
-              PublishedCumulativeIndicatorProgressModel(quarter = ReportQuarter.Q3, value = 30),
+              // q2 is excluded because it has a null value
+              // q3 is excluded because it has a non-null value but no published value
           ),
           indicator.currentYearProgress,
-          "Quarters with null indicator values must be excluded from currentYearProgress",
+          "Quarters with null indicator values must be excluded from currentYearProgress, and the current quarter must be excluded if unpublished",
       )
     }
 


### PR DESCRIPTION
Retrieve the current year's progress list for published reports. For the current quarter, use the published value. For other quarters, use unpublished values. Exclude future quarters.