### PR TITLE
SW-8093 Only include currentYearProgress when indicator is cumulative

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/accelerator/db/ReportStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/db/ReportStore.kt
@@ -1700,29 +1700,32 @@ class ReportStore(
     val reportsForProgress = REPORTS.`as`("reportsForProgress")
     val rciForProgress = REPORT_COMMON_INDICATORS.`as`("rciForProgress")
     val currentYearProgressField: Field<List<CumulativeIndicatorProgressModel>> =
-        DSL.multiset(
-                DSL.select(
-                        reportsForProgress.REPORT_QUARTER_ID,
-                        rciForProgress.VALUE,
-                    )
-                    .from(rciForProgress)
-                    .join(reportsForProgress)
-                    .on(reportsForProgress.ID.eq(rciForProgress.REPORT_ID))
-                    .where(DSL.year(reportsForProgress.END_DATE).eq(DSL.year(REPORTS.END_DATE)))
-                    .and(reportsForProgress.PROJECT_ID.eq(REPORTS.PROJECT_ID))
-                    .and(rciForProgress.COMMON_INDICATOR_ID.eq(COMMON_INDICATORS.ID))
-                    .and(rciForProgress.VALUE.isNotNull)
-                    .and(reportsForProgress.REPORT_QUARTER_ID.le(REPORTS.REPORT_QUARTER_ID))
-                    .orderBy(reportsForProgress.REPORT_QUARTER_ID)
-            )
-            .convertFrom { results ->
-              results.map { record ->
-                CumulativeIndicatorProgressModel(
-                    quarter = record[reportsForProgress.REPORT_QUARTER_ID]!!,
-                    value = record[rciForProgress.VALUE]!!,
+        DSL.`when`(
+            COMMON_INDICATORS.CLASS_ID.eq(IndicatorClass.Cumulative),
+            DSL.multiset(
+                    DSL.select(
+                            reportsForProgress.REPORT_QUARTER_ID,
+                            rciForProgress.VALUE,
+                        )
+                        .from(rciForProgress)
+                        .join(reportsForProgress)
+                        .on(reportsForProgress.ID.eq(rciForProgress.REPORT_ID))
+                        .where(DSL.year(reportsForProgress.END_DATE).eq(DSL.year(REPORTS.END_DATE)))
+                        .and(reportsForProgress.PROJECT_ID.eq(REPORTS.PROJECT_ID))
+                        .and(rciForProgress.COMMON_INDICATOR_ID.eq(COMMON_INDICATORS.ID))
+                        .and(rciForProgress.VALUE.isNotNull)
+                        .and(reportsForProgress.REPORT_QUARTER_ID.le(REPORTS.REPORT_QUARTER_ID))
+                        .orderBy(reportsForProgress.REPORT_QUARTER_ID)
                 )
-              }
-            }
+                .convertFrom { results ->
+                  results.map { record ->
+                    CumulativeIndicatorProgressModel(
+                        quarter = record[reportsForProgress.REPORT_QUARTER_ID]!!,
+                        value = record[rciForProgress.VALUE]!!,
+                    )
+                  }
+                },
+        )
 
     return DSL.multiset(
             DSL.select(
@@ -1785,29 +1788,32 @@ class ReportStore(
     val reportsForProgress = REPORTS.`as`("reportsForProgress")
     val rpiForProgress = REPORT_PROJECT_INDICATORS.`as`("rpiForProgress")
     val currentYearProgressField: Field<List<CumulativeIndicatorProgressModel>> =
-        DSL.multiset(
-                DSL.select(
-                        reportsForProgress.REPORT_QUARTER_ID,
-                        rpiForProgress.VALUE,
-                    )
-                    .from(rpiForProgress)
-                    .join(reportsForProgress)
-                    .on(reportsForProgress.ID.eq(rpiForProgress.REPORT_ID))
-                    .where(DSL.year(reportsForProgress.END_DATE).eq(DSL.year(REPORTS.END_DATE)))
-                    .and(reportsForProgress.PROJECT_ID.eq(REPORTS.PROJECT_ID))
-                    .and(rpiForProgress.PROJECT_INDICATOR_ID.eq(PROJECT_INDICATORS.ID))
-                    .and(rpiForProgress.VALUE.isNotNull)
-                    .and(reportsForProgress.REPORT_QUARTER_ID.le(REPORTS.REPORT_QUARTER_ID))
-                    .orderBy(reportsForProgress.REPORT_QUARTER_ID)
-            )
-            .convertFrom { results ->
-              results.map { record ->
-                CumulativeIndicatorProgressModel(
-                    quarter = record[reportsForProgress.REPORT_QUARTER_ID]!!,
-                    value = record[rpiForProgress.VALUE]!!,
+        DSL.`when`(
+            PROJECT_INDICATORS.CLASS_ID.eq(IndicatorClass.Cumulative),
+            DSL.multiset(
+                    DSL.select(
+                            reportsForProgress.REPORT_QUARTER_ID,
+                            rpiForProgress.VALUE,
+                        )
+                        .from(rpiForProgress)
+                        .join(reportsForProgress)
+                        .on(reportsForProgress.ID.eq(rpiForProgress.REPORT_ID))
+                        .where(DSL.year(reportsForProgress.END_DATE).eq(DSL.year(REPORTS.END_DATE)))
+                        .and(reportsForProgress.PROJECT_ID.eq(REPORTS.PROJECT_ID))
+                        .and(rpiForProgress.PROJECT_INDICATOR_ID.eq(PROJECT_INDICATORS.ID))
+                        .and(rpiForProgress.VALUE.isNotNull)
+                        .and(reportsForProgress.REPORT_QUARTER_ID.le(REPORTS.REPORT_QUARTER_ID))
+                        .orderBy(reportsForProgress.REPORT_QUARTER_ID)
                 )
-              }
-            }
+                .convertFrom { results ->
+                  results.map { record ->
+                    CumulativeIndicatorProgressModel(
+                        quarter = record[reportsForProgress.REPORT_QUARTER_ID]!!,
+                        value = record[rpiForProgress.VALUE]!!,
+                    )
+                  }
+                },
+        )
 
     return DSL.multiset(
             DSL.select(
@@ -2168,33 +2174,36 @@ class ReportStore(
     val raciForProgress = REPORT_AUTO_CALCULATED_INDICATORS.`as`("raciForProgress")
     val effectiveValue = DSL.coalesce(raciForProgress.OVERRIDE_VALUE, raciForProgress.SYSTEM_VALUE)
     val currentYearProgressField: Field<List<CumulativeIndicatorProgressModel>> =
-        DSL.multiset(
-                DSL.select(
-                        reportsForProgress.REPORT_QUARTER_ID,
-                        effectiveValue,
-                    )
-                    .from(raciForProgress)
-                    .join(reportsForProgress)
-                    .on(reportsForProgress.ID.eq(raciForProgress.REPORT_ID))
-                    .where(DSL.year(reportsForProgress.END_DATE).eq(DSL.year(REPORTS.END_DATE)))
-                    .and(reportsForProgress.PROJECT_ID.eq(REPORTS.PROJECT_ID))
-                    .and(
-                        raciForProgress.AUTO_CALCULATED_INDICATOR_ID.eq(
-                            AUTO_CALCULATED_INDICATORS.ID
+        DSL.`when`(
+            AUTO_CALCULATED_INDICATORS.CLASS_ID.eq(IndicatorClass.Cumulative),
+            DSL.multiset(
+                    DSL.select(
+                            reportsForProgress.REPORT_QUARTER_ID,
+                            effectiveValue,
                         )
-                    )
-                    .and(effectiveValue.isNotNull)
-                    .and(reportsForProgress.REPORT_QUARTER_ID.le(REPORTS.REPORT_QUARTER_ID))
-                    .orderBy(reportsForProgress.REPORT_QUARTER_ID)
-            )
-            .convertFrom { results ->
-              results.map { record ->
-                CumulativeIndicatorProgressModel(
-                    quarter = record[reportsForProgress.REPORT_QUARTER_ID]!!,
-                    value = record[effectiveValue]!!,
+                        .from(raciForProgress)
+                        .join(reportsForProgress)
+                        .on(reportsForProgress.ID.eq(raciForProgress.REPORT_ID))
+                        .where(DSL.year(reportsForProgress.END_DATE).eq(DSL.year(REPORTS.END_DATE)))
+                        .and(reportsForProgress.PROJECT_ID.eq(REPORTS.PROJECT_ID))
+                        .and(
+                            raciForProgress.AUTO_CALCULATED_INDICATOR_ID.eq(
+                                AUTO_CALCULATED_INDICATORS.ID
+                            )
+                        )
+                        .and(effectiveValue.isNotNull)
+                        .and(reportsForProgress.REPORT_QUARTER_ID.le(REPORTS.REPORT_QUARTER_ID))
+                        .orderBy(reportsForProgress.REPORT_QUARTER_ID)
                 )
-              }
-            }
+                .convertFrom { results ->
+                  results.map { record ->
+                    CumulativeIndicatorProgressModel(
+                        quarter = record[reportsForProgress.REPORT_QUARTER_ID]!!,
+                        value = record[effectiveValue]!!,
+                    )
+                  }
+                },
+        )
 
     return DSL.multiset(
             DSL.select(

--- a/src/main/kotlin/com/terraformation/backend/funder/db/PublishedReportStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/funder/db/PublishedReportStore.kt
@@ -244,41 +244,50 @@ class PublishedReportStore(
         )
 
     val currentYearProgressField: Field<List<PublishedCumulativeIndicatorProgressModel>> =
-        DSL.multiset(
-                DSL.select(
-                        reportsForProgress.REPORT_QUARTER_ID,
-                        progressValue.`as`("progress_value"),
-                    )
-                    .from(reportIndicatorsForProgress)
-                    .join(reportsForProgress)
-                    .on(reportsForProgress.ID.eq(reportIdProgressField))
-                    .leftJoin(publishedIndicatorForProgress)
-                    .on(
-                        publishedReportIdForProgressField
-                            .eq(reportIdProgressField)
-                            .and(publishedIndicatorIdForProgress.eq(indicatorTableIdField))
-                            .and(publishedReportIdForProgressField.eq(PUBLISHED_REPORTS.REPORT_ID))
-                    )
-                    .where(
-                        DSL.year(reportsForProgress.END_DATE)
-                            .eq(DSL.year(PUBLISHED_REPORTS.END_DATE))
-                    )
-                    .and(reportsForProgress.PROJECT_ID.eq(PUBLISHED_REPORTS.PROJECT_ID))
-                    .and(indicatorIdForProgress.eq(indicatorTableIdField))
-                    .and(progressValue.isNotNull)
-                    .and(
-                        reportsForProgress.REPORT_QUARTER_ID.le(PUBLISHED_REPORTS.REPORT_QUARTER_ID)
-                    )
-                    .orderBy(reportsForProgress.REPORT_QUARTER_ID)
-            )
-            .convertFrom { results ->
-              results.map { record ->
-                PublishedCumulativeIndicatorProgressModel(
-                    quarter = record[reportsForProgress.REPORT_QUARTER_ID]!!,
-                    value = record[DSL.field("progress_value", SQLDataType.INTEGER)]!!,
+        DSL.`when`(
+            indicatorClassField.eq(IndicatorClass.Cumulative),
+            DSL.multiset(
+                    DSL.select(
+                            reportsForProgress.REPORT_QUARTER_ID,
+                            progressValue.`as`("progress_value"),
+                        )
+                        .from(reportIndicatorsForProgress)
+                        .join(reportsForProgress)
+                        .on(reportsForProgress.ID.eq(reportIdProgressField))
+                        .leftJoin(publishedIndicatorForProgress)
+                        .on(
+                            publishedReportIdForProgressField
+                                .eq(reportIdProgressField)
+                                .and(publishedIndicatorIdForProgress.eq(indicatorTableIdField))
+                                .and(
+                                    publishedReportIdForProgressField.eq(
+                                        PUBLISHED_REPORTS.REPORT_ID
+                                    )
+                                )
+                        )
+                        .where(
+                            DSL.year(reportsForProgress.END_DATE)
+                                .eq(DSL.year(PUBLISHED_REPORTS.END_DATE))
+                        )
+                        .and(reportsForProgress.PROJECT_ID.eq(PUBLISHED_REPORTS.PROJECT_ID))
+                        .and(indicatorIdForProgress.eq(indicatorTableIdField))
+                        .and(progressValue.isNotNull)
+                        .and(
+                            reportsForProgress.REPORT_QUARTER_ID.le(
+                                PUBLISHED_REPORTS.REPORT_QUARTER_ID
+                            )
+                        )
+                        .orderBy(reportsForProgress.REPORT_QUARTER_ID)
                 )
-              }
-            }
+                .convertFrom { results ->
+                  results.map { record ->
+                    PublishedCumulativeIndicatorProgressModel(
+                        quarter = record[reportsForProgress.REPORT_QUARTER_ID]!!,
+                        value = record[DSL.field("progress_value", SQLDataType.INTEGER)]!!,
+                    )
+                  }
+                },
+        )
 
     val reportIndicatorForReport = reportIndicatorTable.`as`("reportIndicatorForReport")
     val repIndicatorIdForReport = reportIndicatorForReport.field(reportTableIndicatorIdField)!!
@@ -338,25 +347,28 @@ class PublishedReportStore(
                 .orderBy(indicatorReferenceField)
         )
         .convertFrom { result ->
-          result.map {
+          result.map { record ->
             PublishedReportIndicatorModel(
-                baseline = it[baselineField],
-                category = it[indicatorCategoryField],
-                classId = it[indicatorClassField],
-                currentYearProgress = it[currentYearProgressField],
-                description = it[indicatorDescriptionField],
-                endOfProjectTarget = it[endTargetField],
-                indicatorId = it[indicatorTableIdField.asNonNullable()],
-                level = it[indicatorTypeField],
-                name = it[indicatorNameField],
-                previousYearCumulativeTotal = it[sumAtPreviousYearEnd],
-                progressNotes = it[progressNotesField],
-                projectsComments = it[projectsCommentsField],
-                refId = it[indicatorReferenceField],
-                status = it[statusField],
-                target = it[targetField],
-                unit = it[unitField],
-                value = it[valueField],
+                baseline = record[baselineField],
+                category = record[indicatorCategoryField],
+                classId = record[indicatorClassField],
+                currentYearProgress =
+                    record[currentYearProgressField].takeIf {
+                      record[indicatorClassField] == IndicatorClass.Cumulative
+                    },
+                description = record[indicatorDescriptionField],
+                endOfProjectTarget = record[endTargetField],
+                indicatorId = record[indicatorTableIdField.asNonNullable()],
+                level = record[indicatorTypeField],
+                name = record[indicatorNameField],
+                previousYearCumulativeTotal = record[sumAtPreviousYearEnd],
+                progressNotes = record[progressNotesField],
+                projectsComments = record[projectsCommentsField],
+                refId = record[indicatorReferenceField],
+                status = record[statusField],
+                target = record[targetField],
+                unit = record[unitField],
+                value = record[valueField],
             )
           }
         }

--- a/src/test/kotlin/com/terraformation/backend/funder/db/PublishedReportStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/funder/db/PublishedReportStoreTest.kt
@@ -22,6 +22,7 @@ import java.time.Instant
 import java.time.LocalDate
 import java.util.UUID
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
@@ -463,7 +464,6 @@ class PublishedReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
           PublishedReportIndicatorModel(
               category = IndicatorCategory.Biodiversity,
               classId = IndicatorClass.Level,
-              currentYearProgress = emptyList(),
               description = "Project Indicator Description",
               indicatorId = projectIndicatorId,
               level = IndicatorLevel.Output,
@@ -609,7 +609,6 @@ class PublishedReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
           PublishedReportIndicatorModel(
               category = AutoCalculatedIndicator.SurvivalRate.categoryId,
               classId = IndicatorClass.Level,
-              currentYearProgress = emptyList(),
               description = AutoCalculatedIndicator.SurvivalRate.description,
               indicatorId = AutoCalculatedIndicator.SurvivalRate,
               level = AutoCalculatedIndicator.SurvivalRate.levelId,
@@ -808,7 +807,7 @@ class PublishedReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
     }
 
     @Test
-    fun `currentYearProgress is empty for a non-cumulative indicator`() {
+    fun `currentYearProgress is null for a non-cumulative indicator`() {
       insertFundingEntityProject()
       insertProjectReportConfig()
 
@@ -859,13 +858,9 @@ class PublishedReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
           indicator.classId,
           "Indicator class should be Level for this test",
       )
-      assertEquals(
-          listOf(
-              PublishedCumulativeIndicatorProgressModel(quarter = ReportQuarter.Q1, value = 50),
-              PublishedCumulativeIndicatorProgressModel(quarter = ReportQuarter.Q2, value = 60),
-          ),
+      assertNull(
           indicator.currentYearProgress,
-          "currentYearProgress is populated regardless of indicator class; consumers decide whether to use it",
+          "currentYearProgress is null for non-cumulative indicators",
       )
     }
 


### PR DESCRIPTION
Only return `currentYearProgress` when an indicator class is cumulative.

Ensure there is test coverage for this as well.