### PR TITLE
SW-8096 Change indicators target/value/progress to Numeric/BigDecimal

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/accelerator/api/ProjectAcceleratorDetailsController.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/api/ProjectAcceleratorDetailsController.kt
@@ -192,13 +192,13 @@ data class MetricProgressPayload(
       model: IndicatorProgressModel
   ) : this(
       metric = model.indicator,
-      progress = model.progress,
+      progress = model.progress.toInt(),
   )
 }
 
 data class IndicatorProgressPayload(
     val indicator: AutoCalculatedIndicator,
-    val progress: Int,
+    val progress: BigDecimal,
 ) {
   constructor(
       model: IndicatorProgressModel

--- a/src/main/kotlin/com/terraformation/backend/accelerator/api/ProjectReportsController.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/api/ProjectReportsController.kt
@@ -569,7 +569,7 @@ class ProjectReportsController(
         projectId = projectId,
         year = payload.year,
         indicatorId = payload.metricId,
-        target = payload.target,
+        target = payload.target?.toBigDecimal(),
     )
     return SimpleSuccessResponsePayload()
   }
@@ -586,7 +586,7 @@ class ProjectReportsController(
         projectId = projectId,
         year = payload.year,
         indicatorId = payload.metricId,
-        target = payload.target,
+        target = payload.target?.toBigDecimal(),
     )
     return SimpleSuccessResponsePayload()
   }
@@ -603,7 +603,7 @@ class ProjectReportsController(
         projectId = projectId,
         year = payload.year,
         indicatorId = payload.metric,
-        target = payload.target,
+        target = payload.target?.toBigDecimal(),
     )
     return SimpleSuccessResponsePayload()
   }
@@ -941,15 +941,15 @@ data class ReportStandardMetricPayload(
       projectsComments = model.entry.projectsComments,
       reference = model.indicator.refId,
       status = model.entry.status,
-      target = model.entry.target,
+      target = model.entry.target?.toInt(),
       type = model.indicator.level,
-      value = model.entry.value,
+      value = model.entry.value?.toInt(),
   )
 }
 
 data class CumulativeIndicatorProgressPayload(
     val quarter: ReportQuarter,
-    val value: Int,
+    val value: BigDecimal,
 ) {
   constructor(
       model: CumulativeIndicatorProgressModel
@@ -983,8 +983,8 @@ data class ReportCommonIndicatorPayload(
     val projectsComments: String?,
     val refId: String,
     val status: ReportIndicatorStatus?,
-    val target: Int?,
-    val value: Int?,
+    val target: BigDecimal?,
+    val value: BigDecimal?,
 ) {
   constructor(
       model: ReportCommonIndicatorModel
@@ -1023,7 +1023,7 @@ data class ReportStandardMetricEntriesPayload(
           progressNotes = progressNotes,
           projectsComments = projectsComments,
           status = status,
-          value = value,
+          value = value?.toBigDecimal(),
       )
 }
 
@@ -1032,7 +1032,7 @@ data class ReportCommonIndicatorEntriesPayload(
     val progressNotes: String?,
     val projectsComments: String?,
     val status: ReportIndicatorStatus?,
-    val value: Int?,
+    val value: BigDecimal?,
 ) {
   fun toModel() =
       ReportIndicatorEntryModel(
@@ -1066,14 +1066,14 @@ data class ReportSystemMetricPayload(
       description = model.indicator.description,
       isPublishable = model.indicator.isPublishable,
       metric = model.indicator,
-      overrideValue = model.entry.overrideValue,
+      overrideValue = model.entry.overrideValue?.toInt(),
       progressNotes = model.entry.progressNotes,
       projectsComments = model.entry.projectsComments,
       reference = model.indicator.refId,
       status = model.entry.status,
       systemTime = model.entry.systemTime,
-      systemValue = model.entry.systemValue,
-      target = model.entry.target,
+      systemValue = model.entry.systemValue?.toInt(),
+      target = model.entry.target?.toInt(),
       type = model.indicator.levelId,
   )
 }
@@ -1092,7 +1092,7 @@ data class ReportAutoCalculatedIndicatorPayload(
     val isPublishable: Boolean,
     val level: IndicatorLevel,
     val indicator: AutoCalculatedIndicator,
-    val overrideValue: Int?,
+    val overrideValue: BigDecimal?,
     @Schema(
         description =
             "If the indicator is cumulative, the cumulative total at the end of the previous year"
@@ -1103,8 +1103,8 @@ data class ReportAutoCalculatedIndicatorPayload(
     val refId: String,
     val status: ReportIndicatorStatus?,
     val systemTime: Instant?,
-    val systemValue: Int?,
-    val target: Int?,
+    val systemValue: BigDecimal?,
+    val target: BigDecimal?,
 ) {
   constructor(
       model: ReportAutoCalculatedIndicatorModel
@@ -1144,13 +1144,13 @@ data class ReportSystemMetricEntriesPayload(
           progressNotes = progressNotes,
           projectsComments = projectsComments,
           status = status,
-          value = overrideValue,
+          value = overrideValue?.toBigDecimal(),
       )
 }
 
 data class ReportAutoCalculatedIndicatorEntriesPayload(
     val indicator: AutoCalculatedIndicator,
-    val overrideValue: Int?,
+    val overrideValue: BigDecimal?,
     val progressNotes: String?,
     val projectsComments: String?,
     val status: ReportIndicatorStatus?,
@@ -1204,10 +1204,10 @@ data class ReportProjectMetricPayload(
       projectsComments = model.entry.projectsComments,
       reference = model.indicator.refId,
       status = model.entry.status,
-      target = model.entry.target,
+      target = model.entry.target?.toInt(),
       type = model.indicator.level,
       unit = model.indicator.unit,
-      value = model.entry.value,
+      value = model.entry.value?.toInt(),
   )
 }
 
@@ -1235,9 +1235,9 @@ data class ReportProjectIndicatorPayload(
     val projectsComments: String?,
     val refId: String,
     val status: ReportIndicatorStatus?,
-    val target: Int?,
+    val target: BigDecimal?,
     val unit: String?,
-    val value: Int?,
+    val value: BigDecimal?,
 ) {
   constructor(
       model: ReportProjectIndicatorModel
@@ -1277,7 +1277,7 @@ data class ReportProjectMetricEntriesPayload(
           progressNotes = progressNotes,
           projectsComments = projectsComments,
           status = status,
-          value = value,
+          value = value?.toBigDecimal(),
       )
 }
 
@@ -1286,7 +1286,7 @@ data class ReportProjectIndicatorEntriesPayload(
     val progressNotes: String?,
     val projectsComments: String?,
     val status: ReportIndicatorStatus?,
-    val value: Int?,
+    val value: BigDecimal?,
 ) {
   fun toModel() =
       ReportIndicatorEntryModel(
@@ -1375,19 +1375,19 @@ data class UpdateSystemMetricTargetRequestPayload(
 data class UpdateProjectIndicatorTargetRequestPayload(
     val year: Int,
     val indicatorId: ProjectIndicatorId,
-    val target: Int?,
+    val target: BigDecimal?,
 )
 
 data class UpdateCommonIndicatorTargetRequestPayload(
     val year: Int,
     val indicatorId: CommonIndicatorId,
-    val target: Int?,
+    val target: BigDecimal?,
 )
 
 data class UpdateAutoCalculatedIndicatorTargetRequestPayload(
     val year: Int,
     val indicator: AutoCalculatedIndicator,
-    val target: Int?,
+    val target: BigDecimal?,
 )
 
 data class UpdateProjectIndicatorBaselineTargetRequestPayload(

--- a/src/main/kotlin/com/terraformation/backend/accelerator/db/ProjectAcceleratorDetailsStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/db/ProjectAcceleratorDetailsStore.kt
@@ -18,6 +18,7 @@ import com.terraformation.backend.db.default_schema.tables.references.PROJECT_LA
 import com.terraformation.backend.db.funder.tables.references.PUBLISHED_REPORTS
 import com.terraformation.backend.db.funder.tables.references.PUBLISHED_REPORT_AUTO_CALCULATED_INDICATORS
 import jakarta.inject.Named
+import java.math.BigDecimal
 import java.net.URI
 import java.time.InstantSource
 import org.jooq.Condition
@@ -213,7 +214,8 @@ class ProjectAcceleratorDetailsStore(
                   AutoCalculatedIndicator.SpeciesPlanted
               ),
               DSL.max(PUBLISHED_REPORT_AUTO_CALCULATED_INDICATORS.VALUE),
-              DSL.sum(PUBLISHED_REPORT_AUTO_CALCULATED_INDICATORS.VALUE).cast(Int::class.java),
+              DSL.sum(PUBLISHED_REPORT_AUTO_CALCULATED_INDICATORS.VALUE)
+                  .cast(BigDecimal::class.java),
           )
       return DSL.multiset(
               DSL.select(
@@ -243,7 +245,7 @@ class ProjectAcceleratorDetailsStore(
                       record[
                           PUBLISHED_REPORT_AUTO_CALCULATED_INDICATORS
                               .AUTO_CALCULATED_INDICATOR_ID]!!,
-                  progress = record[progressField] ?: 0,
+                  progress = record[progressField] ?: BigDecimal.ZERO,
               )
             }
           }

--- a/src/main/kotlin/com/terraformation/backend/accelerator/db/ReportStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/db/ReportStore.kt
@@ -100,6 +100,7 @@ import java.time.InstantSource
 import java.time.LocalDate
 import java.time.Month
 import java.time.ZoneId
+import kotlin.toBigDecimal
 import org.jooq.Condition
 import org.jooq.DSLContext
 import org.jooq.Field
@@ -785,7 +786,7 @@ class ReportStore(
       projectId: ProjectId,
       year: Int,
       indicatorId: ProjectIndicatorId,
-      target: Int?,
+      target: BigDecimal?,
   ) {
     requirePermissions { updateProjectReports(projectId) }
 
@@ -807,7 +808,7 @@ class ReportStore(
       projectId: ProjectId,
       year: Int,
       indicatorId: CommonIndicatorId,
-      target: Int?,
+      target: BigDecimal?,
   ) {
     requirePermissions { updateProjectReports(projectId) }
 
@@ -829,7 +830,7 @@ class ReportStore(
       projectId: ProjectId,
       year: Int,
       indicatorId: AutoCalculatedIndicator,
-      target: Int?,
+      target: BigDecimal?,
   ) {
     requirePermissions { updateProjectReports(projectId) }
 
@@ -1327,7 +1328,7 @@ class ReportStore(
     val table = indicatorIdField.table!!
     val reportIdField =
         table.field("report_id", SQLDataType.BIGINT.asConvertedDataType(ReportIdConverter()))!!
-    val valueField = table.field("value", Int::class.java)!!
+    val valueField = table.field("value", BigDecimal::class.java)!!
     val projectsCommentsField = table.field("projects_comments", String::class.java)!!
     val progressNotesField = table.field("progress_notes", String::class.java)
     val statusField =
@@ -1456,7 +1457,7 @@ class ReportStore(
       projectId: ProjectId,
       year: Int,
       indicatorIdField: TableField<*, ID?>,
-      targets: Map<ID, Int?>,
+      targets: Map<ID, BigDecimal?>,
   ) {
     if (targets.isEmpty()) {
       return
@@ -1466,7 +1467,7 @@ class ReportStore(
     val projectIdField =
         table.field("project_id", SQLDataType.BIGINT.asConvertedDataType(ProjectIdConverter()))!!
     val yearField = table.field("year", Int::class.java)!!
-    val targetField = table.field("target", Int::class.java)!!
+    val targetField = table.field("target", BigDecimal::class.java)!!
 
     var insertQuery = dslContext.insertInto(table).set()
 
@@ -1938,20 +1939,19 @@ class ReportStore(
   private val hectaresPlantedField =
       with(SUBSTRATA) {
         DSL.field(
-                DSL.select(DSL.sum(AREA_HA))
-                    .from(this)
-                    .join(PLANTING_SITES)
-                    .on(PLANTING_SITES.ID.eq(PLANTING_SITE_ID))
-                    .where(
-                        timestampToLocalDateField(
-                                PLANTING_COMPLETED_TIME,
-                                plantingSiteTimeZoneField(PLANTING_SITE_ID),
-                            )
-                            .le(REPORTS.END_DATE)
-                    )
-                    .and(PLANTING_SITES.PROJECT_ID.eq(REPORTS.PROJECT_ID))
-            )
-            .convertFrom { it.toInt() }
+            DSL.select(DSL.sum(AREA_HA))
+                .from(this)
+                .join(PLANTING_SITES)
+                .on(PLANTING_SITES.ID.eq(PLANTING_SITE_ID))
+                .where(
+                    timestampToLocalDateField(
+                            PLANTING_COMPLETED_TIME,
+                            plantingSiteTimeZoneField(PLANTING_SITE_ID),
+                        )
+                        .le(REPORTS.END_DATE)
+                )
+                .and(PLANTING_SITES.PROJECT_ID.eq(REPORTS.PROJECT_ID))
+        )
       }
 
   private val observationsInReportPeriod =
@@ -1973,7 +1973,7 @@ class ReportStore(
           )
 
   // Calculate survival rate by fetching observations from observationResultsStore
-  private fun calculateSurvivalRateForReport(reportId: ReportId): Int? {
+  private fun calculateSurvivalRateForReport(reportId: ReportId): BigDecimal? {
     // retrieve the latest observation for each planting site in the report's project within the
     // report period. observationsInReportPeriod only returns one observation per planting site.
     val observationIds =
@@ -2013,18 +2013,17 @@ class ReportStore(
           }
     }
 
-    return calculateSurvivalRate(numKnownLive, sumDensity)
+    return calculateSurvivalRate(numKnownLive, sumDensity)?.toBigDecimal()
   }
 
   private val seedsCollectedField =
       with(ACCESSIONS) {
         DSL.field(
-                DSL.select(DSL.sum(EST_SEED_COUNT) + DSL.sum(TOTAL_WITHDRAWN_COUNT))
-                    .from(this)
-                    .where(PROJECT_ID.eq(REPORTS.PROJECT_ID))
-                    .and(COLLECTED_DATE.between(REPORTS.START_DATE, REPORTS.END_DATE))
-            )
-            .convertFrom { it?.toInt() }
+            DSL.select(DSL.sum(EST_SEED_COUNT) + DSL.sum(TOTAL_WITHDRAWN_COUNT))
+                .from(this)
+                .where(PROJECT_ID.eq(REPORTS.PROJECT_ID))
+                .and(COLLECTED_DATE.between(REPORTS.START_DATE, REPORTS.END_DATE))
+        )
       }
 
   private val withdrawnSeedlingsField =
@@ -2048,17 +2047,16 @@ class ReportStore(
   private val seedlingsField =
       with(BATCHES) {
         DSL.field(
-                DSL.select(
-                        DSL.sum(READY_QUANTITY) +
-                            DSL.sum(GERMINATING_QUANTITY) +
-                            DSL.sum(ACTIVE_GROWTH_QUANTITY) +
-                            DSL.coalesce(DSL.sum(withdrawnSeedlingsField), 0)
-                    )
-                    .from(this)
-                    .where(PROJECT_ID.eq(REPORTS.PROJECT_ID))
-                    .and(ADDED_DATE.between(REPORTS.START_DATE, REPORTS.END_DATE))
-            )
-            .convertFrom { it?.toInt() }
+            DSL.select(
+                    DSL.sum(READY_QUANTITY) +
+                        DSL.sum(GERMINATING_QUANTITY) +
+                        DSL.sum(ACTIVE_GROWTH_QUANTITY) +
+                        DSL.coalesce(DSL.sum(withdrawnSeedlingsField), 0)
+                )
+                .from(this)
+                .where(PROJECT_ID.eq(REPORTS.PROJECT_ID))
+                .and(ADDED_DATE.between(REPORTS.START_DATE, REPORTS.END_DATE))
+        )
       }
 
   // For species, we total up the number of trees planted per species, and take only ones that are
@@ -2066,53 +2064,53 @@ class ReportStore(
   private val speciesPlantedField =
       with(PLANTINGS) {
         DSL.field(
-            DSL.select(DSL.count())
-                .from(
-                    DSL.select(SPECIES_ID)
-                        .from(this)
-                        .join(DELIVERIES)
-                        .on(DELIVERIES.ID.eq(DELIVERY_ID))
-                        .join(WITHDRAWAL_SUMMARIES)
-                        .on(WITHDRAWAL_SUMMARIES.ID.eq(DELIVERIES.WITHDRAWAL_ID))
-                        .join(PLANTING_SITES)
-                        .on(PLANTING_SITES.ID.eq(PLANTING_SITE_ID))
-                        .where(
-                            WITHDRAWAL_SUMMARIES.WITHDRAWN_DATE.between(
-                                REPORTS.START_DATE,
-                                REPORTS.END_DATE,
+                DSL.select(DSL.count())
+                    .from(
+                        DSL.select(SPECIES_ID)
+                            .from(this)
+                            .join(DELIVERIES)
+                            .on(DELIVERIES.ID.eq(DELIVERY_ID))
+                            .join(WITHDRAWAL_SUMMARIES)
+                            .on(WITHDRAWAL_SUMMARIES.ID.eq(DELIVERIES.WITHDRAWAL_ID))
+                            .join(PLANTING_SITES)
+                            .on(PLANTING_SITES.ID.eq(PLANTING_SITE_ID))
+                            .where(
+                                WITHDRAWAL_SUMMARIES.WITHDRAWN_DATE.between(
+                                    REPORTS.START_DATE,
+                                    REPORTS.END_DATE,
+                                )
                             )
-                        )
-                        .and(PLANTING_SITES.PROJECT_ID.eq(REPORTS.PROJECT_ID))
-                        .and(WITHDRAWAL_SUMMARIES.PURPOSE_ID.notEqual(WithdrawalPurpose.Undo))
-                        .and(WITHDRAWAL_SUMMARIES.UNDONE_BY_WITHDRAWAL_ID.isNull)
-                        .groupBy(SPECIES_ID)
-                        .having(DSL.sum(NUM_PLANTS).ge(BigDecimal.ZERO))
-                )
-        )
+                            .and(PLANTING_SITES.PROJECT_ID.eq(REPORTS.PROJECT_ID))
+                            .and(WITHDRAWAL_SUMMARIES.PURPOSE_ID.notEqual(WithdrawalPurpose.Undo))
+                            .and(WITHDRAWAL_SUMMARIES.UNDONE_BY_WITHDRAWAL_ID.isNull)
+                            .groupBy(SPECIES_ID)
+                            .having(DSL.sum(NUM_PLANTS).ge(BigDecimal.ZERO))
+                    )
+            )
+            .convertFrom { it?.toBigDecimal() }
       }
 
   private val treesPlantedField =
       with(PLANTINGS) {
         DSL.field(
-                DSL.select(DSL.sum(NUM_PLANTS))
-                    .from(this)
-                    .join(DELIVERIES)
-                    .on(DELIVERIES.ID.eq(DELIVERY_ID))
-                    .join(WITHDRAWAL_SUMMARIES)
-                    .on(WITHDRAWAL_SUMMARIES.ID.eq(DELIVERIES.WITHDRAWAL_ID))
-                    .join(PLANTING_SITES)
-                    .on(PLANTING_SITES.ID.eq(PLANTING_SITE_ID))
-                    .where(
-                        WITHDRAWAL_SUMMARIES.WITHDRAWN_DATE.between(
-                            REPORTS.START_DATE,
-                            REPORTS.END_DATE,
-                        )
+            DSL.select(DSL.sum(NUM_PLANTS))
+                .from(this)
+                .join(DELIVERIES)
+                .on(DELIVERIES.ID.eq(DELIVERY_ID))
+                .join(WITHDRAWAL_SUMMARIES)
+                .on(WITHDRAWAL_SUMMARIES.ID.eq(DELIVERIES.WITHDRAWAL_ID))
+                .join(PLANTING_SITES)
+                .on(PLANTING_SITES.ID.eq(PLANTING_SITE_ID))
+                .where(
+                    WITHDRAWAL_SUMMARIES.WITHDRAWN_DATE.between(
+                        REPORTS.START_DATE,
+                        REPORTS.END_DATE,
                     )
-                    .and(PLANTING_SITES.PROJECT_ID.eq(REPORTS.PROJECT_ID))
-                    .and(WITHDRAWAL_SUMMARIES.PURPOSE_ID.notEqual(WithdrawalPurpose.Undo))
-                    .and(WITHDRAWAL_SUMMARIES.UNDONE_BY_WITHDRAWAL_ID.isNull)
-            )
-            .convertFrom { it?.toInt() }
+                )
+                .and(PLANTING_SITES.PROJECT_ID.eq(REPORTS.PROJECT_ID))
+                .and(WITHDRAWAL_SUMMARIES.PURPOSE_ID.notEqual(WithdrawalPurpose.Undo))
+                .and(WITHDRAWAL_SUMMARIES.UNDONE_BY_WITHDRAWAL_ID.isNull)
+        )
       }
 
   private val systemTerrawareValueField =
@@ -2142,8 +2140,8 @@ class ReportStore(
                   AUTO_CALCULATED_INDICATORS.ID.eq(AutoCalculatedIndicator.SurvivalRate),
                   DSL.value(null, REPORT_AUTO_CALCULATED_INDICATORS.SYSTEM_VALUE),
               )
-              .else_(0),
-          DSL.value(0),
+              .else_(BigDecimal.ZERO),
+          DSL.value(BigDecimal.ZERO),
       )
 
   private val systemValueField =

--- a/src/main/kotlin/com/terraformation/backend/accelerator/model/IndicatorProgressModel.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/model/IndicatorProgressModel.kt
@@ -1,6 +1,7 @@
 package com.terraformation.backend.accelerator.model
 
 import com.terraformation.backend.db.accelerator.AutoCalculatedIndicator
+import java.math.BigDecimal
 
 val TRACKED_ACCUMULATED_INDICATORS =
     listOf(
@@ -11,5 +12,5 @@ val TRACKED_ACCUMULATED_INDICATORS =
 
 data class IndicatorProgressModel(
     val indicator: AutoCalculatedIndicator,
-    val progress: Int,
+    val progress: BigDecimal,
 )

--- a/src/main/kotlin/com/terraformation/backend/accelerator/model/ReportIndicatorsModel.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/model/ReportIndicatorsModel.kt
@@ -24,7 +24,7 @@ import org.jooq.Record
 
 data class CumulativeIndicatorProgressModel(
     val quarter: ReportQuarter,
-    val value: Int,
+    val value: BigDecimal,
 )
 
 data class ReportIndicatorEntryModel(
@@ -33,8 +33,8 @@ data class ReportIndicatorEntryModel(
     val projectsComments: String? = null,
     val progressNotes: String? = null,
     val status: ReportIndicatorStatus? = null,
-    val target: Int? = null,
-    val value: Int? = null,
+    val target: BigDecimal? = null,
+    val value: BigDecimal? = null,
 )
 
 data class ReportCommonIndicatorModel(
@@ -146,11 +146,11 @@ data class ReportProjectIndicatorModel(
 }
 
 data class ReportAutoCalculatedIndicatorEntryModel(
-    val target: Int? = null,
-    val systemValue: Int?,
+    val target: BigDecimal? = null,
+    val systemValue: BigDecimal?,
     /** Time when system value is recorded. If null, the system value is current. */
     val systemTime: Instant? = null,
-    val overrideValue: Int? = null,
+    val overrideValue: BigDecimal? = null,
     val modifiedBy: UserId? = null,
     val modifiedTime: Instant? = null,
     val progressNotes: String? = null,
@@ -158,7 +158,10 @@ data class ReportAutoCalculatedIndicatorEntryModel(
     val status: ReportIndicatorStatus? = null,
 ) {
   companion object {
-    fun of(record: Record, systemValueField: Field<Int?>): ReportAutoCalculatedIndicatorEntryModel {
+    fun of(
+        record: Record,
+        systemValueField: Field<BigDecimal?>,
+    ): ReportAutoCalculatedIndicatorEntryModel {
       return with(REPORT_AUTO_CALCULATED_INDICATORS) {
         ReportAutoCalculatedIndicatorEntryModel(
             target = record[REPORT_AUTO_CALCULATED_INDICATOR_TARGETS.TARGET],
@@ -197,7 +200,7 @@ data class ReportAutoCalculatedIndicatorModel(
   companion object {
     fun of(
         record: Record,
-        systemValueField: Field<Int?>,
+        systemValueField: Field<BigDecimal?>,
         previousYearTotalField: Field<BigDecimal?>,
         currentYearProgressField: Field<List<CumulativeIndicatorProgressModel>>,
     ): ReportAutoCalculatedIndicatorModel {

--- a/src/main/kotlin/com/terraformation/backend/funder/api/FunderReportsController.kt
+++ b/src/main/kotlin/com/terraformation/backend/funder/api/FunderReportsController.kt
@@ -88,7 +88,7 @@ data class ReportChallengePayload(
 
 data class PublishedCumulativeIndicatorProgressPayload(
     val quarter: ReportQuarter,
-    val value: Int,
+    val value: BigDecimal,
 ) {
   constructor(
       model: PublishedCumulativeIndicatorProgressModel
@@ -122,10 +122,10 @@ data class PublishedReportMetricPayload(
       projectsComments = model.projectsComments,
       reference = model.refId,
       status = model.status,
-      target = model.target,
+      target = model.target?.toInt(),
       type = model.level,
       unit = model.unit,
-      value = model.value,
+      value = model.value?.toInt(),
   )
 }
 
@@ -154,9 +154,9 @@ data class PublishedReportIndicatorPayload(
     val projectsComments: String?,
     val refId: String,
     val status: ReportIndicatorStatus?,
-    val target: Int?,
+    val target: BigDecimal?,
     val unit: String?,
-    val value: Int?,
+    val value: BigDecimal?,
 ) {
   constructor(
       model: PublishedReportIndicatorModel<*>

--- a/src/main/kotlin/com/terraformation/backend/funder/db/PublishedProjectDetailsStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/funder/db/PublishedProjectDetailsStore.kt
@@ -83,7 +83,8 @@ class PublishedProjectDetailsStore(
                       AutoCalculatedIndicator.SpeciesPlanted
                   ),
                   DSL.max(PUBLISHED_REPORT_AUTO_CALCULATED_INDICATORS.VALUE),
-                  DSL.sum(PUBLISHED_REPORT_AUTO_CALCULATED_INDICATORS.VALUE).cast(Int::class.java),
+                  DSL.sum(PUBLISHED_REPORT_AUTO_CALCULATED_INDICATORS.VALUE)
+                      .cast(BigDecimal::class.java),
               )
           dslContext
               .select(AUTO_CALCULATED_INDICATOR_ID, progressField)
@@ -108,7 +109,7 @@ class PublishedProjectDetailsStore(
                         record[
                             PUBLISHED_REPORT_AUTO_CALCULATED_INDICATORS
                                 .AUTO_CALCULATED_INDICATOR_ID]!!,
-                    progress = record[progressField] ?: 0,
+                    progress = record[progressField] ?: BigDecimal.ZERO,
                 )
               }
         }

--- a/src/main/kotlin/com/terraformation/backend/funder/db/PublishedReportStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/funder/db/PublishedReportStore.kt
@@ -142,12 +142,13 @@ class PublishedReportStore(
             "status_id",
             SQLDataType.INTEGER.asConvertedDataType(ReportIndicatorStatusConverter()),
         )!!
+
     val projectsCommentsField =
         publishedIndicatorTable.field("projects_comments", String::class.java)!!
-    val valueField = publishedIndicatorTable.field("value", Int::class.java)!!
+    val valueField = publishedIndicatorTable.field("value", BigDecimal::class.java)!!
 
     val targetTable = targetTableIndicatorIdField.table!!
-    val targetField = targetTable.field("target", Int::class.java)!!
+    val targetField = targetTable.field("target", BigDecimal::class.java)!!
     val targetYearField = targetTable.field("year", Int::class.java)!!
     val targetProjectIdField =
         targetTable.field(
@@ -192,10 +193,10 @@ class PublishedReportStore(
             SQLDataType.BIGINT.asConvertedDataType(ReportIdConverter()),
         )!!
     val reportValueField =
-        reportIndicatorTable.field("value", Int::class.java)
+        reportIndicatorTable.field("value", BigDecimal::class.java)
             ?: DSL.coalesce(
-                reportIndicatorTable.field("override_value", Int::class.java)!!,
-                reportIndicatorTable.field("system_value", Int::class.java)!!,
+                reportIndicatorTable.field("override_value", BigDecimal::class.java)!!,
+                reportIndicatorTable.field("system_value", BigDecimal::class.java)!!,
             )
     val reportsForSum = REPORTS.`as`("reportsForSum")
     val sumAtPreviousYearEnd =
@@ -214,10 +215,10 @@ class PublishedReportStore(
     val reportIndicatorsForProgress = reportIndicatorTable.`as`("reportIndicatorsForProgress")
     val indicatorIdForProgress = reportIndicatorsForProgress.field(reportTableIndicatorIdField)!!
     val indicatorValueProgressField =
-        reportIndicatorsForProgress.field("value", Int::class.java)
+        reportIndicatorsForProgress.field("value", BigDecimal::class.java)
             ?: DSL.coalesce(
-                reportIndicatorsForProgress.field("override_value", Int::class.java)!!,
-                reportIndicatorsForProgress.field("system_value", Int::class.java)!!,
+                reportIndicatorsForProgress.field("override_value", BigDecimal::class.java)!!,
+                reportIndicatorsForProgress.field("system_value", BigDecimal::class.java)!!,
             )
     val reportIdProgressField =
         reportIndicatorsForProgress.field(
@@ -233,7 +234,8 @@ class PublishedReportStore(
         )!!
     val publishedIndicatorIdForProgress =
         publishedIndicatorForProgress.field(publishedIndicatorIdField)!!
-    val publishedValueForProgress = publishedIndicatorForProgress.field("value", Int::class.java)!!
+    val publishedValueForProgress =
+        publishedIndicatorForProgress.field("value", BigDecimal::class.java)!!
     // For previous quarters, use the report value directly. For the current quarter, use the
     // published value only (null if no published entry, which excludes it from the result).
     val progressValue =
@@ -283,7 +285,7 @@ class PublishedReportStore(
                   results.map { record ->
                     PublishedCumulativeIndicatorProgressModel(
                         quarter = record[reportsForProgress.REPORT_QUARTER_ID]!!,
-                        value = record[DSL.field("progress_value", SQLDataType.INTEGER)]!!,
+                        value = record[DSL.field("progress_value", SQLDataType.NUMERIC)]!!,
                     )
                   }
                 },

--- a/src/main/kotlin/com/terraformation/backend/funder/model/PublishedReportIndicatorModel.kt
+++ b/src/main/kotlin/com/terraformation/backend/funder/model/PublishedReportIndicatorModel.kt
@@ -9,7 +9,7 @@ import java.math.BigDecimal
 
 data class PublishedCumulativeIndicatorProgressModel(
     val quarter: ReportQuarter,
-    val value: Int,
+    val value: BigDecimal,
 )
 
 data class PublishedReportIndicatorModel<ID : Any>(
@@ -27,7 +27,7 @@ data class PublishedReportIndicatorModel<ID : Any>(
     val projectsComments: String?,
     val refId: String,
     val status: ReportIndicatorStatus?,
-    val target: Int?,
+    val target: BigDecimal?,
     val unit: String?,
-    val value: Int?,
+    val value: BigDecimal?,
 )

--- a/src/main/resources/db/migration/0450/V469__ReportIndicatorValues.sql
+++ b/src/main/resources/db/migration/0450/V469__ReportIndicatorValues.sql
@@ -1,0 +1,29 @@
+-- Report indicators
+ALTER TABLE accelerator.report_auto_calculated_indicators
+    ALTER COLUMN system_value TYPE NUMERIC,
+    ALTER COLUMN override_value TYPE NUMERIC;
+
+ALTER TABLE accelerator.report_common_indicators ALTER COLUMN value TYPE NUMERIC;
+
+ALTER TABLE accelerator.report_project_indicators ALTER COLUMN value TYPE NUMERIC;
+
+-- Published report indicators
+ALTER TABLE funder.published_report_auto_calculated_indicators ALTER COLUMN value TYPE NUMERIC;
+
+ALTER TABLE funder.published_report_common_indicators ALTER COLUMN value TYPE NUMERIC;
+
+ALTER TABLE funder.published_report_project_indicators ALTER COLUMN value TYPE NUMERIC;
+
+-- Report targets
+ALTER TABLE accelerator.report_auto_calculated_indicator_targets ALTER COLUMN target TYPE NUMERIC;
+
+ALTER TABLE accelerator.report_common_indicator_targets ALTER COLUMN target TYPE NUMERIC;
+
+ALTER TABLE accelerator.report_project_indicator_targets ALTER COLUMN target TYPE NUMERIC;
+
+-- Published report targets
+ALTER TABLE funder.published_auto_calculated_indicator_targets ALTER COLUMN target TYPE NUMERIC;
+
+ALTER TABLE funder.published_common_indicator_targets ALTER COLUMN target TYPE NUMERIC;
+
+ALTER TABLE funder.published_project_indicator_targets ALTER COLUMN target TYPE NUMERIC;

--- a/src/test/kotlin/com/terraformation/backend/accelerator/db/ProjectAcceleratorDetailsStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/db/ProjectAcceleratorDetailsStoreTest.kt
@@ -61,38 +61,38 @@ class ProjectAcceleratorDetailsStoreTest : DatabaseTest(), RunsAsUser {
       insertPublishedReport()
       insertPublishedReportAutoCalculatedIndicator(
           indicator = AutoCalculatedIndicator.HectaresPlanted,
-          value = 100,
+          value = BigDecimal(100),
       )
       insertPublishedReportAutoCalculatedIndicator(
           indicator = AutoCalculatedIndicator.TreesPlanted,
-          value = 10,
+          value = BigDecimal(10),
       )
       insertPublishedReportAutoCalculatedIndicator(
           indicator = AutoCalculatedIndicator.SeedsCollected,
-          value = 1000,
+          value = BigDecimal(1000),
       )
       insertPublishedReportAutoCalculatedIndicator(
           indicator = AutoCalculatedIndicator.SpeciesPlanted,
-          value = 1,
+          value = BigDecimal(1),
       )
 
       insertReport()
       insertPublishedReport()
       insertPublishedReportAutoCalculatedIndicator(
           indicator = AutoCalculatedIndicator.HectaresPlanted,
-          value = 200,
+          value = BigDecimal(200),
       )
       insertPublishedReportAutoCalculatedIndicator(
           indicator = AutoCalculatedIndicator.TreesPlanted,
-          value = 20,
+          value = BigDecimal(20),
       )
       insertPublishedReportAutoCalculatedIndicator(
           indicator = AutoCalculatedIndicator.SeedsCollected,
-          value = 2000,
+          value = BigDecimal(2000),
       )
       insertPublishedReportAutoCalculatedIndicator(
           indicator = AutoCalculatedIndicator.SpeciesPlanted,
-          value = 2,
+          value = BigDecimal(2),
       )
 
       // To ensure that the fetchOne works as expected when there are multiple rows
@@ -169,12 +169,18 @@ class ProjectAcceleratorDetailsStoreTest : DatabaseTest(), RunsAsUser {
               maxCarbonAccumulation = detailsRow.maxCarbonAccumulation,
               indicatorProgress =
                   listOf(
-                      IndicatorProgressModel(indicator = AutoCalculatedIndicator.TreesPlanted, 30),
+                      IndicatorProgressModel(
+                          indicator = AutoCalculatedIndicator.TreesPlanted,
+                          BigDecimal(30),
+                      ),
                       // Species Planted utilize max instead of sum
-                      IndicatorProgressModel(indicator = AutoCalculatedIndicator.SpeciesPlanted, 2),
+                      IndicatorProgressModel(
+                          indicator = AutoCalculatedIndicator.SpeciesPlanted,
+                          BigDecimal(2),
+                      ),
                       IndicatorProgressModel(
                           indicator = AutoCalculatedIndicator.HectaresPlanted,
-                          300,
+                          BigDecimal(300),
                       ),
                       // Seeds Collected and other indicator progress is not tracked
                   ),

--- a/src/test/kotlin/com/terraformation/backend/accelerator/db/ReportStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/db/ReportStoreTest.kt
@@ -2055,10 +2055,7 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
       insertReportCommonIndicatorTarget(
           commonIndicatorId = commonIndicatorId1,
           year = 1970,
-          target =
-              BigDecimal(
-                  55,
-              ),
+          target = BigDecimal(55),
       )
       insertReportCommonIndicator(
           reportId = reportId,
@@ -2073,10 +2070,7 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
       insertReportCommonIndicatorTarget(
           commonIndicatorId = commonIndicatorId2,
           year = 1970,
-          target =
-              BigDecimal(
-                  25,
-              ),
+          target = BigDecimal(25),
       )
       insertReportCommonIndicator(
           reportId = reportId,
@@ -2680,10 +2674,7 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
       insertReportCommonIndicatorTarget(
           commonIndicatorId = commonIndicatorId1,
           year = 1970,
-          target =
-              BigDecimal(
-                  55,
-              ),
+          target = BigDecimal(55),
       )
       insertReportCommonIndicator(
           reportId = reportId,
@@ -2698,10 +2689,7 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
       insertReportCommonIndicatorTarget(
           commonIndicatorId = commonIndicatorId2,
           year = 1970,
-          target =
-              BigDecimal(
-                  30,
-              ),
+          target = BigDecimal(30),
       )
       insertReportCommonIndicator(
           reportId = reportId,
@@ -3166,10 +3154,7 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
       insertReportCommonIndicatorTarget(
           commonIndicatorId = commonIndicatorId1,
           year = 1970,
-          target =
-              BigDecimal(
-                  55,
-              ),
+          target = BigDecimal(55),
       )
       insertReportCommonIndicator(
           reportId = reportId,
@@ -3184,10 +3169,7 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
       insertReportCommonIndicatorTarget(
           commonIndicatorId = commonIndicatorId2,
           year = 1970,
-          target =
-              BigDecimal(
-                  30,
-              ),
+          target = BigDecimal(30),
       )
       insertReportCommonIndicator(
           reportId = reportId,
@@ -4565,10 +4547,7 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
       insertReportCommonIndicatorTarget(
           commonIndicatorId = commonIndicatorId1,
           year = 2030,
-          target =
-              BigDecimal(
-                  10,
-              ),
+          target = BigDecimal(10),
       )
       insertReportCommonIndicator(
           reportId = reportId,
@@ -4582,10 +4561,7 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
       insertReportCommonIndicatorTarget(
           commonIndicatorId = commonIndicatorId2,
           year = 2030,
-          target =
-              BigDecimal(
-                  20,
-              ),
+          target = BigDecimal(20),
       )
       insertReportCommonIndicator(
           reportId = reportId,

--- a/src/test/kotlin/com/terraformation/backend/accelerator/db/ReportStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/db/ReportStoreTest.kt
@@ -308,7 +308,7 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
       insertReportProjectIndicatorTarget(
           projectIndicatorId = projectIndicatorId,
           year = 1970,
-          target = 100,
+          target = BigDecimal(100),
       )
       insertReportProjectIndicator(
           reportId = reportId,
@@ -341,7 +341,7 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
                       ),
                   entry =
                       ReportIndicatorEntryModel(
-                          target = 100,
+                          target = BigDecimal(100),
                           status = ReportIndicatorStatus.OnTrack,
                           modifiedTime = Instant.ofEpochSecond(1500),
                           modifiedBy = user.userId,
@@ -387,12 +387,12 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
       insertReportCommonIndicatorTarget(
           commonIndicatorId = commonIndicatorId1,
           year = 1970,
-          target = 55,
+          target = BigDecimal(55),
       )
       insertReportCommonIndicator(
           reportId = reportId,
           indicatorId = commonIndicatorId1,
-          value = 45,
+          value = BigDecimal(45),
           projectsComments = "Almost at target",
           progressNotes = "Not quite there yet",
           modifiedTime = Instant.ofEpochSecond(3000),
@@ -406,7 +406,7 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
       insertReportCommonIndicatorTarget(
           commonIndicatorId = commonIndicatorId2,
           year = 1970,
-          target = 25,
+          target = BigDecimal(25),
       )
       insertReportCommonIndicator(
           reportId = reportId,
@@ -461,8 +461,8 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
                       ),
                   entry =
                       ReportIndicatorEntryModel(
-                          target = 55,
-                          value = 45,
+                          target = BigDecimal(55),
+                          value = BigDecimal(45),
                           projectsComments = "Almost at target",
                           progressNotes = "Not quite there yet",
                           modifiedTime = Instant.ofEpochSecond(3000),
@@ -486,7 +486,7 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
                       ),
                   entry =
                       ReportIndicatorEntryModel(
-                          target = 25,
+                          target = BigDecimal(25),
                           status = ReportIndicatorStatus.Unlikely,
                           modifiedTime = Instant.ofEpochSecond(1500),
                           modifiedBy = user.userId,
@@ -498,7 +498,7 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
       insertReportAutoCalculatedIndicatorTarget(
           indicator = AutoCalculatedIndicator.Seedlings,
           year = 1970,
-          target = 1000,
+          target = BigDecimal(1000),
       )
       insertReportAutoCalculatedIndicator(
           reportId = reportId,
@@ -510,12 +510,12 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
       insertReportAutoCalculatedIndicatorTarget(
           indicator = AutoCalculatedIndicator.SeedsCollected,
           year = 1970,
-          target = 2000,
+          target = BigDecimal(2000),
       )
       insertReportAutoCalculatedIndicator(
           reportId = reportId,
           indicator = AutoCalculatedIndicator.SeedsCollected,
-          systemValue = 1800,
+          systemValue = BigDecimal(1800),
           systemTime = Instant.ofEpochSecond(8000),
           modifiedTime = Instant.ofEpochSecond(500),
           modifiedBy = user.userId,
@@ -528,14 +528,14 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
       insertReportAutoCalculatedIndicatorTarget(
           indicator = AutoCalculatedIndicator.TreesPlanted,
           year = 1970,
-          target = 600,
+          target = BigDecimal(600),
       )
       insertReportAutoCalculatedIndicator(
           reportId = reportId,
           indicator = AutoCalculatedIndicator.TreesPlanted,
-          systemValue = 300,
+          systemValue = BigDecimal(300),
           systemTime = Instant.ofEpochSecond(7000),
-          overrideValue = 800,
+          overrideValue = BigDecimal(800),
           status = ReportIndicatorStatus.Achieved,
           modifiedTime = Instant.ofEpochSecond(700),
           modifiedBy = user.userId,
@@ -553,21 +553,21 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
                   indicator = AutoCalculatedIndicator.SeedsCollected,
                   entry =
                       ReportAutoCalculatedIndicatorEntryModel(
-                          target = 2000,
-                          systemValue = 1800,
+                          target = BigDecimal(2000),
+                          systemValue = BigDecimal(1800),
                           systemTime = Instant.ofEpochSecond(8000),
                           modifiedTime = Instant.ofEpochSecond(500),
                           modifiedBy = user.userId,
                       ),
                   baseline = BigDecimal.TEN,
                   currentYearProgress =
-                      listOf(CumulativeIndicatorProgressModel(ReportQuarter.Q1, 1800)),
+                      listOf(CumulativeIndicatorProgressModel(ReportQuarter.Q1, BigDecimal(1800))),
               ),
               ReportAutoCalculatedIndicatorModel(
                   indicator = AutoCalculatedIndicator.HectaresPlanted,
                   entry =
                       ReportAutoCalculatedIndicatorEntryModel(
-                          systemValue = 0,
+                          systemValue = BigDecimal(0),
                       ),
                   currentYearProgress = emptyList(),
               ),
@@ -575,8 +575,8 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
                   indicator = AutoCalculatedIndicator.Seedlings,
                   entry =
                       ReportAutoCalculatedIndicatorEntryModel(
-                          target = 1000,
-                          systemValue = 0,
+                          target = BigDecimal(1000),
+                          systemValue = BigDecimal(0),
                           modifiedTime = Instant.ofEpochSecond(2500),
                           modifiedBy = user.userId,
                       ),
@@ -586,10 +586,10 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
                   indicator = AutoCalculatedIndicator.TreesPlanted,
                   entry =
                       ReportAutoCalculatedIndicatorEntryModel(
-                          target = 600,
-                          systemValue = 300,
+                          target = BigDecimal(600),
+                          systemValue = BigDecimal(300),
                           systemTime = Instant.ofEpochSecond(7000),
-                          overrideValue = 800,
+                          overrideValue = BigDecimal(800),
                           status = ReportIndicatorStatus.Achieved,
                           modifiedTime = Instant.ofEpochSecond(700),
                           modifiedBy = user.userId,
@@ -597,13 +597,13 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
                   baseline = BigDecimal("20"),
                   endOfProjectTarget = BigDecimal("1500"),
                   currentYearProgress =
-                      listOf(CumulativeIndicatorProgressModel(ReportQuarter.Q1, 800)),
+                      listOf(CumulativeIndicatorProgressModel(ReportQuarter.Q1, BigDecimal(800))),
               ),
               ReportAutoCalculatedIndicatorModel(
                   indicator = AutoCalculatedIndicator.SpeciesPlanted,
                   entry =
                       ReportAutoCalculatedIndicatorEntryModel(
-                          systemValue = 0,
+                          systemValue = BigDecimal(0),
                       ),
               ),
               ReportAutoCalculatedIndicatorModel(
@@ -657,7 +657,7 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
                   indicator = AutoCalculatedIndicator.SeedsCollected,
                   entry =
                       ReportAutoCalculatedIndicatorEntryModel(
-                          systemValue = 98,
+                          systemValue = BigDecimal(98),
                       ),
                   currentYearProgress = emptyList(),
               ),
@@ -665,7 +665,7 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
                   indicator = AutoCalculatedIndicator.HectaresPlanted,
                   entry =
                       ReportAutoCalculatedIndicatorEntryModel(
-                          systemValue = 60,
+                          systemValue = BigDecimal(60),
                       ),
                   currentYearProgress = emptyList(),
               ),
@@ -673,7 +673,7 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
                   indicator = AutoCalculatedIndicator.Seedlings,
                   entry =
                       ReportAutoCalculatedIndicatorEntryModel(
-                          systemValue = 83,
+                          systemValue = BigDecimal(83),
                       ),
                   currentYearProgress = emptyList(),
               ),
@@ -681,7 +681,7 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
                   indicator = AutoCalculatedIndicator.TreesPlanted,
                   entry =
                       ReportAutoCalculatedIndicatorEntryModel(
-                          systemValue = 27,
+                          systemValue = BigDecimal(27),
                       ),
                   currentYearProgress = emptyList(),
               ),
@@ -689,7 +689,7 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
                   indicator = AutoCalculatedIndicator.SpeciesPlanted,
                   entry =
                       ReportAutoCalculatedIndicatorEntryModel(
-                          systemValue = 1,
+                          systemValue = BigDecimal(1),
                       ),
               ),
               ReportAutoCalculatedIndicatorModel(
@@ -697,8 +697,10 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
                   entry =
                       ReportAutoCalculatedIndicatorEntryModel(
                           systemValue =
-                              (sitesLiveSum * 100.0 / (site1T0Density + site2T0Density))
-                                  .roundToInt(),
+                              BigDecimal(
+                                  (sitesLiveSum * 100.0 / (site1T0Density + site2T0Density))
+                                      .roundToInt()
+                              ),
                       ),
               ),
           ),
@@ -726,8 +728,10 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
               entry =
                   ReportAutoCalculatedIndicatorEntryModel(
                       systemValue =
-                          (sitesLiveSum * 100.0 / (site1T0DensityWithTemp + site2T0Density))
-                              .roundToInt(),
+                          BigDecimal(
+                              (sitesLiveSum * 100.0 / (site1T0DensityWithTemp + site2T0Density))
+                                  .roundToInt()
+                          ),
                   ),
           ),
           autoCalculatedIndicators.find { it.indicator == AutoCalculatedIndicator.SurvivalRate },
@@ -760,7 +764,8 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
               indicator = AutoCalculatedIndicator.SurvivalRate,
               entry =
                   ReportAutoCalculatedIndicatorEntryModel(
-                      systemValue = ((5 + 6 + 7 + 8) * 100.0 / (10 + 11 + 12 + 13)).roundToInt(),
+                      systemValue =
+                          BigDecimal(((5 + 6 + 7 + 8) * 100.0 / (10 + 11 + 12 + 13)).roundToInt()),
                   ),
           ),
           autoCalculatedIndicators.find { it.indicator == AutoCalculatedIndicator.SurvivalRate },
@@ -783,8 +788,11 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
               entry =
                   ReportAutoCalculatedIndicatorEntryModel(
                       systemValue =
-                          ((11 + 12 + 13 + 14) * 100.0 / (10 + 11 + 12 + 13 + 20 + 21 + 22 + 23))
-                              .roundToInt(),
+                          BigDecimal(
+                              ((11 + 12 + 13 + 14) * 100.0 /
+                                      (10 + 11 + 12 + 13 + 20 + 21 + 22 + 23))
+                                  .roundToInt()
+                          ),
                   ),
           ),
           autoCalculatedIndicatorsWithTemp.find {
@@ -1080,20 +1088,20 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
       insertReportProjectIndicatorTarget(
           projectIndicatorId = projectIndicatorId,
           year = 2024,
-          target = 100,
+          target = BigDecimal(100),
       )
       // Target for a different year - should not cause duplicate rows
       insertReportProjectIndicatorTarget(
           projectIndicatorId = projectIndicatorId,
           year = 2025,
-          target = 999,
+          target = BigDecimal(999),
       )
       // Target for a different project in the same year - should not cause duplicate rows
       insertReportProjectIndicatorTarget(
           projectId = otherProjectId,
           projectIndicatorId = projectIndicatorId,
           year = 2024,
-          target = 888,
+          target = BigDecimal(888),
       )
 
       val report = store.fetch(includeIndicators = true).single()
@@ -1114,7 +1122,7 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
                       refId = "1.1",
                       tfOwner = "Carbon",
                   ),
-              entry = ReportIndicatorEntryModel(target = 100),
+              entry = ReportIndicatorEntryModel(target = BigDecimal(100)),
           )
       assertEquals(
           listOf(expected),
@@ -1136,20 +1144,20 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
       insertReportCommonIndicatorTarget(
           commonIndicatorId = commonIndicatorId,
           year = 2024,
-          target = 200,
+          target = BigDecimal(200),
       )
       // Target for a different year - should not cause duplicate rows
       insertReportCommonIndicatorTarget(
           commonIndicatorId = commonIndicatorId,
           year = 2025,
-          target = 999,
+          target = BigDecimal(999),
       )
       // Target for a different project in the same year - should not cause duplicate rows
       insertReportCommonIndicatorTarget(
           projectId = otherProjectId,
           commonIndicatorId = commonIndicatorId,
           year = 2024,
-          target = 888,
+          target = BigDecimal(888),
       )
 
       val report = store.fetch(includeIndicators = true).single()
@@ -1168,7 +1176,7 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
                       refId = "1.1",
                       tfOwner = "Carbon",
                   ),
-              entry = ReportIndicatorEntryModel(target = 200),
+              entry = ReportIndicatorEntryModel(target = BigDecimal(200)),
           )
       assertEquals(
           listOf(expected),
@@ -1189,20 +1197,20 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
       insertReportAutoCalculatedIndicatorTarget(
           indicator = AutoCalculatedIndicator.SeedsCollected,
           year = 2024,
-          target = 300,
+          target = BigDecimal(300),
       )
       // Target for a different year - should not cause duplicate rows
       insertReportAutoCalculatedIndicatorTarget(
           indicator = AutoCalculatedIndicator.SeedsCollected,
           year = 2025,
-          target = 999,
+          target = BigDecimal(999),
       )
       // Target for a different project in the same year - should not cause duplicate rows
       insertReportAutoCalculatedIndicatorTarget(
           projectId = otherProjectId,
           indicator = AutoCalculatedIndicator.SeedsCollected,
           year = 2024,
-          target = 888,
+          target = BigDecimal(888),
       )
 
       val report = store.fetch(includeIndicators = true).single()
@@ -1211,8 +1219,8 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
               indicator = AutoCalculatedIndicator.SeedsCollected,
               entry =
                   ReportAutoCalculatedIndicatorEntryModel(
-                      target = 300,
-                      systemValue = 0,
+                      target = BigDecimal(300),
+                      systemValue = BigDecimal(0),
                   ),
               currentYearProgress = emptyList(),
           )
@@ -1336,45 +1344,48 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
           endDate = LocalDate.of(2024, 6, 30),
           configId = otherProjectConfigId,
       )
-      insertReportProjectIndicator(indicatorId = otherProjectIndicatorId, value = 10_000)
-      insertReportCommonIndicator(indicatorId = commonIndicatorId1, value = 20_000)
+      insertReportProjectIndicator(
+          indicatorId = otherProjectIndicatorId,
+          value = BigDecimal(10_000),
+      )
+      insertReportCommonIndicator(indicatorId = commonIndicatorId1, value = BigDecimal(20_000))
       insertReportAutoCalculatedIndicator(
           indicator = AutoCalculatedIndicator.SeedsCollected,
-          systemValue = 30_000,
+          systemValue = BigDecimal(30_000),
       )
 
       // oldReport1
       insertReport(endDate = LocalDate.of(2024, 9, 30))
-      insertReportProjectIndicator(indicatorId = projectIndicatorId1, value = 10)
-      insertReportProjectIndicator(indicatorId = projectIndicatorId2, value = 11)
-      insertReportCommonIndicator(indicatorId = commonIndicatorId1, value = 20)
-      insertReportCommonIndicator(indicatorId = commonIndicatorId2, value = 21)
+      insertReportProjectIndicator(indicatorId = projectIndicatorId1, value = BigDecimal(10))
+      insertReportProjectIndicator(indicatorId = projectIndicatorId2, value = BigDecimal(11))
+      insertReportCommonIndicator(indicatorId = commonIndicatorId1, value = BigDecimal(20))
+      insertReportCommonIndicator(indicatorId = commonIndicatorId2, value = BigDecimal(21))
       insertReportAutoCalculatedIndicator(
           indicator = AutoCalculatedIndicator.SeedsCollected,
-          systemValue = 30,
+          systemValue = BigDecimal(30),
       )
       insertReportAutoCalculatedIndicator(
           indicator = AutoCalculatedIndicator.HectaresPlanted,
-          systemValue = 29,
-          overrideValue = 31, // overrideValue takes precedence
+          systemValue = BigDecimal(29),
+          overrideValue = BigDecimal(31), // overrideValue takes precedence
       )
 
       // oldReport2
       insertReport(endDate = LocalDate.of(2024, 12, 31))
-      insertReportProjectIndicator(indicatorId = projectIndicatorId1, value = 100)
-      insertReportProjectIndicator(indicatorId = projectIndicatorId2, value = 101)
-      insertReportCommonIndicator(indicatorId = commonIndicatorId1, value = 200)
-      insertReportCommonIndicator(indicatorId = commonIndicatorId2, value = 201)
+      insertReportProjectIndicator(indicatorId = projectIndicatorId1, value = BigDecimal(100))
+      insertReportProjectIndicator(indicatorId = projectIndicatorId2, value = BigDecimal(101))
+      insertReportCommonIndicator(indicatorId = commonIndicatorId1, value = BigDecimal(200))
+      insertReportCommonIndicator(indicatorId = commonIndicatorId2, value = BigDecimal(201))
 
       insertReportAutoCalculatedIndicator(
           indicator = AutoCalculatedIndicator.SeedsCollected,
-          systemValue = 300,
-          overrideValue = 301, // overrideValue takes precedence
+          systemValue = BigDecimal(300),
+          overrideValue = BigDecimal(301), // overrideValue takes precedence
       )
       insertReportAutoCalculatedIndicator(
           indicator = AutoCalculatedIndicator.HectaresPlanted,
-          systemValue = 299,
-          overrideValue = 302, // overrideValue takes precedence
+          systemValue = BigDecimal(299),
+          overrideValue = BigDecimal(302), // overrideValue takes precedence
       )
 
       val reportId =
@@ -1385,11 +1396,11 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
       insertReportCommonIndicator(indicatorId = commonIndicatorId2)
       insertReportAutoCalculatedIndicator(
           indicator = AutoCalculatedIndicator.SeedsCollected,
-          systemValue = 3000,
+          systemValue = BigDecimal(3000),
       )
       insertReportAutoCalculatedIndicator(
           indicator = AutoCalculatedIndicator.HectaresPlanted,
-          systemValue = 4000,
+          systemValue = BigDecimal(4000),
       )
 
       val projectIndicators =
@@ -1496,11 +1507,11 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
                       ReportAutoCalculatedIndicatorEntryModel(
                           modifiedBy = user.userId,
                           modifiedTime = Instant.EPOCH,
-                          systemValue = 3000,
+                          systemValue = BigDecimal(3000),
                           systemTime = Instant.EPOCH,
                       ),
                   currentYearProgress =
-                      listOf(CumulativeIndicatorProgressModel(ReportQuarter.Q1, 3000)),
+                      listOf(CumulativeIndicatorProgressModel(ReportQuarter.Q1, BigDecimal(3000))),
                   previousYearCumulativeTotal = BigDecimal("331"),
               ),
               ReportAutoCalculatedIndicatorModel(
@@ -1509,26 +1520,26 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
                       ReportAutoCalculatedIndicatorEntryModel(
                           modifiedBy = user.userId,
                           modifiedTime = Instant.EPOCH,
-                          systemValue = 4000,
+                          systemValue = BigDecimal(4000),
                           systemTime = Instant.EPOCH,
                       ),
                   currentYearProgress =
-                      listOf(CumulativeIndicatorProgressModel(ReportQuarter.Q1, 4000)),
+                      listOf(CumulativeIndicatorProgressModel(ReportQuarter.Q1, BigDecimal(4000))),
                   previousYearCumulativeTotal = BigDecimal("333"),
               ),
               ReportAutoCalculatedIndicatorModel(
                   indicator = AutoCalculatedIndicator.Seedlings,
-                  entry = ReportAutoCalculatedIndicatorEntryModel(systemValue = 0),
+                  entry = ReportAutoCalculatedIndicatorEntryModel(systemValue = BigDecimal(0)),
                   currentYearProgress = emptyList(),
               ),
               ReportAutoCalculatedIndicatorModel(
                   indicator = AutoCalculatedIndicator.TreesPlanted,
-                  entry = ReportAutoCalculatedIndicatorEntryModel(systemValue = 0),
+                  entry = ReportAutoCalculatedIndicatorEntryModel(systemValue = BigDecimal(0)),
                   currentYearProgress = emptyList(),
               ),
               ReportAutoCalculatedIndicatorModel(
                   indicator = AutoCalculatedIndicator.SpeciesPlanted,
-                  entry = ReportAutoCalculatedIndicatorEntryModel(systemValue = 0),
+                  entry = ReportAutoCalculatedIndicatorEntryModel(systemValue = BigDecimal(0)),
               ),
               ReportAutoCalculatedIndicatorModel(
                   indicator = AutoCalculatedIndicator.SurvivalRate,
@@ -1595,33 +1606,33 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
       insertReportCommonIndicator(
           reportId = q1ReportId,
           indicatorId = cumulativeCommonIndicatorId,
-          value = 11,
+          value = BigDecimal(11),
       )
       insertReportCommonIndicator(
           reportId = q1ReportId,
           indicatorId = levelCommonIndicatorId,
-          value = 100,
+          value = BigDecimal(100),
       )
       insertReportProjectIndicator(
           reportId = q1ReportId,
           indicatorId = cumulativeProjectIndicatorId,
-          value = 21,
+          value = BigDecimal(21),
       )
       insertReportProjectIndicator(
           reportId = q1ReportId,
           indicatorId = levelProjectIndicatorId,
-          value = 100,
+          value = BigDecimal(100),
       )
       insertReportAutoCalculatedIndicator(
           reportId = q1ReportId,
           indicator = AutoCalculatedIndicator.SeedsCollected,
-          systemValue = 31,
+          systemValue = BigDecimal(31),
       )
       insertReportAutoCalculatedIndicator(
           reportId = q1ReportId,
           indicator = AutoCalculatedIndicator.HectaresPlanted,
-          systemValue = 41,
-          overrideValue = 40, // override takes precedence
+          systemValue = BigDecimal(41),
+          overrideValue = BigDecimal(40), // override takes precedence
       )
 
       // Q2 report - values contribute to Q3's currentYearProgress
@@ -1634,32 +1645,32 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
       insertReportCommonIndicator(
           reportId = q2ReportId,
           indicatorId = cumulativeCommonIndicatorId,
-          value = 12,
+          value = BigDecimal(12),
       )
       insertReportCommonIndicator(
           reportId = q2ReportId,
           indicatorId = levelCommonIndicatorId,
-          value = 200,
+          value = BigDecimal(200),
       )
       insertReportProjectIndicator(
           reportId = q2ReportId,
           indicatorId = cumulativeProjectIndicatorId,
-          value = 22,
+          value = BigDecimal(22),
       )
       insertReportProjectIndicator(
           reportId = q2ReportId,
           indicatorId = levelProjectIndicatorId,
-          value = 200,
+          value = BigDecimal(200),
       )
       insertReportAutoCalculatedIndicator(
           reportId = q2ReportId,
           indicator = AutoCalculatedIndicator.SeedsCollected,
-          systemValue = 32,
+          systemValue = BigDecimal(32),
       )
       insertReportAutoCalculatedIndicator(
           reportId = q2ReportId,
           indicator = AutoCalculatedIndicator.HectaresPlanted,
-          systemValue = 42,
+          systemValue = BigDecimal(42),
       )
 
       // Q3 report (current report being fetched)
@@ -1669,17 +1680,20 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
               startDate = LocalDate.of(2025, 7, 1),
               endDate = LocalDate.of(2025, 9, 30),
           )
-      insertReportCommonIndicator(indicatorId = cumulativeCommonIndicatorId, value = 13)
-      insertReportCommonIndicator(indicatorId = levelCommonIndicatorId, value = 300)
-      insertReportProjectIndicator(indicatorId = cumulativeProjectIndicatorId, value = 23)
-      insertReportProjectIndicator(indicatorId = levelProjectIndicatorId, value = 300)
+      insertReportCommonIndicator(indicatorId = cumulativeCommonIndicatorId, value = BigDecimal(13))
+      insertReportCommonIndicator(indicatorId = levelCommonIndicatorId, value = BigDecimal(300))
+      insertReportProjectIndicator(
+          indicatorId = cumulativeProjectIndicatorId,
+          value = BigDecimal(23),
+      )
+      insertReportProjectIndicator(indicatorId = levelProjectIndicatorId, value = BigDecimal(300))
       insertReportAutoCalculatedIndicator(
           indicator = AutoCalculatedIndicator.SeedsCollected,
-          systemValue = 33,
+          systemValue = BigDecimal(33),
       )
       insertReportAutoCalculatedIndicator(
           indicator = AutoCalculatedIndicator.HectaresPlanted,
-          systemValue = 43,
+          systemValue = BigDecimal(43),
       )
 
       // Q4 report (future quarter relative to Q3 - should be excluded from currentYearProgress)
@@ -1692,22 +1706,22 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
       insertReportCommonIndicator(
           reportId = q4ReportId,
           indicatorId = cumulativeCommonIndicatorId,
-          value = 14,
+          value = BigDecimal(14),
       )
       insertReportProjectIndicator(
           reportId = q4ReportId,
           indicatorId = cumulativeProjectIndicatorId,
-          value = 24,
+          value = BigDecimal(24),
       )
       insertReportAutoCalculatedIndicator(
           reportId = q4ReportId,
           indicator = AutoCalculatedIndicator.SeedsCollected,
-          systemValue = 34,
+          systemValue = BigDecimal(34),
       )
       insertReportAutoCalculatedIndicator(
           reportId = q4ReportId,
           indicator = AutoCalculatedIndicator.HectaresPlanted,
-          systemValue = 44,
+          systemValue = BigDecimal(44),
       )
 
       // Other project's report in same year - should not appear in current year progress
@@ -1717,7 +1731,10 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
           quarter = ReportQuarter.Q1,
           endDate = LocalDate.of(2025, 3, 31),
       )
-      insertReportCommonIndicator(indicatorId = cumulativeCommonIndicatorId, value = 888)
+      insertReportCommonIndicator(
+          indicatorId = cumulativeCommonIndicatorId,
+          value = BigDecimal(888),
+      )
 
       clock.instant = LocalDate.of(2025, 12, 20).atStartOfDay().toInstant(ZoneOffset.UTC)
 
@@ -1757,13 +1774,22 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
                               ReportIndicatorEntryModel(
                                   modifiedBy = user.userId,
                                   modifiedTime = Instant.EPOCH,
-                                  value = 13,
+                                  value = BigDecimal(13),
                               ),
                           currentYearProgress =
                               listOf(
-                                  CumulativeIndicatorProgressModel(ReportQuarter.Q1, 11),
-                                  CumulativeIndicatorProgressModel(ReportQuarter.Q2, 12),
-                                  CumulativeIndicatorProgressModel(ReportQuarter.Q3, 13),
+                                  CumulativeIndicatorProgressModel(
+                                      ReportQuarter.Q1,
+                                      BigDecimal(11),
+                                  ),
+                                  CumulativeIndicatorProgressModel(
+                                      ReportQuarter.Q2,
+                                      BigDecimal(12),
+                                  ),
+                                  CumulativeIndicatorProgressModel(
+                                      ReportQuarter.Q3,
+                                      BigDecimal(13),
+                                  ),
                               ),
                       ),
                       ReportCommonIndicatorModel(
@@ -1784,7 +1810,7 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
                               ReportIndicatorEntryModel(
                                   modifiedBy = user.userId,
                                   modifiedTime = Instant.EPOCH,
-                                  value = 300,
+                                  value = BigDecimal(300),
                               ),
                       ),
                   ),
@@ -1809,13 +1835,22 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
                               ReportIndicatorEntryModel(
                                   modifiedBy = user.userId,
                                   modifiedTime = Instant.EPOCH,
-                                  value = 23,
+                                  value = BigDecimal(23),
                               ),
                           currentYearProgress =
                               listOf(
-                                  CumulativeIndicatorProgressModel(ReportQuarter.Q1, 21),
-                                  CumulativeIndicatorProgressModel(ReportQuarter.Q2, 22),
-                                  CumulativeIndicatorProgressModel(ReportQuarter.Q3, 23),
+                                  CumulativeIndicatorProgressModel(
+                                      ReportQuarter.Q1,
+                                      BigDecimal(21),
+                                  ),
+                                  CumulativeIndicatorProgressModel(
+                                      ReportQuarter.Q2,
+                                      BigDecimal(22),
+                                  ),
+                                  CumulativeIndicatorProgressModel(
+                                      ReportQuarter.Q3,
+                                      BigDecimal(23),
+                                  ),
                               ),
                       ),
                       ReportProjectIndicatorModel(
@@ -1837,7 +1872,7 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
                               ReportIndicatorEntryModel(
                                   modifiedBy = user.userId,
                                   modifiedTime = Instant.EPOCH,
-                                  value = 300,
+                                  value = BigDecimal(300),
                               ),
                       ),
                   ),
@@ -1849,14 +1884,23 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
                               ReportAutoCalculatedIndicatorEntryModel(
                                   modifiedBy = user.userId,
                                   modifiedTime = Instant.EPOCH,
-                                  systemValue = 33,
+                                  systemValue = BigDecimal(33),
                                   systemTime = Instant.EPOCH,
                               ),
                           currentYearProgress =
                               listOf(
-                                  CumulativeIndicatorProgressModel(ReportQuarter.Q1, 31),
-                                  CumulativeIndicatorProgressModel(ReportQuarter.Q2, 32),
-                                  CumulativeIndicatorProgressModel(ReportQuarter.Q3, 33),
+                                  CumulativeIndicatorProgressModel(
+                                      ReportQuarter.Q1,
+                                      BigDecimal(31),
+                                  ),
+                                  CumulativeIndicatorProgressModel(
+                                      ReportQuarter.Q2,
+                                      BigDecimal(32),
+                                  ),
+                                  CumulativeIndicatorProgressModel(
+                                      ReportQuarter.Q3,
+                                      BigDecimal(33),
+                                  ),
                               ),
                       ),
                       ReportAutoCalculatedIndicatorModel(
@@ -1865,29 +1909,41 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
                               ReportAutoCalculatedIndicatorEntryModel(
                                   modifiedBy = user.userId,
                                   modifiedTime = Instant.EPOCH,
-                                  systemValue = 43,
+                                  systemValue = BigDecimal(43),
                                   systemTime = Instant.EPOCH,
                               ),
                           currentYearProgress =
                               listOf(
-                                  CumulativeIndicatorProgressModel(ReportQuarter.Q1, 40),
-                                  CumulativeIndicatorProgressModel(ReportQuarter.Q2, 42),
-                                  CumulativeIndicatorProgressModel(ReportQuarter.Q3, 43),
+                                  CumulativeIndicatorProgressModel(
+                                      ReportQuarter.Q1,
+                                      BigDecimal(40),
+                                  ),
+                                  CumulativeIndicatorProgressModel(
+                                      ReportQuarter.Q2,
+                                      BigDecimal(42),
+                                  ),
+                                  CumulativeIndicatorProgressModel(
+                                      ReportQuarter.Q3,
+                                      BigDecimal(43),
+                                  ),
                               ),
                       ),
                       ReportAutoCalculatedIndicatorModel(
                           indicator = AutoCalculatedIndicator.Seedlings,
-                          entry = ReportAutoCalculatedIndicatorEntryModel(systemValue = 0),
+                          entry =
+                              ReportAutoCalculatedIndicatorEntryModel(systemValue = BigDecimal(0)),
                           currentYearProgress = emptyList(),
                       ),
                       ReportAutoCalculatedIndicatorModel(
                           indicator = AutoCalculatedIndicator.TreesPlanted,
-                          entry = ReportAutoCalculatedIndicatorEntryModel(systemValue = 0),
+                          entry =
+                              ReportAutoCalculatedIndicatorEntryModel(systemValue = BigDecimal(0)),
                           currentYearProgress = emptyList(),
                       ),
                       ReportAutoCalculatedIndicatorModel(
                           indicator = AutoCalculatedIndicator.SpeciesPlanted,
-                          entry = ReportAutoCalculatedIndicatorEntryModel(systemValue = 0),
+                          entry =
+                              ReportAutoCalculatedIndicatorEntryModel(systemValue = BigDecimal(0)),
                       ),
                       ReportAutoCalculatedIndicatorModel(
                           indicator = AutoCalculatedIndicator.SurvivalRate,
@@ -1924,7 +1980,7 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
       insertReportProjectIndicatorTarget(
           projectIndicatorId = projectIndicatorId,
           year = 1970,
-          target = 100,
+          target = BigDecimal(100),
       )
       insertReportProjectIndicator(
           reportId = reportId,
@@ -1956,7 +2012,7 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
                       ),
                   entry =
                       ReportIndicatorEntryModel(
-                          target = 100,
+                          target = BigDecimal(100),
                           status = ReportIndicatorStatus.OnTrack,
                           modifiedTime = Instant.ofEpochSecond(1500),
                           modifiedBy = user.userId,
@@ -1999,12 +2055,15 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
       insertReportCommonIndicatorTarget(
           commonIndicatorId = commonIndicatorId1,
           year = 1970,
-          target = 55,
+          target =
+              BigDecimal(
+                  55,
+              ),
       )
       insertReportCommonIndicator(
           reportId = reportId,
           indicatorId = commonIndicatorId1,
-          value = 45,
+          value = BigDecimal(45),
           projectsComments = "Almost at target",
           progressNotes = "Not quite there yet",
           modifiedTime = Instant.ofEpochSecond(3000),
@@ -2014,7 +2073,10 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
       insertReportCommonIndicatorTarget(
           commonIndicatorId = commonIndicatorId2,
           year = 1970,
-          target = 25,
+          target =
+              BigDecimal(
+                  25,
+              ),
       )
       insertReportCommonIndicator(
           reportId = reportId,
@@ -2063,15 +2125,15 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
                       ),
                   entry =
                       ReportIndicatorEntryModel(
-                          target = 55,
-                          value = 45,
+                          target = BigDecimal(55),
+                          value = BigDecimal(45),
                           projectsComments = "Almost at target",
                           progressNotes = "Not quite there yet",
                           modifiedTime = Instant.ofEpochSecond(3000),
                           modifiedBy = user.userId,
                       ),
                   currentYearProgress =
-                      listOf(CumulativeIndicatorProgressModel(ReportQuarter.Q1, 45)),
+                      listOf(CumulativeIndicatorProgressModel(ReportQuarter.Q1, BigDecimal(45))),
               ),
               ReportCommonIndicatorModel(
                   indicator =
@@ -2089,7 +2151,7 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
                       ),
                   entry =
                       ReportIndicatorEntryModel(
-                          target = 25,
+                          target = BigDecimal(25),
                           status = ReportIndicatorStatus.OffTrack,
                           modifiedTime = Instant.ofEpochSecond(1500),
                           modifiedBy = user.userId,
@@ -2100,7 +2162,7 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
       insertReportAutoCalculatedIndicatorTarget(
           indicator = AutoCalculatedIndicator.Seedlings,
           year = 1970,
-          target = 1000,
+          target = BigDecimal(1000),
       )
       insertReportAutoCalculatedIndicator(
           reportId = reportId,
@@ -2112,12 +2174,12 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
       insertReportAutoCalculatedIndicatorTarget(
           indicator = AutoCalculatedIndicator.SeedsCollected,
           year = 1970,
-          target = 2000,
+          target = BigDecimal(2000),
       )
       insertReportAutoCalculatedIndicator(
           reportId = reportId,
           indicator = AutoCalculatedIndicator.SeedsCollected,
-          systemValue = 1800,
+          systemValue = BigDecimal(1800),
           systemTime = Instant.ofEpochSecond(8000),
           modifiedTime = Instant.ofEpochSecond(500),
           modifiedBy = user.userId,
@@ -2126,14 +2188,14 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
       insertReportAutoCalculatedIndicatorTarget(
           indicator = AutoCalculatedIndicator.TreesPlanted,
           year = 1970,
-          target = 600,
+          target = BigDecimal(600),
       )
       insertReportAutoCalculatedIndicator(
           reportId = reportId,
           indicator = AutoCalculatedIndicator.TreesPlanted,
-          systemValue = 300,
+          systemValue = BigDecimal(300),
           systemTime = Instant.ofEpochSecond(7000),
-          overrideValue = 800,
+          overrideValue = BigDecimal(800),
           status = ReportIndicatorStatus.Achieved,
           modifiedTime = Instant.ofEpochSecond(700),
           modifiedBy = user.userId,
@@ -2155,20 +2217,20 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
                   indicator = AutoCalculatedIndicator.SeedsCollected,
                   entry =
                       ReportAutoCalculatedIndicatorEntryModel(
-                          target = 2000,
-                          systemValue = 1800,
+                          target = BigDecimal(2000),
+                          systemValue = BigDecimal(1800),
                           systemTime = Instant.ofEpochSecond(8000),
                           modifiedTime = Instant.ofEpochSecond(500),
                           modifiedBy = user.userId,
                       ),
                   currentYearProgress =
-                      listOf(CumulativeIndicatorProgressModel(ReportQuarter.Q1, 1800)),
+                      listOf(CumulativeIndicatorProgressModel(ReportQuarter.Q1, BigDecimal(1800))),
               ),
               ReportAutoCalculatedIndicatorModel(
                   indicator = AutoCalculatedIndicator.HectaresPlanted,
                   entry =
                       ReportAutoCalculatedIndicatorEntryModel(
-                          systemValue = 0,
+                          systemValue = BigDecimal(0),
                       ),
                   currentYearProgress = emptyList(),
               ),
@@ -2176,8 +2238,8 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
                   indicator = AutoCalculatedIndicator.Seedlings,
                   entry =
                       ReportAutoCalculatedIndicatorEntryModel(
-                          target = 1000,
-                          systemValue = 0,
+                          target = BigDecimal(1000),
+                          systemValue = BigDecimal(0),
                           modifiedTime = Instant.ofEpochSecond(2500),
                           modifiedBy = user.userId,
                       ),
@@ -2187,22 +2249,22 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
                   indicator = AutoCalculatedIndicator.TreesPlanted,
                   entry =
                       ReportAutoCalculatedIndicatorEntryModel(
-                          target = 600,
-                          systemValue = 300,
+                          target = BigDecimal(600),
+                          systemValue = BigDecimal(300),
                           systemTime = Instant.ofEpochSecond(7000),
-                          overrideValue = 800,
+                          overrideValue = BigDecimal(800),
                           status = ReportIndicatorStatus.Achieved,
                           modifiedTime = Instant.ofEpochSecond(700),
                           modifiedBy = user.userId,
                       ),
                   currentYearProgress =
-                      listOf(CumulativeIndicatorProgressModel(ReportQuarter.Q1, 800)),
+                      listOf(CumulativeIndicatorProgressModel(ReportQuarter.Q1, BigDecimal(800))),
               ),
               ReportAutoCalculatedIndicatorModel(
                   indicator = AutoCalculatedIndicator.SpeciesPlanted,
                   entry =
                       ReportAutoCalculatedIndicatorEntryModel(
-                          systemValue = 0,
+                          systemValue = BigDecimal(0),
                       ),
               ),
               ReportAutoCalculatedIndicatorModel(
@@ -2618,12 +2680,15 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
       insertReportCommonIndicatorTarget(
           commonIndicatorId = commonIndicatorId1,
           year = 1970,
-          target = 55,
+          target =
+              BigDecimal(
+                  55,
+              ),
       )
       insertReportCommonIndicator(
           reportId = reportId,
           indicatorId = commonIndicatorId1,
-          value = 45,
+          value = BigDecimal(45),
           projectsComments = "Existing indicator 1 notes",
           status = ReportIndicatorStatus.OnTrack,
           modifiedTime = Instant.ofEpochSecond(3000),
@@ -2633,7 +2698,10 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
       insertReportCommonIndicatorTarget(
           commonIndicatorId = commonIndicatorId2,
           year = 1970,
-          target = 30,
+          target =
+              BigDecimal(
+                  30,
+              ),
       )
       insertReportCommonIndicator(
           reportId = reportId,
@@ -2648,12 +2716,12 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
       insertReportAutoCalculatedIndicatorTarget(
           indicator = AutoCalculatedIndicator.SeedsCollected,
           year = 1970,
-          target = 1000,
+          target = BigDecimal(1000),
       )
       insertReportAutoCalculatedIndicator(
           reportId = reportId,
           indicator = AutoCalculatedIndicator.SeedsCollected,
-          systemValue = 1200,
+          systemValue = BigDecimal(1200),
           systemTime = Instant.ofEpochSecond(4000),
           projectsComments = "Existing seeds collected indicator notes",
           progressNotes = "Existing seeds collected indicator internal comment",
@@ -2664,13 +2732,13 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
       insertReportAutoCalculatedIndicatorTarget(
           indicator = AutoCalculatedIndicator.SpeciesPlanted,
           year = 1970,
-          target = 10,
+          target = BigDecimal(10),
       )
       insertReportAutoCalculatedIndicator(
           reportId = reportId,
           indicator = AutoCalculatedIndicator.SpeciesPlanted,
-          overrideValue = 15,
-          systemValue = 12,
+          overrideValue = BigDecimal(15),
+          systemValue = BigDecimal(12),
           systemTime = Instant.ofEpochSecond(5000),
           projectsComments = "Existing species planted indicator notes",
           progressNotes = "Existing species planted indicator internal comment",
@@ -2689,7 +2757,7 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
               mapOf(
                   commonIndicatorId2 to
                       ReportIndicatorEntryModel(
-                          value = 88,
+                          value = BigDecimal(88),
                           projectsComments = "New indicator 2 notes",
                           progressNotes = "New indicator 2 internal comment",
                           status = ReportIndicatorStatus.OnTrack,
@@ -2700,7 +2768,7 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
                       ),
                   commonIndicatorId3 to
                       ReportIndicatorEntryModel(
-                          value = 45,
+                          value = BigDecimal(45),
                           projectsComments = "New indicator 3 notes",
                           progressNotes = "New indicator 3 internal comment",
                       ),
@@ -2709,14 +2777,14 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
               mapOf(
                   AutoCalculatedIndicator.SpeciesPlanted to
                       ReportIndicatorEntryModel(
-                          value = 4,
+                          value = BigDecimal(4),
                           status = null,
                           projectsComments = "New species planted indicator notes",
                           progressNotes = "New species planted indicator internal comment",
                       ),
                   AutoCalculatedIndicator.TreesPlanted to
                       ReportIndicatorEntryModel(
-                          value = 45,
+                          value = BigDecimal(45),
                           status = ReportIndicatorStatus.Unlikely,
                           projectsComments = "New trees planted indicator notes",
                           progressNotes = "New trees planted indicator internal comment",
@@ -2726,7 +2794,7 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
               mapOf(
                   projectIndicatorId to
                       ReportIndicatorEntryModel(
-                          value = 50,
+                          value = BigDecimal(50),
                           projectsComments = "Project indicator notes",
                           progressNotes = "Project indicator internal comment",
                       ),
@@ -2738,7 +2806,7 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
               ReportCommonIndicatorsRecord(
                   reportId = reportId,
                   commonIndicatorId = commonIndicatorId1,
-                  value = 45,
+                  value = BigDecimal(45),
                   statusId = ReportIndicatorStatus.OnTrack,
                   projectsComments = "Existing indicator 1 notes",
                   modifiedTime = Instant.ofEpochSecond(3000),
@@ -2747,7 +2815,7 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
               ReportCommonIndicatorsRecord(
                   reportId = reportId,
                   commonIndicatorId = commonIndicatorId2,
-                  value = 88,
+                  value = BigDecimal(88),
                   statusId = ReportIndicatorStatus.OnTrack,
                   projectsComments = "New indicator 2 notes",
                   progressNotes = "New indicator 2 internal comment",
@@ -2757,7 +2825,7 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
               ReportCommonIndicatorsRecord(
                   reportId = reportId,
                   commonIndicatorId = commonIndicatorId3,
-                  value = 45,
+                  value = BigDecimal(45),
                   projectsComments = "New indicator 3 notes",
                   progressNotes = "New indicator 3 internal comment",
                   modifiedTime = Instant.ofEpochSecond(9000),
@@ -2773,7 +2841,7 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
               ReportAutoCalculatedIndicatorsRecord(
                   reportId = reportId,
                   autoCalculatedIndicatorId = AutoCalculatedIndicator.SeedsCollected,
-                  systemValue = 1200,
+                  systemValue = BigDecimal(1200),
                   systemTime = Instant.ofEpochSecond(4000),
                   projectsComments = "Existing seeds collected indicator notes",
                   progressNotes = "Existing seeds collected indicator internal comment",
@@ -2783,9 +2851,9 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
               ReportAutoCalculatedIndicatorsRecord(
                   reportId = reportId,
                   autoCalculatedIndicatorId = AutoCalculatedIndicator.SpeciesPlanted,
-                  systemValue = 12,
+                  systemValue = BigDecimal(12),
                   systemTime = Instant.ofEpochSecond(5000),
-                  overrideValue = 4,
+                  overrideValue = BigDecimal(4),
                   statusId = null,
                   projectsComments = "New species planted indicator notes",
                   progressNotes = "New species planted indicator internal comment",
@@ -2795,7 +2863,7 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
               ReportAutoCalculatedIndicatorsRecord(
                   reportId = reportId,
                   autoCalculatedIndicatorId = AutoCalculatedIndicator.TreesPlanted,
-                  overrideValue = 45,
+                  overrideValue = BigDecimal(45),
                   statusId = ReportIndicatorStatus.Unlikely,
                   projectsComments = "New trees planted indicator notes",
                   progressNotes = "New trees planted indicator internal comment",
@@ -2811,7 +2879,7 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
               ReportProjectIndicatorsRecord(
                   reportId = reportId,
                   projectIndicatorId = projectIndicatorId,
-                  value = 50,
+                  value = BigDecimal(50),
                   projectsComments = "Project indicator notes",
                   progressNotes = "Project indicator internal comment",
                   modifiedTime = Instant.ofEpochSecond(9000),
@@ -3098,12 +3166,15 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
       insertReportCommonIndicatorTarget(
           commonIndicatorId = commonIndicatorId1,
           year = 1970,
-          target = 55,
+          target =
+              BigDecimal(
+                  55,
+              ),
       )
       insertReportCommonIndicator(
           reportId = reportId,
           indicatorId = commonIndicatorId1,
-          value = 45,
+          value = BigDecimal(45),
           projectsComments = "Existing indicator 1 notes",
           status = ReportIndicatorStatus.OnTrack,
           modifiedTime = Instant.ofEpochSecond(3000),
@@ -3113,7 +3184,10 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
       insertReportCommonIndicatorTarget(
           commonIndicatorId = commonIndicatorId2,
           year = 1970,
-          target = 30,
+          target =
+              BigDecimal(
+                  30,
+              ),
       )
       insertReportCommonIndicator(
           reportId = reportId,
@@ -3128,12 +3202,12 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
       insertReportAutoCalculatedIndicatorTarget(
           indicator = AutoCalculatedIndicator.SeedsCollected,
           year = 1970,
-          target = 1000,
+          target = BigDecimal(1000),
       )
       insertReportAutoCalculatedIndicator(
           reportId = reportId,
           indicator = AutoCalculatedIndicator.SeedsCollected,
-          systemValue = 1200,
+          systemValue = BigDecimal(1200),
           systemTime = Instant.ofEpochSecond(4000),
           projectsComments = "Existing seeds collected indicator notes",
           progressNotes = "Existing seeds collected indicator internal comment",
@@ -3144,13 +3218,13 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
       insertReportAutoCalculatedIndicatorTarget(
           indicator = AutoCalculatedIndicator.SpeciesPlanted,
           year = 1970,
-          target = 10,
+          target = BigDecimal(10),
       )
       insertReportAutoCalculatedIndicator(
           reportId = reportId,
           indicator = AutoCalculatedIndicator.SpeciesPlanted,
-          overrideValue = 15,
-          systemValue = 12,
+          overrideValue = BigDecimal(15),
+          systemValue = BigDecimal(12),
           systemTime = Instant.ofEpochSecond(5000),
           projectsComments = "Existing species planted indicator notes",
           progressNotes = "Existing species planted indicator internal comment",
@@ -3175,7 +3249,7 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
               mapOf(
                   commonIndicatorId2 to
                       ReportIndicatorEntryModel(
-                          value = 88,
+                          value = BigDecimal(88),
                           projectsComments = "New indicator 2 notes",
                           status = ReportIndicatorStatus.OnTrack,
 
@@ -3198,7 +3272,7 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
                           status = null,
 
                           // These fields are ignored
-                          value = 4,
+                          value = BigDecimal(4),
                           progressNotes = "New species planted indicator internal comment",
                           modifiedTime = Instant.EPOCH,
                           modifiedBy = UserId(99),
@@ -3209,7 +3283,7 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
                           status = ReportIndicatorStatus.Unlikely,
 
                           // These fields are ignored
-                          value = 45,
+                          value = BigDecimal(45),
                           progressNotes = "New trees planted indicator internal comment",
                           modifiedTime = Instant.EPOCH,
                           modifiedBy = UserId(99),
@@ -3219,7 +3293,7 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
               mapOf(
                   projectIndicatorId to
                       ReportIndicatorEntryModel(
-                          value = 50,
+                          value = BigDecimal(50),
                           projectsComments = "Project indicator notes",
                       ),
               ),
@@ -3230,7 +3304,7 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
               ReportCommonIndicatorsRecord(
                   reportId = reportId,
                   commonIndicatorId = commonIndicatorId1,
-                  value = 45,
+                  value = BigDecimal(45),
                   statusId = ReportIndicatorStatus.OnTrack,
                   projectsComments = "Existing indicator 1 notes",
                   modifiedTime = Instant.ofEpochSecond(3000),
@@ -3239,7 +3313,7 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
               ReportCommonIndicatorsRecord(
                   reportId = reportId,
                   commonIndicatorId = commonIndicatorId2,
-                  value = 88,
+                  value = BigDecimal(88),
                   statusId = ReportIndicatorStatus.OnTrack,
                   projectsComments = "New indicator 2 notes",
                   progressNotes = "Existing indicator 2 internal comment",
@@ -3263,7 +3337,7 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
               ReportAutoCalculatedIndicatorsRecord(
                   reportId = reportId,
                   autoCalculatedIndicatorId = AutoCalculatedIndicator.SeedsCollected,
-                  systemValue = 1200,
+                  systemValue = BigDecimal(1200),
                   systemTime = Instant.ofEpochSecond(4000),
                   projectsComments = "Existing seeds collected indicator notes",
                   progressNotes = "Existing seeds collected indicator internal comment",
@@ -3273,10 +3347,10 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
               ReportAutoCalculatedIndicatorsRecord(
                   reportId = reportId,
                   autoCalculatedIndicatorId = AutoCalculatedIndicator.SpeciesPlanted,
-                  systemValue = 12,
+                  systemValue = BigDecimal(12),
                   systemTime = Instant.ofEpochSecond(5000),
                   statusId = null,
-                  overrideValue = 15,
+                  overrideValue = BigDecimal(15),
                   projectsComments = "New species planted indicator notes",
                   progressNotes = "Existing species planted indicator internal comment",
                   modifiedTime = Instant.ofEpochSecond(9000),
@@ -3299,7 +3373,7 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
               ReportProjectIndicatorsRecord(
                   reportId = reportId,
                   projectIndicatorId = projectIndicatorId,
-                  value = 50,
+                  value = BigDecimal(50),
                   projectsComments = "Project indicator notes",
                   modifiedTime = Instant.ofEpochSecond(9000),
                   modifiedBy = user.userId,
@@ -3368,23 +3442,23 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
 
       insertReportAutoCalculatedIndicator(
           indicator = AutoCalculatedIndicator.SeedsCollected,
-          systemValue = 1000,
+          systemValue = BigDecimal(1000),
           systemTime = Instant.ofEpochSecond(3000),
-          overrideValue = 74,
+          overrideValue = BigDecimal(74),
           modifiedBy = otherUserId,
           modifiedTime = Instant.ofEpochSecond(3000),
       )
       insertReportAutoCalculatedIndicator(
           indicator = AutoCalculatedIndicator.Seedlings,
-          systemValue = 2000,
+          systemValue = BigDecimal(2000),
           systemTime = Instant.ofEpochSecond(3000),
-          overrideValue = 98,
+          overrideValue = BigDecimal(98),
           modifiedBy = otherUserId,
           modifiedTime = Instant.ofEpochSecond(3000),
       )
       insertReportAutoCalculatedIndicator(
           indicator = AutoCalculatedIndicator.TreesPlanted,
-          systemValue = 3000,
+          systemValue = BigDecimal(3000),
           systemTime = Instant.ofEpochSecond(3000),
           modifiedBy = otherUserId,
           modifiedTime = Instant.ofEpochSecond(3000),
@@ -3406,9 +3480,9 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
               ReportAutoCalculatedIndicatorsRecord(
                   reportId = reportId,
                   autoCalculatedIndicatorId = AutoCalculatedIndicator.SeedsCollected,
-                  systemValue = 1000,
+                  systemValue = BigDecimal(1000),
                   systemTime = Instant.ofEpochSecond(3000),
-                  overrideValue = 74,
+                  overrideValue = BigDecimal(74),
                   modifiedBy = otherUserId,
                   modifiedTime = Instant.ofEpochSecond(3000),
               ),
@@ -3460,23 +3534,23 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
 
       insertReportAutoCalculatedIndicator(
           indicator = AutoCalculatedIndicator.SeedsCollected,
-          systemValue = 1000,
+          systemValue = BigDecimal(1000),
           systemTime = Instant.ofEpochSecond(3000),
-          overrideValue = 74,
+          overrideValue = BigDecimal(74),
           modifiedBy = otherUserId,
           modifiedTime = Instant.ofEpochSecond(3000),
       )
       insertReportAutoCalculatedIndicator(
           indicator = AutoCalculatedIndicator.Seedlings,
-          systemValue = 2000,
+          systemValue = BigDecimal(2000),
           systemTime = Instant.ofEpochSecond(3000),
-          overrideValue = 98,
+          overrideValue = BigDecimal(98),
           modifiedBy = otherUserId,
           modifiedTime = Instant.ofEpochSecond(3000),
       )
       insertReportAutoCalculatedIndicator(
           indicator = AutoCalculatedIndicator.TreesPlanted,
-          systemValue = 3000,
+          systemValue = BigDecimal(3000),
           systemTime = Instant.ofEpochSecond(3000),
           modifiedBy = otherUserId,
           modifiedTime = Instant.ofEpochSecond(3000),
@@ -3498,16 +3572,16 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
               ReportAutoCalculatedIndicatorsRecord(
                   reportId = reportId,
                   autoCalculatedIndicatorId = AutoCalculatedIndicator.SeedsCollected,
-                  systemValue = 1000,
+                  systemValue = BigDecimal(1000),
                   systemTime = Instant.ofEpochSecond(3000),
-                  overrideValue = 74,
+                  overrideValue = BigDecimal(74),
                   modifiedBy = otherUserId,
                   modifiedTime = Instant.ofEpochSecond(3000),
               ),
               ReportAutoCalculatedIndicatorsRecord(
                   reportId = reportId,
                   autoCalculatedIndicatorId = AutoCalculatedIndicator.Seedlings,
-                  systemValue = 83,
+                  systemValue = BigDecimal(83),
                   systemTime = clock.instant,
                   modifiedBy = user.userId,
                   modifiedTime = clock.instant,
@@ -3515,7 +3589,7 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
               ReportAutoCalculatedIndicatorsRecord(
                   reportId = reportId,
                   autoCalculatedIndicatorId = AutoCalculatedIndicator.TreesPlanted,
-                  systemValue = 27,
+                  systemValue = BigDecimal(27),
                   systemTime = clock.instant,
                   modifiedBy = user.userId,
                   modifiedTime = clock.instant,
@@ -3523,7 +3597,7 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
               ReportAutoCalculatedIndicatorsRecord(
                   reportId = reportId,
                   autoCalculatedIndicatorId = AutoCalculatedIndicator.SpeciesPlanted,
-                  systemValue = 1,
+                  systemValue = BigDecimal(1),
                   systemTime = clock.instant,
                   modifiedBy = user.userId,
                   modifiedTime = clock.instant,
@@ -3610,7 +3684,7 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
               ReportAutoCalculatedIndicatorsRecord(
                   reportId = reportId,
                   autoCalculatedIndicatorId = AutoCalculatedIndicator.SeedsCollected,
-                  systemValue = 98,
+                  systemValue = BigDecimal(98),
                   systemTime = clock.instant,
                   modifiedBy = user.userId,
                   modifiedTime = clock.instant,
@@ -3618,7 +3692,7 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
               ReportAutoCalculatedIndicatorsRecord(
                   reportId = reportId,
                   autoCalculatedIndicatorId = AutoCalculatedIndicator.HectaresPlanted,
-                  systemValue = 60,
+                  systemValue = BigDecimal(60),
                   systemTime = clock.instant,
                   modifiedBy = user.userId,
                   modifiedTime = clock.instant,
@@ -3626,7 +3700,7 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
               ReportAutoCalculatedIndicatorsRecord(
                   reportId = reportId,
                   autoCalculatedIndicatorId = AutoCalculatedIndicator.Seedlings,
-                  systemValue = 83,
+                  systemValue = BigDecimal(83),
                   systemTime = clock.instant,
                   modifiedBy = user.userId,
                   modifiedTime = clock.instant,
@@ -3634,7 +3708,7 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
               ReportAutoCalculatedIndicatorsRecord(
                   reportId = reportId,
                   autoCalculatedIndicatorId = AutoCalculatedIndicator.TreesPlanted,
-                  systemValue = 27,
+                  systemValue = BigDecimal(27),
                   systemTime = clock.instant,
                   modifiedBy = user.userId,
                   modifiedTime = clock.instant,
@@ -3642,7 +3716,7 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
               ReportAutoCalculatedIndicatorsRecord(
                   reportId = reportId,
                   autoCalculatedIndicatorId = AutoCalculatedIndicator.SpeciesPlanted,
-                  systemValue = 1,
+                  systemValue = BigDecimal(1),
                   systemTime = clock.instant,
                   modifiedBy = user.userId,
                   modifiedTime = clock.instant,
@@ -3651,7 +3725,9 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
                   reportId = reportId,
                   autoCalculatedIndicatorId = AutoCalculatedIndicator.SurvivalRate,
                   systemValue =
-                      (sitesLiveSum * 100.0 / (site1T0Density + site2T0Density)).roundToInt(),
+                      BigDecimal(
+                          (sitesLiveSum * 100.0 / (site1T0Density + site2T0Density)).roundToInt()
+                      ),
                   systemTime = clock.instant,
                   modifiedBy = user.userId,
                   modifiedTime = clock.instant,
@@ -4489,13 +4565,16 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
       insertReportCommonIndicatorTarget(
           commonIndicatorId = commonIndicatorId1,
           year = 2030,
-          target = 10,
+          target =
+              BigDecimal(
+                  10,
+              ),
       )
       insertReportCommonIndicator(
           reportId = reportId,
           indicatorId = commonIndicatorId1,
           status = ReportIndicatorStatus.Achieved,
-          value = 10,
+          value = BigDecimal(10),
           projectsComments = null,
           progressNotes = "Common Indicator 1 Progress notes",
       )
@@ -4503,20 +4582,23 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
       insertReportCommonIndicatorTarget(
           commonIndicatorId = commonIndicatorId2,
           year = 2030,
-          target = 20,
+          target =
+              BigDecimal(
+                  20,
+              ),
       )
       insertReportCommonIndicator(
           reportId = reportId,
           indicatorId = commonIndicatorId2,
           status = ReportIndicatorStatus.OnTrack,
-          value = 19,
+          value = BigDecimal(19),
           projectsComments = "Common Indicator 2 Underperformance",
       )
 
       insertReportCommonIndicatorTarget(
           commonIndicatorId = commonIndicatorNullValueId,
           year = 2030,
-          target = 999,
+          target = BigDecimal(999),
       )
       insertReportCommonIndicator(
           reportId = reportId,
@@ -4527,24 +4609,24 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
       insertReportCommonIndicatorTarget(
           commonIndicatorId = commonIndicatorNotPublishableId,
           year = 2030,
-          target = 999,
+          target = BigDecimal(999),
       )
       insertReportCommonIndicator(
           reportId = reportId,
           indicatorId = commonIndicatorNotPublishableId,
-          value = 999,
+          value = BigDecimal(999),
       )
 
       insertReportProjectIndicatorTarget(
           projectIndicatorId = projectIndicatorId1,
           year = 2030,
-          target = 30,
+          target = BigDecimal(30),
       )
       insertReportProjectIndicator(
           reportId = reportId,
           indicatorId = projectIndicatorId1,
           status = ReportIndicatorStatus.Achieved,
-          value = 30,
+          value = BigDecimal(30),
           projectsComments = null,
           progressNotes = "Project Indicator 1 Progress notes",
       )
@@ -4552,20 +4634,20 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
       insertReportProjectIndicatorTarget(
           projectIndicatorId = projectIndicatorId2,
           year = 2030,
-          target = 40,
+          target = BigDecimal(40),
       )
       insertReportProjectIndicator(
           reportId = reportId,
           indicatorId = projectIndicatorId2,
           status = ReportIndicatorStatus.Unlikely,
-          value = 39,
+          value = BigDecimal(39),
           projectsComments = "Project Indicator 2 Underperformance",
       )
 
       insertReportProjectIndicatorTarget(
           projectIndicatorId = projectIndicatorNullValueId,
           year = 2030,
-          target = 999,
+          target = BigDecimal(999),
       )
       insertReportProjectIndicator(
           reportId = reportId,
@@ -4576,38 +4658,38 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
       insertReportProjectIndicatorTarget(
           projectIndicatorId = projectIndicatorNotPublishableId,
           year = 2030,
-          target = 999,
+          target = BigDecimal(999),
       )
       insertReportProjectIndicator(
           reportId = reportId,
           indicatorId = projectIndicatorNotPublishableId,
-          value = 999,
+          value = BigDecimal(999),
       )
 
       // Seeds Collected is not publishable
       insertReportAutoCalculatedIndicatorTarget(
           indicator = AutoCalculatedIndicator.SeedsCollected,
           year = 2030,
-          target = 999,
+          target = BigDecimal(999),
       )
       insertReportAutoCalculatedIndicator(
           reportId = reportId,
           indicator = AutoCalculatedIndicator.SeedsCollected,
           status = ReportIndicatorStatus.Achieved,
-          systemValue = 999,
+          systemValue = BigDecimal(999),
       )
 
       insertReportAutoCalculatedIndicatorTarget(
           indicator = AutoCalculatedIndicator.Seedlings,
           year = 2030,
-          target = 50,
+          target = BigDecimal(50),
       )
       insertReportAutoCalculatedIndicator(
           reportId = reportId,
           indicator = AutoCalculatedIndicator.Seedlings,
           status = ReportIndicatorStatus.OnTrack,
-          overrideValue = 49,
-          systemValue = 39,
+          overrideValue = BigDecimal(49),
+          systemValue = BigDecimal(39),
           projectsComments = "Seedlings underperformance justification",
           progressNotes = "Seedlings progress notes",
       )
@@ -4615,13 +4697,13 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
       insertReportAutoCalculatedIndicatorTarget(
           indicator = AutoCalculatedIndicator.SpeciesPlanted,
           year = 2030,
-          target = 10,
+          target = BigDecimal(10),
       )
       insertReportAutoCalculatedIndicator(
           reportId = reportId,
           indicator = AutoCalculatedIndicator.SpeciesPlanted,
           status = ReportIndicatorStatus.Achieved,
-          systemValue = 10,
+          systemValue = BigDecimal(10),
       )
 
       // Indicators can be published even with no target set
@@ -4634,19 +4716,19 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
           reportId = reportId,
           indicator = AutoCalculatedIndicator.TreesPlanted,
           status = ReportIndicatorStatus.Achieved,
-          systemValue = 100,
+          systemValue = BigDecimal(100),
       )
 
       insertReportAutoCalculatedIndicatorTarget(
           indicator = AutoCalculatedIndicator.SurvivalRate,
           year = 2030,
-          target = 0,
+          target = BigDecimal(0),
       )
       insertReportAutoCalculatedIndicator(
           reportId = reportId,
           indicator = AutoCalculatedIndicator.SurvivalRate,
           status = ReportIndicatorStatus.Unlikely,
-          systemValue = 51,
+          systemValue = BigDecimal(51),
       )
 
       // Baseline and end-of-project targets
@@ -4761,48 +4843,48 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
 
       insertPublishedReportCommonIndicator(
           indicatorId = commonIndicatorId1,
-          value = 100,
+          value = BigDecimal(100),
           progressNotes = "Existing progress notes",
           projectsComments = "Existing underperformance justification",
       )
       insertPublishedReportCommonIndicator(
           indicatorId = commonIndicatorNullValueId,
-          value = 100,
+          value = BigDecimal(100),
       )
       insertPublishedReportCommonIndicator(
           indicatorId = commonIndicatorNotPublishableId,
-          value = 100,
+          value = BigDecimal(100),
       )
 
       insertPublishedReportProjectIndicator(
           indicatorId = projectIndicatorId1,
-          value = 100,
+          value = BigDecimal(100),
           progressNotes = "Existing progress notes",
           projectsComments = "Existing underperformance justification",
       )
       insertPublishedReportProjectIndicator(
           indicatorId = projectIndicatorId2,
-          value = 100,
+          value = BigDecimal(100),
           projectsComments = "Existing underperformance justification",
       )
       insertPublishedReportProjectIndicator(
           indicatorId = projectIndicatorNotPublishableId,
-          value = 100,
+          value = BigDecimal(100),
       )
 
       insertPublishedReportAutoCalculatedIndicator(
           indicator = AutoCalculatedIndicator.SeedsCollected,
-          value = 100,
+          value = BigDecimal(100),
       )
       insertPublishedReportAutoCalculatedIndicator(
           indicator = AutoCalculatedIndicator.Seedlings,
-          value = 100,
+          value = BigDecimal(100),
           progressNotes = "Existing progress notes",
           projectsComments = "Existing underperformance justification",
       )
       insertPublishedReportAutoCalculatedIndicator(
           indicator = AutoCalculatedIndicator.TreesPlanted,
-          value = 100,
+          value = BigDecimal(100),
           projectsComments = "Existing underperformance justification",
       )
 
@@ -4846,24 +4928,24 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
       insertReportCommonIndicatorTarget(
           commonIndicatorId = inactiveCommonIndicatorId,
           year = 2030,
-          target = 55,
+          target = BigDecimal(55),
       )
       insertReportCommonIndicator(
           reportId = reportId,
           indicatorId = inactiveCommonIndicatorId,
-          value = 55,
+          value = BigDecimal(55),
           status = ReportIndicatorStatus.Achieved,
       )
 
       insertReportProjectIndicatorTarget(
           projectIndicatorId = inactiveProjectIndicatorId,
           year = 2030,
-          target = 66,
+          target = BigDecimal(66),
       )
       insertReportProjectIndicator(
           reportId = reportId,
           indicatorId = inactiveProjectIndicatorId,
-          value = 66,
+          value = BigDecimal(66),
           status = ReportIndicatorStatus.Achieved,
       )
 
@@ -4872,11 +4954,11 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
       insertPublishedReport(reportId = reportId, projectId = projectId)
       insertPublishedReportCommonIndicator(
           indicatorId = inactiveCommonIndicatorId,
-          value = 55,
+          value = BigDecimal(55),
       )
       insertPublishedReportProjectIndicator(
           indicatorId = inactiveProjectIndicatorId,
-          value = 66,
+          value = BigDecimal(66),
       )
 
       clock.instant = Instant.ofEpochSecond(10000)
@@ -4888,14 +4970,14 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
                   reportId = reportId,
                   commonIndicatorId = commonIndicatorId1,
                   statusId = ReportIndicatorStatus.Achieved,
-                  value = 10,
+                  value = BigDecimal(10),
                   progressNotes = "Common Indicator 1 Progress notes",
               ),
               PublishedReportCommonIndicatorsRecord(
                   reportId = reportId,
                   commonIndicatorId = commonIndicatorId2,
                   statusId = ReportIndicatorStatus.OnTrack,
-                  value = 19,
+                  value = BigDecimal(19),
                   projectsComments = "Common Indicator 2 Underperformance",
               ),
           ),
@@ -4908,14 +4990,14 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
                   reportId = reportId,
                   projectIndicatorId = projectIndicatorId1,
                   statusId = ReportIndicatorStatus.Achieved,
-                  value = 30,
+                  value = BigDecimal(30),
                   progressNotes = "Project Indicator 1 Progress notes",
               ),
               PublishedReportProjectIndicatorsRecord(
                   reportId = reportId,
                   projectIndicatorId = projectIndicatorId2,
                   statusId = ReportIndicatorStatus.Unlikely,
-                  value = 39,
+                  value = BigDecimal(39),
                   projectsComments = "Project Indicator 2 Underperformance",
               ),
           ),
@@ -4986,7 +5068,7 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
                   reportId = reportId,
                   commonIndicatorId = commonIndicatorId1,
                   statusId = ReportIndicatorStatus.Achieved,
-                  value = 10,
+                  value = BigDecimal(10),
                   projectsComments = null,
                   progressNotes = "Common Indicator 1 Progress notes",
               ),
@@ -4994,7 +5076,7 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
                   reportId = reportId,
                   commonIndicatorId = commonIndicatorId2,
                   statusId = ReportIndicatorStatus.OnTrack,
-                  value = 19,
+                  value = BigDecimal(19),
                   projectsComments = "Common Indicator 2 Underperformance",
               ),
           ),
@@ -5007,7 +5089,7 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
                   reportId = reportId,
                   projectIndicatorId = projectIndicatorId1,
                   statusId = ReportIndicatorStatus.Achieved,
-                  value = 30,
+                  value = BigDecimal(30),
                   projectsComments = null,
                   progressNotes = "Project Indicator 1 Progress notes",
               ),
@@ -5015,7 +5097,7 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
                   reportId = reportId,
                   projectIndicatorId = projectIndicatorId2,
                   statusId = ReportIndicatorStatus.Unlikely,
-                  value = 39,
+                  value = BigDecimal(39),
                   projectsComments = "Project Indicator 2 Underperformance",
               ),
           ),
@@ -5028,7 +5110,7 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
                   reportId = reportId,
                   autoCalculatedIndicatorId = AutoCalculatedIndicator.Seedlings,
                   statusId = ReportIndicatorStatus.OnTrack,
-                  value = 49,
+                  value = BigDecimal(49),
                   projectsComments = "Seedlings underperformance justification",
                   progressNotes = "Seedlings progress notes",
               ),
@@ -5036,25 +5118,25 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
                   reportId = reportId,
                   autoCalculatedIndicatorId = AutoCalculatedIndicator.SpeciesPlanted,
                   statusId = ReportIndicatorStatus.Achieved,
-                  value = 10,
+                  value = BigDecimal(10),
               ),
               PublishedReportAutoCalculatedIndicatorsRecord(
                   reportId = reportId,
                   autoCalculatedIndicatorId = AutoCalculatedIndicator.TreesPlanted,
                   statusId = ReportIndicatorStatus.Achieved,
-                  value = 100,
+                  value = BigDecimal(100),
               ),
               PublishedReportAutoCalculatedIndicatorsRecord(
                   reportId = reportId,
                   autoCalculatedIndicatorId = AutoCalculatedIndicator.SurvivalRate,
                   statusId = ReportIndicatorStatus.Unlikely,
-                  value = 51,
+                  value = BigDecimal(51),
               ),
               PublishedReportAutoCalculatedIndicatorsRecord(
                   reportId = reportId,
                   autoCalculatedIndicatorId = AutoCalculatedIndicator.HectaresPlanted,
                   statusId = null,
-                  value = 0,
+                  value = BigDecimal(0),
               ),
           ),
           "Published report auto calculated indicators table",
@@ -5082,19 +5164,19 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
                   projectId = projectId,
                   projectIndicatorId = projectIndicatorId1,
                   year = 2030,
-                  target = 30,
+                  target = BigDecimal(30),
               ),
               PublishedProjectIndicatorTargetsRecord(
                   projectId = projectId,
                   projectIndicatorId = projectIndicatorId2,
                   year = 2030,
-                  target = 40,
+                  target = BigDecimal(40),
               ),
               PublishedProjectIndicatorTargetsRecord(
                   projectId = projectId,
                   projectIndicatorId = projectIndicatorNullValueId,
                   year = 2030,
-                  target = 999,
+                  target = BigDecimal(999),
               ),
           ),
           "Published project indicator targets table",
@@ -5107,19 +5189,19 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
                   projectId = projectId,
                   commonIndicatorId = commonIndicatorId1,
                   year = 2030,
-                  target = 10,
+                  target = BigDecimal(10),
               ),
               PublishedCommonIndicatorTargetsRecord(
                   projectId = projectId,
                   commonIndicatorId = commonIndicatorId2,
                   year = 2030,
-                  target = 20,
+                  target = BigDecimal(20),
               ),
               PublishedCommonIndicatorTargetsRecord(
                   projectId = projectId,
                   commonIndicatorId = commonIndicatorNullValueId,
                   year = 2030,
-                  target = 999,
+                  target = BigDecimal(999),
               ),
           ),
           "Published common indicator targets table",
@@ -5131,13 +5213,13 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
                   projectId = projectId,
                   autoCalculatedIndicatorId = AutoCalculatedIndicator.Seedlings,
                   year = 2030,
-                  target = 50,
+                  target = BigDecimal(50),
               ),
               PublishedAutoCalculatedIndicatorTargetsRecord(
                   projectId = projectId,
                   autoCalculatedIndicatorId = AutoCalculatedIndicator.SpeciesPlanted,
                   year = 2030,
-                  target = 10,
+                  target = BigDecimal(10),
               ),
               PublishedAutoCalculatedIndicatorTargetsRecord(
                   projectId = projectId,
@@ -5155,7 +5237,7 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
                   projectId = projectId,
                   autoCalculatedIndicatorId = AutoCalculatedIndicator.SurvivalRate,
                   year = 2030,
-                  target = 0,
+                  target = BigDecimal(0),
               ),
           ),
           "Published auto calculated indicator targets table",
@@ -6397,7 +6479,7 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
           projectId = projectId,
           year = 2024,
           indicatorId = projectIndicatorId,
-          target = 100,
+          target = BigDecimal(100),
       )
 
       val targets = reportProjectIndicatorTargetsDao.findAll()
@@ -6405,7 +6487,7 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
       assertEquals(projectId, targets[0].projectId)
       assertEquals(projectIndicatorId, targets[0].projectIndicatorId)
       assertEquals(2024, targets[0].year)
-      assertEquals(100, targets[0].target)
+      assertEquals(BigDecimal(100), targets[0].target)
     }
 
     @Test
@@ -6423,19 +6505,19 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
           projectId = projectId,
           projectIndicatorId = projectIndicatorId,
           year = 2024,
-          target = 100,
+          target = BigDecimal(100),
       )
 
       store.updateProjectIndicatorTarget(
           projectId = projectId,
           year = 2024,
           indicatorId = projectIndicatorId,
-          target = 150,
+          target = BigDecimal(150),
       )
 
       val targets = reportProjectIndicatorTargetsDao.findAll()
       assertEquals(1, targets.size)
-      assertEquals(150, targets[0].target)
+      assertEquals(BigDecimal(150), targets[0].target)
     }
 
     @Test
@@ -6481,7 +6563,7 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
             projectId = projectId,
             year = 2024,
             indicatorId = projectIndicatorId,
-            target = 100,
+            target = BigDecimal(100),
         )
       }
     }
@@ -6504,7 +6586,7 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
           projectId = projectId,
           year = 2024,
           indicatorId = commonIndicatorId,
-          target = 200,
+          target = BigDecimal(200),
       )
 
       val targets = reportCommonIndicatorTargetsDao.findAll()
@@ -6512,7 +6594,7 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
       assertEquals(projectId, targets[0].projectId)
       assertEquals(commonIndicatorId, targets[0].commonIndicatorId)
       assertEquals(2024, targets[0].year)
-      assertEquals(200, targets[0].target)
+      assertEquals(BigDecimal(200), targets[0].target)
     }
 
     @Test
@@ -6530,19 +6612,19 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
           projectId = projectId,
           commonIndicatorId = commonIndicatorId,
           year = 2024,
-          target = 200,
+          target = BigDecimal(200),
       )
 
       store.updateCommonIndicatorTarget(
           projectId = projectId,
           year = 2024,
           indicatorId = commonIndicatorId,
-          target = 250,
+          target = BigDecimal(250),
       )
 
       val targets = reportCommonIndicatorTargetsDao.findAll()
       assertEquals(1, targets.size)
-      assertEquals(250, targets[0].target)
+      assertEquals(BigDecimal(250), targets[0].target)
     }
 
     @Test
@@ -6588,7 +6670,7 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
             projectId = projectId,
             year = 2024,
             indicatorId = commonIndicatorId,
-            target = 200,
+            target = BigDecimal(200),
         )
       }
     }
@@ -6602,7 +6684,7 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
           projectId = projectId,
           year = 2024,
           indicatorId = AutoCalculatedIndicator.TreesPlanted,
-          target = 500,
+          target = BigDecimal(500),
       )
 
       val targets = reportAutoCalculatedIndicatorTargetsDao.findAll()
@@ -6610,7 +6692,7 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
       assertEquals(projectId, targets[0].projectId)
       assertEquals(AutoCalculatedIndicator.TreesPlanted, targets[0].autoCalculatedIndicatorId)
       assertEquals(2024, targets[0].year)
-      assertEquals(500, targets[0].target)
+      assertEquals(BigDecimal(500), targets[0].target)
     }
 
     @Test
@@ -6619,19 +6701,19 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
           projectId = projectId,
           indicator = AutoCalculatedIndicator.TreesPlanted,
           year = 2024,
-          target = 500,
+          target = BigDecimal(500),
       )
 
       store.updateAutoCalculatedIndicatorTarget(
           projectId = projectId,
           year = 2024,
           indicatorId = AutoCalculatedIndicator.TreesPlanted,
-          target = 600,
+          target = BigDecimal(600),
       )
 
       val targets = reportAutoCalculatedIndicatorTargetsDao.findAll()
       assertEquals(1, targets.size)
-      assertEquals(600, targets[0].target)
+      assertEquals(BigDecimal(600), targets[0].target)
     }
 
     @Test
@@ -6659,7 +6741,7 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
             projectId = projectId,
             year = 2024,
             indicatorId = AutoCalculatedIndicator.TreesPlanted,
-            target = 500,
+            target = BigDecimal(500),
         )
       }
     }
@@ -6699,28 +6781,28 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
           projectId = projectId,
           projectIndicatorId = projectIndicatorId1,
           year = 2024,
-          target = 100,
+          target = BigDecimal(100),
       )
       insertReportProjectIndicatorTarget(
           projectId = projectId,
           projectIndicatorId = projectIndicatorId2,
           year = 2024,
-          target = 200,
+          target = BigDecimal(200),
       )
       insertReportProjectIndicatorTarget(
           projectId = projectId,
           projectIndicatorId = projectIndicatorId1,
           year = 2025,
-          target = 150,
+          target = BigDecimal(150),
       )
 
       val targets = store.fetchReportProjectIndicatorTargets(projectId)
 
       assertEquals(
           listOf(
-              ReportProjectIndicatorTargetModel(projectIndicatorId1, 100, 2024),
-              ReportProjectIndicatorTargetModel(projectIndicatorId2, 200, 2024),
-              ReportProjectIndicatorTargetModel(projectIndicatorId1, 150, 2025),
+              ReportProjectIndicatorTargetModel(projectIndicatorId1, BigDecimal(100), 2024),
+              ReportProjectIndicatorTargetModel(projectIndicatorId2, BigDecimal(200), 2024),
+              ReportProjectIndicatorTargetModel(projectIndicatorId1, BigDecimal(150), 2025),
           ),
           targets,
       )
@@ -6761,28 +6843,28 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
           projectId = projectId,
           commonIndicatorId = commonIndicatorId1,
           year = 2024,
-          target = 300,
+          target = BigDecimal(300),
       )
       insertReportCommonIndicatorTarget(
           projectId = projectId,
           commonIndicatorId = commonIndicatorId2,
           year = 2024,
-          target = 400,
+          target = BigDecimal(400),
       )
       insertReportCommonIndicatorTarget(
           projectId = projectId,
           commonIndicatorId = commonIndicatorId1,
           year = 2025,
-          target = 350,
+          target = BigDecimal(350),
       )
 
       val targets = store.fetchReportCommonIndicatorTargets(projectId)
 
       assertEquals(
           listOf(
-              ReportCommonIndicatorTargetModel(commonIndicatorId1, 300, 2024),
-              ReportCommonIndicatorTargetModel(commonIndicatorId2, 400, 2024),
-              ReportCommonIndicatorTargetModel(commonIndicatorId1, 350, 2025),
+              ReportCommonIndicatorTargetModel(commonIndicatorId1, BigDecimal(300), 2024),
+              ReportCommonIndicatorTargetModel(commonIndicatorId2, BigDecimal(400), 2024),
+              ReportCommonIndicatorTargetModel(commonIndicatorId1, BigDecimal(350), 2025),
           ),
           targets,
       )
@@ -6808,19 +6890,19 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
           projectId = projectId,
           indicator = AutoCalculatedIndicator.TreesPlanted,
           year = 2024,
-          target = 500,
+          target = BigDecimal(500),
       )
       insertReportAutoCalculatedIndicatorTarget(
           projectId = projectId,
           indicator = AutoCalculatedIndicator.SeedsCollected,
           year = 2024,
-          target = 1000,
+          target = BigDecimal(1000),
       )
       insertReportAutoCalculatedIndicatorTarget(
           projectId = projectId,
           indicator = AutoCalculatedIndicator.TreesPlanted,
           year = 2025,
-          target = 600,
+          target = BigDecimal(600),
       )
 
       val targets = store.fetchReportAutoCalculatedIndicatorTargets(projectId)
@@ -6829,17 +6911,17 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
           listOf(
               ReportAutoCalculatedIndicatorTargetModel(
                   AutoCalculatedIndicator.SeedsCollected,
-                  1000,
+                  BigDecimal(1000),
                   2024,
               ),
               ReportAutoCalculatedIndicatorTargetModel(
                   AutoCalculatedIndicator.TreesPlanted,
-                  500,
+                  BigDecimal(500),
                   2024,
               ),
               ReportAutoCalculatedIndicatorTargetModel(
                   AutoCalculatedIndicator.TreesPlanted,
-                  600,
+                  BigDecimal(600),
                   2025,
               ),
           ),
@@ -7218,8 +7300,8 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
               name = "Test Indicator 1",
               refId = "1.0",
           )
-      insertReportProjectIndicatorTarget(year = 2024, target = 100)
-      insertReportProjectIndicatorTarget(year = 2025, target = 150)
+      insertReportProjectIndicatorTarget(year = 2024, target = BigDecimal(100))
+      insertReportProjectIndicatorTarget(year = 2025, target = BigDecimal(150))
       insertProjectIndicatorBaselineTarget(baseline = 50, endTarget = 500)
 
       val projectIndicatorId2 =
@@ -7228,7 +7310,7 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
               name = "Test Indicator 2",
               refId = "2.0",
           )
-      insertReportProjectIndicatorTarget(year = 2024, target = 200)
+      insertReportProjectIndicatorTarget(year = 2024, target = BigDecimal(200))
 
       assertEquals(
           listOf(
@@ -7284,7 +7366,7 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
           name = "Test Indicator",
           refId = "1.0",
       )
-      insertReportProjectIndicatorTarget(year = 2024, target = 999)
+      insertReportProjectIndicatorTarget(year = 2024, target = BigDecimal(999))
       insertProjectIndicatorBaselineTarget(baseline = 99, endTarget = 999)
 
       assertEquals(
@@ -7313,8 +7395,8 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
               name = "Test Indicator 1",
               refId = "1.0",
           )
-      insertReportCommonIndicatorTarget(year = 2024, target = 300)
-      insertReportCommonIndicatorTarget(year = 2025, target = 350)
+      insertReportCommonIndicatorTarget(year = 2024, target = BigDecimal(300))
+      insertReportCommonIndicatorTarget(year = 2025, target = BigDecimal(350))
       insertCommonIndicatorBaselineTarget(baseline = 75, endTarget = 750)
 
       val commonIndicatorId2 =
@@ -7323,7 +7405,7 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
               name = "Test Indicator 2",
               refId = "2.0",
           )
-      insertReportCommonIndicatorTarget(year = 2024, target = 400)
+      insertReportCommonIndicatorTarget(year = 2024, target = BigDecimal(400))
 
       assertEquals(
           listOf(
@@ -7379,7 +7461,7 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
           name = "Test Indicator",
           refId = "1.0",
       )
-      insertReportCommonIndicatorTarget(year = 2024, target = 999)
+      insertReportCommonIndicatorTarget(year = 2024, target = BigDecimal(999))
       insertCommonIndicatorBaselineTarget(baseline = 99, endTarget = 999)
 
       assertEquals(
@@ -7405,17 +7487,17 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
       insertReportAutoCalculatedIndicatorTarget(
           indicator = AutoCalculatedIndicator.TreesPlanted,
           year = 2024,
-          target = 500,
+          target = BigDecimal(500),
       )
       insertReportAutoCalculatedIndicatorTarget(
           indicator = AutoCalculatedIndicator.TreesPlanted,
           year = 2025,
-          target = 600,
+          target = BigDecimal(600),
       )
       insertReportAutoCalculatedIndicatorTarget(
           indicator = AutoCalculatedIndicator.SeedsCollected,
           year = 2024,
-          target = 1000,
+          target = BigDecimal(1000),
       )
       insertAutoCalculatedIndicatorBaselineTarget(
           indicator = AutoCalculatedIndicator.TreesPlanted,
@@ -7473,7 +7555,7 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
       insertReportAutoCalculatedIndicatorTarget(
           indicator = AutoCalculatedIndicator.TreesPlanted,
           year = 2024,
-          target = 999,
+          target = BigDecimal(999),
       )
       insertAutoCalculatedIndicatorBaselineTarget(
           indicator = AutoCalculatedIndicator.TreesPlanted,

--- a/src/test/kotlin/com/terraformation/backend/db/DatabaseBackedTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/db/DatabaseBackedTest.kt
@@ -3675,7 +3675,7 @@ abstract class DatabaseBackedTest {
       row: ReportProjectIndicatorsRow = ReportProjectIndicatorsRow(),
       reportId: ReportId = row.reportId ?: inserted.reportId,
       indicatorId: ProjectIndicatorId = row.projectIndicatorId ?: inserted.projectIndicatorId,
-      value: Int? = row.value,
+      value: BigDecimal? = row.value,
       projectsComments: String? = row.projectsComments,
       progressNotes: String? = row.progressNotes,
       status: ReportIndicatorStatus? = row.statusId,
@@ -3701,7 +3701,7 @@ abstract class DatabaseBackedTest {
       row: ReportCommonIndicatorsRow = ReportCommonIndicatorsRow(),
       reportId: ReportId = row.reportId ?: inserted.reportId,
       indicatorId: CommonIndicatorId = row.commonIndicatorId ?: inserted.commonIndicatorId,
-      value: Int? = row.value,
+      value: BigDecimal? = row.value,
       projectsComments: String? = row.projectsComments,
       progressNotes: String? = row.progressNotes,
       status: ReportIndicatorStatus? = row.statusId,
@@ -3728,9 +3728,9 @@ abstract class DatabaseBackedTest {
       reportId: ReportId = row.reportId ?: inserted.reportId,
       indicator: AutoCalculatedIndicator =
           row.autoCalculatedIndicatorId ?: AutoCalculatedIndicator.SeedsCollected,
-      systemValue: Int? = row.systemValue,
+      systemValue: BigDecimal? = row.systemValue,
       systemTime: Instant? = row.systemTime ?: systemValue?.let { Instant.EPOCH },
-      overrideValue: Int? = row.overrideValue,
+      overrideValue: BigDecimal? = row.overrideValue,
       projectsComments: String? = row.projectsComments,
       progressNotes: String? = row.progressNotes,
       status: ReportIndicatorStatus? = row.statusId,
@@ -3760,7 +3760,7 @@ abstract class DatabaseBackedTest {
       projectIndicatorId: ProjectIndicatorId =
           row.projectIndicatorId ?: inserted.projectIndicatorId,
       year: Int = row.year ?: 1970,
-      target: Int? = row.target,
+      target: BigDecimal? = row.target,
   ) {
     val rowWithDefaults =
         row.copy(
@@ -3778,7 +3778,7 @@ abstract class DatabaseBackedTest {
       projectId: ProjectId = row.projectId ?: inserted.projectId,
       commonIndicatorId: CommonIndicatorId = row.commonIndicatorId ?: inserted.commonIndicatorId,
       year: Int = row.year ?: 1970,
-      target: Int? = row.target,
+      target: BigDecimal? = row.target,
   ) {
     val rowWithDefaults =
         row.copy(
@@ -3797,7 +3797,7 @@ abstract class DatabaseBackedTest {
       indicator: AutoCalculatedIndicator =
           row.autoCalculatedIndicatorId ?: AutoCalculatedIndicator.SeedsCollected,
       year: Int = row.year ?: 1970,
-      target: Int? = row.target,
+      target: BigDecimal? = row.target,
   ) {
     val rowWithDefaults =
         row.copy(
@@ -3816,7 +3816,7 @@ abstract class DatabaseBackedTest {
       projectIndicatorId: ProjectIndicatorId =
           row.projectIndicatorId ?: inserted.projectIndicatorId,
       year: Int = row.year ?: 2025,
-      target: Int? = row.target,
+      target: BigDecimal? = row.target,
   ) {
     val rowWithDefaults =
         row.copy(
@@ -3834,7 +3834,7 @@ abstract class DatabaseBackedTest {
       projectId: ProjectId = row.projectId ?: inserted.projectId,
       commonIndicatorId: CommonIndicatorId = row.commonIndicatorId ?: inserted.commonIndicatorId,
       year: Int = row.year ?: 2025,
-      target: Int? = row.target,
+      target: BigDecimal? = row.target,
   ) {
     val rowWithDefaults =
         row.copy(
@@ -3854,7 +3854,7 @@ abstract class DatabaseBackedTest {
       indicator: AutoCalculatedIndicator =
           row.autoCalculatedIndicatorId ?: AutoCalculatedIndicator.SeedsCollected,
       year: Int = row.year ?: 2025,
-      target: Int? = row.target,
+      target: BigDecimal? = row.target,
   ) {
     val rowWithDefaults =
         row.copy(
@@ -4061,7 +4061,7 @@ abstract class DatabaseBackedTest {
       row: PublishedReportProjectIndicatorsRow = PublishedReportProjectIndicatorsRow(),
       reportId: ReportId = row.reportId ?: inserted.reportId,
       indicatorId: ProjectIndicatorId = row.projectIndicatorId ?: inserted.projectIndicatorId,
-      value: Int? = row.value,
+      value: BigDecimal? = row.value,
       projectsComments: String? = row.projectsComments,
       progressNotes: String? = row.progressNotes,
       status: ReportIndicatorStatus? = row.statusId,
@@ -4083,7 +4083,7 @@ abstract class DatabaseBackedTest {
       row: PublishedReportCommonIndicatorsRow = PublishedReportCommonIndicatorsRow(),
       reportId: ReportId = row.reportId ?: inserted.reportId,
       indicatorId: CommonIndicatorId = row.commonIndicatorId ?: inserted.commonIndicatorId,
-      value: Int? = row.value,
+      value: BigDecimal? = row.value,
       projectsComments: String? = row.projectsComments,
       progressNotes: String? = row.progressNotes,
       status: ReportIndicatorStatus? = row.statusId,
@@ -4107,7 +4107,7 @@ abstract class DatabaseBackedTest {
       reportId: ReportId = row.reportId ?: inserted.reportId,
       indicator: AutoCalculatedIndicator =
           row.autoCalculatedIndicatorId ?: AutoCalculatedIndicator.Seedlings,
-      value: Int? = row.value,
+      value: BigDecimal? = row.value,
       projectsComments: String? = row.projectsComments,
       progressNotes: String? = row.progressNotes,
       status: ReportIndicatorStatus? = row.statusId,

--- a/src/test/kotlin/com/terraformation/backend/db/DatabaseBackedTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/db/DatabaseBackedTest.kt
@@ -3675,7 +3675,7 @@ abstract class DatabaseBackedTest {
       row: ReportProjectIndicatorsRow = ReportProjectIndicatorsRow(),
       reportId: ReportId = row.reportId ?: inserted.reportId,
       indicatorId: ProjectIndicatorId = row.projectIndicatorId ?: inserted.projectIndicatorId,
-      value: BigDecimal? = row.value,
+      value: Number? = row.value,
       projectsComments: String? = row.projectsComments,
       progressNotes: String? = row.progressNotes,
       status: ReportIndicatorStatus? = row.statusId,
@@ -3686,7 +3686,7 @@ abstract class DatabaseBackedTest {
         row.copy(
             reportId = reportId,
             projectIndicatorId = indicatorId,
-            value = value,
+            value = value?.toBigDecimal(),
             projectsComments = projectsComments,
             progressNotes = progressNotes,
             statusId = status,
@@ -3701,7 +3701,7 @@ abstract class DatabaseBackedTest {
       row: ReportCommonIndicatorsRow = ReportCommonIndicatorsRow(),
       reportId: ReportId = row.reportId ?: inserted.reportId,
       indicatorId: CommonIndicatorId = row.commonIndicatorId ?: inserted.commonIndicatorId,
-      value: BigDecimal? = row.value,
+      value: Number? = row.value,
       projectsComments: String? = row.projectsComments,
       progressNotes: String? = row.progressNotes,
       status: ReportIndicatorStatus? = row.statusId,
@@ -3712,7 +3712,7 @@ abstract class DatabaseBackedTest {
         row.copy(
             reportId = reportId,
             commonIndicatorId = indicatorId,
-            value = value,
+            value = value?.toBigDecimal(),
             projectsComments = projectsComments,
             progressNotes = progressNotes,
             statusId = status,
@@ -3728,9 +3728,9 @@ abstract class DatabaseBackedTest {
       reportId: ReportId = row.reportId ?: inserted.reportId,
       indicator: AutoCalculatedIndicator =
           row.autoCalculatedIndicatorId ?: AutoCalculatedIndicator.SeedsCollected,
-      systemValue: BigDecimal? = row.systemValue,
+      systemValue: Number? = row.systemValue,
       systemTime: Instant? = row.systemTime ?: systemValue?.let { Instant.EPOCH },
-      overrideValue: BigDecimal? = row.overrideValue,
+      overrideValue: Number? = row.overrideValue,
       projectsComments: String? = row.projectsComments,
       progressNotes: String? = row.progressNotes,
       status: ReportIndicatorStatus? = row.statusId,
@@ -3741,9 +3741,9 @@ abstract class DatabaseBackedTest {
         row.copy(
             reportId = reportId,
             autoCalculatedIndicatorId = indicator,
-            systemValue = systemValue,
+            systemValue = systemValue?.toBigDecimal(),
             systemTime = systemTime,
-            overrideValue = overrideValue,
+            overrideValue = overrideValue?.toBigDecimal(),
             projectsComments = projectsComments,
             progressNotes = progressNotes,
             statusId = status,
@@ -3760,14 +3760,14 @@ abstract class DatabaseBackedTest {
       projectIndicatorId: ProjectIndicatorId =
           row.projectIndicatorId ?: inserted.projectIndicatorId,
       year: Int = row.year ?: 1970,
-      target: BigDecimal? = row.target,
+      target: Number? = row.target,
   ) {
     val rowWithDefaults =
         row.copy(
             projectId = projectId,
             projectIndicatorId = projectIndicatorId,
             year = year,
-            target = target,
+            target = target?.toBigDecimal(),
         )
 
     reportProjectIndicatorTargetsDao.insert(rowWithDefaults)
@@ -3778,14 +3778,14 @@ abstract class DatabaseBackedTest {
       projectId: ProjectId = row.projectId ?: inserted.projectId,
       commonIndicatorId: CommonIndicatorId = row.commonIndicatorId ?: inserted.commonIndicatorId,
       year: Int = row.year ?: 1970,
-      target: BigDecimal? = row.target,
+      target: Number? = row.target,
   ) {
     val rowWithDefaults =
         row.copy(
             projectId = projectId,
             commonIndicatorId = commonIndicatorId,
             year = year,
-            target = target,
+            target = target?.toBigDecimal(),
         )
 
     reportCommonIndicatorTargetsDao.insert(rowWithDefaults)
@@ -3797,14 +3797,14 @@ abstract class DatabaseBackedTest {
       indicator: AutoCalculatedIndicator =
           row.autoCalculatedIndicatorId ?: AutoCalculatedIndicator.SeedsCollected,
       year: Int = row.year ?: 1970,
-      target: BigDecimal? = row.target,
+      target: Number? = row.target,
   ) {
     val rowWithDefaults =
         row.copy(
             projectId = projectId,
             autoCalculatedIndicatorId = indicator,
             year = year,
-            target = target,
+            target = target?.toBigDecimal(),
         )
 
     reportAutoCalculatedIndicatorTargetsDao.insert(rowWithDefaults)
@@ -3816,14 +3816,14 @@ abstract class DatabaseBackedTest {
       projectIndicatorId: ProjectIndicatorId =
           row.projectIndicatorId ?: inserted.projectIndicatorId,
       year: Int = row.year ?: 2025,
-      target: BigDecimal? = row.target,
+      target: Number? = row.target,
   ) {
     val rowWithDefaults =
         row.copy(
             projectId = projectId,
             projectIndicatorId = projectIndicatorId,
             year = year,
-            target = target,
+            target = target?.toBigDecimal(),
         )
 
     publishedProjectIndicatorTargetsDao.insert(rowWithDefaults)
@@ -3834,14 +3834,14 @@ abstract class DatabaseBackedTest {
       projectId: ProjectId = row.projectId ?: inserted.projectId,
       commonIndicatorId: CommonIndicatorId = row.commonIndicatorId ?: inserted.commonIndicatorId,
       year: Int = row.year ?: 2025,
-      target: BigDecimal? = row.target,
+      target: Number? = row.target,
   ) {
     val rowWithDefaults =
         row.copy(
             projectId = projectId,
             commonIndicatorId = commonIndicatorId,
             year = year,
-            target = target,
+            target = target?.toBigDecimal(),
         )
 
     publishedCommonIndicatorTargetsDao.insert(rowWithDefaults)
@@ -3854,14 +3854,14 @@ abstract class DatabaseBackedTest {
       indicator: AutoCalculatedIndicator =
           row.autoCalculatedIndicatorId ?: AutoCalculatedIndicator.SeedsCollected,
       year: Int = row.year ?: 2025,
-      target: BigDecimal? = row.target,
+      target: Number? = row.target,
   ) {
     val rowWithDefaults =
         row.copy(
             projectId = projectId,
             autoCalculatedIndicatorId = indicator,
             year = year,
-            target = target,
+            target = target?.toBigDecimal(),
         )
 
     publishedAutoCalculatedIndicatorTargetsDao.insert(rowWithDefaults)
@@ -4061,7 +4061,7 @@ abstract class DatabaseBackedTest {
       row: PublishedReportProjectIndicatorsRow = PublishedReportProjectIndicatorsRow(),
       reportId: ReportId = row.reportId ?: inserted.reportId,
       indicatorId: ProjectIndicatorId = row.projectIndicatorId ?: inserted.projectIndicatorId,
-      value: BigDecimal? = row.value,
+      value: Number? = row.value,
       projectsComments: String? = row.projectsComments,
       progressNotes: String? = row.progressNotes,
       status: ReportIndicatorStatus? = row.statusId,
@@ -4070,7 +4070,7 @@ abstract class DatabaseBackedTest {
         row.copy(
             reportId = reportId,
             projectIndicatorId = indicatorId,
-            value = value,
+            value = value?.toBigDecimal(),
             projectsComments = projectsComments,
             progressNotes = progressNotes,
             statusId = status,
@@ -4083,7 +4083,7 @@ abstract class DatabaseBackedTest {
       row: PublishedReportCommonIndicatorsRow = PublishedReportCommonIndicatorsRow(),
       reportId: ReportId = row.reportId ?: inserted.reportId,
       indicatorId: CommonIndicatorId = row.commonIndicatorId ?: inserted.commonIndicatorId,
-      value: BigDecimal? = row.value,
+      value: Number? = row.value,
       projectsComments: String? = row.projectsComments,
       progressNotes: String? = row.progressNotes,
       status: ReportIndicatorStatus? = row.statusId,
@@ -4092,7 +4092,7 @@ abstract class DatabaseBackedTest {
         row.copy(
             reportId = reportId,
             commonIndicatorId = indicatorId,
-            value = value,
+            value = value?.toBigDecimal(),
             projectsComments = projectsComments,
             progressNotes = progressNotes,
             statusId = status,
@@ -4107,7 +4107,7 @@ abstract class DatabaseBackedTest {
       reportId: ReportId = row.reportId ?: inserted.reportId,
       indicator: AutoCalculatedIndicator =
           row.autoCalculatedIndicatorId ?: AutoCalculatedIndicator.Seedlings,
-      value: BigDecimal? = row.value,
+      value: Number? = row.value,
       projectsComments: String? = row.projectsComments,
       progressNotes: String? = row.progressNotes,
       status: ReportIndicatorStatus? = row.statusId,
@@ -4116,7 +4116,7 @@ abstract class DatabaseBackedTest {
         row.copy(
             reportId = reportId,
             autoCalculatedIndicatorId = indicator,
-            value = value,
+            value = value?.toBigDecimal(),
             projectsComments = projectsComments,
             progressNotes = progressNotes,
             statusId = status,

--- a/src/test/kotlin/com/terraformation/backend/funder/db/PublishedProjectDetailsStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/funder/db/PublishedProjectDetailsStoreTest.kt
@@ -164,38 +164,38 @@ class PublishedProjectDetailsStoreTest : DatabaseTest(), RunsAsDatabaseUser {
       insertPublishedReport()
       insertPublishedReportAutoCalculatedIndicator(
           indicator = AutoCalculatedIndicator.HectaresPlanted,
-          value = 100,
+          value = BigDecimal(100),
       )
       insertPublishedReportAutoCalculatedIndicator(
           indicator = AutoCalculatedIndicator.TreesPlanted,
-          value = 10,
+          value = BigDecimal(10),
       )
       insertPublishedReportAutoCalculatedIndicator(
           indicator = AutoCalculatedIndicator.SeedsCollected,
-          value = 1000,
+          value = BigDecimal(1000),
       )
       insertPublishedReportAutoCalculatedIndicator(
           indicator = AutoCalculatedIndicator.SpeciesPlanted,
-          value = 1,
+          value = BigDecimal(1),
       )
 
       insertReport()
       insertPublishedReport()
       insertPublishedReportAutoCalculatedIndicator(
           indicator = AutoCalculatedIndicator.HectaresPlanted,
-          value = 200,
+          value = BigDecimal(200),
       )
       insertPublishedReportAutoCalculatedIndicator(
           indicator = AutoCalculatedIndicator.TreesPlanted,
-          value = 20,
+          value = BigDecimal(20),
       )
       insertPublishedReportAutoCalculatedIndicator(
           indicator = AutoCalculatedIndicator.SeedsCollected,
-          value = 2000,
+          value = BigDecimal(2000),
       )
       insertPublishedReportAutoCalculatedIndicator(
           indicator = AutoCalculatedIndicator.SpeciesPlanted,
-          value = 2,
+          value = BigDecimal(2),
       )
 
       val expected =
@@ -209,12 +209,18 @@ class PublishedProjectDetailsStoreTest : DatabaseTest(), RunsAsDatabaseUser {
               methodologyNumber = "methodology",
               indicatorProgress =
                   listOf(
-                      IndicatorProgressModel(indicator = AutoCalculatedIndicator.TreesPlanted, 30),
+                      IndicatorProgressModel(
+                          indicator = AutoCalculatedIndicator.TreesPlanted,
+                          BigDecimal(30),
+                      ),
                       // Species Planted utilize max instead of sum
-                      IndicatorProgressModel(indicator = AutoCalculatedIndicator.SpeciesPlanted, 2),
+                      IndicatorProgressModel(
+                          indicator = AutoCalculatedIndicator.SpeciesPlanted,
+                          BigDecimal(2),
+                      ),
                       IndicatorProgressModel(
                           indicator = AutoCalculatedIndicator.HectaresPlanted,
-                          300,
+                          BigDecimal(300),
                       ),
                       // Seeds Collected and other indicator progress is not tracked
                   ),

--- a/src/test/kotlin/com/terraformation/backend/funder/db/PublishedReportStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/funder/db/PublishedReportStoreTest.kt
@@ -99,25 +99,25 @@ class PublishedReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
 
       // oldReport1
       insertReport(endDate = LocalDate.of(2024, 9, 30))
-      insertReportProjectIndicator(indicatorId = projectIndicatorId1, value = 10)
-      insertReportProjectIndicator(indicatorId = projectIndicatorId2, value = 11)
-      insertReportCommonIndicator(indicatorId = commonIndicatorId1, value = 20)
-      insertReportCommonIndicator(indicatorId = commonIndicatorId2, value = 21)
+      insertReportProjectIndicator(indicatorId = projectIndicatorId1, value = BigDecimal(10))
+      insertReportProjectIndicator(indicatorId = projectIndicatorId2, value = BigDecimal(11))
+      insertReportCommonIndicator(indicatorId = commonIndicatorId1, value = BigDecimal(20))
+      insertReportCommonIndicator(indicatorId = commonIndicatorId2, value = BigDecimal(21))
       insertReportAutoCalculatedIndicator(
           indicator = AutoCalculatedIndicator.SeedsCollected,
-          systemValue = 30,
+          systemValue = BigDecimal(30),
       )
 
       // oldReport2
       insertReport(endDate = LocalDate.of(2024, 12, 31))
-      insertReportProjectIndicator(indicatorId = projectIndicatorId1, value = 100)
-      insertReportProjectIndicator(indicatorId = projectIndicatorId2, value = 101)
-      insertReportCommonIndicator(indicatorId = commonIndicatorId1, value = 200)
-      insertReportCommonIndicator(indicatorId = commonIndicatorId2, value = 201)
+      insertReportProjectIndicator(indicatorId = projectIndicatorId1, value = BigDecimal(100))
+      insertReportProjectIndicator(indicatorId = projectIndicatorId2, value = BigDecimal(101))
+      insertReportCommonIndicator(indicatorId = commonIndicatorId1, value = BigDecimal(200))
+      insertReportCommonIndicator(indicatorId = commonIndicatorId2, value = BigDecimal(201))
       insertReportAutoCalculatedIndicator(
           indicator = AutoCalculatedIndicator.SeedsCollected,
-          systemValue = 29,
-          overrideValue = 31,
+          systemValue = BigDecimal(29),
+          overrideValue = BigDecimal(31),
       )
 
       val reportId1 =
@@ -158,12 +158,12 @@ class PublishedReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
       insertPublishedCommonIndicatorTarget(
           commonIndicatorId = commonIndicatorId1,
           year = 2025,
-          target = 100,
+          target = BigDecimal(100),
       )
       insertPublishedReportCommonIndicator(
           reportId = reportId1,
           indicatorId = commonIndicatorId1,
-          value = 120,
+          value = BigDecimal(120),
           projectsComments = null,
           status = ReportIndicatorStatus.Achieved,
       )
@@ -171,12 +171,12 @@ class PublishedReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
       insertPublishedCommonIndicatorTarget(
           commonIndicatorId = commonIndicatorId2,
           year = 2025,
-          target = 200,
+          target = BigDecimal(200),
       )
       insertPublishedReportCommonIndicator(
           reportId = reportId1,
           indicatorId = commonIndicatorId2,
-          value = 180,
+          value = BigDecimal(180),
           progressNotes = "progress notes 2",
           projectsComments = "Underperformance justification 2",
           status = ReportIndicatorStatus.Unlikely,
@@ -190,7 +190,7 @@ class PublishedReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
       insertPublishedReportProjectIndicator(
           reportId = reportId1,
           indicatorId = projectIndicatorId1,
-          value = 40,
+          value = BigDecimal(40),
           progressNotes = "progress notes 1",
           projectsComments = null,
           status = ReportIndicatorStatus.OnTrack,
@@ -212,12 +212,12 @@ class PublishedReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
       insertPublishedAutoCalculatedIndicatorTarget(
           indicator = AutoCalculatedIndicator.SeedsCollected,
           year = 2025,
-          target = 6,
+          target = BigDecimal(6),
       )
       insertPublishedReportAutoCalculatedIndicator(
           reportId = reportId1,
           indicator = AutoCalculatedIndicator.SeedsCollected,
-          value = 6,
+          value = BigDecimal(6),
           projectsComments = null,
           status = ReportIndicatorStatus.OffTrack,
       )
@@ -225,19 +225,19 @@ class PublishedReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
       insertPublishedCommonIndicatorBaseline(
           commonIndicatorId = commonIndicatorId2,
           baseline = 200,
-          endTarget = 250,
+          endTarget = BigDecimal(250),
       )
 
       insertPublishedProjectIndicatorBaseline(
           projectIndicatorId = projectIndicatorId2,
           baseline = 210,
-          endTarget = 220,
+          endTarget = BigDecimal(220),
       )
 
       insertPublishedAutoCalculatedIndicatorBaseline(
           indicator = AutoCalculatedIndicator.SeedsCollected,
           baseline = 300,
-          endTarget = 400,
+          endTarget = BigDecimal(400),
       )
 
       val reportId2 =
@@ -294,9 +294,9 @@ class PublishedReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
                               progressNotes = null,
                               projectsComments = null,
                               status = ReportIndicatorStatus.OffTrack,
-                              target = 6,
+                              target = BigDecimal(6),
                               unit = "Seeds",
-                              value = 6,
+                              value = BigDecimal(6),
                           ),
                       ),
                   challenges =
@@ -321,9 +321,9 @@ class PublishedReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
                               projectsComments = "Underperformance justification 2",
                               refId = "1.1.1",
                               status = ReportIndicatorStatus.Unlikely,
-                              target = 200,
+                              target = BigDecimal(200),
                               unit = null,
-                              value = 180,
+                              value = BigDecimal(180),
                           ),
                           PublishedReportIndicatorModel(
                               category = IndicatorCategory.Climate,
@@ -339,9 +339,9 @@ class PublishedReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
                               projectsComments = null,
                               refId = "1.1.2",
                               status = ReportIndicatorStatus.Achieved,
-                              target = 100,
+                              target = BigDecimal(100),
                               unit = null,
-                              value = 120,
+                              value = BigDecimal(120),
                           ),
                       ),
                   endDate = LocalDate.of(2025, 3, 31),
@@ -372,7 +372,7 @@ class PublishedReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
                               status = ReportIndicatorStatus.OnTrack,
                               target = null,
                               unit = "%",
-                              value = 40,
+                              value = BigDecimal(40),
                           ),
                           PublishedReportIndicatorModel(
                               baseline = BigDecimal.valueOf(210),
@@ -434,7 +434,7 @@ class PublishedReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
       insertPublishedReportProjectIndicator(
           reportId = reportId,
           indicatorId = projectIndicatorId,
-          value = 10,
+          value = BigDecimal(10),
           status = ReportIndicatorStatus.OnTrack,
       )
 
@@ -442,13 +442,13 @@ class PublishedReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
       insertPublishedProjectIndicatorTarget(
           projectIndicatorId = projectIndicatorId,
           year = 2024,
-          target = 100,
+          target = BigDecimal(100),
       )
       // Target for a different year — should not cause a duplicate row
       insertPublishedProjectIndicatorTarget(
           projectIndicatorId = projectIndicatorId,
           year = 2025,
-          target = 999,
+          target = BigDecimal(999),
       )
       // Target for a different project in the same year — should not cause a duplicate row
       val otherProjectId = insertProject()
@@ -456,7 +456,7 @@ class PublishedReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
           projectId = otherProjectId,
           projectIndicatorId = projectIndicatorId,
           year = 2024,
-          target = 888,
+          target = BigDecimal(888),
       )
 
       val reports = store.fetchPublishedReports(projectId)
@@ -472,9 +472,9 @@ class PublishedReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
               projectsComments = null,
               refId = "1.2.1",
               status = ReportIndicatorStatus.OnTrack,
-              target = 100,
+              target = BigDecimal(100),
               unit = null,
-              value = 10,
+              value = BigDecimal(10),
           )
       assertEquals(
           listOf(expected),
@@ -511,7 +511,7 @@ class PublishedReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
       insertPublishedReportCommonIndicator(
           reportId = reportId,
           indicatorId = commonIndicatorId,
-          value = 20,
+          value = BigDecimal(20),
           status = ReportIndicatorStatus.Achieved,
       )
 
@@ -519,13 +519,13 @@ class PublishedReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
       insertPublishedCommonIndicatorTarget(
           commonIndicatorId = commonIndicatorId,
           year = 2024,
-          target = 200,
+          target = BigDecimal(200),
       )
       // Target for a different year — should not cause a duplicate row
       insertPublishedCommonIndicatorTarget(
           commonIndicatorId = commonIndicatorId,
           year = 2025,
-          target = 999,
+          target = BigDecimal(999),
       )
       // Target for a different project in the same year — should not cause a duplicate row
       val otherProjectId = insertProject()
@@ -533,7 +533,7 @@ class PublishedReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
           projectId = otherProjectId,
           commonIndicatorId = commonIndicatorId,
           year = 2024,
-          target = 888,
+          target = BigDecimal(888),
       )
 
       val reports = store.fetchPublishedReports(projectId)
@@ -550,9 +550,9 @@ class PublishedReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
               projectsComments = null,
               refId = "1.1.1",
               status = ReportIndicatorStatus.Achieved,
-              target = 200,
+              target = BigDecimal(200),
               unit = null,
-              value = 20,
+              value = BigDecimal(20),
           )
       assertEquals(
           listOf(expected),
@@ -579,7 +579,7 @@ class PublishedReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
       insertPublishedReportAutoCalculatedIndicator(
           reportId = reportId,
           indicator = AutoCalculatedIndicator.SurvivalRate,
-          value = 5,
+          value = BigDecimal(5),
           status = ReportIndicatorStatus.OnTrack,
       )
 
@@ -587,13 +587,13 @@ class PublishedReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
       insertPublishedAutoCalculatedIndicatorTarget(
           indicator = AutoCalculatedIndicator.SurvivalRate,
           year = 2024,
-          target = 300,
+          target = BigDecimal(300),
       )
       // Target for a different year — should not cause a duplicate row
       insertPublishedAutoCalculatedIndicatorTarget(
           indicator = AutoCalculatedIndicator.SurvivalRate,
           year = 2025,
-          target = 999,
+          target = BigDecimal(999),
       )
       // Target for a different project in the same year — should not cause a duplicate row
       val otherProjectId = insertProject()
@@ -601,7 +601,7 @@ class PublishedReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
           projectId = otherProjectId,
           indicator = AutoCalculatedIndicator.SurvivalRate,
           year = 2024,
-          target = 888,
+          target = BigDecimal(888),
       )
 
       val reports = store.fetchPublishedReports(projectId)
@@ -617,9 +617,9 @@ class PublishedReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
               projectsComments = null,
               refId = AutoCalculatedIndicator.SurvivalRate.refId,
               status = ReportIndicatorStatus.OnTrack,
-              target = 300,
+              target = BigDecimal(300),
               unit = "%",
-              value = 5,
+              value = BigDecimal(5),
           )
       assertEquals(
           listOf(expected),
@@ -653,7 +653,7 @@ class PublishedReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
       insertReportCommonIndicator(
           reportId = priorYearReportId,
           indicatorId = commonIndicatorId,
-          value = 999,
+          value = BigDecimal(999),
       )
 
       val q1ReportId =
@@ -665,7 +665,7 @@ class PublishedReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
       insertReportCommonIndicator(
           reportId = q1ReportId,
           indicatorId = commonIndicatorId,
-          value = 10,
+          value = BigDecimal(10),
       )
 
       val q2ReportId =
@@ -677,7 +677,7 @@ class PublishedReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
       insertReportCommonIndicator(
           reportId = q2ReportId,
           indicatorId = commonIndicatorId,
-          value = 20,
+          value = BigDecimal(20),
       )
 
       val q3ReportId =
@@ -690,7 +690,7 @@ class PublishedReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
           reportId = q3ReportId,
           indicatorId = commonIndicatorId,
           // current quarter value is ignored, only published value is used for the current quarter
-          value = 29,
+          value = BigDecimal(29),
       )
 
       insertPublishedReport(
@@ -702,7 +702,7 @@ class PublishedReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
       insertPublishedReportCommonIndicator(
           reportId = q3ReportId,
           indicatorId = commonIndicatorId,
-          value = 30,
+          value = BigDecimal(30),
           status = ReportIndicatorStatus.OnTrack,
       )
 
@@ -716,7 +716,7 @@ class PublishedReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
       insertReportCommonIndicator(
           reportId = q4ReportId,
           indicatorId = commonIndicatorId,
-          value = 40,
+          value = BigDecimal(40),
       )
 
       val reports = store.fetchPublishedReports(projectId)
@@ -724,9 +724,18 @@ class PublishedReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
 
       assertEquals(
           listOf(
-              PublishedCumulativeIndicatorProgressModel(quarter = ReportQuarter.Q1, value = 10),
-              PublishedCumulativeIndicatorProgressModel(quarter = ReportQuarter.Q2, value = 20),
-              PublishedCumulativeIndicatorProgressModel(quarter = ReportQuarter.Q3, value = 30),
+              PublishedCumulativeIndicatorProgressModel(
+                  quarter = ReportQuarter.Q1,
+                  value = BigDecimal(10),
+              ),
+              PublishedCumulativeIndicatorProgressModel(
+                  quarter = ReportQuarter.Q2,
+                  value = BigDecimal(20),
+              ),
+              PublishedCumulativeIndicatorProgressModel(
+                  quarter = ReportQuarter.Q3,
+                  value = BigDecimal(30),
+              ),
           ),
           indicator.currentYearProgress,
           "currentYearProgress contains all quarters in the current year, excluding future quarters",
@@ -757,7 +766,7 @@ class PublishedReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
       insertReportCommonIndicator(
           reportId = q1ReportId,
           indicatorId = commonIndicatorId,
-          value = 10,
+          value = BigDecimal(10),
       )
 
       // Q2 has a null value for this indicator — must be excluded
@@ -782,7 +791,7 @@ class PublishedReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
       insertReportCommonIndicator(
           reportId = q3ReportId,
           indicatorId = commonIndicatorId,
-          value = 30,
+          value = BigDecimal(30),
       )
 
       insertPublishedReport(
@@ -797,7 +806,10 @@ class PublishedReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
 
       assertEquals(
           listOf(
-              PublishedCumulativeIndicatorProgressModel(quarter = ReportQuarter.Q1, value = 10),
+              PublishedCumulativeIndicatorProgressModel(
+                  quarter = ReportQuarter.Q1,
+                  value = BigDecimal(10),
+              ),
               // q2 is excluded because it has a null value
               // q3 is excluded because it has a non-null value but no published value
           ),
@@ -827,7 +839,11 @@ class PublishedReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
               endDate = LocalDate.of(2025, 3, 31),
               quarter = ReportQuarter.Q1,
           )
-      insertReportCommonIndicator(reportId = q1ReportId, indicatorId = levelIndicatorId, value = 50)
+      insertReportCommonIndicator(
+          reportId = q1ReportId,
+          indicatorId = levelIndicatorId,
+          value = BigDecimal(50),
+      )
 
       val q2ReportId =
           insertReport(
@@ -835,7 +851,11 @@ class PublishedReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
               endDate = LocalDate.of(2025, 6, 30),
               quarter = ReportQuarter.Q2,
           )
-      insertReportCommonIndicator(reportId = q2ReportId, indicatorId = levelIndicatorId, value = 60)
+      insertReportCommonIndicator(
+          reportId = q2ReportId,
+          indicatorId = levelIndicatorId,
+          value = BigDecimal(60),
+      )
 
       insertPublishedReport(
           reportId = q2ReportId,
@@ -846,7 +866,7 @@ class PublishedReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
       insertPublishedReportCommonIndicator(
           reportId = q2ReportId,
           indicatorId = levelIndicatorId,
-          value = 60,
+          value = BigDecimal(60),
           status = ReportIndicatorStatus.OnTrack,
       )
 


### PR DESCRIPTION
This is a pretty large PR, but I couldn't think of ways to split it up without adding lots of temporary conversions to Int/BigDecimal that would never see production, but if it's preferred to split up I'm happy to change. The majority of the changes are updates to the tests to wrap the Ints with BigDecimal.

We want to support decimals with our indicators. Update the tables to change the following from `integer` to `numeric`:

- value
- system_value
- override_value
- target

(some of the others were already set to numeric in preparation for this change, e.g. baseline).
Update the code to keep Int only for the old metric endpoints/payloads, but to use BigDecimal everywhere else.

Replaces PRs #4051 and #4052  (and cherry picked many of the changes from them).

Co-authored-by: Tommy Lau [8563294+tommylau523@users.noreply.github.com](mailto:8563294+tommylau523@users.noreply.github.com)