### PR TITLE
SW-8169 Update HectaresPlanted indicator definition

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/accelerator/db/ReportStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/db/ReportStore.kt
@@ -1936,24 +1936,6 @@ class ReportStore(
         .asNonNullable()
   }
 
-  private val hectaresPlantedField =
-      with(SUBSTRATA) {
-        DSL.field(
-            DSL.select(DSL.sum(AREA_HA))
-                .from(this)
-                .join(PLANTING_SITES)
-                .on(PLANTING_SITES.ID.eq(PLANTING_SITE_ID))
-                .where(
-                    timestampToLocalDateField(
-                            PLANTING_COMPLETED_TIME,
-                            plantingSiteTimeZoneField(PLANTING_SITE_ID),
-                        )
-                        .le(REPORTS.END_DATE)
-                )
-                .and(PLANTING_SITES.PROJECT_ID.eq(REPORTS.PROJECT_ID))
-        )
-      }
-
   private val observationsInReportPeriod =
       DSL.select(OBSERVATIONS.ID)
           .distinctOn(OBSERVATIONS.PLANTING_SITE_ID)
@@ -2016,16 +1998,6 @@ class ReportStore(
     return calculateSurvivalRate(numKnownLive, sumDensity)?.toBigDecimal()
   }
 
-  private val seedsCollectedField =
-      with(ACCESSIONS) {
-        DSL.field(
-            DSL.select(DSL.sum(EST_SEED_COUNT) + DSL.sum(TOTAL_WITHDRAWN_COUNT))
-                .from(this)
-                .where(PROJECT_ID.eq(REPORTS.PROJECT_ID))
-                .and(COLLECTED_DATE.between(REPORTS.START_DATE, REPORTS.END_DATE))
-        )
-      }
-
   private val withdrawnSeedlingsField =
       with(BATCH_WITHDRAWALS) {
         DSL.field(
@@ -2056,6 +2028,16 @@ class ReportStore(
                 .from(this)
                 .where(PROJECT_ID.eq(REPORTS.PROJECT_ID))
                 .and(ADDED_DATE.between(REPORTS.START_DATE, REPORTS.END_DATE))
+        )
+      }
+
+  private val seedsCollectedField =
+      with(ACCESSIONS) {
+        DSL.field(
+            DSL.select(DSL.sum(EST_SEED_COUNT) + DSL.sum(TOTAL_WITHDRAWN_COUNT))
+                .from(this)
+                .where(PROJECT_ID.eq(REPORTS.PROJECT_ID))
+                .and(COLLECTED_DATE.between(REPORTS.START_DATE, REPORTS.END_DATE))
         )
       }
 
@@ -2110,6 +2092,24 @@ class ReportStore(
                 .and(PLANTING_SITES.PROJECT_ID.eq(REPORTS.PROJECT_ID))
                 .and(WITHDRAWAL_SUMMARIES.PURPOSE_ID.notEqual(WithdrawalPurpose.Undo))
                 .and(WITHDRAWAL_SUMMARIES.UNDONE_BY_WITHDRAWAL_ID.isNull)
+        )
+      }
+
+  private val hectaresPlantedField =
+      with(SUBSTRATA) {
+        DSL.field(
+            DSL.select(DSL.sum(AREA_HA))
+                .from(this)
+                .join(PLANTING_SITES)
+                .on(PLANTING_SITES.ID.eq(PLANTING_SITE_ID))
+                .where(
+                    timestampToLocalDateField(
+                            PLANTING_COMPLETED_TIME,
+                            plantingSiteTimeZoneField(PLANTING_SITE_ID),
+                        )
+                        .between(REPORTS.START_DATE, REPORTS.END_DATE)
+                )
+                .and(PLANTING_SITES.PROJECT_ID.eq(REPORTS.PROJECT_ID))
         )
       }
 

--- a/src/main/resources/db/migration/0450/V470__ResetSavedHectaresPlanted.sql
+++ b/src/main/resources/db/migration/0450/V470__ResetSavedHectaresPlanted.sql
@@ -1,0 +1,5 @@
+-- Reset cached hectares planted so that the new definition is used
+UPDATE accelerator.report_auto_calculated_indicators
+SET system_time = NULL, system_value = NULL
+WHERE auto_calculated_indicator_id = 6 AND system_value IS NOT NULL
+;

--- a/src/test/kotlin/com/terraformation/backend/accelerator/db/ReportStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/db/ReportStoreTest.kt
@@ -665,7 +665,7 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
                   indicator = AutoCalculatedIndicator.HectaresPlanted,
                   entry =
                       ReportAutoCalculatedIndicatorEntryModel(
-                          systemValue = BigDecimal(60),
+                          systemValue = BigDecimal(40),
                       ),
                   currentYearProgress = emptyList(),
               ),
@@ -3674,7 +3674,7 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
               ReportAutoCalculatedIndicatorsRecord(
                   reportId = reportId,
                   autoCalculatedIndicatorId = AutoCalculatedIndicator.HectaresPlanted,
-                  systemValue = BigDecimal(60),
+                  systemValue = BigDecimal(40),
                   systemTime = clock.instant,
                   modifiedBy = user.userId,
                   modifiedTime = clock.instant,
@@ -5616,6 +5616,7 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
         plotDensity = BigDecimal.valueOf(13).toPlantsPerHectare(),
     )
 
+    // Not counted towards hectares planted, planting completed before report period
     val subzoneId2 =
         insertSubstratum(
             areaHa = BigDecimal(20),


### PR DESCRIPTION
The auto calculated indicator "Hectares Planted" was previously using a sum of planted substrata area since the beginning of time. Because it is a cumulative indicator (meaning each report should include only the data for that report period), it should only include substrata area that completed planting during the report period. 

In order to correct existing reports, wipe out the `system_time` and `system_value` values in `report_auto_calculated_indicators` (only for this indicator) which tells Terraware to use live data for (unpublished) reports. Reports will need to be republished to update the published counterparts if desired, which product is aware of.