### PR TITLE
SW-8179 Use only published data for cumulative indicators' progress

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/funder/db/PublishedReportStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/funder/db/PublishedReportStore.kt
@@ -14,9 +14,6 @@ import com.terraformation.backend.db.accelerator.tables.references.COMMON_INDICA
 import com.terraformation.backend.db.accelerator.tables.references.PROJECT_ACCELERATOR_DETAILS
 import com.terraformation.backend.db.accelerator.tables.references.PROJECT_INDICATORS
 import com.terraformation.backend.db.accelerator.tables.references.REPORTS
-import com.terraformation.backend.db.accelerator.tables.references.REPORT_AUTO_CALCULATED_INDICATORS
-import com.terraformation.backend.db.accelerator.tables.references.REPORT_COMMON_INDICATORS
-import com.terraformation.backend.db.accelerator.tables.references.REPORT_PROJECT_INDICATORS
 import com.terraformation.backend.db.asNonNullable
 import com.terraformation.backend.db.default_schema.ProjectId
 import com.terraformation.backend.db.default_schema.ProjectIdConverter
@@ -128,7 +125,6 @@ class PublishedReportStore(
       publishedIndicatorIdField: TableField<*, ID?>,
       targetTableIndicatorIdField: TableField<*, ID?>,
       baselineTableIndicatorIdField: TableField<*, ID?>,
-      reportTableIndicatorIdField: TableField<*, ID?>,
   ): Field<List<PublishedReportIndicatorModel<ID>>> {
     val publishedIndicatorTable = publishedIndicatorIdField.table!!
     val reportIdField =
@@ -186,64 +182,47 @@ class PublishedReportStore(
         )!!
     val unitField = indicatorTable.field("unit", String::class.java) ?: DSL.value(null as String?)
 
-    val reportIndicatorTable = reportTableIndicatorIdField.table!!
-    val reportIndicatorReportField =
-        reportIndicatorTable.field(
+    val publishedIndicatorTableForSum = publishedIndicatorTable.`as`("publishedIndicatorForSum")
+    val sumIndicatorIdField = publishedIndicatorTableForSum.field(publishedIndicatorIdField)!!
+    val publishedIndicatorSumReportField =
+        publishedIndicatorTableForSum.field(
             "report_id",
             SQLDataType.BIGINT.asConvertedDataType(ReportIdConverter()),
         )!!
-    val reportValueField =
-        reportIndicatorTable.field("value", BigDecimal::class.java)
+    val publishedValueForSumField =
+        publishedIndicatorTableForSum.field("value", BigDecimal::class.java)
             ?: DSL.coalesce(
-                reportIndicatorTable.field("override_value", BigDecimal::class.java)!!,
-                reportIndicatorTable.field("system_value", BigDecimal::class.java)!!,
+                publishedIndicatorTableForSum.field("override_value", BigDecimal::class.java)!!,
+                publishedIndicatorTableForSum.field("system_value", BigDecimal::class.java)!!,
             )
     val reportsForSum = REPORTS.`as`("reportsForSum")
     val sumAtPreviousYearEnd =
         DSL.`when`(
             indicatorClassField.eq(IndicatorClass.Cumulative),
-            DSL.select(DSL.sum(reportValueField))
-                .from(reportIndicatorTable)
+            DSL.select(DSL.sum(publishedValueForSumField))
+                .from(publishedIndicatorTableForSum)
                 .join(reportsForSum)
-                .on(reportsForSum.ID.eq(reportIndicatorReportField))
+                .on(reportsForSum.ID.eq(publishedIndicatorSumReportField))
                 .where(DSL.year(reportsForSum.END_DATE).lt(DSL.year(PUBLISHED_REPORTS.END_DATE)))
                 .and(reportsForSum.PROJECT_ID.eq(PUBLISHED_REPORTS.PROJECT_ID))
-                .and(reportTableIndicatorIdField.eq(indicatorTableIdField)),
+                .and(sumIndicatorIdField.eq(indicatorTableIdField)),
         )
 
     val reportsForProgress = REPORTS.`as`("reportsForProgress")
-    val reportIndicatorsForProgress = reportIndicatorTable.`as`("reportIndicatorsForProgress")
-    val indicatorIdForProgress = reportIndicatorsForProgress.field(reportTableIndicatorIdField)!!
+    val publishedIndicatorsForProgress =
+        publishedIndicatorTable.`as`("publishedIndicatorsForProgress")
+    val indicatorIdForProgress = publishedIndicatorsForProgress.field(publishedIndicatorIdField)!!
     val indicatorValueProgressField =
-        reportIndicatorsForProgress.field("value", BigDecimal::class.java)
+        publishedIndicatorsForProgress.field("value", BigDecimal::class.java)
             ?: DSL.coalesce(
-                reportIndicatorsForProgress.field("override_value", BigDecimal::class.java)!!,
-                reportIndicatorsForProgress.field("system_value", BigDecimal::class.java)!!,
+                publishedIndicatorsForProgress.field("override_value", BigDecimal::class.java)!!,
+                publishedIndicatorsForProgress.field("system_value", BigDecimal::class.java)!!,
             )
     val reportIdProgressField =
-        reportIndicatorsForProgress.field(
+        publishedIndicatorsForProgress.field(
             "report_id",
             SQLDataType.BIGINT.asConvertedDataType(ReportIdConverter()),
         )!!
-    val publishedIndicatorForProgress =
-        publishedIndicatorTable.`as`("publishedIndicatorForProgress")
-    val publishedReportIdForProgressField =
-        publishedIndicatorForProgress.field(
-            "report_id",
-            SQLDataType.BIGINT.asConvertedDataType(ReportIdConverter()),
-        )!!
-    val publishedIndicatorIdForProgress =
-        publishedIndicatorForProgress.field(publishedIndicatorIdField)!!
-    val publishedValueForProgress =
-        publishedIndicatorForProgress.field("value", BigDecimal::class.java)!!
-    // For previous quarters, use the report value directly. For the current quarter, use the
-    // published value only (null if no published entry, which excludes it from the result).
-    val progressValue =
-        DSL.if_(
-            reportsForProgress.REPORT_QUARTER_ID.eq(PUBLISHED_REPORTS.REPORT_QUARTER_ID),
-            publishedValueForProgress,
-            indicatorValueProgressField,
-        )
 
     val currentYearProgressField: Field<List<PublishedCumulativeIndicatorProgressModel>> =
         DSL.`when`(
@@ -251,29 +230,18 @@ class PublishedReportStore(
             DSL.multiset(
                     DSL.select(
                             reportsForProgress.REPORT_QUARTER_ID,
-                            progressValue.`as`("progress_value"),
+                            indicatorValueProgressField.`as`("progress_value"),
                         )
-                        .from(reportIndicatorsForProgress)
+                        .from(publishedIndicatorsForProgress)
                         .join(reportsForProgress)
                         .on(reportsForProgress.ID.eq(reportIdProgressField))
-                        .leftJoin(publishedIndicatorForProgress)
-                        .on(
-                            publishedReportIdForProgressField
-                                .eq(reportIdProgressField)
-                                .and(publishedIndicatorIdForProgress.eq(indicatorTableIdField))
-                                .and(
-                                    publishedReportIdForProgressField.eq(
-                                        PUBLISHED_REPORTS.REPORT_ID
-                                    )
-                                )
-                        )
                         .where(
                             DSL.year(reportsForProgress.END_DATE)
                                 .eq(DSL.year(PUBLISHED_REPORTS.END_DATE))
                         )
                         .and(reportsForProgress.PROJECT_ID.eq(PUBLISHED_REPORTS.PROJECT_ID))
                         .and(indicatorIdForProgress.eq(indicatorTableIdField))
-                        .and(progressValue.isNotNull)
+                        .and(indicatorValueProgressField.isNotNull)
                         .and(
                             reportsForProgress.REPORT_QUARTER_ID.le(
                                 PUBLISHED_REPORTS.REPORT_QUARTER_ID
@@ -290,14 +258,6 @@ class PublishedReportStore(
                   }
                 },
         )
-
-    val reportIndicatorForReport = reportIndicatorTable.`as`("reportIndicatorForReport")
-    val repIndicatorIdForReport = reportIndicatorForReport.field(reportTableIndicatorIdField)!!
-    val repReportIdForReport =
-        reportIndicatorForReport.field(
-            "report_id",
-            SQLDataType.BIGINT.asConvertedDataType(ReportIdConverter()),
-        )!!
 
     return DSL.multiset(
             DSL.select(
@@ -326,12 +286,6 @@ class PublishedReportStore(
                         .eq(indicatorTableIdField)
                         .and(reportIdField.eq(PUBLISHED_REPORTS.REPORT_ID))
                 )
-                .leftJoin(reportIndicatorForReport)
-                .on(
-                    repIndicatorIdForReport
-                        .eq(indicatorTableIdField)
-                        .and(repReportIdForReport.eq(PUBLISHED_REPORTS.REPORT_ID))
-                )
                 .leftJoin(targetTable)
                 .on(
                     targetTableIndicatorIdField
@@ -345,7 +299,7 @@ class PublishedReportStore(
                         .eq(indicatorTableIdField)
                         .and(baselineProjectIdField.eq(PUBLISHED_REPORTS.PROJECT_ID))
                 )
-                .where(publishedIndicatorIdField.isNotNull.or(repIndicatorIdForReport.isNotNull))
+                .where(publishedIndicatorIdField.isNotNull)
                 .orderBy(indicatorReferenceField)
         )
         .convertFrom { result ->
@@ -394,7 +348,6 @@ class PublishedReportStore(
           PUBLISHED_REPORT_PROJECT_INDICATORS.PROJECT_INDICATOR_ID,
           PUBLISHED_PROJECT_INDICATOR_TARGETS.PROJECT_INDICATOR_ID,
           PUBLISHED_PROJECT_INDICATOR_BASELINES.PROJECT_INDICATOR_ID,
-          REPORT_PROJECT_INDICATORS.PROJECT_INDICATOR_ID,
       )
 
   private val commonIndicatorsMultiset =
@@ -403,7 +356,6 @@ class PublishedReportStore(
           PUBLISHED_REPORT_COMMON_INDICATORS.COMMON_INDICATOR_ID,
           PUBLISHED_COMMON_INDICATOR_TARGETS.COMMON_INDICATOR_ID,
           PUBLISHED_COMMON_INDICATOR_BASELINES.COMMON_INDICATOR_ID,
-          REPORT_COMMON_INDICATORS.COMMON_INDICATOR_ID,
       )
 
   private val autoCalculatedIndicatorsMultiset =
@@ -412,6 +364,5 @@ class PublishedReportStore(
           PUBLISHED_REPORT_AUTO_CALCULATED_INDICATORS.AUTO_CALCULATED_INDICATOR_ID,
           PUBLISHED_AUTO_CALCULATED_INDICATOR_TARGETS.AUTO_CALCULATED_INDICATOR_ID,
           PUBLISHED_AUTO_CALCULATED_INDICATOR_BASELINES.AUTO_CALCULATED_INDICATOR_ID,
-          REPORT_AUTO_CALCULATED_INDICATORS.AUTO_CALCULATED_INDICATOR_ID,
       )
 }

--- a/src/test/kotlin/com/terraformation/backend/funder/db/PublishedReportStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/funder/db/PublishedReportStoreTest.kt
@@ -107,6 +107,25 @@ class PublishedReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
           indicator = AutoCalculatedIndicator.SeedsCollected,
           systemValue = BigDecimal(30),
       )
+      insertPublishedReport(
+          quarter = ReportQuarter.Q3,
+          startDate = LocalDate.of(2024, 7, 1),
+          endDate = LocalDate.of(2024, 9, 30),
+      )
+      insertPublishedReportProjectIndicator(
+          indicatorId = projectIndicatorId1,
+          value = BigDecimal(10),
+      )
+      insertPublishedReportProjectIndicator(
+          indicatorId = projectIndicatorId2,
+          value = BigDecimal(11),
+      )
+      insertPublishedReportCommonIndicator(indicatorId = commonIndicatorId1, value = BigDecimal(20))
+      insertPublishedReportCommonIndicator(indicatorId = commonIndicatorId2, value = BigDecimal(21))
+      insertPublishedReportAutoCalculatedIndicator(
+          indicator = AutoCalculatedIndicator.SeedsCollected,
+          value = BigDecimal(30),
+      )
 
       // oldReport2
       insertReport(endDate = LocalDate.of(2024, 12, 31))
@@ -118,6 +137,31 @@ class PublishedReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
           indicator = AutoCalculatedIndicator.SeedsCollected,
           systemValue = BigDecimal(29),
           overrideValue = BigDecimal(31),
+      )
+      insertPublishedReport(
+          quarter = ReportQuarter.Q4,
+          startDate = LocalDate.of(2024, 10, 1),
+          endDate = LocalDate.of(2024, 12, 31),
+      )
+      insertPublishedReportProjectIndicator(
+          indicatorId = projectIndicatorId1,
+          value = BigDecimal(100),
+      )
+      insertPublishedReportProjectIndicator(
+          indicatorId = projectIndicatorId2,
+          value = BigDecimal(101),
+      )
+      insertPublishedReportCommonIndicator(
+          indicatorId = commonIndicatorId1,
+          value = BigDecimal(200),
+      )
+      insertPublishedReportCommonIndicator(
+          indicatorId = commonIndicatorId2,
+          value = BigDecimal(201),
+      )
+      insertPublishedReportAutoCalculatedIndicator(
+          indicator = AutoCalculatedIndicator.SeedsCollected,
+          value = BigDecimal(31),
       )
 
       val reportId1 =
@@ -258,6 +302,7 @@ class PublishedReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
               PublishedReportModel(
                   achievements = emptyList(),
                   additionalComments = null,
+                  // indicators are only included in current quarter if they have a published value
                   autoCalculatedIndicators = emptyList(),
                   challenges = emptyList(),
                   commonIndicators = emptyList(),
@@ -283,7 +328,13 @@ class PublishedReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
                               baseline = BigDecimal.valueOf(300),
                               classId = IndicatorClass.Cumulative,
                               category = AutoCalculatedIndicator.SeedsCollected.categoryId,
-                              currentYearProgress = emptyList(),
+                              currentYearProgress =
+                                  listOf(
+                                      PublishedCumulativeIndicatorProgressModel(
+                                          quarter = ReportQuarter.Q1,
+                                          value = BigDecimal(6),
+                                      )
+                                  ),
                               description = AutoCalculatedIndicator.SeedsCollected.description,
                               endOfProjectTarget = BigDecimal.valueOf(400),
                               indicatorId = AutoCalculatedIndicator.SeedsCollected,
@@ -310,7 +361,13 @@ class PublishedReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
                               baseline = BigDecimal.valueOf(200),
                               category = IndicatorCategory.Community,
                               classId = IndicatorClass.Cumulative,
-                              currentYearProgress = emptyList(),
+                              currentYearProgress =
+                                  listOf(
+                                      PublishedCumulativeIndicatorProgressModel(
+                                          quarter = ReportQuarter.Q1,
+                                          value = BigDecimal(180),
+                                      )
+                                  ),
                               description = "Common Indicator Description 2",
                               endOfProjectTarget = BigDecimal.valueOf(250),
                               indicatorId = commonIndicatorId2,
@@ -328,7 +385,13 @@ class PublishedReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
                           PublishedReportIndicatorModel(
                               category = IndicatorCategory.Climate,
                               classId = IndicatorClass.Cumulative,
-                              currentYearProgress = emptyList(),
+                              currentYearProgress =
+                                  listOf(
+                                      PublishedCumulativeIndicatorProgressModel(
+                                          quarter = ReportQuarter.Q1,
+                                          value = BigDecimal(120),
+                                      )
+                                  ),
                               description = "Common Indicator Description 1",
                               endOfProjectTarget = null,
                               indicatorId = commonIndicatorId1,
@@ -359,7 +422,13 @@ class PublishedReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
                               baseline = null,
                               category = IndicatorCategory.Biodiversity,
                               classId = IndicatorClass.Cumulative,
-                              currentYearProgress = emptyList(),
+                              currentYearProgress =
+                                  listOf(
+                                      PublishedCumulativeIndicatorProgressModel(
+                                          quarter = ReportQuarter.Q1,
+                                          value = BigDecimal(40),
+                                      )
+                                  ),
                               description = "Project Indicator Description 1",
                               endOfProjectTarget = null,
                               indicatorId = projectIndicatorId1,
@@ -402,7 +471,9 @@ class PublishedReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
                   startDate = LocalDate.of(2025, 1, 1),
               ),
           ),
-          store.fetchPublishedReports(projectId),
+          store.fetchPublishedReports(projectId).filter {
+            listOf(reportId1, reportId2).contains(it.reportId) // ignore previous year's setup data
+          },
       )
     }
 
@@ -541,7 +612,13 @@ class PublishedReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
           PublishedReportIndicatorModel(
               category = IndicatorCategory.Climate,
               classId = IndicatorClass.Cumulative,
-              currentYearProgress = emptyList(),
+              currentYearProgress =
+                  listOf(
+                      PublishedCumulativeIndicatorProgressModel(
+                          quarter = ReportQuarter.Q1,
+                          value = BigDecimal(20),
+                      )
+                  ),
               description = "Common Indicator Description",
               indicatorId = commonIndicatorId,
               level = IndicatorLevel.Output,
@@ -650,7 +727,12 @@ class PublishedReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
               endDate = LocalDate.of(2024, 12, 31),
               quarter = ReportQuarter.Q4,
           )
-      insertReportCommonIndicator(
+      insertPublishedReport(
+          startDate = LocalDate.of(2024, 10, 1),
+          endDate = LocalDate.of(2024, 12, 31),
+          quarter = ReportQuarter.Q4,
+      )
+      insertPublishedReportCommonIndicator(
           reportId = priorYearReportId,
           indicatorId = commonIndicatorId,
           value = BigDecimal(999),
@@ -662,7 +744,12 @@ class PublishedReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
               endDate = LocalDate.of(2025, 3, 31),
               quarter = ReportQuarter.Q1,
           )
-      insertReportCommonIndicator(
+      insertPublishedReport(
+          startDate = LocalDate.of(2025, 1, 1),
+          endDate = LocalDate.of(2025, 3, 31),
+          quarter = ReportQuarter.Q1,
+      )
+      insertPublishedReportCommonIndicator(
           reportId = q1ReportId,
           indicatorId = commonIndicatorId,
           value = BigDecimal(10),
@@ -674,7 +761,12 @@ class PublishedReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
               endDate = LocalDate.of(2025, 6, 30),
               quarter = ReportQuarter.Q2,
           )
-      insertReportCommonIndicator(
+      insertPublishedReport(
+          startDate = LocalDate.of(2025, 4, 1),
+          endDate = LocalDate.of(2025, 6, 30),
+          quarter = ReportQuarter.Q2,
+      )
+      insertPublishedReportCommonIndicator(
           reportId = q2ReportId,
           indicatorId = commonIndicatorId,
           value = BigDecimal(20),
@@ -686,18 +778,16 @@ class PublishedReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
               endDate = LocalDate.of(2025, 9, 30),
               quarter = ReportQuarter.Q3,
           )
+      insertPublishedReport(
+          startDate = LocalDate.of(2025, 7, 1),
+          endDate = LocalDate.of(2025, 9, 30),
+          quarter = ReportQuarter.Q3,
+      )
       insertReportCommonIndicator(
           reportId = q3ReportId,
           indicatorId = commonIndicatorId,
           // current quarter value is ignored, only published value is used for the current quarter
           value = BigDecimal(29),
-      )
-
-      insertPublishedReport(
-          reportId = q3ReportId,
-          startDate = LocalDate.of(2025, 7, 1),
-          endDate = LocalDate.of(2025, 9, 30),
-          quarter = ReportQuarter.Q3,
       )
       insertPublishedReportCommonIndicator(
           reportId = q3ReportId,
@@ -713,14 +803,19 @@ class PublishedReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
               endDate = LocalDate.of(2025, 12, 31),
               quarter = ReportQuarter.Q4,
           )
-      insertReportCommonIndicator(
+      insertPublishedReport(
+          startDate = LocalDate.of(2025, 10, 1),
+          endDate = LocalDate.of(2025, 12, 31),
+          quarter = ReportQuarter.Q4,
+      )
+      insertPublishedReportCommonIndicator(
           reportId = q4ReportId,
           indicatorId = commonIndicatorId,
           value = BigDecimal(40),
       )
 
       val reports = store.fetchPublishedReports(projectId)
-      val indicator = reports.single().commonIndicators.single()
+      val indicator = reports.find { it.reportId == q3ReportId }!!.commonIndicators.single()
 
       assertEquals(
           listOf(
@@ -743,7 +838,7 @@ class PublishedReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
     }
 
     @Test
-    fun `currentYearProgress excludes quarters where the indicator value is null and excludes current quarter if unpublished`() {
+    fun `currentYearProgress excludes quarters where the indicator value is null`() {
       insertFundingEntityProject()
       insertProjectReportConfig()
 
@@ -763,7 +858,12 @@ class PublishedReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
               endDate = LocalDate.of(2025, 3, 31),
               quarter = ReportQuarter.Q1,
           )
-      insertReportCommonIndicator(
+      insertPublishedReport(
+          startDate = LocalDate.of(2025, 1, 1),
+          endDate = LocalDate.of(2025, 3, 31),
+          quarter = ReportQuarter.Q1,
+      )
+      insertPublishedReportCommonIndicator(
           reportId = q1ReportId,
           indicatorId = commonIndicatorId,
           value = BigDecimal(10),
@@ -776,7 +876,12 @@ class PublishedReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
               endDate = LocalDate.of(2025, 6, 30),
               quarter = ReportQuarter.Q2,
           )
-      insertReportCommonIndicator(
+      insertPublishedReport(
+          startDate = LocalDate.of(2025, 4, 1),
+          endDate = LocalDate.of(2025, 6, 30),
+          quarter = ReportQuarter.Q2,
+      )
+      insertPublishedReportCommonIndicator(
           reportId = q2ReportId,
           indicatorId = commonIndicatorId,
           value = null,
@@ -788,21 +893,19 @@ class PublishedReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
               endDate = LocalDate.of(2025, 9, 30),
               quarter = ReportQuarter.Q3,
           )
-      insertReportCommonIndicator(
+      insertPublishedReport(
+          startDate = LocalDate.of(2025, 7, 1),
+          endDate = LocalDate.of(2025, 9, 30),
+          quarter = ReportQuarter.Q3,
+      )
+      insertPublishedReportCommonIndicator(
           reportId = q3ReportId,
           indicatorId = commonIndicatorId,
           value = BigDecimal(30),
       )
 
-      insertPublishedReport(
-          reportId = q3ReportId,
-          startDate = LocalDate.of(2025, 7, 1),
-          endDate = LocalDate.of(2025, 9, 30),
-          quarter = ReportQuarter.Q3,
-      )
-
       val reports = store.fetchPublishedReports(projectId)
-      val indicator = reports.single().commonIndicators.single()
+      val indicator = reports.find { it.reportId == q3ReportId }!!.commonIndicators.single()
 
       assertEquals(
           listOf(
@@ -811,7 +914,10 @@ class PublishedReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
                   value = BigDecimal(10),
               ),
               // q2 is excluded because it has a null value
-              // q3 is excluded because it has a non-null value but no published value
+              PublishedCumulativeIndicatorProgressModel(
+                  quarter = ReportQuarter.Q3,
+                  value = BigDecimal(30),
+              ),
           ),
           indicator.currentYearProgress,
           "Quarters with null indicator values must be excluded from currentYearProgress, and the current quarter must be excluded if unpublished",


### PR DESCRIPTION
Unpublishable indicators started showing up in funder reports because we were joining both published and unpublished report indicators in order to retrieve unpublished progress for cumulative indicators. Specifically, we were returning all indicators that had data in previous quarters, regardless of if they were publishable or not.

Product decided to only use published data for indicators, so remove the join to the unpublished data, and only return indicators that have a published value.