### PR TITLE
SW-8170 Calculate unpublished properties for reports

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/accelerator/ReportService.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/ReportService.kt
@@ -1,6 +1,9 @@
 package com.terraformation.backend.accelerator
 
 import com.terraformation.backend.accelerator.db.ReportStore
+import com.terraformation.backend.accelerator.model.PublishedReportComparedProps
+import com.terraformation.backend.accelerator.model.ReportModel
+import com.terraformation.backend.auth.currentUser
 import com.terraformation.backend.customer.model.SystemUser
 import com.terraformation.backend.customer.model.requirePermissions
 import com.terraformation.backend.daily.DailyTaskTimeArrivedEvent
@@ -9,6 +12,7 @@ import com.terraformation.backend.db.accelerator.ReportId
 import com.terraformation.backend.db.accelerator.tables.daos.ReportPhotosDao
 import com.terraformation.backend.db.accelerator.tables.pojos.ReportPhotosRow
 import com.terraformation.backend.db.default_schema.FileId
+import com.terraformation.backend.db.default_schema.ProjectId
 import com.terraformation.backend.db.funder.tables.daos.PublishedReportPhotosDao
 import com.terraformation.backend.db.funder.tables.pojos.PublishedReportPhotosRow
 import com.terraformation.backend.file.FileService
@@ -16,6 +20,7 @@ import com.terraformation.backend.file.SizedInputStream
 import com.terraformation.backend.file.ThumbnailService
 import com.terraformation.backend.file.event.FileReferenceDeletedEvent
 import com.terraformation.backend.file.model.NewFileMetadata
+import com.terraformation.backend.funder.db.PublishedReportStore
 import com.terraformation.backend.log.perClassLogger
 import jakarta.inject.Named
 import java.io.InputStream
@@ -31,6 +36,7 @@ class ReportService(
     private val reportPhotosDao: ReportPhotosDao,
     private val reportStore: ReportStore,
     private val publishedReportPhotosDao: PublishedReportPhotosDao,
+    private val publishedReportStore: PublishedReportStore,
     private val systemUser: SystemUser,
     private val thumbnailService: ThumbnailService,
 ) {
@@ -46,6 +52,41 @@ class ReportService(
         log.warn("Failed to notify upcoming reports: ${e.message}")
       }
     }
+  }
+
+  fun fetch(
+      projectId: ProjectId? = null,
+      year: Int? = null,
+      includeArchived: Boolean = false,
+      includeFuture: Boolean = false,
+      includeIndicators: Boolean = false,
+      computeUnpublishedChanges: Boolean = false,
+  ): List<ReportModel> {
+    val reports =
+        reportStore.fetch(
+            projectId = projectId,
+            year = year,
+            includeArchived = includeArchived,
+            includeFuture = includeFuture,
+            includeIndicators = includeIndicators,
+        )
+    if (!computeUnpublishedChanges) {
+      return reports
+    }
+    return applyUnpublishedProperties(reports, includeIndicators)
+  }
+
+  fun fetchOne(
+      reportId: ReportId,
+      includeIndicators: Boolean = false,
+      computeUnpublishedChanges: Boolean = false,
+  ): ReportModel {
+    val report = reportStore.fetchOne(reportId, includeIndicators)
+    if (!computeUnpublishedChanges) {
+      return report
+    }
+    val results = applyUnpublishedProperties(listOf(report), includeIndicators)
+    return results.first()
   }
 
   fun deleteReportPhoto(reportId: ReportId, fileId: FileId) {
@@ -117,6 +158,84 @@ class ReportService(
     }
 
     reportPhotosDao.update(reportPhotosRow.copy(caption = caption))
+  }
+
+  private fun applyUnpublishedProperties(
+      reports: List<ReportModel>,
+      includeIndicators: Boolean,
+  ): List<ReportModel> {
+    if (reports.isEmpty()) {
+      return reports
+    }
+
+    val allowedToViewPublished = reports.filter { currentUser().canReadPublishedReport(it.id) }
+
+    val publishedByReportId =
+        publishedReportStore.fetchPublishedReportsByIds(allowedToViewPublished.map { it.id })
+
+    return reports.map { report ->
+      val published = publishedByReportId[report.id] ?: return@map report
+
+      val changed = mutableListOf<PublishedReportComparedProps>()
+
+      if (report.highlights != published.highlights) {
+        changed.add(PublishedReportComparedProps.Highlights)
+      }
+      if (report.financialSummaries != published.financialSummaries) {
+        changed.add(PublishedReportComparedProps.FinancialSummaries)
+      }
+      if (report.additionalComments != published.additionalComments) {
+        changed.add(PublishedReportComparedProps.AdditionalComments)
+      }
+
+      if (report.achievements.toSet() != published.achievements.toSet()) {
+        changed.add(PublishedReportComparedProps.Achievements)
+      }
+
+      val currentChallenges = report.challenges.map { it.challenge to it.mitigationPlan }.toSet()
+      val pubChallenges = published.challenges.map { it.challenge to it.mitigationPlan }.toSet()
+      if (currentChallenges != pubChallenges) {
+        changed.add(PublishedReportComparedProps.Challenges)
+      }
+
+      if (report.photos.map { it.fileId }.toSet() != published.photos.map { it.fileId }.toSet()) {
+        changed.add(PublishedReportComparedProps.Photos)
+      }
+
+      if (includeIndicators) {
+        val pubAutoCalc =
+            published.autoCalculatedIndicators.associate { it.indicatorId to it.value }
+        val hasAutoCalcChanged =
+            pubAutoCalc.any { (indicator, pubValue) ->
+              val current = report.autoCalculatedIndicators.find { it.indicator == indicator }
+              val currentValue = current?.let { it.entry.overrideValue ?: it.entry.systemValue }
+              currentValue != pubValue
+            }
+        if (hasAutoCalcChanged) {
+          changed.add(PublishedReportComparedProps.AutoCalculatedIndicators)
+        }
+
+        val pubCommon = published.commonIndicators.associate { it.indicatorId to it.value }
+        val currentCommon =
+            report.commonIndicators
+                .filter { it.indicator.isPublishable }
+                .associate { it.indicator.id to it.entry.value }
+        if (currentCommon != pubCommon) {
+          changed.add(PublishedReportComparedProps.CommonIndicators)
+        }
+
+        val pubProject = published.projectIndicators.associate { it.indicatorId to it.value }
+        val currentProject =
+            report.projectIndicators
+                .filter { it.indicator.isPublishable }
+                .associate { it.indicator.id to it.entry.value }
+        if (currentProject != pubProject) {
+          changed.add(PublishedReportComparedProps.ProjectIndicators)
+        }
+      }
+
+      report.copy(unpublishedProperties = changed)
+    }
   }
 
   private fun deletePublishedReportPhoto(reportId: ReportId, fileId: FileId) {

--- a/src/main/kotlin/com/terraformation/backend/accelerator/ReportService.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/ReportService.kt
@@ -206,36 +206,44 @@ class ReportService(
 
       if (includeIndicators) {
         val pubAutoCalc =
-            published.autoCalculatedIndicators.associate { it.indicatorId to it.value }
+            published.autoCalculatedIndicators.associate {
+              it.indicatorId to (it.value to it.progressNotes)
+            }
         val hasAutoCalcChanged =
-            pubAutoCalc.any { (indicator, pubValue) ->
+            pubAutoCalc.any { (indicator, pubData) ->
               val current = report.autoCalculatedIndicators.find { it.indicator == indicator }
               val currentValue = current?.let { it.entry.overrideValue ?: it.entry.systemValue }
-              currentValue != pubValue
+              val currentProgressNotes = current?.entry?.progressNotes
+              currentValue != pubData.first || currentProgressNotes != pubData.second
             }
         if (hasAutoCalcChanged) {
           changed.add(PublishedReportComparedProps.AutoCalculatedIndicators)
         }
 
-        val pubCommon = published.commonIndicators.associate { it.indicatorId to it.value }
+        val pubCommon =
+            published.commonIndicators.associate {
+              it.indicatorId to (it.value to it.progressNotes)
+            }
         val currentCommon =
             report.commonIndicators
                 .filter { it.indicator.isPublishable }
-                .associate { it.indicator.id to it.entry.value }
+                .associate { it.indicator.id to (it.entry.value to it.entry.progressNotes) }
         if (currentCommon != pubCommon) {
           changed.add(PublishedReportComparedProps.CommonIndicators)
         }
 
-        val pubProject = published.projectIndicators.associate { it.indicatorId to it.value }
+        val pubProject =
+            published.projectIndicators.associate {
+              it.indicatorId to (it.value to it.progressNotes)
+            }
         val currentProject =
             report.projectIndicators
                 .filter { it.indicator.isPublishable }
-                .associate { it.indicator.id to it.entry.value }
+                .associate { it.indicator.id to (it.entry.value to it.entry.progressNotes) }
         if (currentProject != pubProject) {
           changed.add(PublishedReportComparedProps.ProjectIndicators)
         }
       }
-
       report.copy(unpublishedProperties = changed)
     }
   }

--- a/src/main/kotlin/com/terraformation/backend/accelerator/ReportService.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/ReportService.kt
@@ -198,7 +198,9 @@ class ReportService(
         changed.add(PublishedReportComparedProps.Challenges)
       }
 
-      if (report.photos.map { it.fileId }.toSet() != published.photos.map { it.fileId }.toSet()) {
+      val currentPhotos = report.photos.map { it.fileId to it.caption }.toSet()
+      val publishedPhotos = published.photos.map { it.fileId to it.caption }.toSet()
+      if (currentPhotos != publishedPhotos) {
         changed.add(PublishedReportComparedProps.Photos)
       }
 

--- a/src/main/kotlin/com/terraformation/backend/accelerator/ReportService.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/ReportService.kt
@@ -205,6 +205,11 @@ class ReportService(
       }
 
       if (includeIndicators) {
+        // For auto calculated indicators, only compare published to current when there is a
+        // published row. The current report will always have all publishable auto calc indicators
+        // with a value of 0 even if those indicators don't have values in the report. Additionally,
+        // we always publish auto calc indicators whether they have a value or not when publishing.
+        // Thus we only care about the current indicators if there's no corresponding auto calc.
         val pubAutoCalc =
             published.autoCalculatedIndicators.associate {
               it.indicatorId to (it.value to it.progressNotes)
@@ -219,7 +224,6 @@ class ReportService(
         if (hasAutoCalcChanged) {
           changed.add(PublishedReportComparedProps.AutoCalculatedIndicators)
         }
-
         val pubCommon =
             published.commonIndicators.associate {
               it.indicatorId to (it.value to it.progressNotes)

--- a/src/main/kotlin/com/terraformation/backend/accelerator/api/ProjectReportsController.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/api/ProjectReportsController.kt
@@ -9,6 +9,7 @@ import com.terraformation.backend.accelerator.model.CumulativeIndicatorProgressM
 import com.terraformation.backend.accelerator.model.ExistingProjectReportConfigModel
 import com.terraformation.backend.accelerator.model.NewProjectReportConfigModel
 import com.terraformation.backend.accelerator.model.ProjectIndicatorTargetsModel
+import com.terraformation.backend.accelerator.model.PublishedReportComparedProps
 import com.terraformation.backend.accelerator.model.ReportAutoCalculatedIndicatorModel
 import com.terraformation.backend.accelerator.model.ReportAutoCalculatedIndicatorTargetModel
 import com.terraformation.backend.accelerator.model.ReportChallengeModel
@@ -102,12 +103,13 @@ class ProjectReportsController(
       @RequestParam includeIndicators: Boolean? = null,
   ): ListAcceleratorReportsResponsePayload {
     val reports =
-        reportStore.fetch(
+        reportService.fetch(
             projectId = projectId,
             year = year,
             includeArchived = includeArchived ?: false,
             includeFuture = includeFuture ?: false,
             includeIndicators = includeIndicators ?: includeMetrics ?: false,
+            computeUnpublishedChanges = false,
         )
     return ListAcceleratorReportsResponsePayload(reports.map { AcceleratorReportPayload(it) })
   }
@@ -124,9 +126,10 @@ class ProjectReportsController(
       @RequestParam includeIndicators: Boolean? = null,
   ): GetAcceleratorReportResponsePayload {
     val model =
-        reportStore.fetchOne(
+        reportService.fetchOne(
             reportId = reportId,
             includeIndicators = includeIndicators ?: includeMetrics ?: false,
+            computeUnpublishedChanges = true,
         )
     return GetAcceleratorReportResponsePayload(AcceleratorReportPayload(model))
   }
@@ -859,6 +862,7 @@ data class AcceleratorReportPayload(
     val submittedTime: Instant?,
     @Schema(description = "Use autoCalculatedIndicators instead", deprecated = true)
     val systemMetrics: List<ReportSystemMetricPayload>,
+    val unpublishedProperties: List<PublishedReportComparedProps>,
 ) {
   constructor(
       model: ReportModel
@@ -890,6 +894,7 @@ data class AcceleratorReportPayload(
       submittedByUser = model.submittedByUser?.let { SimpleUserPayload(it) },
       submittedTime = model.submittedTime,
       systemMetrics = model.autoCalculatedIndicators.map { ReportSystemMetricPayload(it) },
+      unpublishedProperties = model.unpublishedProperties,
   )
 }
 

--- a/src/main/kotlin/com/terraformation/backend/accelerator/db/ReportStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/db/ReportStore.kt
@@ -91,6 +91,7 @@ import com.terraformation.backend.db.tracking.tables.references.PLANTINGS
 import com.terraformation.backend.db.tracking.tables.references.PLANTING_SITES
 import com.terraformation.backend.db.tracking.tables.references.SUBSTRATA
 import com.terraformation.backend.i18n.Messages
+import com.terraformation.backend.tracking.db.ObservationResultsStore
 import com.terraformation.backend.tracking.model.calculateSurvivalRate
 import jakarta.inject.Named
 import java.math.BigDecimal
@@ -118,8 +119,7 @@ class ReportStore(
     private val dslContext: DSLContext,
     private val eventPublisher: ApplicationEventPublisher,
     private val messages: Messages,
-    private val observationResultsStore:
-        com.terraformation.backend.tracking.db.ObservationResultsStore,
+    private val observationResultsStore: ObservationResultsStore,
     private val reportsDao: ReportsDao,
     private val systemUser: SystemUser,
 ) {

--- a/src/main/kotlin/com/terraformation/backend/accelerator/model/ReportModel.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/model/ReportModel.kt
@@ -1,5 +1,6 @@
 package com.terraformation.backend.accelerator.model
 
+import com.fasterxml.jackson.annotation.JsonValue
 import com.terraformation.backend.auth.currentUser
 import com.terraformation.backend.customer.model.SimpleUserModel
 import com.terraformation.backend.db.accelerator.CommonIndicatorId
@@ -20,6 +21,18 @@ import java.time.Instant
 import java.time.LocalDate
 import org.jooq.Field
 import org.jooq.Record
+
+enum class PublishedReportComparedProps(@get:JsonValue val jsonValue: String) {
+  Achievements("achievements"),
+  AdditionalComments("additionalComments"),
+  AutoCalculatedIndicators("autoCalculatedIndicators"),
+  Challenges("challenges"),
+  CommonIndicators("commonIndicators"),
+  FinancialSummaries("financialSummaries"),
+  Highlights("highlights"),
+  Photos("photos"),
+  ProjectIndicators("projectIndicators"),
+}
 
 data class ReportChallengeModel(
     val challenge: String,
@@ -85,6 +98,7 @@ data class ReportModel(
     val submittedBy: UserId? = null,
     val submittedByUser: SimpleUserModel? = null,
     val submittedTime: Instant? = null,
+    val unpublishedProperties: List<PublishedReportComparedProps> = emptyList(),
 ) {
 
   /** Describes the reporting period of this report. For example "2025 Q1" or "2025 Annual" */
@@ -153,6 +167,7 @@ data class ReportModel(
         achievementsField: Field<List<String>>?,
         challengesField: Field<List<ReportChallengeModel>>?,
         usersField: Field<Map<UserId, SimpleUserModel>>,
+        unpublishedProperties: List<PublishedReportComparedProps> = emptyList(),
     ): ReportModel {
       val usersMap = record[usersField]!!
       val createdById = record[REPORTS.CREATED_BY]!!
@@ -195,6 +210,7 @@ data class ReportModel(
             commonIndicators = commonIndicatorsField?.let { record[it] } ?: emptyList(),
             autoCalculatedIndicators =
                 autoCalculatedIndicatorsField?.let { record[it] } ?: emptyList(),
+            unpublishedProperties = unpublishedProperties,
         )
       }
     }

--- a/src/test/kotlin/com/terraformation/backend/accelerator/ReportServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/ReportServiceTest.kt
@@ -685,7 +685,7 @@ class ReportServiceTest : DatabaseTest(), RunsAsDatabaseUser {
     }
 
     @Test
-    fun `does not compare progress notes or projectsComments for commonIndicators`() {
+    fun `does not identify commonIndicators as changed when only projectsComments changed`() {
       insertCommonIndicator(isPublishable = true)
       insertPublishedReport(
           highlights = "highlights",
@@ -694,12 +694,10 @@ class ReportServiceTest : DatabaseTest(), RunsAsDatabaseUser {
       )
       insertPublishedReportCommonIndicator(
           value = BigDecimal(10),
-          progressNotes = "old progress notes",
           projectsComments = "old projects comments",
       )
       insertReportCommonIndicator(
           value = BigDecimal(10),
-          progressNotes = "new progress notes",
           projectsComments = "new projects comments",
       )
 
@@ -708,8 +706,144 @@ class ReportServiceTest : DatabaseTest(), RunsAsDatabaseUser {
           service
               .fetchOne(reportId, includeIndicators = true, computeUnpublishedChanges = true)
               .unpublishedProperties,
-          "CommonIndicators should not be flagged when only notes/comments changed",
+          "CommonIndicators should not be flagged when only projectsComments changed",
       )
     }
+
+    @Test
+    fun `identifies commonIndicators as changed when progressNotes changed`() {
+      insertCommonIndicator(isPublishable = true)
+      insertPublishedReport(
+          highlights = "highlights",
+          additionalComments = "additional comments",
+          financialSummaries = "financial summaries",
+      )
+      insertPublishedReportCommonIndicator(value = BigDecimal(10), progressNotes = "old notes")
+      insertReportCommonIndicator(value = BigDecimal(10), progressNotes = "new notes")
+
+      assertEquals(
+          listOf(PublishedReportComparedProps.CommonIndicators),
+          service
+              .fetchOne(reportId, includeIndicators = true, computeUnpublishedChanges = true)
+              .unpublishedProperties,
+          "CommonIndicators should be flagged when progressNotes changed",
+      )
+    }
+
+    @Test
+    fun `identifies projectIndicators as changed when progressNotes changed`() {
+      insertProjectIndicator(isPublishable = true)
+      insertPublishedReport(
+          highlights = "highlights",
+          additionalComments = "additional comments",
+          financialSummaries = "financial summaries",
+      )
+      insertPublishedReportProjectIndicator(value = BigDecimal(10), progressNotes = "old notes")
+      insertReportProjectIndicator(value = BigDecimal(10), progressNotes = "new notes")
+
+      assertEquals(
+          listOf(PublishedReportComparedProps.ProjectIndicators),
+          service
+              .fetchOne(reportId, includeIndicators = true, computeUnpublishedChanges = true)
+              .unpublishedProperties,
+          "ProjectIndicators should be flagged when progressNotes changed",
+      )
+    }
+
+    @Test
+    fun `identifies autoCalculatedIndicators as changed when progressNotes changed`() {
+      insertPublishedReport(
+          highlights = "highlights",
+          additionalComments = "additional comments",
+          financialSummaries = "financial summaries",
+      )
+      insertPublishedReportAutoCalculatedIndicator(
+          indicator = AutoCalculatedIndicator.Seedlings,
+          value = BigDecimal(40),
+          progressNotes = "old notes",
+      )
+      insertReportAutoCalculatedIndicator(
+          indicator = AutoCalculatedIndicator.Seedlings,
+          systemValue = BigDecimal(40),
+          progressNotes = "new notes",
+      )
+
+      assertEquals(
+          listOf(PublishedReportComparedProps.AutoCalculatedIndicators),
+          service
+              .fetchOne(reportId, includeIndicators = true, computeUnpublishedChanges = true)
+              .unpublishedProperties,
+          "AutoCalculatedIndicators should be flagged when progressNotes changed",
+      )
+    }
+
+    //    @Test
+    //    fun `does not identify commonIndicators as changed when progressNotes matches`() {
+    //      insertCommonIndicator(isPublishable = true)
+    //      insertPublishedReport(
+    //          highlights = "highlights",
+    //          additionalComments = "additional comments",
+    //          financialSummaries = "financial summaries",
+    //      )
+    //      insertPublishedReportCommonIndicator(value = BigDecimal(10), progressNotes = "same
+    // notes")
+    //      insertReportCommonIndicator(value = BigDecimal(10), progressNotes = "same notes")
+    //
+    //      assertEquals(
+    //          emptyList<PublishedReportComparedProps>(),
+    //          service
+    //              .fetchOne(reportId, includeIndicators = true, computeUnpublishedChanges = true)
+    //              .unpublishedProperties,
+    //          "CommonIndicators should not be flagged when progressNotes matches",
+    //      )
+    //    }
+    //
+    //    @Test
+    //    fun `does not identify projectIndicators as changed when progressNotes matches`() {
+    //      insertProjectIndicator(isPublishable = true)
+    //      insertPublishedReport(
+    //          highlights = "highlights",
+    //          additionalComments = "additional comments",
+    //          financialSummaries = "financial summaries",
+    //      )
+    //      insertPublishedReportProjectIndicator(value = BigDecimal(10), progressNotes = "same
+    // notes")
+    //      insertReportProjectIndicator(value = BigDecimal(10), progressNotes = "same notes")
+    //
+    //      assertEquals(
+    //          emptyList<PublishedReportComparedProps>(),
+    //          service
+    //              .fetchOne(reportId, includeIndicators = true, computeUnpublishedChanges = true)
+    //              .unpublishedProperties,
+    //          "ProjectIndicators should not be flagged when progressNotes matches",
+    //      )
+    //    }
+    //
+    //    @Test
+    //    fun `does not identify autoCalculatedIndicators as changed when progressNotes matches`() {
+    //      insertPublishedReport(
+    //          highlights = "highlights",
+    //          additionalComments = "additional comments",
+    //          financialSummaries = "financial summaries",
+    //      )
+    //      insertPublishedReportAutoCalculatedIndicator(
+    //          indicator = AutoCalculatedIndicator.Seedlings,
+    //          value = BigDecimal(40),
+    //          progressNotes = "same notes",
+    //      )
+    //      insertReportAutoCalculatedIndicator(
+    //          indicator = AutoCalculatedIndicator.Seedlings,
+    //          systemValue = BigDecimal(40),
+    //          progressNotes = "same notes",
+    //      )
+    //
+    //      assertEquals(
+    //          emptyList<PublishedReportComparedProps>(),
+    //          service
+    //              .fetchOne(reportId, includeIndicators = true, computeUnpublishedChanges = true)
+    //              .unpublishedProperties,
+    //          "AutoCalculatedIndicators should not be flagged when progressNotes matches",
+    //      )
+    //    }
   }
 }

--- a/src/test/kotlin/com/terraformation/backend/accelerator/ReportServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/ReportServiceTest.kt
@@ -507,16 +507,21 @@ class ReportServiceTest : DatabaseTest(), RunsAsDatabaseUser {
           overrideValue = BigDecimal(60),
       )
 
+      insertFile()
+      insertReportPhoto(caption = "new caption")
+      insertPublishedReportPhoto(caption = "old caption")
+
       assertEquals(
           setOf(
-              PublishedReportComparedProps.Highlights,
               PublishedReportComparedProps.Achievements,
-              PublishedReportComparedProps.Challenges,
               PublishedReportComparedProps.AdditionalComments,
-              PublishedReportComparedProps.FinancialSummaries,
-              PublishedReportComparedProps.CommonIndicators,
-              PublishedReportComparedProps.ProjectIndicators,
               PublishedReportComparedProps.AutoCalculatedIndicators,
+              PublishedReportComparedProps.Challenges,
+              PublishedReportComparedProps.CommonIndicators,
+              PublishedReportComparedProps.FinancialSummaries,
+              PublishedReportComparedProps.Highlights,
+              PublishedReportComparedProps.Photos,
+              PublishedReportComparedProps.ProjectIndicators,
           ),
           service
               .fetchOne(reportId, includeIndicators = true, computeUnpublishedChanges = true)

--- a/src/test/kotlin/com/terraformation/backend/accelerator/ReportServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/ReportServiceTest.kt
@@ -150,7 +150,7 @@ class ReportServiceTest : DatabaseTest(), RunsAsDatabaseUser {
                   additionalComments = "additional comments",
               )
           ),
-          "Report was updated with notification sent",
+          "Report was updated with upcomingNotificationSentTime",
       )
     }
   }
@@ -776,74 +776,5 @@ class ReportServiceTest : DatabaseTest(), RunsAsDatabaseUser {
           "AutoCalculatedIndicators should be flagged when progressNotes changed",
       )
     }
-
-    //    @Test
-    //    fun `does not identify commonIndicators as changed when progressNotes matches`() {
-    //      insertCommonIndicator(isPublishable = true)
-    //      insertPublishedReport(
-    //          highlights = "highlights",
-    //          additionalComments = "additional comments",
-    //          financialSummaries = "financial summaries",
-    //      )
-    //      insertPublishedReportCommonIndicator(value = BigDecimal(10), progressNotes = "same
-    // notes")
-    //      insertReportCommonIndicator(value = BigDecimal(10), progressNotes = "same notes")
-    //
-    //      assertEquals(
-    //          emptyList<PublishedReportComparedProps>(),
-    //          service
-    //              .fetchOne(reportId, includeIndicators = true, computeUnpublishedChanges = true)
-    //              .unpublishedProperties,
-    //          "CommonIndicators should not be flagged when progressNotes matches",
-    //      )
-    //    }
-    //
-    //    @Test
-    //    fun `does not identify projectIndicators as changed when progressNotes matches`() {
-    //      insertProjectIndicator(isPublishable = true)
-    //      insertPublishedReport(
-    //          highlights = "highlights",
-    //          additionalComments = "additional comments",
-    //          financialSummaries = "financial summaries",
-    //      )
-    //      insertPublishedReportProjectIndicator(value = BigDecimal(10), progressNotes = "same
-    // notes")
-    //      insertReportProjectIndicator(value = BigDecimal(10), progressNotes = "same notes")
-    //
-    //      assertEquals(
-    //          emptyList<PublishedReportComparedProps>(),
-    //          service
-    //              .fetchOne(reportId, includeIndicators = true, computeUnpublishedChanges = true)
-    //              .unpublishedProperties,
-    //          "ProjectIndicators should not be flagged when progressNotes matches",
-    //      )
-    //    }
-    //
-    //    @Test
-    //    fun `does not identify autoCalculatedIndicators as changed when progressNotes matches`() {
-    //      insertPublishedReport(
-    //          highlights = "highlights",
-    //          additionalComments = "additional comments",
-    //          financialSummaries = "financial summaries",
-    //      )
-    //      insertPublishedReportAutoCalculatedIndicator(
-    //          indicator = AutoCalculatedIndicator.Seedlings,
-    //          value = BigDecimal(40),
-    //          progressNotes = "same notes",
-    //      )
-    //      insertReportAutoCalculatedIndicator(
-    //          indicator = AutoCalculatedIndicator.Seedlings,
-    //          systemValue = BigDecimal(40),
-    //          progressNotes = "same notes",
-    //      )
-    //
-    //      assertEquals(
-    //          emptyList<PublishedReportComparedProps>(),
-    //          service
-    //              .fetchOne(reportId, includeIndicators = true, computeUnpublishedChanges = true)
-    //              .unpublishedProperties,
-    //          "AutoCalculatedIndicators should not be flagged when progressNotes matches",
-    //      )
-    //    }
   }
 }

--- a/src/test/kotlin/com/terraformation/backend/accelerator/ReportServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/ReportServiceTest.kt
@@ -1,16 +1,23 @@
 package com.terraformation.backend.accelerator
 
 import com.terraformation.backend.RunsAsDatabaseUser
+import com.terraformation.backend.TestClock
 import com.terraformation.backend.TestEventPublisher
 import com.terraformation.backend.accelerator.db.ReportStore
+import com.terraformation.backend.accelerator.model.PublishedReportComparedProps
 import com.terraformation.backend.assertIsEventListener
 import com.terraformation.backend.customer.model.SystemUser
 import com.terraformation.backend.customer.model.TerrawareUser
 import com.terraformation.backend.daily.DailyTaskTimeArrivedEvent
 import com.terraformation.backend.db.DatabaseTest
 import com.terraformation.backend.db.ReportNotFoundException
+import com.terraformation.backend.db.accelerator.AutoCalculatedIndicator
 import com.terraformation.backend.db.accelerator.ReportId
+import com.terraformation.backend.db.accelerator.ReportQuarter
+import com.terraformation.backend.db.accelerator.ReportStatus
 import com.terraformation.backend.db.accelerator.tables.records.ReportPhotosRecord
+import com.terraformation.backend.db.accelerator.tables.records.ReportsRecord
+import com.terraformation.backend.db.accelerator.tables.references.REPORTS
 import com.terraformation.backend.db.default_schema.GlobalRole
 import com.terraformation.backend.db.default_schema.OrganizationId
 import com.terraformation.backend.db.default_schema.ProjectId
@@ -21,12 +28,19 @@ import com.terraformation.backend.file.SizedInputStream
 import com.terraformation.backend.file.ThumbnailService
 import com.terraformation.backend.file.event.FileReferenceDeletedEvent
 import com.terraformation.backend.file.model.FileMetadata
+import com.terraformation.backend.funder.db.PublishedReportStore
+import com.terraformation.backend.i18n.Messages
+import com.terraformation.backend.tracking.db.ObservationResultsStore
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
 import java.io.ByteArrayInputStream
+import java.math.BigDecimal
+import java.time.LocalDate
+import java.time.Month
 import java.time.ZoneOffset
 import org.junit.jupiter.api.Assertions.assertArrayEquals
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
@@ -38,9 +52,24 @@ import org.springframework.security.access.AccessDeniedException
 class ReportServiceTest : DatabaseTest(), RunsAsDatabaseUser {
   override lateinit var user: TerrawareUser
 
+  private val clock = TestClock()
+  private val messages = Messages()
   private val eventPublisher = TestEventPublisher()
-  private val reportStore = mockk<ReportStore>()
   private val fileService = mockk<FileService>()
+  private val reportStore: ReportStore by lazy {
+    ReportStore(
+        clock,
+        dslContext,
+        eventPublisher,
+        messages,
+        ObservationResultsStore(dslContext),
+        reportsDao,
+        SystemUser(usersDao),
+    )
+  }
+  private val publishedReportStore: PublishedReportStore by lazy {
+    PublishedReportStore(dslContext)
+  }
 
   private val service: ReportService by lazy {
     ReportService(
@@ -50,6 +79,7 @@ class ReportServiceTest : DatabaseTest(), RunsAsDatabaseUser {
         reportPhotosDao,
         reportStore,
         publishedReportPhotosDao,
+        publishedReportStore,
         SystemUser(usersDao),
         ThumbnailService(dslContext, fileService, listOf(mockk()), mockk()),
     )
@@ -65,15 +95,17 @@ class ReportServiceTest : DatabaseTest(), RunsAsDatabaseUser {
 
   @BeforeEach
   fun setup() {
-    every { reportStore.notifyUpcomingReports() } returns 1
-
     organizationId = insertOrganization(timeZone = ZoneOffset.UTC)
     projectId = insertProject()
     insertProjectReportConfig()
-    reportId = insertReport()
-    insertPublishedReport()
+    reportId =
+        insertReport(
+            status = ReportStatus.Approved,
+            highlights = "highlights",
+            additionalComments = "additional comments",
+            financialSummaries = "financial summaries",
+        )
 
-    every { reportStore.publishReport(any()) } returns Unit
     every { fileService.storeFile(any(), any(), any(), any(), any()) } answers
         {
           val func = arg<((storedFile: FileService.StoredFile) -> Unit)?>(4)
@@ -89,9 +121,37 @@ class ReportServiceTest : DatabaseTest(), RunsAsDatabaseUser {
   inner class Daily {
     @Test
     fun `notifies upcoming reports daily`() {
+      with(REPORTS) {
+        dslContext
+            .update(this)
+            .set(STATUS_ID, ReportStatus.NotSubmitted)
+            .setNull(SUBMITTED_BY)
+            .setNull(SUBMITTED_TIME)
+            .execute()
+      }
       service.on(DailyTaskTimeArrivedEvent())
-      verify(exactly = 1) { reportStore.notifyUpcomingReports() }
       assertIsEventListener<DailyTaskTimeArrivedEvent>(service)
+      assertTableEquals(
+          listOf(
+              ReportsRecord(
+                  configId = inserted.projectReportConfigId,
+                  projectId = projectId,
+                  statusId = ReportStatus.NotSubmitted,
+                  startDate = LocalDate.EPOCH,
+                  endDate = LocalDate.EPOCH.plusDays(1),
+                  createdBy = user.userId,
+                  createdTime = clock.instant(),
+                  modifiedBy = user.userId,
+                  modifiedTime = clock.instant(),
+                  highlights = "highlights",
+                  reportQuarterId = ReportQuarter.Q1,
+                  upcomingNotificationSentTime = clock.instant(),
+                  financialSummaries = "financial summaries",
+                  additionalComments = "additional comments",
+              )
+          ),
+          "Report was updated with notification sent",
+      )
     }
   }
 
@@ -99,8 +159,10 @@ class ReportServiceTest : DatabaseTest(), RunsAsDatabaseUser {
   inner class PublishReport {
     @Test
     fun `publishes report and deletes photos marked as deleted`() {
+      insertUserGlobalRole(role = GlobalRole.AcceleratorAdmin)
       val existingFileId = insertFile()
       insertReportPhoto()
+      insertPublishedReport()
       insertPublishedReportPhoto()
 
       insertFile()
@@ -109,13 +171,10 @@ class ReportServiceTest : DatabaseTest(), RunsAsDatabaseUser {
 
       service.publishReport(reportId)
 
-      verify(exactly = 1) { reportStore.publishReport(reportId) }
-
       assertTableEquals(
           listOf(ReportPhotosRecord(reportId = reportId, fileId = existingFileId, deleted = false)),
           "Report photos",
       )
-
       assertTableEquals(
           listOf(PublishedReportPhotosRecord(reportId = reportId, fileId = existingFileId)),
           "Published report photos",
@@ -167,6 +226,7 @@ class ReportServiceTest : DatabaseTest(), RunsAsDatabaseUser {
 
     @Test
     fun `sets photo to deleted if already published`() {
+      insertPublishedReport()
       insertUserGlobalRole(role = GlobalRole.TFExpert)
 
       val existingFileId = insertFile()
@@ -343,6 +403,307 @@ class ReportServiceTest : DatabaseTest(), RunsAsDatabaseUser {
                   deleted = false,
               ),
           )
+      )
+    }
+  }
+
+  @Nested
+  inner class UnpublishedProperties {
+    @BeforeEach
+    fun setUp() {
+      insertUserGlobalRole(role = GlobalRole.AcceleratorAdmin)
+    }
+
+    @Test
+    fun `returns empty list when report has never been published`() {
+      assertEquals(
+          emptyList<PublishedReportComparedProps>(),
+          service.fetchOne(reportId, computeUnpublishedChanges = true).unpublishedProperties,
+          "Report has not been published",
+      )
+    }
+
+    @Test
+    fun `returns empty list when computeUnpublishedChanges is false`() {
+      assertEquals(
+          emptyList<PublishedReportComparedProps>(),
+          service.fetchOne(reportId, computeUnpublishedChanges = false).unpublishedProperties,
+          "Not requesting unpublished properties",
+      )
+    }
+
+    @Test
+    fun `returns empty list when user doesn't have permission to view published report`() {
+      deleteUserGlobalRole(role = GlobalRole.AcceleratorAdmin)
+      insertOrganizationUser(role = Role.Manager)
+
+      assertEquals(
+          emptyList<PublishedReportComparedProps>(),
+          service.fetchOne(reportId, computeUnpublishedChanges = true).unpublishedProperties,
+          "User can't read published reports",
+      )
+    }
+
+    @Test
+    fun `returns empty list when report matches published qualitative properties`() {
+      insertPublishedReport(
+          highlights = "highlights",
+          additionalComments = "additional comments",
+          financialSummaries = "financial summaries",
+      )
+      insertReportAchievement(position = 0, achievement = "Achievement A")
+      insertPublishedReportAchievement(position = 0, achievement = "Achievement A")
+      insertReportChallenge(position = 0, challenge = "Challenge A", mitigationPlan = "Plan A")
+      insertPublishedReportChallenge(
+          position = 0,
+          challenge = "Challenge A",
+          mitigationPlan = "Plan A",
+      )
+
+      assertEquals(
+          emptyList<PublishedReportComparedProps>(),
+          service.fetchOne(reportId, computeUnpublishedChanges = true).unpublishedProperties,
+          "unpublishedProperties should be empty when nothing changed",
+      )
+    }
+
+    @Test
+    fun `identifies all changed properties`() {
+      val commonIndicatorId = insertCommonIndicator(isPublishable = true)
+      val projectIndicatorId = insertProjectIndicator(isPublishable = true)
+
+      // Published version: old values for all properties
+      insertPublishedReport(
+          highlights = "old highlights",
+          additionalComments = "old comments",
+          financialSummaries = "old financial summaries",
+      )
+      // Published has no achievements or challenges
+      insertPublishedReportCommonIndicator(
+          indicatorId = commonIndicatorId,
+          value = BigDecimal(10),
+      )
+      insertPublishedReportProjectIndicator(
+          indicatorId = projectIndicatorId,
+          value = BigDecimal(30),
+      )
+      insertPublishedReportAutoCalculatedIndicator(
+          indicator = AutoCalculatedIndicator.Seedlings,
+          value = BigDecimal(50),
+      )
+
+      // Current draft: different values for all properties
+      insertReportAchievement(position = 0, achievement = "New Achievement")
+      insertReportChallenge(
+          position = 0,
+          challenge = "New Challenge",
+          mitigationPlan = "New Plan",
+      )
+      insertReportCommonIndicator(indicatorId = commonIndicatorId, value = BigDecimal(20))
+      insertReportProjectIndicator(indicatorId = projectIndicatorId, value = BigDecimal(40))
+      insertReportAutoCalculatedIndicator(
+          indicator = AutoCalculatedIndicator.Seedlings,
+          systemValue = BigDecimal(40),
+          overrideValue = BigDecimal(60),
+      )
+
+      assertEquals(
+          setOf(
+              PublishedReportComparedProps.Highlights,
+              PublishedReportComparedProps.Achievements,
+              PublishedReportComparedProps.Challenges,
+              PublishedReportComparedProps.AdditionalComments,
+              PublishedReportComparedProps.FinancialSummaries,
+              PublishedReportComparedProps.CommonIndicators,
+              PublishedReportComparedProps.ProjectIndicators,
+              PublishedReportComparedProps.AutoCalculatedIndicators,
+          ),
+          service
+              .fetchOne(reportId, includeIndicators = true, computeUnpublishedChanges = true)
+              .unpublishedProperties
+              .toSet(),
+          "Unpublished properties should contain all props",
+      )
+    }
+
+    @Test
+    fun `identifies photos as changed when new photo added`() {
+      insertFile()
+      insertPublishedReport(
+          highlights = "highlights",
+          additionalComments = "additional comments",
+          financialSummaries = "financial summaries",
+      )
+      // Current report has photo; published has none
+      insertReportPhoto()
+
+      assertEquals(
+          listOf(PublishedReportComparedProps.Photos),
+          service.fetchOne(reportId, computeUnpublishedChanges = true).unpublishedProperties,
+          "Adding a photo causes unpublishedProperties to include photos",
+      )
+    }
+
+    @Test
+    fun `identifies photos as changed when photo removed`() {
+      insertFile()
+      insertPublishedReport(
+          highlights = "highlights",
+          additionalComments = "additional comments",
+          financialSummaries = "financial summaries",
+      )
+      // Insert the photo as deleted in the current report to satisfy the FK on
+      // published_report_photos
+      insertReportPhoto(deleted = true)
+      insertPublishedReportPhoto()
+
+      assertEquals(
+          listOf(PublishedReportComparedProps.Photos),
+          service.fetchOne(reportId, computeUnpublishedChanges = true).unpublishedProperties,
+          "Removing a photo causes unpublishedProperties to include photos",
+      )
+    }
+
+    @Test
+    fun `does not identify commonIndicators as changed for non-publishable indicators`() {
+      insertCommonIndicator(isPublishable = false)
+      insertPublishedReport(
+          highlights = "highlights",
+          additionalComments = "additional comments",
+          financialSummaries = "financial summaries",
+      )
+      // Published has no common indicator row (non-publishable not published)
+      insertReportCommonIndicator(value = BigDecimal(99))
+
+      assertEquals(
+          emptyList<PublishedReportComparedProps>(),
+          service
+              .fetchOne(reportId, includeIndicators = true, computeUnpublishedChanges = true)
+              .unpublishedProperties,
+          "CommonIndicators should not be flagged for non-publishable indicators",
+      )
+    }
+
+    @Test
+    fun `does not identify projectIndicators as changed for non-publishable indicators`() {
+      insertProjectIndicator(isPublishable = false)
+      insertPublishedReport(
+          highlights = "highlights",
+          additionalComments = "additional comments",
+          financialSummaries = "financial summaries",
+      )
+      // Published has no project indicator row (non-publishable not published)
+      insertReportProjectIndicator(value = BigDecimal(99))
+
+      assertEquals(
+          emptyList<PublishedReportComparedProps>(),
+          service
+              .fetchOne(reportId, includeIndicators = true, computeUnpublishedChanges = true)
+              .unpublishedProperties,
+          "ProjectIndicators should not be flagged for non-publishable indicators",
+      )
+    }
+
+    @Test
+    fun `uses system value when no override for autoCalculatedIndicators comparison`() {
+      insertPublishedReport(
+          highlights = "highlights",
+          additionalComments = "additional comments",
+          financialSummaries = "financial summaries",
+      )
+      // Publish Seedlings=40 only; other indicators have no published rows and no current rows.
+      insertPublishedReportAutoCalculatedIndicator(
+          indicator = AutoCalculatedIndicator.Seedlings,
+          value = BigDecimal(40),
+      )
+      // System value 40, no override — should match the published value of 40
+      insertReportAutoCalculatedIndicator(
+          indicator = AutoCalculatedIndicator.Seedlings,
+          systemValue = BigDecimal(40),
+      )
+
+      assertEquals(
+          emptyList<PublishedReportComparedProps>(),
+          service
+              .fetchOne(reportId, includeIndicators = true, computeUnpublishedChanges = true)
+              .unpublishedProperties,
+          "AutoCalculatedIndicators should not be flagged when system value matches published",
+      )
+    }
+
+    @Test
+    fun `returns correct unpublishedProperties per report when fetching multiple reports`() {
+      // Report 1 (reportId from setUp): never published → unpublishedProperties == emptyList()
+
+      // Report 2: published and unpublished matches exactly → unpublishedProperties == emptyList()
+      val reportId2 =
+          insertReport(
+              startDate = LocalDate.of(2030, Month.JANUARY, 1),
+              endDate = LocalDate.of(2030, Month.MARCH, 31),
+              highlights = "same highlights",
+          )
+      insertPublishedReport(highlights = "same highlights")
+
+      // Report 3: published but highlights differs → unpublishedProperties contains Highlights
+      val reportId3 =
+          insertReport(
+              startDate = LocalDate.of(2030, Month.APRIL, 1),
+              endDate = LocalDate.of(2030, Month.JUNE, 30),
+              highlights = "new highlights",
+          )
+      insertPublishedReport(highlights = "old highlights")
+
+      val reports =
+          service.fetch(
+              projectId = projectId,
+              includeFuture = true,
+              includeIndicators = true,
+              computeUnpublishedChanges = true,
+          )
+      val byId = reports.associateBy { it.id }
+
+      assertEquals(
+          emptyList<PublishedReportComparedProps>(),
+          byId[reportId]?.unpublishedProperties,
+          "Report 1 (never published): unpublishedProperties should be empty",
+      )
+      assertEquals(
+          emptyList<PublishedReportComparedProps>(),
+          byId[reportId2]?.unpublishedProperties,
+          "Report 2 (published, no changes): unpublishedProperties should be empty",
+      )
+      assertEquals(
+          listOf(PublishedReportComparedProps.Highlights),
+          byId[reportId3]?.unpublishedProperties,
+          "Report 3 (highlights changed): unpublishedProperties should just be Highlights",
+      )
+    }
+
+    @Test
+    fun `does not compare progress notes or projectsComments for commonIndicators`() {
+      insertCommonIndicator(isPublishable = true)
+      insertPublishedReport(
+          highlights = "highlights",
+          additionalComments = "additional comments",
+          financialSummaries = "financial summaries",
+      )
+      insertPublishedReportCommonIndicator(
+          value = BigDecimal(10),
+          progressNotes = "old progress notes",
+          projectsComments = "old projects comments",
+      )
+      insertReportCommonIndicator(
+          value = BigDecimal(10),
+          progressNotes = "new progress notes",
+          projectsComments = "new projects comments",
+      )
+
+      assertEquals(
+          emptyList<PublishedReportComparedProps>(),
+          service
+              .fetchOne(reportId, includeIndicators = true, computeUnpublishedChanges = true)
+              .unpublishedProperties,
+          "CommonIndicators should not be flagged when only notes/comments changed",
       )
     }
   }


### PR DESCRIPTION
Calculate and return unpublished properties for reports.

For photos, also check `caption`. For indicators, only check `value` and `progressNotes`.

Co-authored-by: Claude Sonnet 4.6 [noreply@anthropic.com](mailto:noreply@anthropic.com)