### PR TITLE
Only compare unpublished non-null values for indicators

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/accelerator/ReportService.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/ReportService.kt
@@ -224,13 +224,15 @@ class ReportService(
         if (hasAutoCalcChanged) {
           changed.add(PublishedReportComparedProps.AutoCalculatedIndicators)
         }
+        // only check common and project indicators with a non-null value, since that's all we
+        // publish for those
         val pubCommon =
             published.commonIndicators.associate {
               it.indicatorId to (it.value to it.progressNotes)
             }
         val currentCommon =
             report.commonIndicators
-                .filter { it.indicator.isPublishable }
+                .filter { it.indicator.isPublishable && it.entry.value != null }
                 .associate { it.indicator.id to (it.entry.value to it.entry.progressNotes) }
         if (currentCommon != pubCommon) {
           changed.add(PublishedReportComparedProps.CommonIndicators)
@@ -242,7 +244,7 @@ class ReportService(
             }
         val currentProject =
             report.projectIndicators
-                .filter { it.indicator.isPublishable }
+                .filter { it.indicator.isPublishable && it.entry.value != null }
                 .associate { it.indicator.id to (it.entry.value to it.entry.progressNotes) }
         if (currentProject != pubProject) {
           changed.add(PublishedReportComparedProps.ProjectIndicators)

--- a/src/test/kotlin/com/terraformation/backend/accelerator/ReportServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/ReportServiceTest.kt
@@ -590,6 +590,25 @@ class ReportServiceTest : DatabaseTest(), RunsAsDatabaseUser {
     }
 
     @Test
+    fun `does not check commonIndicators with null values`() {
+      insertCommonIndicator(isPublishable = true)
+      insertPublishedReport(
+          highlights = "highlights",
+          additionalComments = "additional comments",
+          financialSummaries = "financial summaries",
+      )
+      insertReportCommonIndicator(value = null)
+
+      assertEquals(
+          emptyList<PublishedReportComparedProps>(),
+          service
+              .fetchOne(reportId, includeIndicators = true, computeUnpublishedChanges = true)
+              .unpublishedProperties,
+          "CommonIndicators should not be flagged for non-publishable indicators",
+      )
+    }
+
+    @Test
     fun `does not identify projectIndicators as changed for non-publishable indicators`() {
       insertProjectIndicator(isPublishable = false)
       insertPublishedReport(
@@ -599,6 +618,25 @@ class ReportServiceTest : DatabaseTest(), RunsAsDatabaseUser {
       )
       // Published has no project indicator row (non-publishable not published)
       insertReportProjectIndicator(value = BigDecimal(99))
+
+      assertEquals(
+          emptyList<PublishedReportComparedProps>(),
+          service
+              .fetchOne(reportId, includeIndicators = true, computeUnpublishedChanges = true)
+              .unpublishedProperties,
+          "ProjectIndicators should not be flagged for non-publishable indicators",
+      )
+    }
+
+    @Test
+    fun `does not check projectIndicators with null values`() {
+      insertProjectIndicator(isPublishable = true)
+      insertPublishedReport(
+          highlights = "highlights",
+          additionalComments = "additional comments",
+          financialSummaries = "financial summaries",
+      )
+      insertReportProjectIndicator(value = null)
 
       assertEquals(
           emptyList<PublishedReportComparedProps>(),

--- a/src/test/kotlin/com/terraformation/backend/accelerator/ReportServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/ReportServiceTest.kt
@@ -604,7 +604,7 @@ class ReportServiceTest : DatabaseTest(), RunsAsDatabaseUser {
           service
               .fetchOne(reportId, includeIndicators = true, computeUnpublishedChanges = true)
               .unpublishedProperties,
-          "CommonIndicators should not be flagged for non-publishable indicators",
+          "CommonIndicators should not be flagged for indicators with null values",
       )
     }
 
@@ -643,7 +643,7 @@ class ReportServiceTest : DatabaseTest(), RunsAsDatabaseUser {
           service
               .fetchOne(reportId, includeIndicators = true, computeUnpublishedChanges = true)
               .unpublishedProperties,
-          "ProjectIndicators should not be flagged for non-publishable indicators",
+          "ProjectIndicators should not be flagged for indicators with null values",
       )
     }
 


### PR DESCRIPTION
We only publish project and common indicators that are publishable _and_ have non-null values. When comparing the same for `unpublishedProperties`, only check indicators with non-null values (in addition to publishable).