### PR TITLE
Format admin html pages according to .editorconfig

### DIFF
--- a/src/main/resources/templates/admin/acceleratorProjectDeliverable.html
+++ b/src/main/resources/templates/admin/acceleratorProjectDeliverable.html
@@ -47,21 +47,22 @@
     <tr>
         <td>Set Override</td>
         <td>
-            <form method="POST" th:action="|/admin/acceleratorProjects/${project.id}/deliverables/${deliverable.id}|">
-                <input type="hidden" name="operation" value="upsert" />
+            <form method="POST"
+                  th:action="|/admin/acceleratorProjects/${project.id}/deliverables/${deliverable.id}|">
+                <input type="hidden" name="operation" value="upsert"/>
                 <input type="date"
                        name="dueDate"
                        required
                        th:disabled="${!canManageDeliverables}"
-                       th:value="${dueDates.projectDueDate}" />
+                       th:value="${dueDates.projectDueDate}"/>
                 <input type="submit"
                        th:if="${dueDates.projectDueDate != null}"
                        th:disabled="${!canManageDeliverables}"
-                       value="Update" />
+                       value="Update"/>
                 <input type="submit"
                        th:if="${dueDates.projectDueDate == null}"
                        th:disabled="${!canManageDeliverables}"
-                       value="Add" />
+                       value="Add"/>
             </form>
         </td>
     </tr>
@@ -70,10 +71,10 @@
         <td>
             <form method="POST"
                   th:action="|/admin/acceleratorProjects/${project.id}/deliverables/${deliverable.id}|">
-                <input type="hidden" name="operation" value="remove" />
+                <input type="hidden" name="operation" value="remove"/>
                 <input type="submit"
                        th:disabled="${!canManageDeliverables}"
-                       value="Remove" />
+                       value="Remove"/>
             </form>
         </td>
     </tr>

--- a/src/main/resources/templates/admin/acceleratorProjectView.html
+++ b/src/main/resources/templates/admin/acceleratorProjectView.html
@@ -6,7 +6,7 @@
 <span th:replace="~{/admin/header :: top}"/>
 
 <a href="/admin/">Home</a>
- -
+-
 <a href="/admin/acceleratorProjects">Accelerator Projects</a>
 
 <h2 th:text="|${project.name} (${project.id})|">Project (123)</h2>
@@ -52,7 +52,7 @@
             <form method="POST"
                   th:id="|deliverables-${module.id}|"
                   th:action="|/admin/acceleratorProjects/${project.id}/deliverables|">
-                <input type="submit" value="View" />
+                <input type="submit" value="View"/>
             </form>
         </td>
     </tr>

--- a/src/main/resources/templates/admin/ask/chat.html
+++ b/src/main/resources/templates/admin/ask/chat.html
@@ -6,10 +6,12 @@
             color: darkgreen;
             white-space: preserve-breaks;
         }
+
         .answer {
             color: blue;
             margin-left: 10em;
         }
+
         .error {
             color: red;
             margin-left: 10em;
@@ -17,7 +19,9 @@
     </style>
 
     <th:block th:fragment="additionalScript">
-        <script src="https://unpkg.com/htmx.org@2.0.4" integrity="sha384-HGfztofotfshcF7+8n44JQL2oJmowVChPTg48S+jvZoztPfvwD79OC/LTtG6dMp+" crossorigin="anonymous"></script>
+        <script src="https://unpkg.com/htmx.org@2.0.4"
+                integrity="sha384-HGfztofotfshcF7+8n44JQL2oJmowVChPTg48S+jvZoztPfvwD79OC/LTtG6dMp+"
+                crossorigin="anonymous"></script>
 
         <script>
             function submitOnEnter(event) {

--- a/src/main/resources/templates/admin/ask/exchange.html
+++ b/src/main/resources/templates/admin/ask/exchange.html
@@ -1,9 +1,9 @@
-<div class="question" th:text="${query}" th:if="${query != null}" />
-<div class="answer" th:utext="${answer}" th:if="${answer != null}" />
+<div class="question" th:text="${query}" th:if="${query != null}"/>
+<div class="answer" th:utext="${answer}" th:if="${answer != null}"/>
 <div class="error" th:if="${answer == null && query != null}">
     <b>Unable to get an answer!</b> This may be a temporary problem; wait a moment and try again.
     Conversation ID:
-    <th:block th:utext="${conversationId}" />
+    <th:block th:utext="${conversationId}"/>
 </div>
 
 <form id="queryForm" th:hx-post="|/admin/ask/projects/${projectId}|" hx-swap="outerHTML"
@@ -11,7 +11,8 @@
     <label>
         Question (Enter to submit, Shift-Enter for line break):
         <br/>
-        <textarea id="query" rows=4 cols=80 name="query" autofocus th:if="${answer != null}"></textarea>
+        <textarea id="query" rows=4 cols=80 name="query" autofocus
+                  th:if="${answer != null}"></textarea>
         <textarea id="query" rows=4 cols=80 name="query" autofocus th:if="${answer == null}"
                   th:text="${query}"></textarea>
     </label>

--- a/src/main/resources/templates/admin/ask/index.html
+++ b/src/main/resources/templates/admin/ask/index.html
@@ -20,7 +20,8 @@
     <label>
         Project:
         <select name="projectId">
-            <option th:each="project : ${projects}" th:value="${project.id}" th:text="|${project.name} (${project.id})|"/>
+            <option th:each="project : ${projects}" th:value="${project.id}"
+                    th:text="|${project.name} (${project.id})|"/>
         </select>
     </label>
     <br/>

--- a/src/main/resources/templates/admin/convertApi.html
+++ b/src/main/resources/templates/admin/convertApi.html
@@ -2,8 +2,13 @@
 <html xmlns:th="http://www.thymeleaf.org">
 <head th:replace="~{/admin/header :: head}">
     <style th:fragment="additionalStyle">
-        form { padding-bottom: 1em; }
-        mux-player { max-width: 640px; }
+        form {
+            padding-bottom: 1em;
+        }
+
+        mux-player {
+            max-width: 640px;
+        }
     </style>
 </head>
 <body>
@@ -14,7 +19,7 @@
 
 <h2>ConvertAPI Integration</h2>
 
-<img th:if="${fileId != null}" height="100" th:src="|/admin/mux/thumbnail/${fileId}?height=100|" />
+<img th:if="${fileId != null}" height="100" th:src="|/admin/mux/thumbnail/${fileId}?height=100|"/>
 
 <th:block th:if="${convertApiEnabled}">
     <h3>Upload File and View Thumbnail</h3>

--- a/src/main/resources/templates/admin/disclaimers.html
+++ b/src/main/resources/templates/admin/disclaimers.html
@@ -38,7 +38,8 @@
         </td>
         <td th:text="${disclaimer.users.size()}">Disclaimer Number of Acceptance</td>
         <td>
-            <form method="POST" id="delete" th:action="|/admin/disclaimers/${disclaimer.id}/delete|">
+            <form method="POST" id="delete"
+                  th:action="|/admin/disclaimers/${disclaimer.id}/delete|">
                 <input type="submit" value="Delete"/>
             </form>
         </td>
@@ -53,21 +54,21 @@
         Effective Date
         <input type="date"
                name="effectiveDate"
-               required />
+               required/>
     </label>
-    <br />
+    <br/>
     <label>
         Content
-        <br />
+        <br/>
         <textarea
                 name="content"
                 rows="4"
                 cols="50"
                 placeholder="Enter disclaimer content here"></textarea>
     </label>
-    <br />
+    <br/>
     <input type="submit"
-           value="Submit" />
+           value="Submit"/>
 </form>
 
 </body>

--- a/src/main/resources/templates/admin/documentProducer.html
+++ b/src/main/resources/templates/admin/documentProducer.html
@@ -43,7 +43,8 @@
 
 <h2>Import All Variable CSV</h2>
 
-<form method="POST" action="/admin/document-producer/uploadAllVariables" enctype="multipart/form-data">
+<form method="POST" action="/admin/document-producer/uploadAllVariables"
+      enctype="multipart/form-data">
     <label for="uploadManifestCsv">CSV</label>
     <input type="file" id="uploadAllVariableCsv" name="file" minlength="1"/>
     <br>

--- a/src/main/resources/templates/admin/geoServer.html
+++ b/src/main/resources/templates/admin/geoServer.html
@@ -53,7 +53,7 @@
                     <option th:each="availableFeatureType : ${availableFeatureTypes}"
                             th:value="${availableFeatureType}"
                             th:text="${availableFeatureType.displayName}"
-                            th:selected="${availableFeatureType == featureType}" />
+                            th:selected="${availableFeatureType == featureType}"/>
                 </select>
             </label>
             <label>
@@ -64,26 +64,32 @@
                 View As
                 <select name="resultFormat">
                     <option value="Map" th:selected="${resultFormat == 'Map'}">Map</option>
-                    <option value="GeoJsonLongLat" th:selected="${resultFormat == 'GeoJsonLongLat'}">GeoJSON (longitude/latitude)</option>
-                    <option value="GeoJsonOriginal" th:selected="${resultFormat == 'GeoJsonOriginal'}">GeoJSON (original coordinate system)</option>
+                    <option value="GeoJsonLongLat"
+                            th:selected="${resultFormat == 'GeoJsonLongLat'}">GeoJSON
+                        (longitude/latitude)
+                    </option>
+                    <option value="GeoJsonOriginal"
+                            th:selected="${resultFormat == 'GeoJsonOriginal'}">GeoJSON (original
+                        coordinate system)
+                    </option>
                 </select>
             </label>
             <input type="submit" value="Query"/>
         </form>
 
         <p th:if="${geoJsonResults != null || results != null}">
-            <form method="POST" action="/admin/geoServer/setForProject">
-                <input type="hidden" name="featureType" th:value="${featureType}"/>
-                <input type="hidden" name="filter" th:value="${filter}"/>
-                <input type="hidden" name="resultFormat" th:value="${resultFormat}"/>
-                <label>
-                    Use filter
-                    <code th:text="${filter}">x=y</code>
-                    <th:block th:text="|as ${featureType.displayName} CQL for project ID|"/>
-                    <input type="number" name="projectId" required />
-                    <input type="submit" value="Update Project" />
-                </label>
-            </form>
+        <form method="POST" action="/admin/geoServer/setForProject">
+            <input type="hidden" name="featureType" th:value="${featureType}"/>
+            <input type="hidden" name="filter" th:value="${filter}"/>
+            <input type="hidden" name="resultFormat" th:value="${resultFormat}"/>
+            <label>
+                Use filter
+                <code th:text="${filter}">x=y</code>
+                <th:block th:text="|as ${featureType.displayName} CQL for project ID|"/>
+                <input type="number" name="projectId" required/>
+                <input type="submit" value="Update Project"/>
+            </label>
+        </form>
         </p>
 
         <th:block th:if="${results != null}">

--- a/src/main/resources/templates/admin/header.html
+++ b/src/main/resources/templates/admin/header.html
@@ -6,7 +6,7 @@
     </title>
 
     <script src="/admin/admin.js" type="application/javascript"></script>
-    <link href="/admin/admin.css" rel="stylesheet" />
+    <link href="/admin/admin.css" rel="stylesheet"/>
 
     <th:block th:replace="~{::additionalScript} ?: ~{}"/>
     <th:block th:replace="~{::additionalStyle} ?: ~{}"/>

--- a/src/main/resources/templates/admin/hubSpot.html
+++ b/src/main/resources/templates/admin/hubSpot.html
@@ -2,7 +2,9 @@
 <html xmlns:th="http://www.thymeleaf.org">
 <head th:replace="~{/admin/header :: head}">
     <style th:fragment="additionalStyle">
-        form { padding-bottom: 1em; }
+        form {
+            padding-bottom: 1em;
+        }
     </style>
 </head>
 <body>

--- a/src/main/resources/templates/admin/internalTag.html
+++ b/src/main/resources/templates/admin/internalTag.html
@@ -50,7 +50,8 @@
         </tr>
         <tr>
             <td><label for="description">Description</label></td>
-            <td><input type="text" id="description" name="description" th:value="${tag.description}"/></td>
+            <td><input type="text" id="description" name="description"
+                       th:value="${tag.description}"/></td>
         </tr>
         <tr>
             <td>Type</td>
@@ -64,7 +65,8 @@
     </table>
 </form>
 
-<form id="deleteTagForm" method="POST" th:action="|/admin/deleteInternalTag/${tag.id}|" th:if="!${tag.isSystem}">
+<form id="deleteTagForm" method="POST" th:action="|/admin/deleteInternalTag/${tag.id}|"
+      th:if="!${tag.isSystem}">
     <table>
         <tr>
             <td>
@@ -77,7 +79,9 @@
 <h3>Organizations With This Tag</h3>
 
 <ul th:if="!${organizations.isEmpty()}">
-    <li th:each="organization : ${organizations}" th:text="|${organization.name} (${organization.id})|">Org Name (123)</li>
+    <li th:each="organization : ${organizations}"
+        th:text="|${organization.name} (${organization.id})|">Org Name (123)
+    </li>
 </ul>
 
 <p th:if="${organizations.isEmpty()}">

--- a/src/main/resources/templates/admin/listDeviceManagers.html
+++ b/src/main/resources/templates/admin/listDeviceManagers.html
@@ -29,7 +29,8 @@
             <a th:href="|/admin/deviceManagers/${manager.id}|" th:text="${manager.sensorKitId}">ABCDE</a>
         </td>
         <td th:text="${manager.facilityId}">
-            <a th:href="|/admin/facility/${manager.facilityId}|" th:text="${manager.facilityId}">567</a>
+            <a th:href="|/admin/facility/${manager.facilityId}|"
+               th:text="${manager.facilityId}">567</a>
         </td>
         <td th:text="${manager.userId}">123</td>
         <td th:text="${manager.isOnline()}">true</td>

--- a/src/main/resources/templates/admin/monitoringPlots.html
+++ b/src/main/resources/templates/admin/monitoringPlots.html
@@ -23,7 +23,7 @@
 <form method="POST" action="/admin/calculatePlotBoundary">
     <label>
         Existing monitoring plot ID
-        <input type="text" name="monitoringPlotId" required />
+        <input type="text" name="monitoringPlotId" required/>
     </label>
     <input type="submit" value="Calculate"/>
 </form>
@@ -33,11 +33,11 @@
 <form method="POST" action="/admin/calculatePlotBoundary">
     <label>
         Grid origin (GeoJSON or WKT)
-        <input type="text" name="gridOrigin" required />
+        <input type="text" name="gridOrigin" required/>
     </label>
     <label>
         Target coordinates (GeoJSON or WKT)
-        <input type="text" name="coordinates" required />
+        <input type="text" name="coordinates" required/>
     </label>
     <input type="submit" value="Calculate"/>
 </form>

--- a/src/main/resources/templates/admin/mux.html
+++ b/src/main/resources/templates/admin/mux.html
@@ -2,8 +2,13 @@
 <html xmlns:th="http://www.thymeleaf.org">
 <head th:replace="~{/admin/header :: head}">
     <style th:fragment="additionalStyle">
-        form { padding-bottom: 1em; }
-        mux-player { max-width: 640px; }
+        form {
+            padding-bottom: 1em;
+        }
+
+        mux-player {
+            max-width: 640px;
+        }
     </style>
 </head>
 <body>

--- a/src/main/resources/templates/admin/organization.html
+++ b/src/main/resources/templates/admin/organization.html
@@ -56,7 +56,7 @@
 
             const map = new mapboxgl.Map({
                 container: 'map',
-                fitBoundsOptions: { padding: 10 },
+                fitBoundsOptions: {padding: 10},
                 style: 'mapbox://styles/mapbox/satellite-streets-v12',
             });
 
@@ -127,7 +127,7 @@
                 const points = [];
                 let position = startingPoint;
                 for (const step of path) {
-                    position = turf.destination(position, step[1], step[0], { units: 'meters'});
+                    position = turf.destination(position, step[1], step[0], {units: 'meters'});
                     points.push(position.geometry.coordinates);
                 }
 
@@ -153,13 +153,14 @@
                 map.easeTo({center: [lng, lat], zoom: 18});
 
                 // Allow the user to drag the site boundary around.
-                draw.changeMode('simple_select', { featureIds: featureIds });
+                draw.changeMode('simple_select', {featureIds: featureIds});
             };
 
             document.getElementById('addMinimalSite').addEventListener('click', addMinimalSite);
             orientation.addEventListener('change', addMinimalSite);
         });
     }
+
     /*]]>*/
 </script>
 

--- a/src/main/resources/templates/admin/plantingSite.html
+++ b/src/main/resources/templates/admin/plantingSite.html
@@ -10,7 +10,7 @@
             padding: .25em;
         }
 
-        table#substrata>tbody>tr>:nth-child(n+3):nth-child(-n+5) {
+        table#substrata > tbody > tr > :nth-child(n+3):nth-child(-n+5) {
             text-align: right;
         }
 
@@ -104,8 +104,8 @@
                 let plantsWarning = '';
                 if (numPlants > 0) {
                     plantsWarning =
-                        `This site has ${numPlants} plants of ${numSpecies} species! ` +
-                        'Deleting it will destroy all records of those plants. ';
+                            `This site has ${numPlants} plants of ${numSpecies} species! ` +
+                            'Deleting it will destroy all records of those plants. ';
                 }
 
                 if (!confirm(plantsWarning + 'Are you sure?')) {
@@ -147,7 +147,8 @@
 </p>
 
 <div id="mapButton" th:if="${site.boundary} != null">
-    <button onclick="showMapPopup()">Click to View Map</button> (opens in new window)
+    <button onclick="showMapPopup()">Click to View Map</button>
+    (opens in new window)
 </div>
 
 <form method="POST" action="/admin/updatePlantingSite" th:if="${canUpdatePlantingSite}">
@@ -244,32 +245,41 @@
             <tr th:each="stratum : ${site.strata}">
                 <td th:text="${stratum.id}">1</td>
                 <td title="Stratum name edits will not show up in the site's map history; they will be applied retroactively, as if they had been the names in the most recently uploaded shapefile. If you want the old names to appear in the map history, upload a new shapefile instead of renaming the strata here.">
-                    <input required name="name" th:value="${stratum.name}" th:form="|stratum-${stratum.id}|"/>
+                    <input required name="name" th:value="${stratum.name}"
+                           th:form="|stratum-${stratum.id}|"/>
                     &#9432;
                 </td>
                 <td>
                     <input type="number" required min="1" name="targetPlantingDensity" size="8"
-                           th:value="${stratum.targetPlantingDensity}" th:form="|stratum-${stratum.id}|"/>
+                           th:value="${stratum.targetPlantingDensity}"
+                           th:form="|stratum-${stratum.id}|"/>
                 </td>
                 <td>
-                    <input type="number" required min="0.001" step="0.001" name="variance" size="8" th:id="|variance-${stratum.id}|"
+                    <input type="number" required min="0.001" step="0.001" name="variance" size="8"
+                           th:id="|variance-${stratum.id}|"
                            th:value="${stratum.variance}" th:form="|stratum-${stratum.id}|"/>
                 </td>
                 <td>
-                    <input type="number" required min="0.001" step="0.001" name="errorMargin" th:id="|errorMargin-${stratum.id}|"
+                    <input type="number" required min="0.001" step="0.001" name="errorMargin"
+                           th:id="|errorMargin-${stratum.id}|"
                            th:value="${stratum.errorMargin}" th:form="|stratum-${stratum.id}|"/>
                 </td>
                 <td>
-                    <input type="number" required min="0.001" step="0.001" name="studentsT" th:id="|studentsT-${stratum.id}|"
+                    <input type="number" required min="0.001" step="0.001" name="studentsT"
+                           th:id="|studentsT-${stratum.id}|"
                            th:value="${stratum.studentsT}" th:form="|stratum-${stratum.id}|"/>
                 </td>
                 <td>
-                    <input type="number" required min="1" name="numPermanent" th:id="|numPermanent-${stratum.id}|"
-                           th:value="${stratum.numPermanentPlots}" th:form="|stratum-${stratum.id}|"/>
+                    <input type="number" required min="1" name="numPermanent"
+                           th:id="|numPermanent-${stratum.id}|"
+                           th:value="${stratum.numPermanentPlots}"
+                           th:form="|stratum-${stratum.id}|"/>
                 </td>
                 <td>
-                    <input type="number" required min="0" name="numTemporary" th:id="|numTemporary-${stratum.id}|"
-                           th:value="${stratum.numTemporaryPlots}" th:form="|stratum-${stratum.id}|"/>
+                    <input type="number" required min="0" name="numTemporary"
+                           th:id="|numTemporary-${stratum.id}|"
+                           th:value="${stratum.numTemporaryPlots}"
+                           th:form="|stratum-${stratum.id}|"/>
                 </td>
                 <td>
                     <span th:id="|total-${stratum.id}|"
@@ -278,7 +288,8 @@
                     </span>
                 </td>
                 <td style="padding-left: 8px;">
-                    <form method="POST" action="/admin/updateStratum" th:id="|stratum-${stratum.id}|">
+                    <form method="POST" action="/admin/updateStratum"
+                          th:id="|stratum-${stratum.id}|">
                         <input type="hidden" name="plantingSiteId" th:value="${site.id}"/>
                         <input type="hidden" name="stratumId" th:value="${stratum.id}"/>
                         <input type="submit" value="Update"/>
@@ -294,7 +305,8 @@
 
         <h3>Upload New Shapefiles</h3>
 
-        <form method="POST" enctype="multipart/form-data" action="/admin/updatePlantingSiteShapefiles">
+        <form method="POST" enctype="multipart/form-data"
+              action="/admin/updatePlantingSiteShapefiles">
             <input type="hidden" name="plantingSiteId" th:value="${site.id}"/>
             <label>
                 Zipfile
@@ -377,10 +389,10 @@
             <td th:text="${observation.startDate}">2023-01-01</td>
             <td th:text="${observation.endDate}">2023-01-31</td>
             <td>
-                    <div th:each="substratumId : ${observation.requestedSubstratumIds}"
-                        th:text="|${substrataById.get(substratumId).fullName} (${substratumId})|">
-                        abc-123 (456)
-                    </div>
+                <div th:each="substratumId : ${observation.requestedSubstratumIds}"
+                     th:text="|${substrataById.get(substratumId).fullName} (${substratumId})|">
+                    abc-123 (456)
+                </div>
             </td>
             <td th:text="${observation.state}">Upcoming</td>
             <td>
@@ -398,10 +410,12 @@
         <tr th:if="${canCreateObservation}">
             <td></td>
             <td>
-                <input type="date" form="createObservation" name="startDate" th:value="${nextObservationStart}"/>
+                <input type="date" form="createObservation" name="startDate"
+                       th:value="${nextObservationStart}"/>
             </td>
             <td>
-                <input type="date" form="createObservation" name="endDate" th:value="${nextObservationEnd}"/>
+                <input type="date" form="createObservation" name="endDate"
+                       th:value="${nextObservationEnd}"/>
             </td>
             <td>
                 <select multiple form="createObservation" name="requestedSubstratumIds">

--- a/src/main/resources/templates/admin/splats.html
+++ b/src/main/resources/templates/admin/splats.html
@@ -5,6 +5,7 @@
         td {
             vertical-align: top;
         }
+
         td input {
             margin-top: 0;
         }
@@ -26,75 +27,87 @@
 <form method="POST" action="/admin/splats/process">
     <table>
         <thead>
-            <tr>
-                <th>Step</th>
-                <th>Setting</th>
-                <th/>
-                <th>Explanation</th>
-            </tr>
+        <tr>
+            <th>Step</th>
+            <th>Setting</th>
+            <th/>
+            <th>Explanation</th>
+        </tr>
         </thead>
         <tbody>
-            <tr>
-                <td rowspan="2"></td>
-                <td>Observation&nbsp;ID</td>
-                <td colspan="2"><input type="text" name="observationId" required/></td>
-            </tr>
-            <tr>
-                <td>File ID</td>
-                <td colspan="2"><input type="text" name="fileId" required/></td>
-            </tr>
+        <tr>
+            <td rowspan="2"></td>
+            <td>Observation&nbsp;ID</td>
+            <td colspan="2"><input type="text" name="observationId" required/></td>
+        </tr>
+        <tr>
+            <td>File ID</td>
+            <td colspan="2"><input type="text" name="fileId" required/></td>
+        </tr>
         </tbody>
 
-        <tr><td colspan="4"><hr/></td></tr>
+        <tr>
+            <td colspan="4">
+                <hr/>
+            </td>
+        </tr>
 
         <tbody>
-            <tr>
-                <td rowspan="3">extract</td>
-                <td>FPS</td>
-                <td><input type="text" name="fps" placeholder="10"/></td>
-                <td>
-                    Frames per second to extract from the video.
-                </td>
-            </tr>
-            <tr>
-                <td>Max Size</td>
-                <td><input type="text" name="maxSize" placeholder="1600"/></td>
-                <td>
-                    Downscale video frames to fit within a square this many pixels tall and wide.
-                </td>
-            </tr>
-            <tr>
-                <td>Other Args</td>
-                <td><input type="text" name="stepArgs[extract]"/></td>
-                <td>
-                    Additional space-separated arguments to pass to splat.py extract.
-                </td>
-            </tr>
+        <tr>
+            <td rowspan="3">extract</td>
+            <td>FPS</td>
+            <td><input type="text" name="fps" placeholder="10"/></td>
+            <td>
+                Frames per second to extract from the video.
+            </td>
+        </tr>
+        <tr>
+            <td>Max Size</td>
+            <td><input type="text" name="maxSize" placeholder="1600"/></td>
+            <td>
+                Downscale video frames to fit within a square this many pixels tall and wide.
+            </td>
+        </tr>
+        <tr>
+            <td>Other Args</td>
+            <td><input type="text" name="stepArgs[extract]"/></td>
+            <td>
+                Additional space-separated arguments to pass to splat.py extract.
+            </td>
+        </tr>
         </tbody>
 
-        <tr><td colspan="4"><hr/></td></tr>
+        <tr>
+            <td colspan="4">
+                <hr/>
+            </td>
+        </tr>
 
         <tbody>
-            <tr>
-                <td rowspan="2">filter-blurry</td>
-                <td>Keep %</td>
-                <td><input type="text" name="keepPercent" placeholder="100"/></td>
-                <td>
-                    Percentage of frames to keep after checking for blurriness. If this is 90, the
-                    blurriest 10% of frames will be dropped. A value of 100 will skip the filter-blurry
-                    step.
-                </td>
-            </tr>
-            <tr>
-                <td>Other Args</td>
-                <td><input type="text" name="stepArgs[filter-blurry]"/></td>
-                <td>
-                    Additional space-separated arguments to pass to splat.py filter-blurry.
-                </td>
-            </tr>
+        <tr>
+            <td rowspan="2">filter-blurry</td>
+            <td>Keep %</td>
+            <td><input type="text" name="keepPercent" placeholder="100"/></td>
+            <td>
+                Percentage of frames to keep after checking for blurriness. If this is 90, the
+                blurriest 10% of frames will be dropped. A value of 100 will skip the filter-blurry
+                step.
+            </td>
+        </tr>
+        <tr>
+            <td>Other Args</td>
+            <td><input type="text" name="stepArgs[filter-blurry]"/></td>
+            <td>
+                Additional space-separated arguments to pass to splat.py filter-blurry.
+            </td>
+        </tr>
         </tbody>
 
-        <tr><td colspan="4"><hr/></td></tr>
+        <tr>
+            <td colspan="4">
+                <hr/>
+            </td>
+        </tr>
 
         <tbody>
         <tr>
@@ -107,83 +120,108 @@
         </tr>
         </tbody>
 
-        <tr><td colspan="4"><hr/></td></tr>
+        <tr>
+            <td colspan="4">
+                <hr/>
+            </td>
+        </tr>
 
         <tbody>
-            <tr>
-                <td rowspan="2">feature-matcher</td>
-                <td>Subcommand</td>
-                <td>
-                    <input type="text" name="featureMatcherSubcommand" placeholder="sequential_matcher"/>
-                </td>
-                <td>
-                    Which colmap subcommand to use for feature matching.
-                </td>
-            </tr>
-            <tr>
-                <td>Other Args</td>
-                <td><input type="text" name="stepArgs[feature-matcher]"/></td>
-                <td>
-                    Additional space-separated arguments to pass to colmap.
-                </td>
-            </tr>
+        <tr>
+            <td rowspan="2">feature-matcher</td>
+            <td>Subcommand</td>
+            <td>
+                <input type="text" name="featureMatcherSubcommand"
+                       placeholder="sequential_matcher"/>
+            </td>
+            <td>
+                Which colmap subcommand to use for feature matching.
+            </td>
+        </tr>
+        <tr>
+            <td>Other Args</td>
+            <td><input type="text" name="stepArgs[feature-matcher]"/></td>
+            <td>
+                Additional space-separated arguments to pass to colmap.
+            </td>
+        </tr>
         </tbody>
 
-        <tr><td colspan="4"><hr/></td></tr>
+        <tr>
+            <td colspan="4">
+                <hr/>
+            </td>
+        </tr>
 
         <tbody>
-            <tr>
-                <td>colmap</td>
-                <td>Other Args</td>
-                <td><input type="text" name="stepArgs[colmap]"/></td>
-                <td>
-                    Additional space-separated arguments to pass to colmap.
-                </td>
-            </tr>
+        <tr>
+            <td>colmap</td>
+            <td>Other Args</td>
+            <td><input type="text" name="stepArgs[colmap]"/></td>
+            <td>
+                Additional space-separated arguments to pass to colmap.
+            </td>
+        </tr>
         </tbody>
 
-        <tr><td colspan="4"><hr/></td></tr>
+        <tr>
+            <td colspan="4">
+                <hr/>
+            </td>
+        </tr>
 
         <tbody>
-            <tr>
-                <td>model-converter-1</td>
-                <td>Other Args</td>
-                <td><input type="text" name="stepArgs[model-converter-1]"/></td>
-                <td>
-                    Additional space-separated arguments to pass to the first invocation of
-                    colmap model_converter.
-                </td>
-            </tr>
+        <tr>
+            <td>model-converter-1</td>
+            <td>Other Args</td>
+            <td><input type="text" name="stepArgs[model-converter-1]"/></td>
+            <td>
+                Additional space-separated arguments to pass to the first invocation of
+                colmap model_converter.
+            </td>
+        </tr>
         </tbody>
 
-        <tr><td colspan="4"><hr/></td></tr>
+        <tr>
+            <td colspan="4">
+                <hr/>
+            </td>
+        </tr>
 
         <tbody>
-            <tr>
-                <td>check-1</td>
-                <td>Other Args</td>
-                <td><input type="text" name="stepArgs[check-1]"/></td>
-                <td>
-                    Additional space-separated arguments to pass to the first invocation of
-                    check_reconstruction.py.
-                </td>
-            </tr>
+        <tr>
+            <td>check-1</td>
+            <td>Other Args</td>
+            <td><input type="text" name="stepArgs[check-1]"/></td>
+            <td>
+                Additional space-separated arguments to pass to the first invocation of
+                check_reconstruction.py.
+            </td>
+        </tr>
         </tbody>
 
-        <tr><td colspan="4"><hr/></td></tr>
+        <tr>
+            <td colspan="4">
+                <hr/>
+            </td>
+        </tr>
 
         <tbody>
-            <tr>
-                <td>prune-spikes</td>
-                <td>Other Args</td>
-                <td><input type="text" name="stepArgs[prune-spikes]"/></td>
-                <td>
-                    Additional space-separated arguments to pass to prune_spikes.py if it is run.
-                </td>
-            </tr>
+        <tr>
+            <td>prune-spikes</td>
+            <td>Other Args</td>
+            <td><input type="text" name="stepArgs[prune-spikes]"/></td>
+            <td>
+                Additional space-separated arguments to pass to prune_spikes.py if it is run.
+            </td>
+        </tr>
         </tbody>
 
-        <tr><td colspan="4"><hr/></td></tr>
+        <tr>
+            <td colspan="4">
+                <hr/>
+            </td>
+        </tr>
 
         <tbody>
         <tr>
@@ -197,7 +235,11 @@
         </tr>
         </tbody>
 
-        <tr><td colspan="4"><hr/></td></tr>
+        <tr>
+            <td colspan="4">
+                <hr/>
+            </td>
+        </tr>
 
         <tbody>
         <tr>
@@ -210,7 +252,11 @@
         </tr>
         </tbody>
 
-        <tr><td colspan="4"><hr/></td></tr>
+        <tr>
+            <td colspan="4">
+                <hr/>
+            </td>
+        </tr>
 
         <tbody>
         <tr>
@@ -224,7 +270,11 @@
         </tr>
         </tbody>
 
-        <tr><td colspan="4"><hr/></td></tr>
+        <tr>
+            <td colspan="4">
+                <hr/>
+            </td>
+        </tr>
 
         <tbody>
         <tr>
@@ -238,135 +288,163 @@
         </tr>
         </tbody>
 
-        <tr><td colspan="4"><hr/></td></tr>
+        <tr>
+            <td colspan="4">
+                <hr/>
+            </td>
+        </tr>
 
         <tbody>
-            <tr>
-                <td rowspan="2">prune-tail</td>
-                <td>Tail Pruning</td>
-                <td>
-                    <select name="tailPruning">
-                        <option value="" selected>Default</option>
-                        <option value="true">Enable</option>
-                        <option value="false">Disable</option>
-                    </select>
-                </td>
-                <td>
-                    Enable or disable tail pruning. Default is enabled. Tail pruning is not run if
-                    check-3 succeeds, regardless of this setting.
-                </td>
-            </tr>
-            <tr>
-                <td>Other Args</td>
-                <td><input type="text" name="stepArgs[prune-tail]"/></td>
-                <td>
-                    Additional space-separated arguments to pass to prune_tail.py.
-                </td>
-            </tr>
+        <tr>
+            <td rowspan="2">prune-tail</td>
+            <td>Tail Pruning</td>
+            <td>
+                <select name="tailPruning">
+                    <option value="" selected>Default</option>
+                    <option value="true">Enable</option>
+                    <option value="false">Disable</option>
+                </select>
+            </td>
+            <td>
+                Enable or disable tail pruning. Default is enabled. Tail pruning is not run if
+                check-3 succeeds, regardless of this setting.
+            </td>
+        </tr>
+        <tr>
+            <td>Other Args</td>
+            <td><input type="text" name="stepArgs[prune-tail]"/></td>
+            <td>
+                Additional space-separated arguments to pass to prune_tail.py.
+            </td>
+        </tr>
         </tbody>
 
-        <tr><td colspan="4"><hr/></td></tr>
+        <tr>
+            <td colspan="4">
+                <hr/>
+            </td>
+        </tr>
 
         <tbody>
-            <tr>
-                <td>prepare</td>
-                <td>Other Args</td>
-                <td><input type="text" name="stepArgs[prepare]"/></td>
-                <td>
-                    Additional space-separated arguments to pass to splat.py prepare.
-                </td>
-            </tr>
+        <tr>
+            <td>prepare</td>
+            <td>Other Args</td>
+            <td><input type="text" name="stepArgs[prepare]"/></td>
+            <td>
+                Additional space-separated arguments to pass to splat.py prepare.
+            </td>
+        </tr>
         </tbody>
 
-        <tr><td colspan="4"><hr/></td></tr>
+        <tr>
+            <td colspan="4">
+                <hr/>
+            </td>
+        </tr>
 
         <tbody>
-            <tr>
-                <td rowspan="4">gsplat</td>
-                <td>Data Factor</td>
-                <td><input type="text" name="dataFactor" placeholder="1"/></td>
-                <td>
-                    Downscale frames by this factor during model training. You will probably want
-                    to adjust Max Size rather than this.
-                </td>
-            </tr>
-            <tr>
-                <td>Max Steps</td>
-                <td><input type="text" name="maxSteps" placeholder="30000"/></td>
-                <td>
-                    Number of training steps to run.
-                </td>
-            </tr>
-            <tr>
-                <td>SSIM Lambda</td>
-                <td><input type="text" name="ssimLambda" placeholder="0.1"/></td>
-                <td>
-                    Controls how much the training loss emphasizes structural similarity (SSIM) versus
-                    raw pixel accuracy. Higher values tend to produce smoother, more visually
-                    consistent results, while lower values prioritize sharper pixel-level detail.
-                    Higher values also tend to produce larger model files.
-                </td>
-            </tr>
-            <tr>
-                <td>Other Args</td>
-                <td><input type="text" name="stepArgs[gsplat]"/></td>
-                <td>
-                    Additional space-separated arguments to pass to simple_trainer.py.
-                </td>
-            </tr>
+        <tr>
+            <td rowspan="4">gsplat</td>
+            <td>Data Factor</td>
+            <td><input type="text" name="dataFactor" placeholder="1"/></td>
+            <td>
+                Downscale frames by this factor during model training. You will probably want
+                to adjust Max Size rather than this.
+            </td>
+        </tr>
+        <tr>
+            <td>Max Steps</td>
+            <td><input type="text" name="maxSteps" placeholder="30000"/></td>
+            <td>
+                Number of training steps to run.
+            </td>
+        </tr>
+        <tr>
+            <td>SSIM Lambda</td>
+            <td><input type="text" name="ssimLambda" placeholder="0.1"/></td>
+            <td>
+                Controls how much the training loss emphasizes structural similarity (SSIM) versus
+                raw pixel accuracy. Higher values tend to produce smoother, more visually
+                consistent results, while lower values prioritize sharper pixel-level detail.
+                Higher values also tend to produce larger model files.
+            </td>
+        </tr>
+        <tr>
+            <td>Other Args</td>
+            <td><input type="text" name="stepArgs[gsplat]"/></td>
+            <td>
+                Additional space-separated arguments to pass to simple_trainer.py.
+            </td>
+        </tr>
         </tbody>
 
-        <tr><td colspan="4"><hr/></td></tr>
+        <tr>
+            <td colspan="4">
+                <hr/>
+            </td>
+        </tr>
 
         <tbody>
-            <tr>
-                <td>splat-transform</td>
-                <td>Other Args</td>
-                <td><input type="text" name="stepArgs[splat-transform]"/></td>
-                <td>
-                    Additional space-separated arguments to pass to splat-transform.
-                </td>
-            </tr>
+        <tr>
+            <td>splat-transform</td>
+            <td>Other Args</td>
+            <td><input type="text" name="stepArgs[splat-transform]"/></td>
+            <td>
+                Additional space-separated arguments to pass to splat-transform.
+            </td>
+        </tr>
         </tbody>
 
-        <tr><td colspan="4"><hr/></td></tr>
+        <tr>
+            <td colspan="4">
+                <hr/>
+            </td>
+        </tr>
 
         <tbody>
-            <tr>
-                <td rowspan="4"></td>
-                <td>Abort After</td>
-                <td><input type="text" name="abortAfter"/></td>
-                <td>
-                    Abort the processing run after this step. Step names are the same as the
-                    names in the left column of this table.
-                </td>
-            </tr>
-            <tr>
-                <td>Restart At</td>
-                <td><input type="text" name="restartAt"/></td>
-                <td>
-                    Restart the processing run at this step, using the files in the archived job
-                    directory. Step names are the same as the names in the left column of this
-                    table.
-                </td>
-            </tr>
+        <tr>
+            <td rowspan="4"></td>
+            <td>Abort After</td>
+            <td><input type="text" name="abortAfter"/></td>
+            <td>
+                Abort the processing run after this step. Step names are the same as the
+                names in the left column of this table.
+            </td>
+        </tr>
+        <tr>
+            <td>Restart At</td>
+            <td><input type="text" name="restartAt"/></td>
+            <td>
+                Restart the processing run at this step, using the files in the archived job
+                directory. Step names are the same as the names in the left column of this
+                table.
+            </td>
+        </tr>
 
         </tbody>
 
-        <tr><td colspan="4"><hr/></td></tr>
+        <tr>
+            <td colspan="4">
+                <hr/>
+            </td>
+        </tr>
 
         <tbody>
         <tr>
             <td rowspan="2">birdnet</td>
             <td>Run BirdNET</td>
-            <td><input type="checkbox" id="runBirdNet" name="runBirdNet" /></td>
+            <td><input type="checkbox" id="runBirdNet" name="runBirdNet"/></td>
             <td>
                 Enable BirdNET
             </td>
         </tr>
         </tbody>
 
-        <tr><td colspan="4"><hr/></td></tr>
+        <tr>
+            <td colspan="4">
+                <hr/>
+            </td>
+        </tr>
 
         <tr>
             <td colspan="2"/>

--- a/src/main/resources/templates/admin/voters.html
+++ b/src/main/resources/templates/admin/voters.html
@@ -85,35 +85,35 @@
         </td>
         <td>
             <th:block th:if="${selectedUser != null}">
-            <form method="POST"
-                  th:id="add-user-default-voter"
-                  action="/admin/voters/default/add">
-                <input type="hidden"
-                       name="email"
-                       th:if="${selectedEmail} != null"
-                       th:value="${selectedEmail}"/>
-                <input type="hidden" name="userId" th:value="${selectedUser}"/>
-                <input type="submit"
-                       value="Add"
-                       th:disabled="${#sets.contains(defaultVoters, selectedUser)}" />
-            </form>
+                <form method="POST"
+                      th:id="add-user-default-voter"
+                      action="/admin/voters/default/add">
+                    <input type="hidden"
+                           name="email"
+                           th:if="${selectedEmail} != null"
+                           th:value="${selectedEmail}"/>
+                    <input type="hidden" name="userId" th:value="${selectedUser}"/>
+                    <input type="submit"
+                           value="Add"
+                           th:disabled="${#sets.contains(defaultVoters, selectedUser)}"/>
+                </form>
             </th:block>
         </td>
         <td>
             <th:block th:if="${selectedUser != null}">
-            <form method="POST"
-                  th:id="remove-user-default-voter"
-                  th:if="${#sets.contains(defaultVoters, selectedUser)}"
-                  action="/admin/voters/default/remove">
-                <input type="hidden"
-                       name="email"
-                       th:if="${selectedEmail} != null"
-                       th:value="${selectedEmail}"/>
-                <input type="hidden" name="userIds" th:value="${selectedUser}"/>
-                <input type="submit"
-                       value="Remove"
-                       th:disabled="${!#sets.contains(defaultVoters, selectedUser)}" />
-            </form>
+                <form method="POST"
+                      th:id="remove-user-default-voter"
+                      th:if="${#sets.contains(defaultVoters, selectedUser)}"
+                      action="/admin/voters/default/remove">
+                    <input type="hidden"
+                           name="email"
+                           th:if="${selectedEmail} != null"
+                           th:value="${selectedEmail}"/>
+                    <input type="hidden" name="userIds" th:value="${selectedUser}"/>
+                    <input type="submit"
+                           value="Remove"
+                           th:disabled="${!#sets.contains(defaultVoters, selectedUser)}"/>
+                </form>
             </th:block>
         </td>
     </tr>
@@ -144,36 +144,36 @@
         </td>
         <td>
             <th:block th:if="${selectedUser != null}">
-            <form method="POST"
-                  th:id="|add-user-${project.projectId}|"
-                  action="/admin/voters/add">
-                <input type="hidden"
-                       name="email"
-                       th:if="${selectedEmail} != null"
-                       th:value="${selectedEmail}"/>
-                <input type="hidden" name="projectId" th:value="${project.projectId}"/>
-                <input type="hidden" name="userId" th:value="${selectedUser}"/>
-                <input type="submit"
-                       value="Add"
-                       th:disabled="${#sets.contains(projectVoters.get(project.projectId), selectedUser)}" />
-            </form>
+                <form method="POST"
+                      th:id="|add-user-${project.projectId}|"
+                      action="/admin/voters/add">
+                    <input type="hidden"
+                           name="email"
+                           th:if="${selectedEmail} != null"
+                           th:value="${selectedEmail}"/>
+                    <input type="hidden" name="projectId" th:value="${project.projectId}"/>
+                    <input type="hidden" name="userId" th:value="${selectedUser}"/>
+                    <input type="submit"
+                           value="Add"
+                           th:disabled="${#sets.contains(projectVoters.get(project.projectId), selectedUser)}"/>
+                </form>
             </th:block>
         </td>
         <td>
             <th:block th:if="${selectedUser != null}">
-            <form method="POST"
-                  th:id="|remove-user-${project.projectId}|"
-                  action="/admin/voters/remove">
-                <input type="hidden"
-                       name="email"
-                       th:if="${selectedEmail} != null"
-                       th:value="${selectedEmail}"/>
-                <input type="hidden" name="projectId" th:value="${project.projectId}"/>
-                <input type="hidden" name="userIds" th:value="${selectedUser}"/>
-                <input type="submit"
-                       value="Remove"
-                       th:disabled="${!#sets.contains(projectVoters.get(project.projectId), selectedUser)}" />
-            </form>
+                <form method="POST"
+                      th:id="|remove-user-${project.projectId}|"
+                      action="/admin/voters/remove">
+                    <input type="hidden"
+                           name="email"
+                           th:if="${selectedEmail} != null"
+                           th:value="${selectedEmail}"/>
+                    <input type="hidden" name="projectId" th:value="${project.projectId}"/>
+                    <input type="hidden" name="userIds" th:value="${selectedUser}"/>
+                    <input type="submit"
+                           value="Remove"
+                           th:disabled="${!#sets.contains(projectVoters.get(project.projectId), selectedUser)}"/>
+                </form>
             </th:block>
         </td>
     </tr>


### PR DESCRIPTION
Format all admin html pages (using `cmd+option+L` in IntelliJ) to match `.editorconfig`. 