### PR TITLE
SW-8202 Suppress search service logs in CI tests

### DIFF
--- a/.buildkite/scripts/build-and-test.sh
+++ b/.buildkite/scripts/build-and-test.sh
@@ -43,6 +43,11 @@ echo "--- :gradle: Compile tests"
 ./gradlew testClasses
 
 echo "--- :junit: Run tests"
+
+# Suppress some debug log messages that add up to megabytes of test output and slow down annotating
+# the test results.
+export LOGGING_LEVEL_COM_TERRAFORMATION_BACKEND_SEARCH=INFO
+
 ./gradlew test
 
 # We don't run the tests that depend on external services here. We want failures in that test suite


### PR DESCRIPTION
The log messages from SearchService add up to megabytes of output on a test run
thanks to the fact that we're stress-testing the search code with large complex
queries. The "annotate test results" step in the Buildkite build then has to
parse through all that data, which causes the annotation to take a lot longer
than it otherwise would.