### PR TITLE
[DRAFT] Allow Buildkite steps to run in parallel

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -56,8 +56,8 @@ agents:
   queue: "x86-8core"
 
 steps:
-  - label: ":gradle: Build and test"
-    key: "build-and-test"
+  - label: ":gradle: Build"
+    key: "build"
     plugins:
       - *shallow-clone
       - cache#v1.10.0:
@@ -79,15 +79,39 @@ steps:
       - artifacts#v1.9.4:
           upload: ".gradle-home/caches/build-cache-1"
           compressed: "build-cache.tgz"
-    command: .buildkite/scripts/build-and-test.sh
+    command: .buildkite/scripts/build.sh
+    artifact_paths:
+      - "build/generator.*"
+
+  - label: ":gradle: Run internal tests"
+    key: "run-tests"
+    depends_on: "build"
+    plugins:
+      - *shallow-clone
+      - *cache-gradle-home
+      - *cache-node-modules
+      - *restore-build-cache
+      - *restore-build
+      - *restore-dot-gradle
+      - artifacts#v1.9.4:
+          upload: "build"
+          compressed: "build.tgz"
+      - artifacts#v1.9.4:
+          upload: ".gradle"
+          compressed: "dot-gradle.tgz"
+      - artifacts#v1.9.4:
+          upload: ".gradle-home/caches/build-cache-1"
+          compressed: "build-cache.tgz"
+    command: .buildkite/scripts/run-tests.sh
     artifact_paths:
       # We need to upload the test results as individual files so they can be consumed by the
       # junit-annotate plugin.
       - "build/test-results/**/*.xml"
+      - "build/generator.*"
 
   - label: ":junit: Run external service integration tests"
     key: "external-tests"
-    depends_on: "build-and-test"
+    depends_on: "run-tests"
     soft_fail: true
     if: "build.branch != 'main' && build.tag == null"
     plugins:
@@ -108,10 +132,6 @@ steps:
 
   - label: ":python: Check scripts"
     key: "check-scripts"
-    depends_on:
-      - step: "build-and-test"
-      - step: "external-tests"
-        allow_failure: true
     if_changed: "scripts/**"
     plugins:
       - *shallow-clone
@@ -128,8 +148,7 @@ steps:
   - label: ":junit: Annotate build with test results"
     key: "junit-annotate"
     depends_on:
-      - step: "build-and-test"
-      - step: "check-scripts"
+      - step: "run-tests"
       - step: "external-tests"
         allow_failure: true
     plugins:
@@ -141,7 +160,7 @@ steps:
 
   - label: ":docker: Build and push Docker image"
     key: "docker"
-    depends_on: "junit-annotate"
+    depends_on: "build"
     plugins:
       - *shallow-clone
       - *load-secrets
@@ -177,7 +196,7 @@ steps:
 
   - label: ":buildkite: Promote branch-level script cache to pipeline-level"
     key: "promote-script-cache"
-    depends_on: "promote-caches"
+    depends_on: "check-scripts"
     branches: "main"
     if_changed: "scripts/**"
     plugins:
@@ -194,10 +213,7 @@ steps:
     key: "deploy"
     concurrency: 1
     concurrency_group: "terraware-server/deploy"
-    depends_on:
-      - "docker"
-      - "promote-caches"
-      - "promote-script-cache"
+    depends_on: "docker"
     if: "build.branch == 'main' || build.tag =~ /^v2[0-9]+\\.[0-9]+/"
     plugins:
       - *shallow-clone
@@ -215,9 +231,7 @@ steps:
 
   - label: ":speech_balloon: Notify PR of staging deploy"
     key: "notify-pr"
-    depends_on:
-      - "deploy"
-      - "release-notes"
+    depends_on: "deploy"
     branches: "main"
     plugins:
       - *shallow-clone
@@ -226,9 +240,7 @@ steps:
 
   - label: ":books: Generate and deploy docs"
     key: "generate-docs"
-    depends_on:
-      - "docker"
-      - "notify-pr"
+    depends_on: "docker"
     branches: "main"
     plugins:
       - *shallow-clone

--- a/.buildkite/scripts/build.sh
+++ b/.buildkite/scripts/build.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+.buildkite/scripts/install-deps.sh --java --tools --node
+
+echo "--- :gradle: Download dependencies"
+
+# We don't care about build caches from previous runs.
+if [ -d "$GRADLE_USER_HOME/caches/build-cache-1" ]; then
+    rm -rf "$GRADLE_USER_HOME/caches/build-cache-1"
+fi
+
+./gradlew downloadDependencies yarn
+
+echo "--- :gradle: Generate jOOQ classes"
+./gradlew generateJooqClasses
+
+echo "--- :gradle: Check code style"
+./gradlew spotlessCheck
+
+echo "--- :gradle: Compile main"
+./gradlew classes

--- a/.buildkite/scripts/run-tests.sh
+++ b/.buildkite/scripts/run-tests.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+.buildkite/scripts/install-deps.sh --java --tools
+
+echo "--- :openapi: Generate OpenAPI docs to test that server can start up"
+./gradlew generateOpenApiDocs
+
+echo "--- :openapi: Diff OpenAPI docs against staging"
+if curl -f -s https://staging.terraware.io/v3/api-docs.yaml > staging.yaml; then
+  for f in openapi.yaml staging.yaml; do
+    yq -i '
+      .info.version = null |
+      .servers[0].url = null |
+      .components.securitySchemes.openId.openIdConnectUrl = null' "$f"
+  done
+
+  # Indent the diff output so the "---" in the diff header isn't treated as a section header.
+  diff -u staging.yaml openapi.yaml | sed 's/^/ /' || true
+else
+  echo "Unable to fetch OpenAPI schema from staging"
+fi
+
+echo "--- :gradle: Compile tests"
+./gradlew testClasses
+
+echo "--- :junit: Run tests"
+
+# Suppress some debug log messages that add up to megabytes of test output and slow down annotating
+# the test results.
+export LOGGING_LEVEL_COM_TERRAFORMATION_BACKEND_SEARCH=INFO
+
+./gradlew test
+
+# We don't run the tests that depend on external services here. We want failures in that test suite
+# to show up as soft failures in the build status, which requires that we run them in a separate
+# build step.


### PR DESCRIPTION
Relax the dependency graph in the Buildkite pipeline to allow independent steps to
run concurrently.