### PR TITLE
SW-8202 Fix release notes generation, Jira update

### DIFF
--- a/.buildkite/scripts/lib/fetch-tag.sh
+++ b/.buildkite/scripts/lib/fetch-tag.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Keep fetching older and older commits until we find a particular tag.
+# Fetch all the commits between a particular tag and the current HEAD.
 #
 set -euo pipefail
 
@@ -16,19 +16,21 @@ MAX_DEPTH=500
 STEP=50
 DEPTH=0
 
+HEAD_REF="$(git rev-parse HEAD)"
+
 while true; do
-    if git rev-parse "$SEARCH_TAG" >/dev/null 2>&1; then
-        echo "Found tag $SEARCH_TAG"
+    if git merge-base --is-ancestor "$SEARCH_TAG" HEAD >/dev/null 2>&1; then
+        echo "Found history from $SEARCH_TAG to HEAD"
         exit 0
     fi
 
     if [ "$DEPTH" -ge "$MAX_DEPTH" ]; then
-        echo "Could not find tag $SEARCH_TAG"
+        echo "Could not find history between $SEARCH_TAG and HEAD"
         exit 1
     fi
 
     DEPTH=$((DEPTH + STEP))
 
     echo "Fetching with depth=$DEPTH"
-    git fetch --tags --depth=$DEPTH
+    git fetch --depth=$DEPTH origin "$HEAD_REF"
 done

--- a/.buildkite/scripts/release-notes.sh
+++ b/.buildkite/scripts/release-notes.sh
@@ -44,7 +44,7 @@ echo "--- :atlassian-jira: Transition Jira issues"
 if [[ -n "${JIRA_BASE_URL:-}" && -n "${JIRA_USER_EMAIL:-}" && -n "${JIRA_API_TOKEN:-}" ]]; then
     # Fetch the unreleased log from GitHub Pages and extract Jira issue keys
     JIRA_ISSUES=$(curl -s https://terraware.github.io/terraware-server/unreleased.log |
-        grep -Eo 'SW-[0-9]+' || true |
+        (grep -Eo 'SW-[0-9]+' || true) |
         sort -u)
 
     JIRA_AUTH=$(echo -n "${JIRA_USER_EMAIL}:${JIRA_API_TOKEN}" | base64)

--- a/.buildkite/scripts/release-notes.sh
+++ b/.buildkite/scripts/release-notes.sh
@@ -44,7 +44,7 @@ echo "--- :atlassian-jira: Transition Jira issues"
 if [[ -n "${JIRA_BASE_URL:-}" && -n "${JIRA_USER_EMAIL:-}" && -n "${JIRA_API_TOKEN:-}" ]]; then
     # Fetch the unreleased log from GitHub Pages and extract Jira issue keys
     JIRA_ISSUES=$(curl -s https://terraware.github.io/terraware-server/unreleased.log |
-        grep -Eo 'SW-[0-9]+' |
+        grep -Eo 'SW-[0-9]+' || true |
         sort -u)
 
     JIRA_AUTH=$(echo -n "${JIRA_USER_EMAIL}:${JIRA_API_TOKEN}" | base64)


### PR DESCRIPTION
We weren't fetching additional commits correctly when generating the unreleased
changes log, and we weren't handling the case where a release didn't contain
any commits that mentioned Jira tasks.