### PR TITLE
SW-8202 Improve cache usage between steps

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -9,10 +9,23 @@ common:
   - &cache-gradle-home-args
     <<: *cache-common-args
     path: ".gradle-home"
+    manifest:
+      - "build.gradle.kts"
+      - "gradle.properties"
+      - "settings.gradle.kts"
 
   - &cache-gradle-home
     cache#v1.10.0:
       <<: *cache-gradle-home-args
+
+  - &cache-node-modules-args
+    <<: *cache-common-args
+    path: "node_modules"
+    manifest: "yarn.lock"
+
+  - &cache-node-modules
+    cache#v1.10.0:
+      <<: *cache-node-modules-args
 
   - &load-secrets
     seek-oss/aws-sm#v2.4.1:
@@ -49,22 +62,14 @@ steps:
       - *shallow-clone
       - cache#v1.10.0:
           <<: *cache-gradle-home-args
-          manifest:
-            - "build.gradle.kts"
-            - "gradle.properties"
-            - "settings.gradle.kts"
           save:
             - file
             - branch
-          force: true
       - cache#v1.10.0:
-          <<: *cache-common-args
-          path: "node_modules"
-          manifest: "yarn.lock"
+          <<: *cache-node-modules-args
           save:
             - file
             - branch
-          force: true
       - artifacts#v1.9.4:
           upload: "build"
           compressed: "build.tgz"
@@ -88,6 +93,7 @@ steps:
     plugins:
       - *shallow-clone
       - *cache-gradle-home
+      - *cache-node-modules
       - *restore-build-cache
       - *restore-build
       - *restore-dot-gradle
@@ -140,6 +146,7 @@ steps:
       - *shallow-clone
       - *load-secrets
       - *cache-gradle-home
+      - *cache-node-modules
       - cache#v1.10.0:
           <<: *cache-common-args
           path: ".buildx-cache"
@@ -160,10 +167,9 @@ steps:
       - cache#v1.10.0: &promote-cache
           <<: *cache-gradle-home-args
           save: "pipeline"
-          force: true
       - cache#v1.10.0:
-          <<: *promote-cache
-          path: "node_modules"
+          <<: *cache-node-modules-args
+          save: "pipeline"
       - cache#v1.10.0:
           <<: *promote-cache
           path: ".buildx-cache"

--- a/.buildkite/scripts/install-deps.sh
+++ b/.buildkite/scripts/install-deps.sh
@@ -12,14 +12,12 @@ PYTHON_VERSION=3.13
 
 install_corretto() {
     JAVA_HOME="/usr/lib/jvm/java-${JAVA_VERSION}-amazon-corretto"
-    if [ -f "$JAVA_HOME/bin/java" ]; then
-        return
+    if [ ! -f "$JAVA_HOME/bin/java" ]; then
+        echo "Installing Amazon Corretto ${JAVA_VERSION}..."
+        sudo rpm --import https://yum.corretto.aws/corretto.key
+        sudo curl -sL -o /etc/yum.repos.d/corretto.repo https://yum.corretto.aws/corretto.repo
+        sudo dnf install -y "java-${JAVA_VERSION}-amazon-corretto-devel"
     fi
-
-    echo "Installing Amazon Corretto ${JAVA_VERSION}..."
-    sudo rpm --import https://yum.corretto.aws/corretto.key
-    sudo curl -sL -o /etc/yum.repos.d/corretto.repo https://yum.corretto.aws/corretto.repo
-    sudo dnf install -y "java-${JAVA_VERSION}-amazon-corretto-devel"
 
     echo "JAVA_HOME=${JAVA_HOME}" >> "$BUILDKITE_ENV_FILE"
     echo "org.gradle.java.installations.paths=${JAVA_HOME}" >> gradle.properties

--- a/.buildkite/scripts/install-deps.sh
+++ b/.buildkite/scripts/install-deps.sh
@@ -19,8 +19,8 @@ install_corretto() {
         sudo dnf install -y "java-${JAVA_VERSION}-amazon-corretto-devel"
     fi
 
-    echo "JAVA_HOME=${JAVA_HOME}" >> "$BUILDKITE_ENV_FILE"
-    echo "org.gradle.java.installations.paths=${JAVA_HOME}" >> gradle.properties
+    #echo "JAVA_HOME=${JAVA_HOME}" >> "$BUILDKITE_ENV_FILE"
+    #echo "org.gradle.java.installations.paths=${JAVA_HOME}" >> gradle.properties
 }
 
 install_jq() {

--- a/.buildkite/scripts/install-deps.sh
+++ b/.buildkite/scripts/install-deps.sh
@@ -11,16 +11,14 @@ NODE_VERSION=22
 PYTHON_VERSION=3.13
 
 install_corretto() {
-    JAVA_HOME="/usr/lib/jvm/java-${JAVA_VERSION}-amazon-corretto"
-    if [ ! -f "$JAVA_HOME/bin/java" ]; then
-        echo "Installing Amazon Corretto ${JAVA_VERSION}..."
-        sudo rpm --import https://yum.corretto.aws/corretto.key
-        sudo curl -sL -o /etc/yum.repos.d/corretto.repo https://yum.corretto.aws/corretto.repo
-        sudo dnf install -y "java-${JAVA_VERSION}-amazon-corretto-devel"
+    if [ -f "/usr/lib/jvm/java-${JAVA_VERSION}-amazon-corretto/bin/java" ]; then
+        return
     fi
 
-    #echo "JAVA_HOME=${JAVA_HOME}" >> "$BUILDKITE_ENV_FILE"
-    #echo "org.gradle.java.installations.paths=${JAVA_HOME}" >> gradle.properties
+    echo "Installing Amazon Corretto ${JAVA_VERSION}..."
+    sudo rpm --import https://yum.corretto.aws/corretto.key
+    sudo curl -sL -o /etc/yum.repos.d/corretto.repo https://yum.corretto.aws/corretto.repo
+    sudo dnf install -y "java-${JAVA_VERSION}-amazon-corretto-devel"
 }
 
 install_jq() {


### PR DESCRIPTION
Restore the `node_modules` directory in steps that run Gradle so the Yarn
task isn't considered out of date.

Don't mutate gradle.properties to set the Java home directory; Gradle will
figure out the correct Java home on its own.

Always use manifests for the Gradle home and `node_modules` cache entries
so Buildkite can skip re-uploading them if they haven't changed.