### PR TITLE
SW-8244 Fix NPE in survival rate recalculation when substrata are deleted

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/tracking/db/ObservationStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/db/ObservationStore.kt
@@ -849,18 +849,17 @@ class ObservationStore(
           conditions.map { ObservationPlotConditionsRow(observationId, monitoringPlotId, it) }
       )
 
-      val plantsRecords =
-          plants.map { plantsRow ->
-            RecordedPlantsRecord(
-                certaintyId = plantsRow.certaintyId,
-                gpsCoordinates = plantsRow.gpsCoordinates,
-                monitoringPlotId = monitoringPlotId,
-                observationId = observationId,
-                speciesId = plantsRow.speciesId,
-                speciesName = plantsRow.speciesName,
-                statusId = plantsRow.statusId,
-            )
-          }
+      val plantsRecords = plants.map { plantsRow ->
+        RecordedPlantsRecord(
+            certaintyId = plantsRow.certaintyId,
+            gpsCoordinates = plantsRow.gpsCoordinates,
+            monitoringPlotId = monitoringPlotId,
+            observationId = observationId,
+            speciesId = plantsRow.speciesId,
+            speciesName = plantsRow.speciesName,
+            statusId = plantsRow.statusId,
+        )
+      }
 
       dslContext.batchInsert(plantsRecords).execute()
 
@@ -1362,12 +1361,11 @@ class ObservationStore(
                 }
               }
               .map { it.id!! }
-      val coordinatesToInsert =
-          coordinates.filter { desired ->
-            existingCoordinates.none {
-              it.positionId == desired.position && it.gpsCoordinates == desired.gpsCoordinates
-            }
-          }
+      val coordinatesToInsert = coordinates.filter { desired ->
+        existingCoordinates.none {
+          it.positionId == desired.position && it.gpsCoordinates == desired.gpsCoordinates
+        }
+      }
 
       if (coordinateIdsToDelete.isNotEmpty()) {
         dslContext
@@ -1623,7 +1621,7 @@ class ObservationStore(
   }
 
   fun recalculateSurvivalRates(stratumId: StratumId) {
-    val substratumGroups: Map<SubstratumId, List<MonitoringPlotId>> =
+    val substratumGroups: Map<SubstratumId?, List<MonitoringPlotId>> =
         with(SUBSTRATUM_HISTORIES) {
           dslContext
               .selectDistinct(
@@ -1635,7 +1633,7 @@ class ObservationStore(
               .on(ID.eq(MONITORING_PLOT_HISTORIES.SUBSTRATUM_HISTORY_ID))
               .where(stratumHistories.STRATUM_ID.eq(stratumId))
               .fetchGroups(
-                  SUBSTRATUM_ID.asNonNullable(),
+                  SUBSTRATUM_ID,
                   MONITORING_PLOT_HISTORIES.MONITORING_PLOT_ID.asNonNullable(),
               )
         }
@@ -1644,7 +1642,9 @@ class ObservationStore(
       recalculateSurvivalRate(ObservationSpeciesPlot(it))
     }
 
-    substratumGroups.keys.forEach { recalculateSurvivalRate(ObservationSpeciesSubstratum(it)) }
+    substratumGroups.keys.filterNotNull().forEach {
+      recalculateSurvivalRate(ObservationSpeciesSubstratum(it))
+    }
 
     recalculateSurvivalRate(ObservationSpeciesStratum(stratumId))
 

--- a/src/main/kotlin/com/terraformation/backend/tracking/db/ObservationStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/db/ObservationStore.kt
@@ -849,17 +849,18 @@ class ObservationStore(
           conditions.map { ObservationPlotConditionsRow(observationId, monitoringPlotId, it) }
       )
 
-      val plantsRecords = plants.map { plantsRow ->
-        RecordedPlantsRecord(
-            certaintyId = plantsRow.certaintyId,
-            gpsCoordinates = plantsRow.gpsCoordinates,
-            monitoringPlotId = monitoringPlotId,
-            observationId = observationId,
-            speciesId = plantsRow.speciesId,
-            speciesName = plantsRow.speciesName,
-            statusId = plantsRow.statusId,
-        )
-      }
+      val plantsRecords =
+          plants.map { plantsRow ->
+            RecordedPlantsRecord(
+                certaintyId = plantsRow.certaintyId,
+                gpsCoordinates = plantsRow.gpsCoordinates,
+                monitoringPlotId = monitoringPlotId,
+                observationId = observationId,
+                speciesId = plantsRow.speciesId,
+                speciesName = plantsRow.speciesName,
+                statusId = plantsRow.statusId,
+            )
+          }
 
       dslContext.batchInsert(plantsRecords).execute()
 
@@ -1361,11 +1362,12 @@ class ObservationStore(
                 }
               }
               .map { it.id!! }
-      val coordinatesToInsert = coordinates.filter { desired ->
-        existingCoordinates.none {
-          it.positionId == desired.position && it.gpsCoordinates == desired.gpsCoordinates
-        }
-      }
+      val coordinatesToInsert =
+          coordinates.filter { desired ->
+            existingCoordinates.none {
+              it.positionId == desired.position && it.gpsCoordinates == desired.gpsCoordinates
+            }
+          }
 
       if (coordinateIdsToDelete.isNotEmpty()) {
         dslContext

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/observationStore/ObservationStoreSurvivalRateCalculationTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/observationStore/ObservationStoreSurvivalRateCalculationTest.kt
@@ -506,8 +506,12 @@ class ObservationStoreSurvivalRateCalculationTest : ObservationScenarioTest() {
     val tempPlotRemoved = insertMonitoringPlot()
     insertObservationPlot(claimedBy = user.userId, isPermanent = false)
     insertStratumT0TempDensity(stratumDensity = BigDecimal.valueOf(20).toPlantsPerHectare())
+    val plotInDeletedSubstratum = insertMonitoringPlot(permanentIndex = 3, substratumId = null)
+    insertObservationPlot(claimedBy = user.userId, isPermanent = true)
+    insertPlotT0Density(plotDensity = BigDecimal.valueOf(6).toPlantsPerHectare())
 
-    val obs1Plots = listOf(plotId, permanentPlotRemoved, tempPlot, tempPlotRemoved)
+    val obs1Plots =
+        listOf(plotId, permanentPlotRemoved, tempPlot, tempPlotRemoved, plotInDeletedSubstratum)
     val obs2Plots = listOf(plotId, tempPlot)
     val removedPlots = listOf(permanentPlotRemoved, tempPlotRemoved)
 
@@ -584,6 +588,9 @@ class ObservationStoreSurvivalRateCalculationTest : ObservationScenarioTest() {
           substratumHistoryId = null,
       )
     }
+    // deleted substratum
+    insertSubstratumHistory(substratumId = null)
+    insertMonitoringPlotHistory(monitoringPlotId = plotInDeletedSubstratum, substratumId = null)
     // end planting site update
 
     val observationId2 = insertObservation()
@@ -640,6 +647,9 @@ class ObservationStoreSurvivalRateCalculationTest : ObservationScenarioTest() {
     val tempPlotRatesUpdated = mapOf(speciesId to 100.0 * 1 / 30, null to 100.0 * 1 / 30)
     val obs2AllPlotsRatesUpdated = mapOf(speciesId to 100.0 * 2 / 40, null to 100.0 * 2 / 40)
     val allPlotRatesUpdated = mapOf(speciesId to 100.0 * 4 / 75, null to 100.0 * 4 / 75)
+    // plots in deleted substrata currently affect species calculations only at a site level. This
+    // is a bug that will be addressed later.
+    val siteRatesUpdated = mapOf(speciesId to 100.0 * 5 / 75, null to 100.0 * 4 / 75)
     val obs1Expected =
         SurvivalRates(
             mapOf(
@@ -650,7 +660,7 @@ class ObservationStoreSurvivalRateCalculationTest : ObservationScenarioTest() {
             ),
             mapOf(substratumId to allPlotRatesUpdated),
             mapOf(stratumId to allPlotRatesUpdated),
-            mapOf(plantingSiteId to allPlotRatesUpdated),
+            mapOf(plantingSiteId to siteRatesUpdated),
         )
     val obs2Expected =
         SurvivalRates(
@@ -659,8 +669,22 @@ class ObservationStoreSurvivalRateCalculationTest : ObservationScenarioTest() {
             mapOf(stratumId to obs2AllPlotsRatesUpdated),
             mapOf(plantingSiteId to obs2AllPlotsRatesUpdated),
         )
-    assertSurvivalRates(obs1Expected, obs1UpdatedResults, "Observation 1 is updated correctly")
-    assertSurvivalRates(obs2Expected, obs2UpdatedResults, "Observation 2 is updated correctly")
+    assertAll(
+        {
+          assertSurvivalRates(
+              obs1Expected,
+              obs1UpdatedResults,
+              "Observation 1 is updated correctly",
+          )
+        },
+        {
+          assertSurvivalRates(
+              obs2Expected,
+              obs2UpdatedResults,
+              "Observation 2 is updated correctly",
+          )
+        },
+    )
   }
 
   @Test


### PR DESCRIPTION
Recalculating survival rates for a stratum was retrieving distinct substrata ids in it and their list of monitoring plots. We were using an `asNonNullable` flag for the `substratum_id`, but this is actually a nullable column to handle deletions of substrata. The `asNonNullable` flag is actually a no-op at runtime and just used as an unchecked cast. This caused an NPE when plots had been observed and their substrata later deleted. Change to filtering out null substrata ids for recalculation.