### PR TITLE
SW-8246 Fix survival rates when substrata are deleted after an observation

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/tracking/db/ObservationResultsStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/db/ObservationResultsStore.kt
@@ -196,13 +196,12 @@ class ObservationResultsStore(private val dslContext: DSLContext) {
             }
             .groupBy { it.substratumId }
 
-    val latestPerSubstratum =
-        resultsBySubstratum.mapValues { (_, results) ->
-          results.maxBy { result ->
-            // Completed time should have at least one non-nulls by filtering by Completed.
-            result.monitoringPlots.maxOf { it.completedTime ?: Instant.EPOCH }
-          }
-        }
+    val latestPerSubstratum = resultsBySubstratum.mapValues { (_, results) ->
+      results.maxBy { result ->
+        // Completed time should have at least one non-nulls by filtering by Completed.
+        result.monitoringPlots.maxOf { it.completedTime ?: Instant.EPOCH }
+      }
+    }
 
     val stratumResults =
         allSubstratumIdsByStratumIds
@@ -211,8 +210,9 @@ class ObservationResultsStore(private val dslContext: DSLContext) {
 
               val areaHa = stratumAreasById[stratumId]!!
               val substratumIds = it.value
-              val substratumResults =
-                  substratumIds.associateWith { substratumId -> latestPerSubstratum[substratumId] }
+              val substratumResults = substratumIds.associateWith { substratumId ->
+                latestPerSubstratum[substratumId]
+              }
 
               stratumId to
                   ObservationStratumRollupResultsModel.of(
@@ -762,11 +762,10 @@ class ObservationResultsStore(private val dslContext: DSLContext) {
                         .asNonNullable()]
             val totalLive = species.sumOf { it.totalLive }
             val totalPlants = species.sumOf { it.totalLive + it.totalExisting + it.totalDead }
-            val totalLiveSpeciesExceptUnknown =
-                species.count {
-                  it.certainty != RecordedSpeciesCertainty.Unknown &&
-                      (it.totalLive + it.totalExisting) > 0
-                }
+            val totalLiveSpeciesExceptUnknown = species.count {
+              it.certainty != RecordedSpeciesCertainty.Unknown &&
+                  (it.totalLive + it.totalExisting) > 0
+            }
 
             val survivalRate = species.calculateSurvivalRate(survivalRateIncludesTempPlots)
 
@@ -831,6 +830,8 @@ class ObservationResultsStore(private val dslContext: DSLContext) {
               .and(
                   MONITORING_PLOT_HISTORIES.PLANTING_SITE_HISTORY_ID.eq(PLANTING_SITE_HISTORIES.ID)
               )
+              //
+              // .and(MONITORING_PLOT_HISTORIES.substratumHistories.SUBSTRATUM_ID.isNotNull)
               .groupBy(MONITORING_PLOT_HISTORIES.SUBSTRATUM_ID, SPECIES_ID)
               .asTable()
         }
@@ -853,6 +854,7 @@ class ObservationResultsStore(private val dslContext: DSLContext) {
               .and(observationIdForPlot(MONITORING_PLOT_ID, OBSERVATIONS.ID, false).isNotNull)
               .and(PLANTING_SITE_HISTORY_ID.eq(PLANTING_SITE_HISTORIES.ID))
               .and(plantingSites.SURVIVAL_RATE_INCLUDES_TEMP_PLOTS.eq(true))
+              //              .and(substratumHistories.SUBSTRATUM_ID.isNotNull)
               .groupBy(SUBSTRATUM_ID, STRATUM_T0_TEMP_DENSITIES.SPECIES_ID)
               .asTable()
         }
@@ -969,6 +971,7 @@ class ObservationResultsStore(private val dslContext: DSLContext) {
                             )
                     )
                 )
+            //                .and(SUBSTRATUM_HISTORIES.SUBSTRATUM_ID.isNotNull)
         )
         .convertFrom { results ->
           results.map { record: Record ->
@@ -983,11 +986,10 @@ class ObservationResultsStore(private val dslContext: DSLContext) {
 
             val species = record[substratumSpeciesMultisetField]
             val totalPlants = species.sumOf { it.totalLive + it.totalDead }
-            val totalLiveSpeciesExceptUnknown =
-                species.count {
-                  it.certainty != RecordedSpeciesCertainty.Unknown &&
-                      (it.totalLive + it.totalExisting) > 0
-                }
+            val totalLiveSpeciesExceptUnknown = species.count {
+              it.certainty != RecordedSpeciesCertainty.Unknown &&
+                  (it.totalLive + it.totalExisting) > 0
+            }
 
             val isCompleted =
                 monitoringPlots.isNotEmpty() && monitoringPlots.all { it.completedTime != null }
@@ -998,8 +1000,9 @@ class ObservationResultsStore(private val dslContext: DSLContext) {
                   null
                 }
 
-            val survivalRatePlots =
-                monitoringPlots.filter { survivalRateIncludesTempPlots || it.isPermanent }
+            val survivalRatePlots = monitoringPlots.filter {
+              survivalRateIncludesTempPlots || it.isPermanent
+            }
             val survivalRate =
                 if (
                     survivalRatePlots.isNotEmpty() &&
@@ -1085,6 +1088,7 @@ class ObservationResultsStore(private val dslContext: DSLContext) {
               .and(
                   MONITORING_PLOT_HISTORIES.PLANTING_SITE_HISTORY_ID.eq(PLANTING_SITE_HISTORIES.ID)
               )
+              //              .and(SUBSTRATUM_HISTORIES.SUBSTRATUM_ID.isNotNull)
               .groupBy(stratumHistoryAlias.STRATUM_ID, SPECIES_ID)
               .asTable()
         }
@@ -1109,6 +1113,7 @@ class ObservationResultsStore(private val dslContext: DSLContext) {
               .and(observationIdForPlot(MONITORING_PLOT_ID, OBSERVATIONS.ID, false).isNotNull)
               .and(PLANTING_SITE_HISTORY_ID.eq(PLANTING_SITE_HISTORIES.ID))
               .and(plantingSites.SURVIVAL_RATE_INCLUDES_TEMP_PLOTS.eq(true))
+              //              .and(SUBSTRATUM_HISTORIES.SUBSTRATUM_ID.isNotNull)
               .groupBy(
                   substratumHistories.stratumHistories.STRATUM_ID,
                   STRATUM_T0_TEMP_DENSITIES.SPECIES_ID,
@@ -1286,11 +1291,13 @@ class ObservationResultsStore(private val dslContext: DSLContext) {
                         .SURVIVAL_RATE_INCLUDES_TEMP_PLOTS
                         .asNonNullable()]
 
-            val identifiedSpecies =
-                species.filter { it.certainty != RecordedSpeciesCertainty.Unknown }
+            val identifiedSpecies = species.filter {
+              it.certainty != RecordedSpeciesCertainty.Unknown
+            }
             val totalPlants = species.sumOf { it.totalLive + it.totalDead }
-            val totalLiveSpeciesExceptUnknown =
-                identifiedSpecies.count { (it.totalLive + it.totalExisting) > 0 }
+            val totalLiveSpeciesExceptUnknown = identifiedSpecies.count {
+              (it.totalLive + it.totalExisting) > 0
+            }
 
             val isCompleted =
                 substrata.isNotEmpty() &&
@@ -1308,10 +1315,11 @@ class ObservationResultsStore(private val dslContext: DSLContext) {
 
             val monitoringPlots = substrata.flatMap { it.monitoringPlots }
 
-            val survivalRateSubstrata =
-                substrata.filter { substratum ->
+            val survivalRateSubstrata = substrata.filter { substratum ->
+              substratum.substratumId != null &&
                   substratum.monitoringPlots.any { survivalRateIncludesTempPlots || it.isPermanent }
-                }
+            }
+            val survivalRatePlots = survivalRateSubstrata.flatMap { it.monitoringPlots }
             val survivalRate =
                 if (
                     survivalRateSubstrata.isNotEmpty() &&
@@ -1323,7 +1331,7 @@ class ObservationResultsStore(private val dslContext: DSLContext) {
                 }
             val survivalRateStdDev =
                 if (survivalRate != null) {
-                  monitoringPlots
+                  survivalRatePlots
                       .mapNotNull { plot ->
                         plot.survivalRate?.let { survivalRate ->
                           val sumDensity = plot.species.mapNotNull { it.t0Density }.sumOf { it }

--- a/src/main/kotlin/com/terraformation/backend/tracking/db/ObservationResultsStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/db/ObservationResultsStore.kt
@@ -655,7 +655,6 @@ class ObservationResultsStore(private val dslContext: DSLContext) {
                                     .STRATUM_ID
                             )
                         )
-                    //                        )
                 )
                 .and(OBSERVATION_ID.eq(OBSERVATIONS.ID).or(OBSERVATION_ID.isNull))
                 .orderBy(SPECIES_ID, SPECIES_NAME)
@@ -830,8 +829,6 @@ class ObservationResultsStore(private val dslContext: DSLContext) {
               .and(
                   MONITORING_PLOT_HISTORIES.PLANTING_SITE_HISTORY_ID.eq(PLANTING_SITE_HISTORIES.ID)
               )
-              //
-              // .and(MONITORING_PLOT_HISTORIES.substratumHistories.SUBSTRATUM_ID.isNotNull)
               .groupBy(MONITORING_PLOT_HISTORIES.SUBSTRATUM_ID, SPECIES_ID)
               .asTable()
         }
@@ -854,7 +851,6 @@ class ObservationResultsStore(private val dslContext: DSLContext) {
               .and(observationIdForPlot(MONITORING_PLOT_ID, OBSERVATIONS.ID, false).isNotNull)
               .and(PLANTING_SITE_HISTORY_ID.eq(PLANTING_SITE_HISTORIES.ID))
               .and(plantingSites.SURVIVAL_RATE_INCLUDES_TEMP_PLOTS.eq(true))
-              //              .and(substratumHistories.SUBSTRATUM_ID.isNotNull)
               .groupBy(SUBSTRATUM_ID, STRATUM_T0_TEMP_DENSITIES.SPECIES_ID)
               .asTable()
         }
@@ -971,7 +967,6 @@ class ObservationResultsStore(private val dslContext: DSLContext) {
                             )
                     )
                 )
-            //                .and(SUBSTRATUM_HISTORIES.SUBSTRATUM_ID.isNotNull)
         )
         .convertFrom { results ->
           results.map { record: Record ->
@@ -1088,7 +1083,6 @@ class ObservationResultsStore(private val dslContext: DSLContext) {
               .and(
                   MONITORING_PLOT_HISTORIES.PLANTING_SITE_HISTORY_ID.eq(PLANTING_SITE_HISTORIES.ID)
               )
-              //              .and(SUBSTRATUM_HISTORIES.SUBSTRATUM_ID.isNotNull)
               .groupBy(stratumHistoryAlias.STRATUM_ID, SPECIES_ID)
               .asTable()
         }
@@ -1113,7 +1107,6 @@ class ObservationResultsStore(private val dslContext: DSLContext) {
               .and(observationIdForPlot(MONITORING_PLOT_ID, OBSERVATIONS.ID, false).isNotNull)
               .and(PLANTING_SITE_HISTORY_ID.eq(PLANTING_SITE_HISTORIES.ID))
               .and(plantingSites.SURVIVAL_RATE_INCLUDES_TEMP_PLOTS.eq(true))
-              //              .and(SUBSTRATUM_HISTORIES.SUBSTRATUM_ID.isNotNull)
               .groupBy(
                   substratumHistories.stratumHistories.STRATUM_ID,
                   STRATUM_T0_TEMP_DENSITIES.SPECIES_ID,

--- a/src/main/kotlin/com/terraformation/backend/tracking/db/PlantingSiteStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/db/PlantingSiteStore.kt
@@ -845,8 +845,8 @@ class PlantingSiteStore(
         }
       }
       is SubstratumEdit.Delete -> {
-        // Plots will be deleted by ON DELETE CASCADE. This may legitimately delete 0 rows if the
-        // parent stratum has already been deleted.
+        // This may legitimately delete 0 rows if the parent stratum has already been deleted.
+        // Plots will be updated to have a null substratum_id by ON DELETE SET NULL.
         dslContext.deleteFrom(SUBSTRATA).where(SUBSTRATA.ID.eq(edit.existingModel.id)).execute()
 
         replacementResults.add(

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/observationStore/ObservationStoreSurvivalRateCalculationTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/observationStore/ObservationStoreSurvivalRateCalculationTest.kt
@@ -12,6 +12,7 @@ import com.terraformation.backend.db.tracking.tables.pojos.RecordedPlantsRow
 import com.terraformation.backend.db.tracking.tables.references.MONITORING_PLOTS
 import com.terraformation.backend.db.tracking.tables.references.PLANTING_SITES
 import com.terraformation.backend.db.tracking.tables.references.STRATUM_T0_TEMP_DENSITIES
+import com.terraformation.backend.db.tracking.tables.references.SUBSTRATA
 import com.terraformation.backend.mockUser
 import com.terraformation.backend.point
 import com.terraformation.backend.tracking.db.ObservationScenarioTest
@@ -506,7 +507,10 @@ class ObservationStoreSurvivalRateCalculationTest : ObservationScenarioTest() {
     val tempPlotRemoved = insertMonitoringPlot()
     insertObservationPlot(claimedBy = user.userId, isPermanent = false)
     insertStratumT0TempDensity(stratumDensity = BigDecimal.valueOf(20).toPlantsPerHectare())
-    val plotInDeletedSubstratum = insertMonitoringPlot(permanentIndex = 3, substratumId = null)
+    val deletedSubstratum = insertSubstratum()
+    insertObservationRequestedSubstratum()
+    val plotInDeletedSubstratum =
+        insertMonitoringPlot(permanentIndex = 3, substratumId = deletedSubstratum)
     insertObservationPlot(claimedBy = user.userId, isPermanent = true)
     insertPlotT0Density(plotDensity = BigDecimal.valueOf(6).toPlantsPerHectare())
 
@@ -550,7 +554,10 @@ class ObservationStoreSurvivalRateCalculationTest : ObservationScenarioTest() {
     val permPlot1Rates = mapOf(speciesId to 100.0 * 1 / 10, null to 100.0 * 1 / 10)
     val permPlot2Rates = mapOf(speciesId to 100.0 * 1 / 5, null to 100.0 * 1 / 5)
     val tempPlotRates = mapOf(speciesId to 100.0 * 1 / 20, null to 100.0 * 1 / 20)
-    val allPlotRates = mapOf(speciesId to 100.0 * 4 / 55, null to 100.0 * 4 / 55)
+    val substratumRates = mapOf(speciesId to 100.0 * 4 / 55, null to 100.0 * 4 / 55)
+    val deletedSubstratumRates = mapOf(speciesId to 100.0 * 1 / 6, null to 100.0 * 1 / 6)
+    val allPlotRates = mapOf(speciesId to 100.0 * 5 / 61, null to 100.0 * 5 / 61)
+    val plotInDeletedSsRates = mapOf(speciesId to 100.0 * 1 / 6, null to 100.0 * 1 / 6)
     assertSurvivalRates(
         SurvivalRates(
             mapOf(
@@ -558,8 +565,9 @@ class ObservationStoreSurvivalRateCalculationTest : ObservationScenarioTest() {
                 permanentPlotRemoved to permPlot2Rates,
                 tempPlot to tempPlotRates,
                 tempPlotRemoved to tempPlotRates,
+                plotInDeletedSubstratum to plotInDeletedSsRates,
             ),
-            mapOf(substratumId to allPlotRates),
+            mapOf(substratumId to substratumRates, deletedSubstratum to deletedSubstratumRates),
             mapOf(stratumId to allPlotRates),
             mapOf(plantingSiteId to allPlotRates),
         ),
@@ -569,7 +577,7 @@ class ObservationStoreSurvivalRateCalculationTest : ObservationScenarioTest() {
     // update planting site
     insertPlantingSiteHistory()
     insertStratumHistory()
-    insertSubstratumHistory()
+    insertSubstratumHistory(substratumId = substratumId)
     dslContext
         .update(MONITORING_PLOTS)
         .set(MONITORING_PLOTS.PERMANENT_INDEX, DSL.castNull(SQLDataType.INTEGER))
@@ -579,8 +587,10 @@ class ObservationStoreSurvivalRateCalculationTest : ObservationScenarioTest() {
         )
         .where(MONITORING_PLOTS.ID.`in`(removedPlots))
         .execute()
-    val newPlotHistory = insertMonitoringPlotHistory(monitoringPlotId = plotId)
-    val newTempPlotHistory = insertMonitoringPlotHistory(monitoringPlotId = tempPlot)
+    val newPlotHistory =
+        insertMonitoringPlotHistory(monitoringPlotId = plotId, substratumId = substratumId)
+    val newTempPlotHistory =
+        insertMonitoringPlotHistory(monitoringPlotId = tempPlot, substratumId = substratumId)
     removedPlots.forEach {
       insertMonitoringPlotHistory(
           monitoringPlotId = it,
@@ -588,13 +598,18 @@ class ObservationStoreSurvivalRateCalculationTest : ObservationScenarioTest() {
           substratumHistoryId = null,
       )
     }
-    // deleted substratum
-    insertSubstratumHistory(substratumId = null)
-    insertMonitoringPlotHistory(monitoringPlotId = plotInDeletedSubstratum, substratumId = null)
+    // delete substratum
+    dslContext.deleteFrom(SUBSTRATA).where(SUBSTRATA.ID.eq(deletedSubstratum)).execute()
+    val deletedSubstratumHistory2 = insertSubstratumHistory(substratumId = null)
+    insertMonitoringPlotHistory(
+        monitoringPlotId = plotInDeletedSubstratum,
+        substratumId = null,
+        substratumHistoryId = deletedSubstratumHistory2,
+    )
     // end planting site update
 
     val observationId2 = insertObservation()
-    insertObservationRequestedSubstratum()
+    insertObservationRequestedSubstratum(substratumId = substratumId)
     insertObservationPlot(
         claimedBy = user.userId,
         monitoringPlotId = plotId,
@@ -649,7 +664,7 @@ class ObservationStoreSurvivalRateCalculationTest : ObservationScenarioTest() {
     val allPlotRatesUpdated = mapOf(speciesId to 100.0 * 4 / 75, null to 100.0 * 4 / 75)
     // plots in deleted substrata currently affect species calculations only at a site level. This
     // is a bug that will be addressed later.
-    val siteRatesUpdated = mapOf(speciesId to 100.0 * 5 / 75, null to 100.0 * 4 / 75)
+    val partialUpdatedRates = mapOf(speciesId to 100.0 * 5 / 75, null to 100.0 * 4 / 75)
     val obs1Expected =
         SurvivalRates(
             mapOf(
@@ -657,10 +672,11 @@ class ObservationStoreSurvivalRateCalculationTest : ObservationScenarioTest() {
                 permanentPlotRemoved to permPlot2Rates,
                 tempPlot to tempPlotRatesUpdated,
                 tempPlotRemoved to tempPlotRatesUpdated,
+                plotInDeletedSubstratum to mapOf(speciesId to 0, null to 100.0 * 1 / 6),
             ),
             mapOf(substratumId to allPlotRatesUpdated),
-            mapOf(stratumId to allPlotRatesUpdated),
-            mapOf(plantingSiteId to siteRatesUpdated),
+            mapOf(stratumId to partialUpdatedRates),
+            mapOf(plantingSiteId to partialUpdatedRates),
         )
     val obs2Expected =
         SurvivalRates(

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/observationStore/ObservationStoreSurvivalRateCalculationTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/observationStore/ObservationStoreSurvivalRateCalculationTest.kt
@@ -662,9 +662,8 @@ class ObservationStoreSurvivalRateCalculationTest : ObservationScenarioTest() {
     val tempPlotRatesUpdated = mapOf(speciesId to 100.0 * 1 / 30, null to 100.0 * 1 / 30)
     val obs2AllPlotsRatesUpdated = mapOf(speciesId to 100.0 * 2 / 40, null to 100.0 * 2 / 40)
     val allPlotRatesUpdated = mapOf(speciesId to 100.0 * 4 / 75, null to 100.0 * 4 / 75)
-    // plots in deleted substrata currently affect species calculations only at a site level. This
-    // is a bug that will be addressed later.
-    val partialUpdatedRates = mapOf(speciesId to 100.0 * 5 / 75, null to 100.0 * 4 / 75)
+    // plots in deleted substrata currently affect species calculations at a site and stratum level.
+    val speciesRatesUpdated = mapOf(speciesId to 100.0 * 5 / 75, null to 100.0 * 4 / 75)
     val obs1Expected =
         SurvivalRates(
             mapOf(
@@ -675,8 +674,8 @@ class ObservationStoreSurvivalRateCalculationTest : ObservationScenarioTest() {
                 plotInDeletedSubstratum to mapOf(speciesId to 0, null to 100.0 * 1 / 6),
             ),
             mapOf(substratumId to allPlotRatesUpdated),
-            mapOf(stratumId to partialUpdatedRates),
-            mapOf(plantingSiteId to partialUpdatedRates),
+            mapOf(stratumId to speciesRatesUpdated),
+            mapOf(plantingSiteId to speciesRatesUpdated),
         )
     val obs2Expected =
         SurvivalRates(


### PR DESCRIPTION
When a substratum is deleted, it wipes out the `substratum_id` field in a few tables, and deletes rows in other tables. Update the stratum definition of aggregate survival rates to exclude substrata that have been deleted. Update the test to more accurately reflect the current state of things.