### PR TITLE
Fix CI testing of Python scripts

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -27,6 +27,13 @@ common:
     cache#v1.10.0:
       <<: *cache-node-modules-args
 
+  - &cache-pip-args
+    <<: *cache-common-args
+    path: "scripts/.pip-cache"
+    manifest:
+      - "scripts/requirements.txt"
+      - ".buildkite/scripts/check-scripts.sh"
+
   - &load-secrets
     seek-oss/aws-sm#v2.4.1:
       json-to-env:
@@ -116,13 +123,10 @@ steps:
     plugins:
       - *shallow-clone
       - cache#v1.10.0:
-          <<: *cache-common-args
-          manifest: "scripts/requirements.txt"
-          path: "scripts/.venv"
+          <<: *cache-pip-args
           save:
             - "file"
             - "branch"
-          force: true
     command: .buildkite/scripts/check-scripts.sh
 
   - label: ":junit: Annotate build with test results"
@@ -183,11 +187,8 @@ steps:
     plugins:
       - *shallow-clone
       - cache#v1.10.0:
-          <<: *cache-common-args
-          path: "scripts/.venv"
-          restore: "branch"
+          <<: *cache-pip-args
           save: "pipeline"
-          force: true
     command: "echo --- :buildkite: Loaded branch-level script cache"
 
   - label: ":amazon-ecs: Deploy to ECS"

--- a/.buildkite/scripts/check-scripts.sh
+++ b/.buildkite/scripts/check-scripts.sh
@@ -10,26 +10,16 @@ echo "--- :python: Install packages"
 
 cd scripts
 
+PIP_CACHE="$(pwd)/.pip-cache"
 VENV_DIR="$(pwd)/.venv"
 
-if [ -f "${VENV_DIR}/bin/python" ]; then
-    venv_python_version=$("${VENV_DIR}/bin/python" -V | cut -d' ' -f2 | cut -d. -f1-2)
-
-    if [ "$venv_python_version" != "$PYTHON_VERSION" ]; then
-        echo "venv Python version is ${venv_python_version}; want ${PYTHON_VERSION}"
-        rm -rf "$VENV_DIR"
-    fi
-fi
-
-if [ ! -d "$VENV_DIR" ]; then
-    echo "Creating venv with $(python$PYTHON_VERSION -V)"
-    python$PYTHON_VERSION -m venv "$VENV_DIR"
-fi
+echo "Creating venv with $(python$PYTHON_VERSION -V)"
+python$PYTHON_VERSION -m venv "$VENV_DIR"
 
 PATH="${VENV_DIR}/bin:$PATH"
 export PATH
 
-pip3 install -r requirements.txt
+PIP_CACHE="$PIP_CACHE" pip3 install -r requirements.txt
 
 echo "--- :python: Check formatting"
 

--- a/.buildkite/scripts/check-scripts.sh
+++ b/.buildkite/scripts/check-scripts.sh
@@ -10,7 +10,7 @@ echo "--- :python: Install packages"
 
 cd scripts
 
-PIP_CACHE="$(pwd)/.pip-cache"
+PIP_CACHE_DIR="$(pwd)/.pip-cache"
 VENV_DIR="$(pwd)/.venv"
 
 echo "Creating venv with $(python$PYTHON_VERSION -V)"
@@ -19,7 +19,7 @@ python$PYTHON_VERSION -m venv "$VENV_DIR"
 PATH="${VENV_DIR}/bin:$PATH"
 export PATH
 
-PIP_CACHE="$PIP_CACHE" pip3 install -r requirements.txt
+PIP_CACHE_DIR="$PIP_CACHE_DIR" pip3 install -r requirements.txt
 
 echo "--- :python: Check formatting"
 

--- a/.buildkite/scripts/install-deps.sh
+++ b/.buildkite/scripts/install-deps.sh
@@ -57,7 +57,7 @@ install_node() {
 }
 
 install_python() {
-    if command -v python$PYTHON_VERSION &>/dev/null; then
+    if command -v python$PYTHON_VERSION > /dev/null; then
         return
     fi
     echo "Installing Python ${PYTHON_VERSION}..."

--- a/scripts/create_species.py
+++ b/scripts/create_species.py
@@ -56,5 +56,3 @@ def main():
 
 if __name__ == "__main__":
     main()
-
-# Dummy change to make CI run scripts checks

--- a/scripts/create_species.py
+++ b/scripts/create_species.py
@@ -56,3 +56,5 @@ def main():
 
 if __name__ == "__main__":
     main()
+
+# Dummy change to make CI run scripts checks


### PR DESCRIPTION
The venv has absolute paths embedded in it, so it won't work to
restore it across build steps. Cache pip's downloaded files instead,
and create a new venv on each run.