### PR TITLE
Buildkite: Use ECR credential helper to avoid sending Docker credentials in plaintext

### DIFF
--- a/.buildkite/hooks/pre-command
+++ b/.buildkite/hooks/pre-command
@@ -37,3 +37,6 @@ export GRADLE_USER_HOME
 export IS_CD
 export MERGED_PR_NUMBER
 export TIER
+
+# Install the ECR credential helper so the ecr plugin can configure it.
+.buildkite/scripts/install-deps.sh --ecr

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -149,6 +149,8 @@ steps:
     plugins:
       - *shallow-clone
       - *load-secrets
+      - ecr#v2.12.0:
+          credential-helper: true
       - *cache-gradle-home
       - *cache-node-modules
       - cache#v1.10.0:

--- a/.buildkite/scripts/docker-build-push.sh
+++ b/.buildkite/scripts/docker-build-push.sh
@@ -33,10 +33,6 @@ docker buildx create --name "$builder_name" --driver docker-container
 trap cleanup_builder EXIT
 
 if [[ "$IS_CD" == true ]]; then
-    echo "--- :docker: Log into Docker Hub"
-
-    docker login -u "$DOCKERHUB_USERNAME" -p "$DOCKERHUB_TOKEN"
-
     echo "--- :docker: Build and push Docker image"
 
     docker_image="${TERRAWARE_SERVER_DOCKER_IMAGE:-terraware/terraware-server}"

--- a/.buildkite/scripts/install-deps.sh
+++ b/.buildkite/scripts/install-deps.sh
@@ -64,6 +64,30 @@ install_python() {
     sudo dnf install -y python$PYTHON_VERSION
 }
 
+install_ecr_credential_helper() {
+    if command -v docker-credential-ecr-login &>/dev/null; then
+        return
+    fi
+
+    echo "Installing Amazon ECR Docker Credential Helper..."
+
+    local version="0.12.0"
+    local arch
+    case "$(uname -m)" in
+        aarch64) arch="arm64" ;;
+        x86_64)  arch="amd64" ;;
+        *)
+            echo "Unsupported architecture: $(uname -m)"
+            exit 1
+            ;;
+    esac
+
+    local url="https://amazon-ecr-credential-helper-releases.s3.us-east-2.amazonaws.com/${version}/linux-${arch}/docker-credential-ecr-login"
+    curl -fsSL "$url" -o /tmp/docker-credential-ecr-login
+    sudo install -m 755 /tmp/docker-credential-ecr-login /usr/local/bin/docker-credential-ecr-login
+    rm -f /tmp/docker-credential-ecr-login
+}
+
 echo "--- :linux: Install system packages"
 
 for arg in "$@"; do
@@ -72,6 +96,7 @@ for arg in "$@"; do
         --tools)  install_jq && install_yq && install_rsync ;;
         --node)   install_node ;;
         --python) install_python ;;
+        --ecr)    install_ecr_credential_helper ;;
         *)
             echo "Unknown argument: $arg"
             exit 1


### PR DESCRIPTION
This PR migrates off sending ECR credentials in the command line and onto the ECR credentials helper plugin.
