### PR TITLE
Show correct default SSIM lambda value in admin UI

### DIFF
--- a/src/main/resources/templates/admin/splats.html
+++ b/src/main/resources/templates/admin/splats.html
@@ -428,7 +428,7 @@
         </tr>
         <tr>
             <td>SSIM Lambda</td>
-            <td><input type="text" name="ssimLambda" placeholder="0.1" th:value="${ssimLambda}"/>
+            <td><input type="text" name="ssimLambda" placeholder="0.2" th:value="${ssimLambda}"/>
             </td>
             <td>
                 Controls how much the training loss emphasizes structural similarity (SSIM) versus


### PR DESCRIPTION
The actual default is 0.2, not 0.1; update the placeholder value in the admin UI's
splats page to reflect reality.