### PR TITLE
Avoid soon-to-be-deprecated Jackson API

### DIFF
--- a/src/test/kotlin/com/terraformation/backend/Helpers.kt
+++ b/src/test/kotlin/com/terraformation/backend/Helpers.kt
@@ -35,7 +35,7 @@ private val prettyPrintingObjectMapper: ObjectMapper by lazy {
       .enable(SerializationFeature.INDENT_OUTPUT)
       .enable(SerializationFeature.ORDER_MAP_ENTRIES_BY_KEYS)
       .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
-      .setSerializationInclusion(JsonInclude.Include.NON_EMPTY)
+      .setDefaultPropertyInclusion(JsonInclude.Include.NON_EMPTY)
 }
 
 /**


### PR DESCRIPTION
The next version of Jackson will deprecate the `setSerializationInclusion`
function, which will break our builds since we use the warnings-as-errors
compiler option. Switch to the non-deprecated alternative.