### PR TITLE
SW-8274 Associate splats with organizations

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/splat/SplatService.kt
+++ b/src/main/kotlin/com/terraformation/backend/splat/SplatService.kt
@@ -2,10 +2,12 @@ package com.terraformation.backend.splat
 
 import com.terraformation.backend.auth.currentUser
 import com.terraformation.backend.config.TerrawareServerConfig
+import com.terraformation.backend.customer.db.ParentStore
 import com.terraformation.backend.customer.model.requirePermissions
 import com.terraformation.backend.db.FileNotFoundException
 import com.terraformation.backend.db.default_schema.AssetStatus
 import com.terraformation.backend.db.default_schema.FileId
+import com.terraformation.backend.db.default_schema.OrganizationId
 import com.terraformation.backend.db.default_schema.tables.references.BIRDNET_RESULTS
 import com.terraformation.backend.db.default_schema.tables.references.FILES
 import com.terraformation.backend.db.default_schema.tables.references.SPLATS
@@ -18,6 +20,7 @@ import com.terraformation.backend.file.SizedInputStream
 import com.terraformation.backend.log.perClassLogger
 import com.terraformation.backend.splat.sqs.SplatterRequestFileLocation
 import com.terraformation.backend.splat.sqs.SplatterRequestMessage
+import com.terraformation.backend.tracking.db.ObservationNotFoundException
 import io.awspring.cloud.sqs.operations.SqsTemplate
 import jakarta.inject.Named
 import java.time.InstantSource
@@ -34,6 +37,7 @@ class SplatService(
     config: TerrawareServerConfig,
     private val dslContext: DSLContext,
     private val fileStore: S3FileStore,
+    private val parentStore: ParentStore,
     private val sqsTemplate: SqsTemplate,
 ) {
   private val log = perClassLogger()
@@ -123,7 +127,11 @@ class SplatService(
   ) {
     ensureObservationFile(observationId, fileId)
 
-    generateSplat(fileId, force, params, runBirdnet)
+    val organizationId =
+        parentStore.getOrganizationId(observationId)
+            ?: throw ObservationNotFoundException(observationId)
+
+    generateSplat(organizationId, fileId, force, params, runBirdnet)
   }
 
   fun recordSplatError(fileId: FileId, errorMessage: String) {
@@ -209,6 +217,7 @@ class SplatService(
   }
 
   private fun generateSplat(
+      organizationId: OrganizationId,
       fileId: FileId,
       force: Boolean = false,
       params: SplatGenerationParams,
@@ -245,6 +254,7 @@ class SplatService(
                 .set(CREATED_BY, currentUser().userId)
                 .set(CREATED_TIME, clock.instant())
                 .set(FILE_ID, fileId)
+                .set(ORGANIZATION_ID, organizationId)
                 .set(SPLAT_STORAGE_URL, splatUrl)
                 .onConflictDoNothing()
                 .execute()

--- a/src/main/resources/db/migration/0450/V472__SplatsOrganizationId.sql
+++ b/src/main/resources/db/migration/0450/V472__SplatsOrganizationId.sql
@@ -2,6 +2,13 @@ ALTER TABLE splats ADD COLUMN organization_id BIGINT REFERENCES organizations;
 
 CREATE INDEX ON splats (organization_id);
 
+DELETE FROM splats s
+WHERE NOT EXISTS (
+    SELECT 1
+    FROM observation_media_files omf
+    WHERE omf.file_id = s.file_id
+);
+
 UPDATE splats s
 SET organization_id = (
     SELECT mp.organization_id

--- a/src/main/resources/db/migration/0450/V472__SplatsOrganizationId.sql
+++ b/src/main/resources/db/migration/0450/V472__SplatsOrganizationId.sql
@@ -5,7 +5,7 @@ CREATE INDEX ON splats (organization_id);
 DELETE FROM splats s
 WHERE NOT EXISTS (
     SELECT 1
-    FROM observation_media_files omf
+    FROM tracking.observation_media_files omf
     WHERE omf.file_id = s.file_id
 );
 

--- a/src/main/resources/db/migration/0450/V472__SplatsOrganizationId.sql
+++ b/src/main/resources/db/migration/0450/V472__SplatsOrganizationId.sql
@@ -1,0 +1,13 @@
+ALTER TABLE splats ADD COLUMN organization_id BIGINT REFERENCES organizations;
+
+CREATE INDEX ON splats (organization_id);
+
+UPDATE splats s
+SET organization_id = (
+    SELECT mp.organization_id
+    FROM tracking.observation_media_files omf
+    JOIN tracking.monitoring_plots mp ON omf.monitoring_plot_id = mp.id
+    WHERE omf.file_id = s.file_id
+);
+
+ALTER TABLE splats ALTER COLUMN organization_id SET NOT NULL;

--- a/src/test/kotlin/com/terraformation/backend/db/DatabaseBackedTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/db/DatabaseBackedTest.kt
@@ -3120,19 +3120,21 @@ abstract class DatabaseBackedTest {
           },
       createdBy: UserId = row.createdBy ?: currentUser().userId,
       createdTime: Instant = row.createdTime ?: Instant.EPOCH,
+      organizationId: OrganizationId = row.organizationId ?: inserted.organizationId,
   ) {
     val rowWithDefaults =
         row.copy(
-            fileId = fileId,
             assetStatusId = assetStatus,
-            originPositionX = originPosition?.x,
-            originPositionY = originPosition?.y,
-            originPositionZ = originPosition?.z,
-            cameraPositionY = cameraPosition?.y,
             cameraPositionX = cameraPosition?.x,
+            cameraPositionY = cameraPosition?.y,
             cameraPositionZ = cameraPosition?.z,
             createdBy = createdBy,
             createdTime = createdTime,
+            fileId = fileId,
+            organizationId = organizationId,
+            originPositionX = originPosition?.x,
+            originPositionY = originPosition?.y,
+            originPositionZ = originPosition?.z,
         )
 
     splatsDao.insert(rowWithDefaults)

--- a/src/test/kotlin/com/terraformation/backend/splat/SplatServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/splat/SplatServiceTest.kt
@@ -3,14 +3,17 @@ package com.terraformation.backend.splat
 import com.terraformation.backend.RunsAsDatabaseUser
 import com.terraformation.backend.TestClock
 import com.terraformation.backend.config.TerrawareServerConfig
+import com.terraformation.backend.customer.db.ParentStore
 import com.terraformation.backend.customer.model.TerrawareUser
 import com.terraformation.backend.db.DatabaseTest
 import com.terraformation.backend.db.FileNotFoundException
 import com.terraformation.backend.db.default_schema.AssetStatus
 import com.terraformation.backend.db.default_schema.FileId
+import com.terraformation.backend.db.default_schema.OrganizationId
 import com.terraformation.backend.db.default_schema.Role
 import com.terraformation.backend.db.default_schema.tables.records.SplatAnnotationsRecord
 import com.terraformation.backend.db.default_schema.tables.references.BIRDNET_RESULTS
+import com.terraformation.backend.db.default_schema.tables.references.SPLATS
 import com.terraformation.backend.db.default_schema.tables.references.SPLAT_ANNOTATIONS
 import com.terraformation.backend.db.tracking.ObservationId
 import com.terraformation.backend.db.tracking.ObservationState
@@ -37,10 +40,11 @@ class SplatServiceTest : DatabaseTest(), RunsAsDatabaseUser {
   private val sqsTemplate: SqsTemplate = mockk()
 
   private val service: SplatService by lazy {
-    SplatService(clock, config, dslContext, fileStore, sqsTemplate)
+    SplatService(clock, config, dslContext, fileStore, ParentStore(dslContext), sqsTemplate)
   }
 
   private lateinit var observationId: ObservationId
+  private lateinit var organizationId: OrganizationId
   private lateinit var fileId: FileId
 
   @BeforeEach
@@ -54,7 +58,7 @@ class SplatServiceTest : DatabaseTest(), RunsAsDatabaseUser {
     every { config.splatter } returns splatterConfig
     every { config.s3BucketName } returns "bucket"
 
-    insertOrganization()
+    organizationId = insertOrganization()
     insertOrganizationUser(role = Role.Admin)
     insertPlantingSite(x = 0, width = 11, gridOrigin = point(1))
     insertMonitoringPlot()
@@ -690,7 +694,7 @@ class SplatServiceTest : DatabaseTest(), RunsAsDatabaseUser {
   }
 
   @Nested
-  inner class GenerateObservationSplatWithBirdnet {
+  inner class GenerateObservationSplat {
     @BeforeEach
     fun setUp() {
       every { fileStore.getPath(any()) } answers { java.nio.file.Paths.get("/path/to/video.mp4") }
@@ -701,6 +705,21 @@ class SplatServiceTest : DatabaseTest(), RunsAsDatabaseUser {
           }
       every { sqsTemplate.send(any<String>(), any<SplatterRequestMessage>()) } returns
           mockk(relaxed = true)
+    }
+
+    @Test
+    fun `associates splat with organization that owns observation`() {
+      insertOrganization()
+
+      service.generateObservationSplat(
+          observationId = observationId,
+          fileId = fileId,
+          runBirdnet = false,
+      )
+
+      val result = dslContext.fetchSingle(SPLATS, SPLATS.FILE_ID.eq(fileId))
+
+      assertEquals(organizationId, result.organizationId, "Organization ID")
     }
 
     @Test


### PR DESCRIPTION
To support efficiently querying an organization's list of virtual walkthroughs
once we start supporting non-observation-based walkthroughs, add an organization
ID column to the splats table and populate it at splat creation time.