### PR TITLE
Delete splats when their videos are deleted

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/admin/AdminSplatsController.kt
+++ b/src/main/kotlin/com/terraformation/backend/admin/AdminSplatsController.kt
@@ -118,7 +118,7 @@ class AdminSplatsController(
 
       val storageUrl = filesDao.fetchOneById(fileId)?.storageUrl
       val modelUrl = splatsDao.fetchOneByFileId(fileId)?.splatStorageUrl
-      val jobDirUrl = "$modelUrl-job.tar.gz"
+      val jobDirUrl = "$modelUrl${SplatService.JOB_ARCHIVE_SUFFIX}"
 
       redirectAttributes.successMessage =
           "Sent request to splatter service. Model and archive will not be available until " +

--- a/src/main/kotlin/com/terraformation/backend/file/FileService.kt
+++ b/src/main/kotlin/com/terraformation/backend/file/FileService.kt
@@ -15,6 +15,7 @@ import com.terraformation.backend.db.default_schema.tables.pojos.FilesRow
 import com.terraformation.backend.db.default_schema.tables.references.FILES
 import com.terraformation.backend.db.default_schema.tables.references.FILE_ACCESS_TOKENS
 import com.terraformation.backend.db.default_schema.tables.references.MUX_ASSETS
+import com.terraformation.backend.db.default_schema.tables.references.SPLATS
 import com.terraformation.backend.db.default_schema.tables.references.THUMBNAILS
 import com.terraformation.backend.file.event.FileDeletionStartedEvent
 import com.terraformation.backend.file.event.FileReferenceDeletedEvent
@@ -59,6 +60,7 @@ class FileService(
       setOf(
           FILE_ACCESS_TOKENS.FILE_ID,
           MUX_ASSETS.FILE_ID,
+          SPLATS.FILE_ID,
           THUMBNAILS.FILE_ID,
       )
 

--- a/src/main/kotlin/com/terraformation/backend/splat/SplatService.kt
+++ b/src/main/kotlin/com/terraformation/backend/splat/SplatService.kt
@@ -17,17 +17,21 @@ import com.terraformation.backend.db.tracking.ObservationId
 import com.terraformation.backend.db.tracking.tables.references.OBSERVATION_MEDIA_FILES
 import com.terraformation.backend.file.S3FileStore
 import com.terraformation.backend.file.SizedInputStream
+import com.terraformation.backend.file.event.FileDeletionStartedEvent
 import com.terraformation.backend.log.perClassLogger
 import com.terraformation.backend.splat.sqs.SplatterRequestFileLocation
 import com.terraformation.backend.splat.sqs.SplatterRequestMessage
 import com.terraformation.backend.tracking.db.ObservationNotFoundException
 import io.awspring.cloud.sqs.operations.SqsTemplate
 import jakarta.inject.Named
+import java.net.URI
+import java.nio.file.NoSuchFileException
 import java.time.InstantSource
 import kotlin.io.path.Path
 import kotlin.io.path.pathString
 import org.jooq.DSLContext
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.context.event.EventListener
 import org.springframework.http.MediaType
 
 @ConditionalOnProperty("terraware.splatter.enabled")
@@ -330,6 +334,31 @@ class SplatService(
     }
   }
 
+  @EventListener
+  fun on(event: FileDeletionStartedEvent) {
+    try {
+      val splatsRecord = dslContext.fetchOne(SPLATS, SPLATS.FILE_ID.eq(event.fileId)) ?: return
+
+      splatsRecord.splatStorageUrl?.let { splatStorageUrl ->
+        try {
+          fileStore.delete(splatStorageUrl)
+        } catch (_: NoSuchFileException) {
+          log.warn("Splats table referred to $splatStorageUrl which does not exist")
+        }
+
+        try {
+          fileStore.delete(URI("$splatStorageUrl$JOB_ARCHIVE_SUFFIX"))
+        } catch (_: NoSuchFileException) {
+          // Not an error if there wasn't a job archive for the splat.
+        }
+
+        splatsRecord.delete()
+      }
+    } catch (e: Exception) {
+      log.error("Unable to delete splat for file ${event.fileId}", e)
+    }
+  }
+
   private fun readSplat(fileId: FileId): SizedInputStream {
     val splatsRecord =
         dslContext.fetchOne(SPLATS, SPLATS.FILE_ID.eq(fileId))
@@ -513,5 +542,9 @@ class SplatService(
     if (!associationExists) {
       throw FileNotFoundException(fileId)
     }
+  }
+
+  companion object {
+    const val JOB_ARCHIVE_SUFFIX = "-job.tar.gz"
   }
 }

--- a/src/test/kotlin/com/terraformation/backend/db/DatabaseBackedTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/db/DatabaseBackedTest.kt
@@ -3121,6 +3121,7 @@ abstract class DatabaseBackedTest {
       createdBy: UserId = row.createdBy ?: currentUser().userId,
       createdTime: Instant = row.createdTime ?: Instant.EPOCH,
       organizationId: OrganizationId = row.organizationId ?: inserted.organizationId,
+      splatStorageUrl: URI? = row.splatStorageUrl,
   ) {
     val rowWithDefaults =
         row.copy(
@@ -3135,6 +3136,7 @@ abstract class DatabaseBackedTest {
             originPositionX = originPosition?.x,
             originPositionY = originPosition?.y,
             originPositionZ = originPosition?.z,
+            splatStorageUrl = splatStorageUrl,
         )
 
     splatsDao.insert(rowWithDefaults)

--- a/src/test/kotlin/com/terraformation/backend/splat/SplatServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/splat/SplatServiceTest.kt
@@ -18,13 +18,18 @@ import com.terraformation.backend.db.default_schema.tables.references.SPLAT_ANNO
 import com.terraformation.backend.db.tracking.ObservationId
 import com.terraformation.backend.db.tracking.ObservationState
 import com.terraformation.backend.file.S3FileStore
+import com.terraformation.backend.file.event.FileDeletionStartedEvent
 import com.terraformation.backend.point
 import com.terraformation.backend.splat.sqs.SplatterRequestMessage
 import com.terraformation.backend.tracking.db.ObservationNotFoundException
 import io.awspring.cloud.sqs.operations.SqsTemplate
+import io.mockk.Runs
 import io.mockk.every
+import io.mockk.just
 import io.mockk.mockk
+import io.mockk.verify
 import java.net.URI
+import java.nio.file.NoSuchFileException
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
@@ -774,6 +779,29 @@ class SplatServiceTest : DatabaseTest(), RunsAsDatabaseUser {
           result?.assetStatusId,
           "Asset status should be reset to Preparing",
       )
+    }
+  }
+
+  @Nested
+  inner class OnFileDeletionStartedEvent {
+    @Test
+    fun `deletes splat file from file store when media file is deleted`() {
+      val url = URI("s3://bucket/file.sog")
+      val jobArchiveUrl = URI("s3://bucket/file.sog-job.tar.gz")
+
+      every { fileStore.delete(url) } just Runs
+      every { fileStore.delete(jobArchiveUrl) } throws NoSuchFileException("Missing!")
+
+      insertSplat(splatStorageUrl = url)
+
+      val event = FileDeletionStartedEvent(fileId, "video/quicktime")
+
+      service.on(event)
+
+      verify(exactly = 1) { fileStore.delete(url) }
+      verify(exactly = 1) { fileStore.delete(jobArchiveUrl) }
+
+      assertTableEmpty(SPLATS)
     }
   }
 }


### PR DESCRIPTION
When a file is deleted and there is a virtual walkthrough based on it, delete the
model and job archive files as well as the row in the splats table. Otherwise the
file deletion will fail because of the foreign-key reference.