### PR TITLE
Make splat storage URL non-nullable

### DIFF
--- a/src/main/resources/db/migration/0450/V473__SplatStorageUrlNotNull.sql
+++ b/src/main/resources/db/migration/0450/V473__SplatStorageUrlNotNull.sql
@@ -1,0 +1,1 @@
+ALTER TABLE splats ALTER COLUMN splat_storage_url SET NOT NULL;

--- a/src/test/kotlin/com/terraformation/backend/db/DatabaseBackedTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/db/DatabaseBackedTest.kt
@@ -3121,7 +3121,7 @@ abstract class DatabaseBackedTest {
       createdBy: UserId = row.createdBy ?: currentUser().userId,
       createdTime: Instant = row.createdTime ?: Instant.EPOCH,
       organizationId: OrganizationId = row.organizationId ?: inserted.organizationId,
-      splatStorageUrl: URI? = row.splatStorageUrl,
+      splatStorageUrl: URI = row.splatStorageUrl ?: URI("s3://bucket/splat"),
   ) {
     val rowWithDefaults =
         row.copy(


### PR DESCRIPTION
We always set the splat storage URL on initial insertion of the splats row, and we
never modify it afterwards, so we can make the column non-nullable.