### PR TITLE
SW-8274 Add permissions for organization media files

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/customer/model/IndividualUser.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/IndividualUser.kt
@@ -184,6 +184,8 @@ data class IndividualUser(
   override fun canCreateObservation(plantingSiteId: PlantingSiteId) =
       isSuperAdmin() || isManagerOrHigher(plantingSiteId)
 
+  override fun canCreateOrganizationMedia(organizationId: OrganizationId) = isMember(organizationId)
+
   override fun canCreateParticipantProjectSpecies(projectId: ProjectId) =
       isTFExpertOrHigher() || isManagerOrHigher(parentStore.getOrganizationId(projectId))
 
@@ -232,6 +234,8 @@ data class IndividualUser(
   override fun canDeleteFundingEntities() = isAcceleratorAdmin()
 
   override fun canDeleteOrganization(organizationId: OrganizationId) = isOwner(organizationId)
+
+  override fun canDeleteOrganizationMedia(organizationId: OrganizationId) = isMember(organizationId)
 
   override fun canDeleteParticipantProjectSpecies(
       participantProjectSpeciesId: ParticipantProjectSpeciesId
@@ -423,6 +427,8 @@ data class IndividualUser(
 
   override fun canReadOrganizationFeatures(organizationId: OrganizationId): Boolean =
       isManagerOrHigher(organizationId)
+
+  override fun canReadOrganizationMedia(organizationId: OrganizationId) = isMember(organizationId)
 
   override fun canReadOrganizationUser(organizationId: OrganizationId, userId: UserId): Boolean {
     return if (userId == this.userId) {
@@ -669,6 +675,8 @@ data class IndividualUser(
 
   override fun canUpdateOrganization(organizationId: OrganizationId) =
       isAdminOrHigher(organizationId)
+
+  override fun canUpdateOrganizationMedia(organizationId: OrganizationId) = isMember(organizationId)
 
   override fun canUpdateParticipantProjectSpecies(
       participantProjectSpeciesId: ParticipantProjectSpeciesId

--- a/src/main/kotlin/com/terraformation/backend/customer/model/PermissionRequirements.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/PermissionRequirements.kt
@@ -307,6 +307,15 @@ class PermissionRequirements(private val user: TerrawareUser) {
     }
   }
 
+  fun createOrganizationMedia(organizationId: OrganizationId) {
+    user.recordPermissionChecks {
+      if (!user.canCreateOrganizationMedia(organizationId)) {
+        readOrganization(organizationId)
+        throw AccessDeniedException("No permission to create media in organization $organizationId")
+      }
+    }
+  }
+
   fun createParticipantProjectSpecies(projectId: ProjectId) {
     user.recordPermissionChecks {
       if (!user.canCreateParticipantProjectSpecies(projectId)) {
@@ -477,6 +486,15 @@ class PermissionRequirements(private val user: TerrawareUser) {
       if (!user.canDeleteOrganization(organizationId)) {
         readOrganization(organizationId)
         throw AccessDeniedException("No permission to delete organization $organizationId")
+      }
+    }
+  }
+
+  fun deleteOrganizationMedia(organizationId: OrganizationId) {
+    user.recordPermissionChecks {
+      if (!user.canDeleteOrganizationMedia(organizationId)) {
+        readOrganization(organizationId)
+        throw AccessDeniedException("No permission to delete media in organization $organizationId")
       }
     }
   }
@@ -1013,6 +1031,15 @@ class PermissionRequirements(private val user: TerrawareUser) {
         throw AccessDeniedException(
             "No permission to read features for organization $organizationId"
         )
+      }
+    }
+  }
+
+  fun readOrganizationMedia(organizationId: OrganizationId) {
+    user.recordPermissionChecks {
+      if (!user.canReadOrganizationMedia(organizationId)) {
+        readOrganization(organizationId)
+        throw AccessDeniedException("No permission to read media in organization $organizationId")
       }
     }
   }
@@ -1671,6 +1698,15 @@ class PermissionRequirements(private val user: TerrawareUser) {
       if (!user.canUpdateOrganization(organizationId)) {
         readOrganization(organizationId)
         throw AccessDeniedException("No permission to update organization $organizationId")
+      }
+    }
+  }
+
+  fun updateOrganizationMedia(organizationId: OrganizationId) {
+    user.recordPermissionChecks {
+      if (!user.canUpdateOrganizationMedia(organizationId)) {
+        readOrganization(organizationId)
+        throw AccessDeniedException("No permission to update media in organization $organizationId")
       }
     }
   }

--- a/src/main/kotlin/com/terraformation/backend/customer/model/TerrawareUser.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/TerrawareUser.kt
@@ -259,6 +259,8 @@ interface TerrawareUser : Principal, UserDetails {
 
   fun canCreateObservation(plantingSiteId: PlantingSiteId): Boolean = defaultPermission
 
+  fun canCreateOrganizationMedia(organizationId: OrganizationId): Boolean = defaultPermission
+
   fun canCreateParticipantProjectSpecies(projectId: ProjectId): Boolean = defaultPermission
 
   fun canCreatePlantingSite(organizationId: OrganizationId): Boolean = defaultPermission
@@ -297,6 +299,8 @@ interface TerrawareUser : Principal, UserDetails {
   fun canDeleteFundingEntities(): Boolean = defaultPermission
 
   fun canDeleteOrganization(organizationId: OrganizationId): Boolean = defaultPermission
+
+  fun canDeleteOrganizationMedia(organizationId: OrganizationId): Boolean = defaultPermission
 
   fun canDeleteParticipantProjectSpecies(
       participantProjectSpeciesId: ParticipantProjectSpeciesId
@@ -432,6 +436,8 @@ interface TerrawareUser : Principal, UserDetails {
   fun canReadOrganizationDeliverables(organizationId: OrganizationId): Boolean = defaultPermission
 
   fun canReadOrganizationFeatures(organizationId: OrganizationId): Boolean = defaultPermission
+
+  fun canReadOrganizationMedia(organizationId: OrganizationId): Boolean = defaultPermission
 
   fun canReadOrganizationUser(organizationId: OrganizationId, userId: UserId): Boolean =
       defaultPermission
@@ -591,6 +597,8 @@ interface TerrawareUser : Principal, UserDetails {
   fun canUpdateObservationQuantities(observationId: ObservationId): Boolean = defaultPermission
 
   fun canUpdateOrganization(organizationId: OrganizationId): Boolean = defaultPermission
+
+  fun canUpdateOrganizationMedia(organizationId: OrganizationId): Boolean = defaultPermission
 
   fun canUpdateParticipantProjectSpecies(
       participantProjectSpeciesId: ParticipantProjectSpeciesId

--- a/src/test/kotlin/com/terraformation/backend/customer/model/PermissionRequirementsTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/model/PermissionRequirementsTest.kt
@@ -370,6 +370,13 @@ internal class PermissionRequirementsTest : RunsAsUser {
       allow { createObservation(plantingSiteId) } ifUser { canCreateObservation(plantingSiteId) }
 
   @Test
+  fun createOrganizationMedia() =
+      allow { createOrganizationMedia(organizationId) } ifUser
+          {
+            canCreateOrganizationMedia(organizationId)
+          }
+
+  @Test
   fun createParticipantProjectSpecies() {
     assertThrows<AccessDeniedException> { requirements.createParticipantProjectSpecies(projectId) }
 
@@ -445,6 +452,13 @@ internal class PermissionRequirementsTest : RunsAsUser {
   @Test
   fun deleteOrganization() =
       allow { deleteOrganization(organizationId) } ifUser { canDeleteOrganization(organizationId) }
+
+  @Test
+  fun deleteOrganizationMedia() =
+      allow { deleteOrganizationMedia(organizationId) } ifUser
+          {
+            canDeleteOrganizationMedia(organizationId)
+          }
 
   @Test
   fun deleteParticipantProjectSpecies() =
@@ -696,6 +710,13 @@ internal class PermissionRequirementsTest : RunsAsUser {
     grant { user.canReadOrganizationFeatures(organizationId) }
     requirements.readOrganizationFeatures(organizationId)
   }
+
+  @Test
+  fun readOrganizationMedia() =
+      allow { readOrganizationMedia(organizationId) } ifUser
+          {
+            canReadOrganizationMedia(organizationId)
+          }
 
   @Test
   fun readOrganizationUser() {
@@ -1064,6 +1085,13 @@ internal class PermissionRequirementsTest : RunsAsUser {
   @Test
   fun updateOrganization() =
       allow { updateOrganization(organizationId) } ifUser { canUpdateOrganization(organizationId) }
+
+  @Test
+  fun updateOrganizationMedia() =
+      allow { updateOrganizationMedia(organizationId) } ifUser
+          {
+            canUpdateOrganizationMedia(organizationId)
+          }
 
   @Test
   fun updateOrganizationNotifications() =

--- a/src/test/kotlin/com/terraformation/backend/customer/model/PermissionTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/model/PermissionTest.kt
@@ -505,21 +505,25 @@ internal class PermissionTest : DatabaseTest() {
         addOrganizationUser = true,
         createDraftPlantingSite = true,
         createFacility = true,
+        createOrganizationMedia = true,
         createPlantingSite = true,
         createProject = true,
         createSpecies = true,
         deleteOrganization = true,
+        deleteOrganizationMedia = true,
         listFacilities = true,
         listOrganizationUsers = true,
         listReports = true,
         readOrganization = true,
         readOrganizationDeliverables = true,
         readOrganizationFeatures = true,
+        readOrganizationMedia = true,
         readOrganizationSelf = true,
         readOrganizationUser = true,
         removeOrganizationSelf = true,
         removeOrganizationUser = true,
         updateOrganization = true,
+        updateOrganizationMedia = true,
     )
 
     permissions.expect(
@@ -747,21 +751,25 @@ internal class PermissionTest : DatabaseTest() {
         addOrganizationUser = true,
         createDraftPlantingSite = true,
         createFacility = true,
+        createOrganizationMedia = true,
         createPlantingSite = true,
         createProject = true,
         createSpecies = true,
         deleteOrganization = true,
+        deleteOrganizationMedia = true,
         listFacilities = true,
         listOrganizationUsers = true,
         listReports = true,
         readOrganization = true,
         readOrganizationDeliverables = true,
         readOrganizationFeatures = true,
+        readOrganizationMedia = true,
         readOrganizationSelf = true,
         readOrganizationUser = true,
         removeOrganizationSelf = true,
         removeOrganizationUser = true,
         updateOrganization = true,
+        updateOrganizationMedia = true,
     )
 
     permissions.expect(
@@ -797,20 +805,24 @@ internal class PermissionTest : DatabaseTest() {
         addOrganizationUser = true,
         createDraftPlantingSite = true,
         createFacility = true,
+        createOrganizationMedia = true,
         createPlantingSite = true,
         createProject = true,
         createSpecies = true,
+        deleteOrganizationMedia = true,
         listFacilities = true,
         listOrganizationUsers = true,
         listReports = true,
         readOrganization = true,
         readOrganizationDeliverables = true,
         readOrganizationFeatures = true,
+        readOrganizationMedia = true,
         readOrganizationSelf = true,
         readOrganizationUser = true,
         removeOrganizationSelf = true,
         removeOrganizationUser = true,
         updateOrganization = true,
+        updateOrganizationMedia = true,
     )
 
     permissions.expect(
@@ -1029,15 +1041,19 @@ internal class PermissionTest : DatabaseTest() {
 
     permissions.expect(
         org1Id,
+        createOrganizationMedia = true,
         createSpecies = true,
+        deleteOrganizationMedia = true,
         listFacilities = true,
         listOrganizationUsers = true,
         readOrganization = true,
         readOrganizationDeliverables = true,
         readOrganizationFeatures = true,
+        readOrganizationMedia = true,
         readOrganizationSelf = true,
         readOrganizationUser = true,
         removeOrganizationSelf = true,
+        updateOrganizationMedia = true,
     )
 
     permissions.expect(
@@ -1216,12 +1232,16 @@ internal class PermissionTest : DatabaseTest() {
 
     permissions.expect(
         org1Id,
+        createOrganizationMedia = true,
+        deleteOrganizationMedia = true,
         listFacilities = true,
         listOrganizationUsers = true,
         readOrganization = true,
+        readOrganizationMedia = true,
         readOrganizationSelf = true,
         readOrganizationUser = true,
         removeOrganizationSelf = true,
+        updateOrganizationMedia = true,
     )
 
     permissions.expect(
@@ -1427,23 +1447,27 @@ internal class PermissionTest : DatabaseTest() {
         addTerraformationContact = true,
         createDraftPlantingSite = true,
         createFacility = true,
+        createOrganizationMedia = true,
         createPlantingSite = true,
         createProject = true,
         createReport = true,
         createSpecies = true,
         deleteOrganization = true,
+        deleteOrganizationMedia = true,
         listFacilities = true,
         listOrganizationUsers = true,
         listReports = true,
         readOrganization = true,
         readOrganizationDeliverables = true,
         readOrganizationFeatures = true,
+        readOrganizationMedia = true,
         readOrganizationSelf = true,
         readOrganizationUser = true,
         removeOrganizationSelf = true,
         removeOrganizationUser = true,
         removeTerraformationContact = true,
         updateOrganization = true,
+        updateOrganizationMedia = true,
     )
 
     permissions.expect(
@@ -1762,22 +1786,26 @@ internal class PermissionTest : DatabaseTest() {
         addTerraformationContact = true,
         createDraftPlantingSite = true,
         createFacility = true,
+        createOrganizationMedia = true,
         createPlantingSite = true,
         createProject = true,
         createReport = true,
         createSpecies = true,
+        deleteOrganizationMedia = true,
         listFacilities = true,
         listOrganizationUsers = true,
         listReports = true,
         readOrganization = true,
         readOrganizationDeliverables = true,
         readOrganizationFeatures = true,
+        readOrganizationMedia = true,
         readOrganizationSelf = true,
         readOrganizationUser = true,
         removeOrganizationSelf = true,
         removeOrganizationUser = true,
         removeTerraformationContact = true,
         updateOrganization = true,
+        updateOrganizationMedia = true,
     )
 
     permissions.expect(
@@ -2030,21 +2058,25 @@ internal class PermissionTest : DatabaseTest() {
         addTerraformationContact = true,
         createDraftPlantingSite = true,
         createFacility = true,
+        createOrganizationMedia = true,
         createPlantingSite = true,
         createProject = true,
         createSpecies = true,
+        deleteOrganizationMedia = true,
         listFacilities = true,
         listOrganizationUsers = true,
         listReports = true,
         readOrganization = true,
         readOrganizationDeliverables = true,
         readOrganizationFeatures = true,
+        readOrganizationMedia = true,
         readOrganizationSelf = true,
         readOrganizationUser = true,
         removeOrganizationSelf = true,
         removeOrganizationUser = true,
         removeTerraformationContact = true,
         updateOrganization = true,
+        updateOrganizationMedia = true,
     )
 
     permissions.expect(
@@ -2290,21 +2322,25 @@ internal class PermissionTest : DatabaseTest() {
         addTerraformationContact = true,
         createDraftPlantingSite = true,
         createFacility = true,
+        createOrganizationMedia = true,
         createPlantingSite = true,
         createProject = true,
         createSpecies = true,
+        deleteOrganizationMedia = true,
         listFacilities = true,
         listOrganizationUsers = true,
         listReports = true,
         readOrganization = true,
         readOrganizationDeliverables = true,
         readOrganizationFeatures = true,
+        readOrganizationMedia = true,
         readOrganizationSelf = true,
         readOrganizationUser = true,
         removeOrganizationSelf = true,
         removeOrganizationUser = true,
         removeTerraformationContact = true,
         updateOrganization = true,
+        updateOrganizationMedia = true,
     )
 
     permissions.expect(
@@ -2538,13 +2574,17 @@ internal class PermissionTest : DatabaseTest() {
 
     permissions.expect(
         org1Id,
+        createOrganizationMedia = true,
+        deleteOrganizationMedia = true,
         listFacilities = true,
         listOrganizationUsers = true,
         readOrganization = true,
         readOrganizationDeliverables = true,
+        readOrganizationMedia = true,
         readOrganizationSelf = true,
         readOrganizationUser = true,
         removeOrganizationSelf = true,
+        updateOrganizationMedia = true,
     )
 
     permissions.expect(
@@ -3098,23 +3138,27 @@ internal class PermissionTest : DatabaseTest() {
         addTerraformationContact: Boolean = false,
         createDraftPlantingSite: Boolean = false,
         createFacility: Boolean = false,
+        createOrganizationMedia: Boolean = false,
         createPlantingSite: Boolean = false,
         createProject: Boolean = false,
         createReport: Boolean = false,
         createSpecies: Boolean = false,
         deleteOrganization: Boolean = false,
+        deleteOrganizationMedia: Boolean = false,
         listFacilities: Boolean = false,
         listOrganizationUsers: Boolean = false,
         listReports: Boolean = false,
         readOrganization: Boolean = false,
         readOrganizationDeliverables: Boolean = false,
         readOrganizationFeatures: Boolean = false,
+        readOrganizationMedia: Boolean = false,
         readOrganizationSelf: Boolean = false,
         readOrganizationUser: Boolean = false,
         removeOrganizationSelf: Boolean = false,
         removeOrganizationUser: Boolean = false,
         removeTerraformationContact: Boolean = false,
         updateOrganization: Boolean = false,
+        updateOrganizationMedia: Boolean = false,
     ) {
       organizations.forEach { organizationId ->
         val idInDatabase = getDatabaseId(organizationId)
@@ -3137,6 +3181,11 @@ internal class PermissionTest : DatabaseTest() {
             createFacility,
             user.canCreateFacility(idInDatabase),
             "Can create facility in organization $organizationId",
+        )
+        assertEquals(
+            createOrganizationMedia,
+            user.canCreateOrganizationMedia(idInDatabase),
+            "Can create media in organization $organizationId",
         )
         assertEquals(
             createPlantingSite,
@@ -3162,6 +3211,11 @@ internal class PermissionTest : DatabaseTest() {
             deleteOrganization,
             user.canDeleteOrganization(idInDatabase),
             "Can delete organization $organizationId",
+        )
+        assertEquals(
+            deleteOrganizationMedia,
+            user.canDeleteOrganizationMedia(idInDatabase),
+            "Can delete media in organization $organizationId",
         )
         assertEquals(
             listFacilities,
@@ -3194,6 +3248,11 @@ internal class PermissionTest : DatabaseTest() {
             "Can read features for organization $organizationId",
         )
         assertEquals(
+            readOrganizationMedia,
+            user.canReadOrganizationMedia(idInDatabase),
+            "Can read media in organization $organizationId",
+        )
+        assertEquals(
             readOrganizationSelf,
             user.canReadOrganizationUser(idInDatabase, userId),
             "Can read self in organization $organizationId",
@@ -3222,6 +3281,11 @@ internal class PermissionTest : DatabaseTest() {
             updateOrganization,
             user.canUpdateOrganization(idInDatabase),
             "Can update organization $organizationId",
+        )
+        assertEquals(
+            updateOrganizationMedia,
+            user.canUpdateOrganizationMedia(idInDatabase),
+            "Can update media in organization $organizationId",
         )
 
         uncheckedOrgs.remove(organizationId)


### PR DESCRIPTION
In preparation for supporting storing media files at the organization level, add
CRUD permissions. Currently, per the spec, all organization users have full access
including deletion.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>