### PR TITLE
SW-8274 Create table for organization-level media files

### DIFF
--- a/src/main/resources/db/migration/0450/V474__OrganizationMediaFiles.sql
+++ b/src/main/resources/db/migration/0450/V474__OrganizationMediaFiles.sql
@@ -1,6 +1,6 @@
 CREATE TABLE organization_media_files (
     file_id BIGINT PRIMARY KEY REFERENCES files ON DELETE CASCADE,
-    organization_id BIGINT NOT NULL REFERENCES organizations ON DELETE CASCADE,
+    organization_id BIGINT NOT NULL REFERENCES organizations,
     caption TEXT
 );
 

--- a/src/main/resources/db/migration/0450/V474__OrganizationMediaFiles.sql
+++ b/src/main/resources/db/migration/0450/V474__OrganizationMediaFiles.sql
@@ -1,0 +1,7 @@
+CREATE TABLE organization_media_files (
+    file_id BIGINT PRIMARY KEY REFERENCES files ON DELETE CASCADE,
+    organization_id BIGINT NOT NULL REFERENCES organizations ON DELETE CASCADE,
+    caption TEXT
+);
+
+CREATE INDEX ON organization_media_files (organization_id);

--- a/src/main/resources/db/migration/R__Comments.sql
+++ b/src/main/resources/db/migration/R__Comments.sql
@@ -152,6 +152,8 @@ COMMENT ON TABLE organization_internal_tags IS 'Which internal (non-user-facing)
 
 COMMENT ON TABLE organization_managed_location_types IS 'Per-organization information about managed location types for business analytics purposes.';
 
+COMMENT ON TABLE organization_media_files IS 'Media files (photos, videos, etc.) associated with organizations.';
+
 COMMENT ON TABLE organization_report_settings IS 'Organization-level settings for quarterly reports. Project-level settings are in `project_report_settings`.';
 
 COMMENT ON TABLE organization_types IS '(Enum) Type of forestry organization for business analytics purposes.';

--- a/src/test/kotlin/com/terraformation/backend/db/DatabaseBackedTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/db/DatabaseBackedTest.kt
@@ -186,6 +186,7 @@ import com.terraformation.backend.db.default_schema.tables.daos.InternalTagsDao
 import com.terraformation.backend.db.default_schema.tables.daos.NotificationsDao
 import com.terraformation.backend.db.default_schema.tables.daos.OrganizationInternalTagsDao
 import com.terraformation.backend.db.default_schema.tables.daos.OrganizationManagedLocationTypesDao
+import com.terraformation.backend.db.default_schema.tables.daos.OrganizationMediaFilesDao
 import com.terraformation.backend.db.default_schema.tables.daos.OrganizationReportSettingsDao
 import com.terraformation.backend.db.default_schema.tables.daos.OrganizationUsersDao
 import com.terraformation.backend.db.default_schema.tables.daos.OrganizationsDao
@@ -237,6 +238,7 @@ import com.terraformation.backend.db.default_schema.tables.references.DEVICES
 import com.terraformation.backend.db.default_schema.tables.references.FACILITIES
 import com.terraformation.backend.db.default_schema.tables.references.NOTIFICATIONS
 import com.terraformation.backend.db.default_schema.tables.references.ORGANIZATIONS
+import com.terraformation.backend.db.default_schema.tables.references.ORGANIZATION_MEDIA_FILES
 import com.terraformation.backend.db.default_schema.tables.references.ORGANIZATION_USERS
 import com.terraformation.backend.db.default_schema.tables.references.SPECIES
 import com.terraformation.backend.db.default_schema.tables.references.SPECIES_ECOSYSTEM_TYPES
@@ -688,6 +690,7 @@ abstract class DatabaseBackedTest {
   protected val organizationInternalTagsDao: OrganizationInternalTagsDao by lazyDao()
   protected val organizationManagedLocationTypesDao: OrganizationManagedLocationTypesDao by
       lazyDao()
+  protected val organizationMediaFilesDao: OrganizationMediaFilesDao by lazyDao()
   protected val organizationReportSettingsDao: OrganizationReportSettingsDao by lazyDao()
   protected val organizationsDao: OrganizationsDao by lazyDao()
   protected val organizationUsersDao: OrganizationUsersDao by lazyDao()
@@ -3104,6 +3107,20 @@ abstract class DatabaseBackedTest {
         )
 
     observationMediaFilesDao.insert(rowWithDefaults)
+  }
+
+  fun insertOrganizationMediaFile(
+      fileId: FileId = inserted.fileId,
+      organizationId: OrganizationId = inserted.organizationId,
+      caption: String? = null,
+  ): FileId {
+    dslContext
+        .insertInto(ORGANIZATION_MEDIA_FILES)
+        .set(ORGANIZATION_MEDIA_FILES.FILE_ID, fileId)
+        .set(ORGANIZATION_MEDIA_FILES.ORGANIZATION_ID, organizationId)
+        .set(ORGANIZATION_MEDIA_FILES.CAPTION, caption)
+        .execute()
+    return fileId
   }
 
   fun insertSplat(

--- a/src/test/kotlin/com/terraformation/backend/db/SchemaDocsGenerator.kt
+++ b/src/test/kotlin/com/terraformation/backend/db/SchemaDocsGenerator.kt
@@ -315,6 +315,7 @@ class SchemaDocsGenerator : DatabaseTest() {
                   "notifications" to setOf(ALL, CUSTOMER),
                   "organization_internal_tags" to setOf(ALL, CUSTOMER),
                   "organization_managed_location_types" to setOf(ALL, CUSTOMER),
+                  "organization_media_files" to setOf(ALL, CUSTOMER),
                   "organization_report_settings" to setOf(ALL, CUSTOMER),
                   "organization_types" to setOf(ALL, CUSTOMER),
                   "organization_users" to setOf(ALL, CUSTOMER),


### PR DESCRIPTION
To support associating video files and virtual walkthroughs with organizations
independently of observations, we need a table to record which files belong
to which organizations.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>