### PR TITLE
SW-8274 Add organization-level media endpoints

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/tracking/OrganizationMediaService.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/OrganizationMediaService.kt
@@ -1,0 +1,127 @@
+package com.terraformation.backend.tracking
+
+import com.terraformation.backend.api.getFilename
+import com.terraformation.backend.api.getPlainContentType
+import com.terraformation.backend.customer.model.requirePermissions
+import com.terraformation.backend.db.FileNotFoundException
+import com.terraformation.backend.db.default_schema.FileId
+import com.terraformation.backend.db.default_schema.OrganizationId
+import com.terraformation.backend.db.default_schema.tables.references.FILES
+import com.terraformation.backend.db.default_schema.tables.references.ORGANIZATION_MEDIA_FILES
+import com.terraformation.backend.file.FileService
+import com.terraformation.backend.file.SUPPORTED_MEDIA_TYPES
+import com.terraformation.backend.file.SizedInputStream
+import com.terraformation.backend.file.event.FileReferenceDeletedEvent
+import com.terraformation.backend.file.model.FileMetadata
+import com.terraformation.backend.file.mux.MuxService
+import com.terraformation.backend.file.mux.MuxStreamModel
+import com.terraformation.backend.log.perClassLogger
+import jakarta.inject.Named
+import org.jooq.DSLContext
+import org.locationtech.jts.geom.Point
+import org.springframework.context.ApplicationEventPublisher
+import org.springframework.web.multipart.MultipartFile
+
+@Named
+class OrganizationMediaService(
+    private val dslContext: DSLContext,
+    private val eventPublisher: ApplicationEventPublisher,
+    private val fileService: FileService,
+    private val muxService: MuxService,
+) {
+  private val log = perClassLogger()
+
+  fun upload(
+      organizationId: OrganizationId,
+      file: MultipartFile,
+      caption: String?,
+  ): FileId {
+    requirePermissions { createOrganizationMedia(organizationId) }
+
+    val contentType = file.getPlainContentType(SUPPORTED_MEDIA_TYPES)
+    val filename = file.getFilename("media")
+
+    val fileId =
+        fileService.storeFile(
+            "organizationMedia",
+            file.inputStream,
+            FileMetadata.of(contentType, filename, file.size),
+        ) { (fileId, _) ->
+          dslContext
+              .insertInto(ORGANIZATION_MEDIA_FILES)
+              .set(ORGANIZATION_MEDIA_FILES.FILE_ID, fileId)
+              .set(ORGANIZATION_MEDIA_FILES.ORGANIZATION_ID, organizationId)
+              .set(ORGANIZATION_MEDIA_FILES.CAPTION, caption)
+              .execute()
+        }
+
+    log.info("Stored media file $fileId for organization $organizationId")
+
+    return fileId
+  }
+
+  fun read(organizationId: OrganizationId, fileId: FileId): SizedInputStream {
+    requirePermissions { readOrganizationMedia(organizationId) }
+    ensureOrganizationFile(organizationId, fileId)
+
+    return fileService.readFile(fileId)
+  }
+
+  fun update(
+      organizationId: OrganizationId,
+      fileId: FileId,
+      caption: String?,
+      gpsCoordinates: Point?,
+  ) {
+    requirePermissions { updateOrganizationMedia(organizationId) }
+    ensureOrganizationFile(organizationId, fileId)
+
+    dslContext
+        .update(ORGANIZATION_MEDIA_FILES)
+        .set(ORGANIZATION_MEDIA_FILES.CAPTION, caption)
+        .where(ORGANIZATION_MEDIA_FILES.FILE_ID.eq(fileId))
+        .execute()
+
+    if (gpsCoordinates != null) {
+      dslContext
+          .update(FILES)
+          .set(FILES.GEOLOCATION, gpsCoordinates)
+          .where(FILES.ID.eq(fileId))
+          .execute()
+    }
+  }
+
+  fun delete(organizationId: OrganizationId, fileId: FileId) {
+    requirePermissions { deleteOrganizationMedia(organizationId) }
+    ensureOrganizationFile(organizationId, fileId)
+
+    dslContext
+        .deleteFrom(ORGANIZATION_MEDIA_FILES)
+        .where(ORGANIZATION_MEDIA_FILES.FILE_ID.eq(fileId))
+        .execute()
+
+    eventPublisher.publishEvent(FileReferenceDeletedEvent(fileId))
+
+    log.info("Deleted media file $fileId from organization $organizationId")
+  }
+
+  fun getStream(organizationId: OrganizationId, fileId: FileId): MuxStreamModel {
+    requirePermissions { readOrganizationMedia(organizationId) }
+    ensureOrganizationFile(organizationId, fileId)
+
+    return muxService.getMuxStream(fileId)
+  }
+
+  private fun ensureOrganizationFile(organizationId: OrganizationId, fileId: FileId) {
+    val exists =
+        dslContext.fetchExists(
+            ORGANIZATION_MEDIA_FILES,
+            ORGANIZATION_MEDIA_FILES.ORGANIZATION_ID.eq(organizationId)
+                .and(ORGANIZATION_MEDIA_FILES.FILE_ID.eq(fileId)),
+        )
+
+    if (!exists) {
+      throw FileNotFoundException(fileId)
+    }
+  }
+}

--- a/src/main/kotlin/com/terraformation/backend/tracking/api/OrganizationMediaController.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/api/OrganizationMediaController.kt
@@ -1,0 +1,136 @@
+package com.terraformation.backend.tracking.api
+
+import com.terraformation.backend.api.ApiResponse200
+import com.terraformation.backend.api.ApiResponse404
+import com.terraformation.backend.api.CustomerEndpoint
+import com.terraformation.backend.api.RequestBodyPhotoFile
+import com.terraformation.backend.api.SimpleSuccessResponsePayload
+import com.terraformation.backend.api.SuccessResponsePayload
+import com.terraformation.backend.api.toResponseEntity
+import com.terraformation.backend.db.default_schema.FileId
+import com.terraformation.backend.db.default_schema.OrganizationId
+import com.terraformation.backend.file.mux.MuxStreamModel
+import com.terraformation.backend.tracking.OrganizationMediaService
+import io.swagger.v3.oas.annotations.Operation
+import org.locationtech.jts.geom.Point
+import org.springframework.http.MediaType
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.DeleteMapping
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.PutMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestPart
+import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.multipart.MultipartFile
+
+@RequestMapping("/api/v1/organizations/{organizationId}/media")
+@RestController
+@CustomerEndpoint
+class OrganizationMediaController(
+    private val organizationMediaService: OrganizationMediaService,
+) {
+  @ApiResponse200
+  @Operation(summary = "Uploads a photo or video associated with an organization.")
+  @PostMapping(consumes = [MediaType.MULTIPART_FORM_DATA_VALUE])
+  @RequestBodyPhotoFile
+  fun uploadOrganizationMediaFile(
+      @PathVariable organizationId: OrganizationId,
+      @RequestPart("file") file: MultipartFile,
+      @RequestPart("payload") payload: UploadOrganizationMediaRequestPayload?,
+  ): UploadOrganizationMediaResponsePayload {
+    val fileId =
+        organizationMediaService.upload(
+            organizationId = organizationId,
+            file = file,
+            caption = payload?.caption,
+        )
+    return UploadOrganizationMediaResponsePayload(fileId)
+  }
+
+  @ApiResponse200
+  @ApiResponse404("The media file does not exist in this organization.")
+  @GetMapping("/{fileId}")
+  @Operation(
+      summary =
+          "Downloads an organization media file. For videos, this is the raw video file, not a " +
+              "streamable version."
+  )
+  fun downloadOrganizationMediaFile(
+      @PathVariable organizationId: OrganizationId,
+      @PathVariable fileId: FileId,
+  ): ResponseEntity<*> {
+    return organizationMediaService.read(organizationId, fileId).toResponseEntity()
+  }
+
+  @ApiResponse200
+  @ApiResponse404("The media file does not exist in this organization.")
+  @PutMapping("/{fileId}")
+  @Operation(summary = "Updates an organization media file's metadata.")
+  fun updateOrganizationMediaFile(
+      @PathVariable organizationId: OrganizationId,
+      @PathVariable fileId: FileId,
+      @RequestBody payload: UpdateOrganizationMediaRequestPayload,
+  ): SimpleSuccessResponsePayload {
+    organizationMediaService.update(
+        organizationId = organizationId,
+        fileId = fileId,
+        caption = payload.caption,
+        gpsCoordinates = payload.gpsCoordinates,
+    )
+    return SimpleSuccessResponsePayload()
+  }
+
+  @ApiResponse200
+  @ApiResponse404("The media file does not exist in this organization.")
+  @DeleteMapping("/{fileId}")
+  @Operation(summary = "Deletes an organization media file.")
+  fun deleteOrganizationMediaFile(
+      @PathVariable organizationId: OrganizationId,
+      @PathVariable fileId: FileId,
+  ): SimpleSuccessResponsePayload {
+    organizationMediaService.delete(organizationId, fileId)
+    return SimpleSuccessResponsePayload()
+  }
+
+  @ApiResponse200
+  @ApiResponse404("The media file does not exist in this organization, or is not a video.")
+  @GetMapping("/{fileId}/stream")
+  @Operation(summary = "Gets Mux stream details for an organization video.")
+  fun getOrganizationMediaFileStream(
+      @PathVariable organizationId: OrganizationId,
+      @PathVariable fileId: FileId,
+  ): GetOrganizationMediaStreamResponsePayload {
+    val stream = organizationMediaService.getStream(organizationId, fileId)
+    return GetOrganizationMediaStreamResponsePayload(stream)
+  }
+}
+
+data class UploadOrganizationMediaRequestPayload(
+    val caption: String? = null,
+)
+
+data class UploadOrganizationMediaResponsePayload(
+    val fileId: FileId,
+) : SuccessResponsePayload
+
+data class UpdateOrganizationMediaRequestPayload(
+    val caption: String? = null,
+    val gpsCoordinates: Point? = null,
+)
+
+data class GetOrganizationMediaStreamResponsePayload(
+    val fileId: FileId,
+    val playbackId: String,
+    val playbackToken: String,
+) : SuccessResponsePayload {
+  constructor(
+      model: MuxStreamModel
+  ) : this(
+      fileId = model.fileId,
+      playbackId = model.playbackId,
+      playbackToken = model.playbackToken,
+  )
+}

--- a/src/test/kotlin/com/terraformation/backend/tracking/OrganizationMediaServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/OrganizationMediaServiceTest.kt
@@ -1,0 +1,306 @@
+package com.terraformation.backend.tracking
+
+import com.terraformation.backend.RunsAsUser
+import com.terraformation.backend.TestClock
+import com.terraformation.backend.TestEventPublisher
+import com.terraformation.backend.assertGeometryEquals
+import com.terraformation.backend.db.DatabaseTest
+import com.terraformation.backend.db.FileNotFoundException
+import com.terraformation.backend.db.default_schema.FileId
+import com.terraformation.backend.db.default_schema.OrganizationId
+import com.terraformation.backend.db.default_schema.tables.records.OrganizationMediaFilesRecord
+import com.terraformation.backend.db.default_schema.tables.references.ORGANIZATION_MEDIA_FILES
+import com.terraformation.backend.file.FileService
+import com.terraformation.backend.file.InMemoryFileStore
+import com.terraformation.backend.file.SizedInputStream
+import com.terraformation.backend.file.event.FileReferenceDeletedEvent
+import com.terraformation.backend.file.mux.MuxService
+import com.terraformation.backend.file.mux.MuxStreamModel
+import com.terraformation.backend.mockUser
+import com.terraformation.backend.point
+import io.mockk.every
+import io.mockk.mockk
+import java.io.ByteArrayInputStream
+import java.net.URI
+import org.junit.jupiter.api.Assertions.assertArrayEquals
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.springframework.mock.web.MockMultipartFile
+import org.springframework.security.access.AccessDeniedException
+
+internal class OrganizationMediaServiceTest : DatabaseTest(), RunsAsUser {
+  override val user = mockUser()
+
+  private val clock = TestClock()
+  private val eventPublisher = TestEventPublisher()
+  private val fileStore = InMemoryFileStore()
+  private val fileService: FileService by lazy {
+    FileService(dslContext, clock, eventPublisher, filesDao, fileStore)
+  }
+  private val muxService: MuxService = mockk()
+
+  private val service: OrganizationMediaService by lazy {
+    OrganizationMediaService(dslContext, eventPublisher, fileService, muxService)
+  }
+
+  private lateinit var organizationId: OrganizationId
+
+  @BeforeEach
+  fun setUp() {
+    organizationId = insertOrganization()
+
+    every { user.canReadOrganization(any()) } returns true
+    every { user.canCreateOrganizationMedia(any()) } returns true
+    every { user.canReadOrganizationMedia(any()) } returns true
+    every { user.canUpdateOrganizationMedia(any()) } returns true
+    every { user.canDeleteOrganizationMedia(any()) } returns true
+  }
+
+  @Nested
+  inner class Upload {
+    @Test
+    fun `inserts organization media file row with correct organization and caption`() {
+      val multipartFile = MockMultipartFile("file", "photo.jpg", "image/jpeg", ByteArray(1024))
+
+      val insertedFileId = service.upload(organizationId, multipartFile, "Test caption")
+
+      assertTableEquals(
+          OrganizationMediaFilesRecord(insertedFileId, organizationId, "Test caption")
+      )
+    }
+
+    @Test
+    fun `throws AccessDeniedException when user cannot create organization media`() {
+      every { user.canCreateOrganizationMedia(any()) } returns false
+
+      val multipartFile = MockMultipartFile("file", "photo.jpg", "image/jpeg", ByteArray(0))
+
+      assertThrows<AccessDeniedException> {
+        service.upload(organizationId, multipartFile, "caption")
+      }
+    }
+  }
+
+  @Nested
+  inner class Read {
+    @Test
+    fun `returns file contents for a valid file in the organization`() {
+      val fileId =
+          insertOrganizationMediaFile(fileId = insertFile(), organizationId = organizationId)
+      val content = ByteArray(10) { it.toByte() }
+      val sizedInputStream = SizedInputStream(ByteArrayInputStream(content), content.size.toLong())
+
+      fileStore.write(URI("http://dummy/1"), sizedInputStream)
+
+      val result = service.read(organizationId, fileId)
+
+      assertArrayEquals(content, result.readAllBytes())
+    }
+
+    @Test
+    fun `throws FileNotFoundException when file does not belong to the organization`() {
+      val otherOrgId = insertOrganization()
+      val fileId = insertOrganizationMediaFile(fileId = insertFile(), organizationId = otherOrgId)
+
+      assertThrows<FileNotFoundException> { service.read(organizationId, fileId) }
+    }
+
+    @Test
+    fun `throws FileNotFoundException when file does not exist`() {
+      val bogusFileId = FileId(99999)
+
+      assertThrows<FileNotFoundException> { service.read(organizationId, bogusFileId) }
+    }
+
+    @Test
+    fun `throws AccessDeniedException when user cannot read organization media`() {
+      every { user.canReadOrganizationMedia(any()) } returns false
+
+      val fileId =
+          insertOrganizationMediaFile(
+              fileId = insertFile(),
+              organizationId = organizationId,
+          )
+
+      assertThrows<AccessDeniedException> { service.read(organizationId, fileId) }
+    }
+  }
+
+  @Nested
+  inner class Update {
+    @Test
+    fun `updates caption`() {
+      val fileId =
+          insertOrganizationMediaFile(
+              fileId = insertFile(),
+              organizationId = organizationId,
+              caption = "Original caption",
+          )
+
+      service.update(organizationId, fileId, caption = "Updated caption", gpsCoordinates = null)
+
+      assertTableEquals(OrganizationMediaFilesRecord(fileId, organizationId, "Updated caption"))
+    }
+
+    @Test
+    fun `clears caption`() {
+      val fileId =
+          insertOrganizationMediaFile(
+              fileId = insertFile(),
+              organizationId = organizationId,
+              caption = "Original caption",
+          )
+
+      service.update(organizationId, fileId, caption = null, gpsCoordinates = null)
+
+      assertTableEquals(OrganizationMediaFilesRecord(fileId, organizationId, null))
+    }
+
+    @Test
+    fun `updates GPS coordinates in files table when provided`() {
+      val fileId =
+          insertOrganizationMediaFile(
+              fileId = insertFile(),
+              organizationId = organizationId,
+          )
+      val geolocation = point(-122.1, 37.7749)
+
+      service.update(organizationId, fileId, caption = null, gpsCoordinates = geolocation)
+
+      assertGeometryEquals(geolocation, filesDao.fetchOneById(fileId)?.geolocation)
+    }
+
+    @Test
+    fun `does not modify geolocation when gpsCoordinates is null`() {
+      val geolocation = point(15, 20)
+      val fileId =
+          insertOrganizationMediaFile(
+              fileId = insertFile(geolocation = geolocation),
+              organizationId = organizationId,
+          )
+
+      service.update(organizationId, fileId, caption = "test", gpsCoordinates = null)
+
+      assertGeometryEquals(geolocation, filesDao.fetchOneById(fileId)?.geolocation)
+    }
+
+    @Test
+    fun `throws FileNotFoundException when file does not belong to the organization`() {
+      val otherOrgId = insertOrganization()
+      val fileId =
+          insertOrganizationMediaFile(
+              fileId = insertFile(),
+              organizationId = otherOrgId,
+          )
+
+      assertThrows<FileNotFoundException> {
+        service.update(organizationId, fileId, caption = "test", gpsCoordinates = null)
+      }
+    }
+
+    @Test
+    fun `throws AccessDeniedException when user cannot update organization media`() {
+      every { user.canUpdateOrganizationMedia(any()) } returns false
+
+      val fileId =
+          insertOrganizationMediaFile(
+              fileId = insertFile(),
+              organizationId = organizationId,
+          )
+
+      assertThrows<AccessDeniedException> {
+        service.update(organizationId, fileId, caption = "test", gpsCoordinates = null)
+      }
+    }
+  }
+
+  @Nested
+  inner class Delete {
+    @Test
+    fun `deletes database row and fires event`() {
+      val fileId =
+          insertOrganizationMediaFile(
+              fileId = insertFile(),
+              organizationId = organizationId,
+          )
+
+      service.delete(organizationId, fileId)
+
+      assertTableEmpty(ORGANIZATION_MEDIA_FILES)
+
+      eventPublisher.assertEventPublished(FileReferenceDeletedEvent(fileId))
+    }
+
+    @Test
+    fun `throws FileNotFoundException when file does not belong to the organization`() {
+      val otherOrgId = insertOrganization()
+      val fileId =
+          insertOrganizationMediaFile(
+              fileId = insertFile(),
+              organizationId = otherOrgId,
+          )
+
+      assertThrows<FileNotFoundException> { service.delete(organizationId, fileId) }
+    }
+
+    @Test
+    fun `throws AccessDeniedException when user cannot delete organization media`() {
+      every { user.canDeleteOrganizationMedia(any()) } returns false
+
+      val fileId =
+          insertOrganizationMediaFile(
+              fileId = insertFile(),
+              organizationId = organizationId,
+          )
+
+      assertThrows<AccessDeniedException> { service.delete(organizationId, fileId) }
+    }
+  }
+
+  @Nested
+  inner class GetStream {
+    @Test
+    fun `returns stream model from Mux`() {
+      val fileId =
+          insertOrganizationMediaFile(
+              fileId = insertFile(),
+              organizationId = organizationId,
+          )
+      val expectedStream = MuxStreamModel(fileId, "playback-123", "token-abc")
+
+      every { muxService.getMuxStream(fileId) } returns expectedStream
+
+      val result = service.getStream(organizationId, fileId)
+
+      assertEquals(expectedStream, result, "Should return the MuxStreamModel from MuxService")
+    }
+
+    @Test
+    fun `throws FileNotFoundException when file does not belong to the organization`() {
+      val otherOrgId = insertOrganization()
+      val fileId =
+          insertOrganizationMediaFile(
+              fileId = insertFile(),
+              organizationId = otherOrgId,
+          )
+
+      assertThrows<FileNotFoundException> { service.getStream(organizationId, fileId) }
+    }
+
+    @Test
+    fun `throws AccessDeniedException when user cannot read organization media`() {
+      every { user.canReadOrganizationMedia(any()) } returns false
+
+      val fileId =
+          insertOrganizationMediaFile(
+              fileId = insertFile(),
+              organizationId = organizationId,
+          )
+
+      assertThrows<AccessDeniedException> { service.getStream(organizationId, fileId) }
+    }
+  }
+}


### PR DESCRIPTION
Add endpoints to allow uploading and viewing photos and videos at the
organization level, not associated with observations, accessions, or
nursery withdrawals.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>