### PR TITLE
SW-8274 Add splat support for organization videos

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/splat/SplatService.kt
+++ b/src/main/kotlin/com/terraformation/backend/splat/SplatService.kt
@@ -10,6 +10,7 @@ import com.terraformation.backend.db.default_schema.FileId
 import com.terraformation.backend.db.default_schema.OrganizationId
 import com.terraformation.backend.db.default_schema.tables.references.BIRDNET_RESULTS
 import com.terraformation.backend.db.default_schema.tables.references.FILES
+import com.terraformation.backend.db.default_schema.tables.references.ORGANIZATION_MEDIA_FILES
 import com.terraformation.backend.db.default_schema.tables.references.SPLATS
 import com.terraformation.backend.db.default_schema.tables.references.SPLAT_ANNOTATIONS
 import com.terraformation.backend.db.tracking.MonitoringPlotId
@@ -136,6 +137,52 @@ class SplatService(
             ?: throw ObservationNotFoundException(observationId)
 
     generateSplat(organizationId, fileId, force, params, runBirdnet)
+  }
+
+  fun generateOrganizationMediaSplat(
+      organizationId: OrganizationId,
+      fileId: FileId,
+      force: Boolean = false,
+      params: SplatGenerationParams = SplatGenerationParams(),
+      runBirdnet: Boolean = true,
+  ) {
+    ensureOrganizationMediaFile(organizationId, fileId)
+
+    generateSplat(organizationId, fileId, force, params, runBirdnet)
+  }
+
+  fun readOrganizationSplat(organizationId: OrganizationId, fileId: FileId): SizedInputStream {
+    ensureOrganizationMediaFile(organizationId, fileId)
+
+    return readSplat(fileId)
+  }
+
+  fun getOrganizationSplatInfo(
+      organizationId: OrganizationId,
+      fileId: FileId,
+  ): SplatInfoModel {
+    ensureOrganizationMediaFile(organizationId, fileId)
+    ensureSplat(fileId)
+
+    val annotations = listSplatAnnotations(fileId)
+    val (originPosition, cameraPosition) = getSplatPositions(fileId)
+
+    return SplatInfoModel(
+        annotations = annotations,
+        cameraPosition = cameraPosition,
+        originPosition = originPosition,
+    )
+  }
+
+  fun setOrganizationSplatAnnotations(
+      organizationId: OrganizationId,
+      fileId: FileId,
+      annotations: List<SplatAnnotationModel<*>>,
+  ) {
+    ensureOrganizationMediaFile(organizationId, fileId)
+    ensureSplat(fileId)
+
+    setSplatAnnotations(fileId, annotations)
   }
 
   fun recordSplatError(fileId: FileId, errorMessage: String) {
@@ -537,6 +584,21 @@ class SplatService(
             OBSERVATION_MEDIA_FILES,
             OBSERVATION_MEDIA_FILES.OBSERVATION_ID.eq(observationId)
                 .and(OBSERVATION_MEDIA_FILES.FILE_ID.eq(fileId)),
+        )
+
+    if (!associationExists) {
+      throw FileNotFoundException(fileId)
+    }
+  }
+
+  private fun ensureOrganizationMediaFile(organizationId: OrganizationId, fileId: FileId) {
+    requirePermissions { readOrganizationMedia(organizationId) }
+
+    val associationExists =
+        dslContext.fetchExists(
+            ORGANIZATION_MEDIA_FILES,
+            ORGANIZATION_MEDIA_FILES.ORGANIZATION_ID.eq(organizationId)
+                .and(ORGANIZATION_MEDIA_FILES.FILE_ID.eq(fileId)),
         )
 
     if (!associationExists) {

--- a/src/main/kotlin/com/terraformation/backend/splat/SplatService.kt
+++ b/src/main/kotlin/com/terraformation/backend/splat/SplatService.kt
@@ -162,16 +162,8 @@ class SplatService(
       fileId: FileId,
   ): SplatInfoModel {
     ensureOrganizationMediaFile(organizationId, fileId)
-    ensureSplat(fileId)
 
-    val annotations = listSplatAnnotations(fileId)
-    val (originPosition, cameraPosition) = getSplatPositions(fileId)
-
-    return SplatInfoModel(
-        annotations = annotations,
-        cameraPosition = cameraPosition,
-        originPosition = originPosition,
-    )
+    return getSplatInfo(fileId)
   }
 
   fun setOrganizationSplatAnnotations(
@@ -217,16 +209,8 @@ class SplatService(
       fileId: FileId,
   ): SplatInfoModel {
     ensureObservationFile(observationId, fileId)
-    ensureSplat(fileId)
 
-    val annotations = listSplatAnnotations(fileId)
-    val (originPosition, cameraPosition) = getSplatPositions(fileId)
-
-    return SplatInfoModel(
-        annotations = annotations,
-        cameraPosition = cameraPosition,
-        originPosition = originPosition,
-    )
+    return getSplatInfo(fileId)
   }
 
   fun recordBirdnetError(fileId: FileId, errorMessage: String) {
@@ -417,6 +401,19 @@ class SplatService(
       AssetStatus.Ready ->
           fileStore.read(splatsRecord.splatStorageUrl!!).withContentType(splatMimeType)
     }
+  }
+
+  private fun getSplatInfo(fileId: FileId): SplatInfoModel {
+    ensureSplat(fileId)
+
+    val annotations = listSplatAnnotations(fileId)
+    val (originPosition, cameraPosition) = getSplatPositions(fileId)
+
+    return SplatInfoModel(
+        annotations = annotations,
+        cameraPosition = cameraPosition,
+        originPosition = originPosition,
+    )
   }
 
   private fun getSplatPositions(fileId: FileId): Pair<CoordinateModel?, CoordinateModel?> {

--- a/src/main/kotlin/com/terraformation/backend/tracking/api/OrganizationSplatsController.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/api/OrganizationSplatsController.kt
@@ -1,0 +1,103 @@
+package com.terraformation.backend.tracking.api
+
+import com.terraformation.backend.api.ApiResponse200
+import com.terraformation.backend.api.ApiResponse202
+import com.terraformation.backend.api.ApiResponse404
+import com.terraformation.backend.api.ApiResponse422
+import com.terraformation.backend.api.CustomerEndpoint
+import com.terraformation.backend.api.ErrorDetails
+import com.terraformation.backend.api.SimpleErrorResponsePayload
+import com.terraformation.backend.api.SimpleSuccessResponsePayload
+import com.terraformation.backend.api.addImmutableCacheControlHeaders
+import com.terraformation.backend.api.toResponseEntity
+import com.terraformation.backend.db.default_schema.FileId
+import com.terraformation.backend.db.default_schema.OrganizationId
+import com.terraformation.backend.splat.SplatGenerationFailedException
+import com.terraformation.backend.splat.SplatNotReadyException
+import com.terraformation.backend.splat.SplatService
+import com.terraformation.backend.splat.api.GenerateSplatRequestPayload
+import com.terraformation.backend.splat.api.GetObservationSplatInfoResponsePayload
+import com.terraformation.backend.splat.api.SetSplatAnnotationsRequestPayload
+import io.swagger.v3.oas.annotations.Operation
+import jakarta.ws.rs.ServiceUnavailableException
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RequestMapping("/api/v1/organizations/{organizationId}/splats")
+@RestController
+@CustomerEndpoint
+class OrganizationSplatsController(
+    @Autowired(required = false) private val splatServiceDependency: SplatService?,
+) {
+  private val splatService: SplatService
+    get() =
+        splatServiceDependency
+            ?: throw ServiceUnavailableException("Splatter service is not enabled")
+
+  @ApiResponse200
+  @ApiResponse202("The video is still being processed and the model is not ready yet.")
+  @ApiResponse404("The media file does not exist in this organization.")
+  @ApiResponse422("The system was unable to generate a splat from the requested file.")
+  @GetMapping("/{fileId}")
+  @Operation(summary = "Downloads a splat model for an organization video.")
+  fun getOrganizationSplatFile(
+      @PathVariable organizationId: OrganizationId,
+      @PathVariable fileId: FileId,
+  ): ResponseEntity<*> {
+    return try {
+      splatService
+          .readOrganizationSplat(organizationId, fileId)
+          .toResponseEntity(addHeaders = addImmutableCacheControlHeaders)
+    } catch (_: SplatGenerationFailedException) {
+      ResponseEntity.unprocessableEntity()
+          .body(SimpleErrorResponsePayload(ErrorDetails("Splat generation failed.")))
+    } catch (_: SplatNotReadyException) {
+      ResponseEntity.accepted()
+          .body(SimpleErrorResponsePayload(ErrorDetails("Splat is not ready yet.")))
+    }
+  }
+
+  @ApiResponse200
+  @ApiResponse404("The media file does not exist in this organization.")
+  @PostMapping
+  @Operation(summary = "Initiates splat generation from an organization video.")
+  fun generateOrganizationSplat(
+      @PathVariable organizationId: OrganizationId,
+      @RequestBody payload: GenerateSplatRequestPayload,
+  ): SimpleSuccessResponsePayload {
+    splatService.generateOrganizationMediaSplat(organizationId, payload.fileId)
+    return SimpleSuccessResponsePayload()
+  }
+
+  @ApiResponse200
+  @ApiResponse404("The media file does not exist in this organization, or has no splat.")
+  @GetMapping("/{fileId}/info")
+  @Operation(summary = "Gets splat info and annotations for an organization video.")
+  fun getOrganizationSplatInfo(
+      @PathVariable organizationId: OrganizationId,
+      @PathVariable fileId: FileId,
+  ): GetObservationSplatInfoResponsePayload {
+    val infoModel = splatService.getOrganizationSplatInfo(organizationId, fileId)
+    return GetObservationSplatInfoResponsePayload(infoModel)
+  }
+
+  @ApiResponse200
+  @ApiResponse404("The media file does not exist in this organization, or has no splat.")
+  @PostMapping("/{fileId}/annotations")
+  @Operation(summary = "Sets annotations for a splat model of an organization video.")
+  fun setOrganizationSplatAnnotations(
+      @PathVariable organizationId: OrganizationId,
+      @PathVariable fileId: FileId,
+      @RequestBody payload: SetSplatAnnotationsRequestPayload,
+  ): SimpleSuccessResponsePayload {
+    val annotations = payload.annotations.map { it.toModel(fileId) }
+    splatService.setOrganizationSplatAnnotations(organizationId, fileId, annotations)
+    return SimpleSuccessResponsePayload()
+  }
+}

--- a/src/test/kotlin/com/terraformation/backend/splat/SplatServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/splat/SplatServiceTest.kt
@@ -7,17 +7,21 @@ import com.terraformation.backend.customer.db.ParentStore
 import com.terraformation.backend.customer.model.TerrawareUser
 import com.terraformation.backend.db.DatabaseTest
 import com.terraformation.backend.db.FileNotFoundException
+import com.terraformation.backend.db.OrganizationNotFoundException
 import com.terraformation.backend.db.default_schema.AssetStatus
 import com.terraformation.backend.db.default_schema.FileId
 import com.terraformation.backend.db.default_schema.OrganizationId
 import com.terraformation.backend.db.default_schema.Role
+import com.terraformation.backend.db.default_schema.tables.records.BirdnetResultsRecord
 import com.terraformation.backend.db.default_schema.tables.records.SplatAnnotationsRecord
+import com.terraformation.backend.db.default_schema.tables.records.SplatsRecord
 import com.terraformation.backend.db.default_schema.tables.references.BIRDNET_RESULTS
 import com.terraformation.backend.db.default_schema.tables.references.SPLATS
 import com.terraformation.backend.db.default_schema.tables.references.SPLAT_ANNOTATIONS
 import com.terraformation.backend.db.tracking.ObservationId
 import com.terraformation.backend.db.tracking.ObservationState
 import com.terraformation.backend.file.S3FileStore
+import com.terraformation.backend.file.SizedInputStream
 import com.terraformation.backend.file.event.FileDeletionStartedEvent
 import com.terraformation.backend.point
 import com.terraformation.backend.splat.sqs.SplatterRequestMessage
@@ -28,8 +32,10 @@ import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
 import io.mockk.verify
+import java.io.ByteArrayInputStream
 import java.net.URI
 import java.nio.file.NoSuchFileException
+import java.time.Instant
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
@@ -802,6 +808,402 @@ class SplatServiceTest : DatabaseTest(), RunsAsDatabaseUser {
       verify(exactly = 1) { fileStore.delete(jobArchiveUrl) }
 
       assertTableEmpty(SPLATS)
+    }
+  }
+
+  @Nested
+  inner class GenerateOrganizationMediaSplat {
+    private lateinit var orgFileId: FileId
+
+    @BeforeEach
+    fun setUp() {
+      orgFileId = insertOrganizationMediaFile()
+
+      every { fileStore.getPath(any()) } answers { java.nio.file.Paths.get("/path/to/video.mp4") }
+      every { fileStore.getUrl(any()) } answers
+          {
+            val path = firstArg<java.nio.file.Path>()
+            URI("s3://bucket/${path.fileName}")
+          }
+      every { sqsTemplate.send(any<String>(), any<SplatterRequestMessage>()) } returns
+          mockk(relaxed = true)
+    }
+
+    @Test
+    fun `creates splat record and sends SQS message`() {
+      service.generateOrganizationMediaSplat(
+          organizationId = organizationId,
+          fileId = orgFileId,
+          runBirdnet = false,
+      )
+
+      assertTableEquals(
+          SplatsRecord(
+              fileId = orgFileId,
+              createdBy = user.userId,
+              createdTime = clock.instant(),
+              assetStatusId = AssetStatus.Preparing,
+              splatStorageUrl = URI("s3://bucket/video.sog"),
+              organizationId = organizationId,
+          )
+      )
+
+      verify(exactly = 1) { sqsTemplate.send(any<String>(), any<SplatterRequestMessage>()) }
+    }
+
+    @Test
+    fun `creates BirdNet result record when runBirdnet is true`() {
+      service.generateOrganizationMediaSplat(
+          organizationId = organizationId,
+          fileId = orgFileId,
+          runBirdnet = true,
+      )
+
+      assertTableEquals(
+          BirdnetResultsRecord(
+              fileId = orgFileId,
+              createdBy = user.userId,
+              createdTime = clock.instant(),
+              assetStatusId = AssetStatus.Preparing,
+              resultsStorageUrl = URI("s3://bucket/video_birdnet.json"),
+          )
+      )
+    }
+
+    @Test
+    fun `does not create BirdNet result when runBirdnet is false`() {
+      service.generateOrganizationMediaSplat(
+          organizationId = organizationId,
+          fileId = orgFileId,
+          runBirdnet = false,
+      )
+
+      assertTableEmpty(BIRDNET_RESULTS)
+    }
+
+    @Test
+    fun `throws FileNotFoundException when file does not belong to organization`() {
+      val unassociatedFileId = insertFile()
+
+      assertThrows<FileNotFoundException> {
+        service.generateOrganizationMediaSplat(
+            organizationId = organizationId,
+            fileId = unassociatedFileId,
+        )
+      }
+    }
+
+    @Test
+    fun `throws FileNotFoundException when file belongs to different organization`() {
+      val otherOrgId = insertOrganization()
+      insertOrganizationUser(organizationId = otherOrgId, role = Role.Admin)
+      val otherOrgFileId =
+          insertOrganizationMediaFile(fileId = insertFile(), organizationId = otherOrgId)
+
+      assertThrows<FileNotFoundException> {
+        service.generateOrganizationMediaSplat(
+            organizationId = organizationId,
+            fileId = otherOrgFileId,
+        )
+      }
+    }
+
+    @Test
+    fun `does not send SQS message when splat already exists and force is false`() {
+      insertSplat(fileId = orgFileId, assetStatus = AssetStatus.Ready)
+
+      service.generateOrganizationMediaSplat(
+          organizationId = organizationId,
+          fileId = orgFileId,
+          force = false,
+          runBirdnet = false,
+      )
+
+      verify(exactly = 0) { sqsTemplate.send(any<String>(), any<SplatterRequestMessage>()) }
+    }
+
+    @Test
+    fun `sends SQS message when splat already exists and force is true`() {
+      insertSplat(fileId = orgFileId, assetStatus = AssetStatus.Ready)
+
+      service.generateOrganizationMediaSplat(
+          organizationId = organizationId,
+          fileId = orgFileId,
+          force = true,
+          runBirdnet = false,
+      )
+
+      verify(exactly = 1) { sqsTemplate.send(any<String>(), any<SplatterRequestMessage>()) }
+
+      assertTableEquals(
+          SplatsRecord(
+              fileId = orgFileId,
+              createdBy = user.userId,
+              createdTime = Instant.EPOCH,
+              assetStatusId = AssetStatus.Preparing,
+              splatStorageUrl = URI("s3://bucket/splat"),
+              organizationId = organizationId,
+          )
+      )
+    }
+
+    @Test
+    fun `throws exception when user is not a member of the organization`() {
+      deleteOrganizationUser()
+
+      assertThrows<OrganizationNotFoundException> {
+        service.generateOrganizationMediaSplat(
+            organizationId = organizationId,
+            fileId = orgFileId,
+        )
+      }
+    }
+  }
+
+  @Nested
+  inner class ReadOrganizationSplat {
+    private lateinit var orgFileId: FileId
+
+    @BeforeEach
+    fun setUp() {
+      orgFileId = insertOrganizationMediaFile()
+    }
+
+    @Test
+    fun `returns splat data for a valid ready file`() {
+      val splatUrl = URI("s3://bucket/splat.sog")
+      insertSplat(fileId = orgFileId, assetStatus = AssetStatus.Ready, splatStorageUrl = splatUrl)
+
+      val expectedStream = SizedInputStream(ByteArrayInputStream(ByteArray(10)), 10)
+      every { fileStore.read(splatUrl) } returns expectedStream
+
+      val result = service.readOrganizationSplat(organizationId, orgFileId)
+
+      assertEquals(10L, result.size, "Stream size")
+    }
+
+    @Test
+    fun `throws FileNotFoundException when file does not belong to organization`() {
+      val unassociatedFileId = insertFile()
+      insertSplat(fileId = unassociatedFileId)
+
+      assertThrows<FileNotFoundException> {
+        service.readOrganizationSplat(organizationId, unassociatedFileId)
+      }
+    }
+
+    @Test
+    fun `throws SplatNotReadyException when splat status is Preparing`() {
+      insertSplat(fileId = orgFileId, assetStatus = AssetStatus.Preparing)
+
+      assertThrows<SplatNotReadyException> {
+        service.readOrganizationSplat(organizationId, orgFileId)
+      }
+    }
+
+    @Test
+    fun `throws SplatGenerationFailedException when splat status is Errored`() {
+      insertSplat(fileId = orgFileId, assetStatus = AssetStatus.Errored)
+
+      assertThrows<SplatGenerationFailedException> {
+        service.readOrganizationSplat(organizationId, orgFileId)
+      }
+    }
+
+    @Test
+    fun `throws FileNotFoundException when no splat record exists for file`() {
+      assertThrows<FileNotFoundException> {
+        service.readOrganizationSplat(organizationId, orgFileId)
+      }
+    }
+
+    @Test
+    fun `throws exception when user is not a member of the organization`() {
+      insertSplat(fileId = orgFileId)
+      deleteOrganizationUser()
+
+      assertThrows<OrganizationNotFoundException> {
+        service.readOrganizationSplat(organizationId, orgFileId)
+      }
+    }
+  }
+
+  @Nested
+  inner class GetOrganizationSplatInfo {
+    private lateinit var orgFileId: FileId
+
+    @BeforeEach
+    fun setUp() {
+      orgFileId = insertOrganizationMediaFile()
+    }
+
+    @Test
+    fun `returns annotations and positions`() {
+      val originPosition = CoordinateModel(10.0, 20.0, 30.0)
+      val cameraPosition = CoordinateModel(40.0, 50.0, 60.0)
+      insertSplat(
+          fileId = orgFileId,
+          originPosition = originPosition,
+          cameraPosition = cameraPosition,
+      )
+
+      val annotationPosition = CoordinateModel(1.0, 2.0, 3.0)
+      val annotationId =
+          insertSplatAnnotation(
+              fileId = orgFileId,
+              title = "Test Annotation",
+              bodyText = "Description",
+              label = "Label",
+              position = annotationPosition,
+          )
+
+      val result = service.getOrganizationSplatInfo(organizationId, orgFileId)
+
+      val expected =
+          SplatInfoModel(
+              annotations =
+                  listOf(
+                      ExistingSplatAnnotationModel(
+                          id = annotationId,
+                          title = "Test Annotation",
+                          bodyText = "Description",
+                          label = "Label",
+                          position = annotationPosition,
+                          fileId = orgFileId,
+                      ),
+                  ),
+              cameraPosition = cameraPosition,
+              originPosition = originPosition,
+          )
+
+      assertEquals(expected, result)
+    }
+
+    @Test
+    fun `returns empty annotations and null positions when none set`() {
+      insertSplat(fileId = orgFileId)
+
+      val result = service.getOrganizationSplatInfo(organizationId, orgFileId)
+
+      assertEquals(SplatInfoModel(emptyList(), null, null), result)
+    }
+
+    @Test
+    fun `throws FileNotFoundException when file does not belong to organization`() {
+      val unassociatedFileId = insertFile()
+      insertSplat(fileId = unassociatedFileId)
+
+      assertThrows<FileNotFoundException> {
+        service.getOrganizationSplatInfo(organizationId, unassociatedFileId)
+      }
+    }
+
+    @Test
+    fun `throws FileNotFoundException when splat does not exist for file`() {
+      assertThrows<FileNotFoundException> {
+        service.getOrganizationSplatInfo(organizationId, orgFileId)
+      }
+    }
+
+    @Test
+    fun `throws exception when user is not a member of the organization`() {
+      insertSplat(fileId = orgFileId)
+      deleteOrganizationUser()
+
+      assertThrows<OrganizationNotFoundException> {
+        service.getOrganizationSplatInfo(organizationId, orgFileId)
+      }
+    }
+  }
+
+  @Nested
+  inner class SetOrganizationSplatAnnotations {
+    private lateinit var orgFileId: FileId
+
+    @BeforeEach
+    fun setUp() {
+      orgFileId = insertOrganizationMediaFile()
+      insertSplat(fileId = orgFileId)
+    }
+
+    @Test
+    fun `creates new annotations`() {
+      val position = CoordinateModel(1.0, 2.0, 3.0)
+      val cameraPos = CoordinateModel(4.0, 5.0, 6.0)
+
+      val annotations =
+          listOf(
+              NewSplatAnnotationModel(
+                  id = null,
+                  title = "Annotation 1",
+                  bodyText = "Body",
+                  label = "Label",
+                  position = position,
+                  cameraPosition = cameraPos,
+                  fileId = orgFileId,
+              ),
+          )
+
+      service.setOrganizationSplatAnnotations(organizationId, orgFileId, annotations)
+
+      assertTableEquals(
+          listOf(
+              SplatAnnotationsRecord(
+                  fileId = orgFileId,
+                  createdBy = user.userId,
+                  createdTime = clock.instant(),
+                  modifiedBy = user.userId,
+                  modifiedTime = clock.instant(),
+                  title = "Annotation 1",
+                  bodyText = "Body",
+                  label = "Label",
+                  positionX = position.x,
+                  positionY = position.y,
+                  positionZ = position.z,
+                  cameraPositionX = cameraPos.x,
+                  cameraPositionY = cameraPos.y,
+                  cameraPositionZ = cameraPos.z,
+              )
+          )
+      )
+    }
+
+    @Test
+    fun `deletes all annotations when empty list provided`() {
+      val position = CoordinateModel(1.0, 2.0, 3.0)
+      insertSplatAnnotation(fileId = orgFileId, title = "Delete Me", position = position)
+
+      service.setOrganizationSplatAnnotations(organizationId, orgFileId, emptyList())
+
+      assertTableEmpty(SPLAT_ANNOTATIONS)
+    }
+
+    @Test
+    fun `throws FileNotFoundException when file does not belong to organization`() {
+      val unassociatedFileId = insertFile()
+      insertSplat(fileId = unassociatedFileId)
+
+      assertThrows<FileNotFoundException> {
+        service.setOrganizationSplatAnnotations(organizationId, unassociatedFileId, emptyList())
+      }
+    }
+
+    @Test
+    fun `throws FileNotFoundException when splat does not exist for file`() {
+      val fileWithoutSplat = insertOrganizationMediaFile(fileId = insertFile())
+
+      assertThrows<FileNotFoundException> {
+        service.setOrganizationSplatAnnotations(organizationId, fileWithoutSplat, emptyList())
+      }
+    }
+
+    @Test
+    fun `throws exception when user is not a member of the organization`() {
+      deleteOrganizationUser()
+
+      assertThrows<OrganizationNotFoundException> {
+        service.setOrganizationSplatAnnotations(organizationId, orgFileId, emptyList())
+      }
     }
   }
 }


### PR DESCRIPTION
Add API endpoints to create and retrieve virtual walkthroughs based on
organization-level videos.

This doesn't include endpoints to list an organization's splats; the search API
can be used for that.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>