### PR TITLE
Delete media files when organization is deleted

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/tracking/OrganizationMediaService.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/OrganizationMediaService.kt
@@ -2,8 +2,10 @@ package com.terraformation.backend.tracking
 
 import com.terraformation.backend.api.getFilename
 import com.terraformation.backend.api.getPlainContentType
+import com.terraformation.backend.customer.event.OrganizationDeletionStartedEvent
 import com.terraformation.backend.customer.model.requirePermissions
 import com.terraformation.backend.db.FileNotFoundException
+import com.terraformation.backend.db.asNonNullable
 import com.terraformation.backend.db.default_schema.FileId
 import com.terraformation.backend.db.default_schema.OrganizationId
 import com.terraformation.backend.db.default_schema.tables.references.FILES
@@ -20,6 +22,7 @@ import jakarta.inject.Named
 import org.jooq.DSLContext
 import org.locationtech.jts.geom.Point
 import org.springframework.context.ApplicationEventPublisher
+import org.springframework.context.event.EventListener
 import org.springframework.web.multipart.MultipartFile
 
 @Named
@@ -110,6 +113,18 @@ class OrganizationMediaService(
     ensureOrganizationFile(organizationId, fileId)
 
     return muxService.getMuxStream(fileId)
+  }
+
+  @EventListener
+  fun on(event: OrganizationDeletionStartedEvent) {
+    val fileIds =
+        dslContext
+            .select(ORGANIZATION_MEDIA_FILES.FILE_ID)
+            .from(ORGANIZATION_MEDIA_FILES)
+            .where(ORGANIZATION_MEDIA_FILES.ORGANIZATION_ID.eq(event.organizationId))
+            .fetch(ORGANIZATION_MEDIA_FILES.FILE_ID.asNonNullable())
+
+    fileIds.forEach { delete(event.organizationId, it) }
   }
 
   private fun ensureOrganizationFile(organizationId: OrganizationId, fileId: FileId) {

--- a/src/test/kotlin/com/terraformation/backend/tracking/OrganizationMediaServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/OrganizationMediaServiceTest.kt
@@ -4,6 +4,7 @@ import com.terraformation.backend.RunsAsUser
 import com.terraformation.backend.TestClock
 import com.terraformation.backend.TestEventPublisher
 import com.terraformation.backend.assertGeometryEquals
+import com.terraformation.backend.customer.event.OrganizationDeletionStartedEvent
 import com.terraformation.backend.db.DatabaseTest
 import com.terraformation.backend.db.FileNotFoundException
 import com.terraformation.backend.db.default_schema.FileId
@@ -301,6 +302,30 @@ internal class OrganizationMediaServiceTest : DatabaseTest(), RunsAsUser {
           )
 
       assertThrows<AccessDeniedException> { service.getStream(organizationId, fileId) }
+    }
+  }
+
+  @Nested
+  inner class OnOrganizationDeletionStartedEvent {
+    @Test
+    fun `deletes all organization media files`() {
+      val otherOrgId = insertOrganization()
+      insertOrganizationMediaFile(fileId = insertFile(), organizationId = otherOrgId)
+
+      val expected = dslContext.fetch(ORGANIZATION_MEDIA_FILES)
+
+      val fileId1 =
+          insertOrganizationMediaFile(fileId = insertFile(), organizationId = organizationId)
+      val fileId2 =
+          insertOrganizationMediaFile(fileId = insertFile(), organizationId = organizationId)
+
+      service.on(OrganizationDeletionStartedEvent(organizationId))
+
+      assertTableEquals(expected)
+
+      eventPublisher.assertEventsPublished(
+          setOf(FileReferenceDeletedEvent(fileId1), FileReferenceDeletedEvent(fileId2))
+      )
     }
   }
 }


### PR DESCRIPTION
When an organization is deleted, we need to clean up all its media files just like
we do with other files.