### PR TITLE
SW-8274 Add organization media thumbnail endpoint

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/tracking/OrganizationMediaService.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/OrganizationMediaService.kt
@@ -13,6 +13,7 @@ import com.terraformation.backend.db.default_schema.tables.references.ORGANIZATI
 import com.terraformation.backend.file.FileService
 import com.terraformation.backend.file.SUPPORTED_MEDIA_TYPES
 import com.terraformation.backend.file.SizedInputStream
+import com.terraformation.backend.file.ThumbnailService
 import com.terraformation.backend.file.event.FileReferenceDeletedEvent
 import com.terraformation.backend.file.model.FileMetadata
 import com.terraformation.backend.file.mux.MuxService
@@ -31,6 +32,7 @@ class OrganizationMediaService(
     private val eventPublisher: ApplicationEventPublisher,
     private val fileService: FileService,
     private val muxService: MuxService,
+    private val thumbnailService: ThumbnailService,
 ) {
   private val log = perClassLogger()
 
@@ -68,6 +70,18 @@ class OrganizationMediaService(
     ensureOrganizationFile(organizationId, fileId)
 
     return fileService.readFile(fileId)
+  }
+
+  fun readThumbnail(
+      organizationId: OrganizationId,
+      fileId: FileId,
+      maxWidth: Int? = null,
+      maxHeight: Int? = null,
+  ): SizedInputStream {
+    requirePermissions { readOrganizationMedia(organizationId) }
+    ensureOrganizationFile(organizationId, fileId)
+
+    return thumbnailService.readFile(fileId, maxWidth, maxHeight)
   }
 
   fun update(

--- a/src/main/kotlin/com/terraformation/backend/tracking/api/OrganizationMediaController.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/api/OrganizationMediaController.kt
@@ -3,6 +3,8 @@ package com.terraformation.backend.tracking.api
 import com.terraformation.backend.api.ApiResponse200
 import com.terraformation.backend.api.ApiResponse404
 import com.terraformation.backend.api.CustomerEndpoint
+import com.terraformation.backend.api.PHOTO_MAXHEIGHT_DESCRIPTION
+import com.terraformation.backend.api.PHOTO_MAXWIDTH_DESCRIPTION
 import com.terraformation.backend.api.RequestBodyPhotoFile
 import com.terraformation.backend.api.SimpleSuccessResponsePayload
 import com.terraformation.backend.api.SuccessResponsePayload
@@ -12,6 +14,7 @@ import com.terraformation.backend.db.default_schema.OrganizationId
 import com.terraformation.backend.file.mux.MuxStreamModel
 import com.terraformation.backend.tracking.OrganizationMediaService
 import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.Parameter
 import org.locationtech.jts.geom.Point
 import org.springframework.http.MediaType
 import org.springframework.http.ResponseEntity
@@ -22,6 +25,7 @@ import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.PutMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RequestPart
 import org.springframework.web.bind.annotation.RestController
 import org.springframework.web.multipart.MultipartFile
@@ -63,6 +67,21 @@ class OrganizationMediaController(
       @PathVariable fileId: FileId,
   ): ResponseEntity<*> {
     return organizationMediaService.read(organizationId, fileId).toResponseEntity()
+  }
+
+  @ApiResponse200
+  @ApiResponse404("The media file does not exist in this organization.")
+  @GetMapping("/{fileId}/thumbnail")
+  @Operation(summary = "Downloads a thumbnail image for an organization media file.")
+  fun getOrganizationMediaFileThumbnail(
+      @PathVariable organizationId: OrganizationId,
+      @PathVariable fileId: FileId,
+      @Parameter(description = PHOTO_MAXWIDTH_DESCRIPTION) @RequestParam maxWidth: Int? = null,
+      @Parameter(description = PHOTO_MAXHEIGHT_DESCRIPTION) @RequestParam maxHeight: Int? = null,
+  ): ResponseEntity<*> {
+    return organizationMediaService
+        .readThumbnail(organizationId, fileId, maxWidth, maxHeight)
+        .toResponseEntity()
   }
 
   @ApiResponse200

--- a/src/test/kotlin/com/terraformation/backend/tracking/OrganizationMediaServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/OrganizationMediaServiceTest.kt
@@ -14,6 +14,7 @@ import com.terraformation.backend.db.default_schema.tables.references.ORGANIZATI
 import com.terraformation.backend.file.FileService
 import com.terraformation.backend.file.InMemoryFileStore
 import com.terraformation.backend.file.SizedInputStream
+import com.terraformation.backend.file.ThumbnailService
 import com.terraformation.backend.file.event.FileReferenceDeletedEvent
 import com.terraformation.backend.file.mux.MuxService
 import com.terraformation.backend.file.mux.MuxStreamModel
@@ -42,9 +43,10 @@ internal class OrganizationMediaServiceTest : DatabaseTest(), RunsAsUser {
     FileService(dslContext, clock, eventPublisher, filesDao, fileStore)
   }
   private val muxService: MuxService = mockk()
+  private val thumbnailService: ThumbnailService = mockk()
 
   private val service: OrganizationMediaService by lazy {
-    OrganizationMediaService(dslContext, eventPublisher, fileService, muxService)
+    OrganizationMediaService(dslContext, eventPublisher, fileService, muxService, thumbnailService)
   }
 
   private lateinit var organizationId: OrganizationId
@@ -127,6 +129,52 @@ internal class OrganizationMediaServiceTest : DatabaseTest(), RunsAsUser {
           )
 
       assertThrows<AccessDeniedException> { service.read(organizationId, fileId) }
+    }
+  }
+
+  @Nested
+  inner class ReadThumbnail {
+    @Test
+    fun `returns thumbnail data`() {
+      val fileId =
+          insertOrganizationMediaFile(fileId = insertFile(), organizationId = organizationId)
+      val maxWidth = 40
+      val maxHeight = 30
+      val thumbnailContent = byteArrayOf(9, 8, 7)
+
+      every { thumbnailService.readFile(fileId, maxWidth, maxHeight) } returns
+          SizedInputStream(thumbnailContent.inputStream(), 3)
+
+      val inputStream = service.readThumbnail(organizationId, fileId, maxWidth, maxHeight)
+      assertArrayEquals(thumbnailContent, inputStream.readAllBytes())
+    }
+
+    @Test
+    fun `throws FileNotFoundException when file does not belong to the organization`() {
+      val otherOrgId = insertOrganization()
+      val fileId = insertOrganizationMediaFile(fileId = insertFile(), organizationId = otherOrgId)
+
+      assertThrows<FileNotFoundException> { service.readThumbnail(organizationId, fileId) }
+    }
+
+    @Test
+    fun `throws FileNotFoundException when file does not exist`() {
+      val bogusFileId = FileId(99999)
+
+      assertThrows<FileNotFoundException> { service.readThumbnail(organizationId, bogusFileId) }
+    }
+
+    @Test
+    fun `throws AccessDeniedException when user cannot read organization media`() {
+      every { user.canReadOrganizationMedia(any()) } returns false
+
+      val fileId =
+          insertOrganizationMediaFile(
+              fileId = insertFile(),
+              organizationId = organizationId,
+          )
+
+      assertThrows<AccessDeniedException> { service.readThumbnail(organizationId, fileId) }
     }
   }
 


### PR DESCRIPTION
Add an endpoint to fetch a thumbnail image for an organization media file.
This uses the same logic as the thumbnail fetching for observation media files
and will return Mux-generated thumbnails (once available) for videos.