### PR TITLE
SW-8285 Support marking splats as needing attention

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/search/table/OrganizationMediaFilesTable.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/table/OrganizationMediaFilesTable.kt
@@ -54,14 +54,8 @@ class OrganizationMediaFilesTable(tables: SearchTables) : SearchTable() {
           geometryField("gpsCoordinates", filesAlias.GEOLOCATION),
           coordinateField("latitude", filesAlias.GEOLOCATION, POINT, LATITUDE),
           coordinateField("longitude", filesAlias.GEOLOCATION, POINT, LONGITUDE),
-          nonLocalizableEnumField(
-              "splatStatus",
-              DSL.field(
-                  DSL.select(SPLATS.ASSET_STATUS_ID)
-                      .from(SPLATS)
-                      .where(SPLATS.FILE_ID.eq(ORGANIZATION_MEDIA_FILES.FILE_ID))
-              ),
-          ),
+          booleanField("needsAttention", SPLATS.NEEDS_ATTENTION),
+          nonLocalizableEnumField("splatStatus", SPLATS.ASSET_STATUS_ID),
       )
 
   override val defaultOrderFields: List<OrderField<*>> = listOf(ORGANIZATION_MEDIA_FILES.FILE_ID)
@@ -70,6 +64,8 @@ class OrganizationMediaFilesTable(tables: SearchTables) : SearchTable() {
     get() =
         ORGANIZATION_MEDIA_FILES.join(filesAlias)
             .on(ORGANIZATION_MEDIA_FILES.FILE_ID.eq(filesAlias.ID))
+            .leftJoin(SPLATS)
+            .on(ORGANIZATION_MEDIA_FILES.FILE_ID.eq(SPLATS.FILE_ID))
 
   override fun conditionForVisibility(): Condition {
     return ORGANIZATION_MEDIA_FILES.ORGANIZATION_ID.`in`(currentUser().organizationRoles.keys)

--- a/src/main/kotlin/com/terraformation/backend/splat/SplatService.kt
+++ b/src/main/kotlin/com/terraformation/backend/splat/SplatService.kt
@@ -177,6 +177,27 @@ class SplatService(
     setSplatAnnotations(fileId, annotations)
   }
 
+  fun setOrganizationSplatNeedsAttention(
+      organizationId: OrganizationId,
+      fileId: FileId,
+      needsAttention: Boolean,
+  ) {
+    requirePermissions { updateOrganizationMedia(organizationId) }
+    ensureOrganizationMediaFile(organizationId, fileId)
+    ensureSplat(fileId)
+
+    // The requirements only call for being able to set the flag; there's no process defined to
+    // clear it. So for now, we only support the false -> true transition, but our API is already
+    // structured to support true -> false if/when the behavior of that transition is defined.
+    if (needsAttention) {
+      dslContext
+          .update(SPLATS)
+          .set(SPLATS.NEEDS_ATTENTION, true)
+          .where(SPLATS.FILE_ID.eq(fileId))
+          .execute()
+    }
+  }
+
   fun recordSplatError(fileId: FileId, errorMessage: String) {
     log.error("Splat generation failed for file $fileId: $errorMessage")
 
@@ -289,6 +310,7 @@ class SplatService(
                 .set(CREATED_BY, currentUser().userId)
                 .set(CREATED_TIME, clock.instant())
                 .set(FILE_ID, fileId)
+                .set(NEEDS_ATTENTION, false)
                 .set(ORGANIZATION_ID, organizationId)
                 .set(SPLAT_STORAGE_URL, splatUrl)
                 .onConflictDoNothing()

--- a/src/main/kotlin/com/terraformation/backend/splat/SplatService.kt
+++ b/src/main/kotlin/com/terraformation/backend/splat/SplatService.kt
@@ -195,6 +195,8 @@ class SplatService(
           .set(SPLATS.NEEDS_ATTENTION, true)
           .where(SPLATS.FILE_ID.eq(fileId))
           .execute()
+    } else {
+      log.warn("Ignoring attempt to clear needs-attention flag")
     }
   }
 

--- a/src/main/kotlin/com/terraformation/backend/tracking/api/OrganizationSplatsController.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/api/OrganizationSplatsController.kt
@@ -25,6 +25,7 @@ import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.PutMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
@@ -103,7 +104,7 @@ class OrganizationSplatsController(
 
   @ApiResponse200
   @ApiResponse404("The media file does not exist in this organization, or has no splat.")
-  @PostMapping("/{fileId}/needsAttention")
+  @PutMapping("/{fileId}/needsAttention")
   @Operation(summary = "Flags a splat as needing administrator attention.")
   fun setOrganizationSplatNeedsAttention(
       @PathVariable organizationId: OrganizationId,

--- a/src/main/kotlin/com/terraformation/backend/tracking/api/OrganizationSplatsController.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/api/OrganizationSplatsController.kt
@@ -100,4 +100,21 @@ class OrganizationSplatsController(
     splatService.setOrganizationSplatAnnotations(organizationId, fileId, annotations)
     return SimpleSuccessResponsePayload()
   }
+
+  @ApiResponse200
+  @ApiResponse404("The media file does not exist in this organization, or has no splat.")
+  @PostMapping("/{fileId}/needsAttention")
+  @Operation(summary = "Flags a splat as needing administrator attention.")
+  fun setOrganizationSplatNeedsAttention(
+      @PathVariable organizationId: OrganizationId,
+      @PathVariable fileId: FileId,
+      @RequestBody payload: SetSplatNeedsAttentionRequestPayload,
+  ): SimpleSuccessResponsePayload {
+    splatService.setOrganizationSplatNeedsAttention(organizationId, fileId, payload.needsAttention)
+    return SimpleSuccessResponsePayload()
+  }
 }
+
+data class SetSplatNeedsAttentionRequestPayload(
+    val needsAttention: Boolean,
+)

--- a/src/main/resources/db/migration/0450/V475__SplatNeedsAttention.sql
+++ b/src/main/resources/db/migration/0450/V475__SplatNeedsAttention.sql
@@ -1,0 +1,3 @@
+ALTER TABLE splats ADD COLUMN needs_attention BOOLEAN;
+UPDATE splats SET needs_attention = FALSE;
+ALTER TABLE splats ALTER COLUMN needs_attention SET NOT NULL;

--- a/src/main/resources/i18n/Messages_en.properties
+++ b/src/main/resources/i18n/Messages_en.properties
@@ -771,6 +771,7 @@ search.organizationMediaFiles.fileId=Organization media file ID
 search.organizationMediaFiles.gpsCoordinates=Organization media file GPS coordinates
 search.organizationMediaFiles.latitude=Organization media file latitude
 search.organizationMediaFiles.longitude=Organization media file longitude
+search.organizationMediaFiles.needsAttention=Organization media file needs attention
 search.organizationMediaFiles.splatStatus=Organization media file splat processing status
 search.organizationUsers.createdTime=Organization membership creation time
 search.organizationUsers.roleName=User role name

--- a/src/main/resources/i18n/Messages_es.properties
+++ b/src/main/resources/i18n/Messages_es.properties
@@ -1355,8 +1355,10 @@ search.organizationMediaFiles.gpsCoordinates=Coordenadas GPS de archivos multime
 search.organizationMediaFiles.latitude=Latitud de archivos multimedia de la organización
 # 7eb9f336
 search.organizationMediaFiles.longitude=Longitud de archivos multimedia de la organización
+# ae0900e6
+search.organizationMediaFiles.needsAttention=El archivo multimedia de la organización requiere atención
 # 789d71e2
-search.organizationMediaFiles.splatStatus=Estado de procesamiento Splat de archivos multimedia de la organización
+search.organizationMediaFiles.splatStatus=Estado de procesamiento splat del archivo multimedia de la organización
 # 4fd03042
 search.organizations.countryCode=Código del país de la organización
 # 62f55565

--- a/src/main/resources/i18n/Messages_fr.properties
+++ b/src/main/resources/i18n/Messages_fr.properties
@@ -1355,8 +1355,10 @@ search.organizationMediaFiles.gpsCoordinates=Coordonnées GPS du fichier média 
 search.organizationMediaFiles.latitude=Latitude du fichier média de l''organisation
 # 7eb9f336
 search.organizationMediaFiles.longitude=Longitude du fichier média de l''organisation
+# ae0900e6
+search.organizationMediaFiles.needsAttention=Un fichier média de l''organisation nécessite une attention particulière
 # 789d71e2
-search.organizationMediaFiles.splatStatus=Statut du traitement Splat des fichiers médias de l''organisation
+search.organizationMediaFiles.splatStatus=Statut de traitement splat du fichier média de l''organisation
 # 4fd03042
 search.organizations.countryCode=Code du pays de l''organisation
 # 62f55565

--- a/src/test/kotlin/com/terraformation/backend/db/DatabaseBackedTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/db/DatabaseBackedTest.kt
@@ -3139,6 +3139,7 @@ abstract class DatabaseBackedTest {
       createdTime: Instant = row.createdTime ?: Instant.EPOCH,
       organizationId: OrganizationId = row.organizationId ?: inserted.organizationId,
       splatStorageUrl: URI = row.splatStorageUrl ?: URI("s3://bucket/splat"),
+      needsAttention: Boolean = row.needsAttention ?: false,
   ) {
     val rowWithDefaults =
         row.copy(
@@ -3149,6 +3150,7 @@ abstract class DatabaseBackedTest {
             createdBy = createdBy,
             createdTime = createdTime,
             fileId = fileId,
+            needsAttention = needsAttention,
             organizationId = organizationId,
             originPositionX = originPosition?.x,
             originPositionY = originPosition?.y,

--- a/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceNestedFieldsTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceNestedFieldsTest.kt
@@ -1103,6 +1103,7 @@ internal class SearchServiceNestedFieldsTest : SearchServiceTest() {
                 "gpsCoordinates" to """{"type":"Point","coordinates":[12,34]}""",
                 "latitude" to "34",
                 "longitude" to "12",
+                "needsAttention" to "false",
                 "splatStatus" to "Ready",
             )
         )

--- a/src/test/kotlin/com/terraformation/backend/splat/SplatServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/splat/SplatServiceTest.kt
@@ -764,6 +764,7 @@ class SplatServiceTest : DatabaseTest(), RunsAsDatabaseUser {
               assetStatusId = AssetStatus.Preparing,
               splatStorageUrl = URI("s3://bucket/video.sog"),
               organizationId = organizationId,
+              needsAttention = false,
           )
       )
     }
@@ -877,6 +878,7 @@ class SplatServiceTest : DatabaseTest(), RunsAsDatabaseUser {
               assetStatusId = AssetStatus.Preparing,
               splatStorageUrl = URI("s3://bucket/video.sog"),
               organizationId = organizationId,
+              needsAttention = false,
           )
       )
 
@@ -975,6 +977,7 @@ class SplatServiceTest : DatabaseTest(), RunsAsDatabaseUser {
               assetStatusId = AssetStatus.Preparing,
               splatStorageUrl = URI("s3://bucket/splat"),
               organizationId = organizationId,
+              needsAttention = false,
           )
       )
     }
@@ -1235,6 +1238,65 @@ class SplatServiceTest : DatabaseTest(), RunsAsDatabaseUser {
 
       assertThrows<OrganizationNotFoundException> {
         service.setOrganizationSplatAnnotations(organizationId, orgFileId, emptyList())
+      }
+    }
+  }
+
+  @Nested
+  inner class SetOrganizationSplatNeedsAttention {
+    private lateinit var orgFileId: FileId
+
+    @BeforeEach
+    fun setUp() {
+      orgFileId = insertOrganizationMediaFile()
+      insertSplat(fileId = orgFileId)
+    }
+
+    @Test
+    fun `sets needs attention on splat`() {
+      service.setOrganizationSplatNeedsAttention(organizationId, orgFileId, true)
+
+      val record = dslContext.fetchOne(SPLATS, SPLATS.FILE_ID.eq(orgFileId))!!
+      assertEquals(true, record.needsAttention)
+    }
+
+    @Test
+    fun `does not clear needs attention when false is passed`() {
+      service.setOrganizationSplatNeedsAttention(organizationId, orgFileId, true)
+      service.setOrganizationSplatNeedsAttention(organizationId, orgFileId, false)
+
+      val record = dslContext.fetchOne(SPLATS, SPLATS.FILE_ID.eq(orgFileId))!!
+      assertEquals(true, record.needsAttention)
+    }
+
+    @Test
+    fun `throws exception if file does not belong to organization`() {
+      val unassociatedFileId = insertFile()
+      insertSplat(fileId = unassociatedFileId)
+
+      assertThrows<FileNotFoundException> {
+        service.setOrganizationSplatNeedsAttention(organizationId, unassociatedFileId, true)
+      }
+    }
+
+    @Test
+    fun `throws exception if splat does not exist`() {
+      val fileWithoutSplat = insertOrganizationMediaFile(fileId = insertFile())
+
+      assertThrows<FileNotFoundException> {
+        service.setOrganizationSplatNeedsAttention(organizationId, fileWithoutSplat, true)
+      }
+    }
+
+    @Test
+    fun `throws exception if user does not have permission`() {
+      val otherOrgId = insertOrganization()
+      val otherFileId = insertFile()
+      insertOrganizationMediaFile(fileId = otherFileId, organizationId = otherOrgId)
+      insertSplat(fileId = otherFileId, organizationId = otherOrgId)
+
+      assertThrows<OrganizationNotFoundException> {
+        service.setOrganizationSplatNeedsAttention(otherOrgId, otherFileId, true)
       }
     }
   }


### PR DESCRIPTION
Add an API endpoint and search field to support users setting the "needs
attention" flag on a splat. For now, per the requirements, we only support
setting the flag, not clearing it, but in anticipation of an eventual request
to support clearing the flag, the API is already structured to let the client
pass in a true or false value.

This does not include any of the notifications that are supposed to be
generated when the flag is set; those will be in a followup change.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
