### PR TITLE
SW-8287 Automatically generate splats from org videos

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/customer/event/OrganizationVideoUploadedEvent.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/event/OrganizationVideoUploadedEvent.kt
@@ -1,0 +1,10 @@
+package com.terraformation.backend.customer.event
+
+import com.terraformation.backend.db.default_schema.FileId
+import com.terraformation.backend.db.default_schema.OrganizationId
+
+/** Published when a video file is uploaded as organization media. */
+data class OrganizationVideoUploadedEvent(
+    val fileId: FileId,
+    val organizationId: OrganizationId,
+)

--- a/src/main/kotlin/com/terraformation/backend/splat/SplatService.kt
+++ b/src/main/kotlin/com/terraformation/backend/splat/SplatService.kt
@@ -3,6 +3,7 @@ package com.terraformation.backend.splat
 import com.terraformation.backend.auth.currentUser
 import com.terraformation.backend.config.TerrawareServerConfig
 import com.terraformation.backend.customer.db.ParentStore
+import com.terraformation.backend.customer.event.OrganizationVideoUploadedEvent
 import com.terraformation.backend.customer.model.requirePermissions
 import com.terraformation.backend.db.FileNotFoundException
 import com.terraformation.backend.db.default_schema.AssetStatus
@@ -411,6 +412,15 @@ class SplatService(
       }
     } catch (e: Exception) {
       log.error("Unable to delete splat for file ${event.fileId}", e)
+    }
+  }
+
+  @EventListener
+  fun on(event: OrganizationVideoUploadedEvent) {
+    try {
+      generateOrganizationMediaSplat(event.organizationId, event.fileId)
+    } catch (e: Exception) {
+      log.error("Failed to auto-generate splat for file ${event.fileId}", e)
     }
   }
 

--- a/src/main/kotlin/com/terraformation/backend/tracking/OrganizationMediaService.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/OrganizationMediaService.kt
@@ -3,6 +3,7 @@ package com.terraformation.backend.tracking
 import com.terraformation.backend.api.getFilename
 import com.terraformation.backend.api.getPlainContentType
 import com.terraformation.backend.customer.event.OrganizationDeletionStartedEvent
+import com.terraformation.backend.customer.event.OrganizationVideoUploadedEvent
 import com.terraformation.backend.customer.model.requirePermissions
 import com.terraformation.backend.db.FileNotFoundException
 import com.terraformation.backend.db.asNonNullable
@@ -61,6 +62,10 @@ class OrganizationMediaService(
         }
 
     log.info("Stored media file $fileId for organization $organizationId")
+
+    if (contentType.startsWith("video/")) {
+      eventPublisher.publishEvent(OrganizationVideoUploadedEvent(fileId, organizationId))
+    }
 
     return fileId
   }

--- a/src/test/kotlin/com/terraformation/backend/splat/SplatServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/splat/SplatServiceTest.kt
@@ -4,6 +4,7 @@ import com.terraformation.backend.RunsAsDatabaseUser
 import com.terraformation.backend.TestClock
 import com.terraformation.backend.config.TerrawareServerConfig
 import com.terraformation.backend.customer.db.ParentStore
+import com.terraformation.backend.customer.event.OrganizationVideoUploadedEvent
 import com.terraformation.backend.customer.model.TerrawareUser
 import com.terraformation.backend.db.DatabaseTest
 import com.terraformation.backend.db.FileNotFoundException
@@ -36,6 +37,7 @@ import java.io.ByteArrayInputStream
 import java.net.URI
 import java.nio.file.NoSuchFileException
 import java.time.Instant
+import kotlin.io.path.Path
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
@@ -1298,6 +1300,48 @@ class SplatServiceTest : DatabaseTest(), RunsAsDatabaseUser {
       assertThrows<OrganizationNotFoundException> {
         service.setOrganizationSplatNeedsAttention(otherOrgId, otherFileId, true)
       }
+    }
+  }
+
+  @Nested
+  inner class OnOrganizationVideoUploadedEvent {
+    private lateinit var orgFileId: FileId
+
+    @BeforeEach
+    fun setUp() {
+      orgFileId = insertOrganizationMediaFile()
+
+      every { fileStore.getPath(any()) } returns Path("/1.sog")
+      every { fileStore.getUrl(any()) } returns URI("s3://bucket/1.sog")
+      every { sqsTemplate.send(any(), any<SplatterRequestMessage>()) } returns mockk(relaxed = true)
+    }
+
+    @Test
+    fun `triggers splat generation on video upload`() {
+      service.on(OrganizationVideoUploadedEvent(orgFileId, organizationId))
+
+      assertTableEquals(
+          SplatsRecord(
+              assetStatusId = AssetStatus.Preparing,
+              createdBy = user.userId,
+              createdTime = clock.instant(),
+              fileId = orgFileId,
+              needsAttention = false,
+              organizationId = organizationId,
+              splatStorageUrl = URI("s3://bucket/1.sog"),
+          )
+      )
+
+      verify(exactly = 1) { sqsTemplate.send(any<String>(), any<SplatterRequestMessage>()) }
+    }
+
+    @Test
+    fun `does not propagate exceptions from splat generation`() {
+      every { fileStore.getPath(any()) } throws RuntimeException("Simulated failure")
+
+      service.on(OrganizationVideoUploadedEvent(orgFileId, organizationId))
+
+      assertTableEmpty(SPLATS)
     }
   }
 }

--- a/src/test/kotlin/com/terraformation/backend/tracking/OrganizationMediaServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/OrganizationMediaServiceTest.kt
@@ -5,6 +5,7 @@ import com.terraformation.backend.TestClock
 import com.terraformation.backend.TestEventPublisher
 import com.terraformation.backend.assertGeometryEquals
 import com.terraformation.backend.customer.event.OrganizationDeletionStartedEvent
+import com.terraformation.backend.customer.event.OrganizationVideoUploadedEvent
 import com.terraformation.backend.db.DatabaseTest
 import com.terraformation.backend.db.FileNotFoundException
 import com.terraformation.backend.db.default_schema.FileId
@@ -84,6 +85,26 @@ internal class OrganizationMediaServiceTest : DatabaseTest(), RunsAsUser {
       assertThrows<AccessDeniedException> {
         service.upload(organizationId, multipartFile, "caption")
       }
+    }
+
+    @Test
+    fun `publishes OrganizationVideoUploadedEvent when video is uploaded`() {
+      val multipartFile = MockMultipartFile("file", "video.mp4", "video/mp4", ByteArray(1))
+
+      val insertedFileId = service.upload(organizationId, multipartFile, "Test caption")
+
+      eventPublisher.assertEventPublished(
+          OrganizationVideoUploadedEvent(insertedFileId, organizationId)
+      )
+    }
+
+    @Test
+    fun `does not publish OrganizationVideoUploadedEvent when image is uploaded`() {
+      val multipartFile = MockMultipartFile("file", "photo.jpg", "image/jpeg", ByteArray(1))
+
+      service.upload(organizationId, multipartFile, "Test caption")
+
+      eventPublisher.assertEventNotPublished<OrganizationVideoUploadedEvent>()
     }
   }
 


### PR DESCRIPTION
For observation videos, we require the user to explicitly request the creation of
a virtual walkthrough, but for organization videos, we want it to happen
automatically when the upload finishes.