### PR TITLE
Support clearing "Needs Attention" flag

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/splat/SplatService.kt
+++ b/src/main/kotlin/com/terraformation/backend/splat/SplatService.kt
@@ -192,32 +192,25 @@ class SplatService(
     ensureOrganizationMediaFile(organizationId, fileId)
     ensureSplat(fileId)
 
-    // The requirements only call for being able to set the flag; there's no process defined to
-    // clear it. So for now, we only support the false -> true transition, but our API is already
-    // structured to support true -> false if/when the behavior of that transition is defined.
-    if (needsAttention) {
-      val rowsUpdated =
-          dslContext
-              .update(SPLATS)
-              .set(SPLATS.NEEDS_ATTENTION, true)
-              .where(SPLATS.FILE_ID.eq(fileId))
-              .and(SPLATS.NEEDS_ATTENTION.eq(false))
-              .execute()
+    val rowsUpdated =
+        dslContext
+            .update(SPLATS)
+            .set(SPLATS.NEEDS_ATTENTION, needsAttention)
+            .where(SPLATS.FILE_ID.eq(fileId))
+            .and(SPLATS.NEEDS_ATTENTION.ne(needsAttention))
+            .execute()
 
-      if (rowsUpdated > 0) {
-        val splatRecord = dslContext.fetchSingle(SPLATS, SPLATS.FILE_ID.eq(fileId))
-        eventPublisher.publishEvent(
-            SplatMarkedNeedsAttentionEvent(
-                fileId = fileId,
-                markedByUserId = currentUser().userId,
-                organizationId = organizationId,
-                uploadedByUserId = splatRecord.createdBy!!,
-                videoUploadedTime = splatRecord.createdTime!!,
-            )
-        )
-      }
-    } else {
-      log.warn("Ignoring attempt to clear needs-attention flag")
+    if (needsAttention && rowsUpdated > 0) {
+      val splatRecord = dslContext.fetchSingle(SPLATS, SPLATS.FILE_ID.eq(fileId))
+      eventPublisher.publishEvent(
+          SplatMarkedNeedsAttentionEvent(
+              fileId = fileId,
+              markedByUserId = currentUser().userId,
+              organizationId = organizationId,
+              uploadedByUserId = splatRecord.createdBy!!,
+              videoUploadedTime = splatRecord.createdTime!!,
+          )
+      )
     }
   }
 

--- a/src/test/kotlin/com/terraformation/backend/splat/SplatServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/splat/SplatServiceTest.kt
@@ -1326,12 +1326,12 @@ class SplatServiceTest : DatabaseTest(), RunsAsDatabaseUser {
     }
 
     @Test
-    fun `does not clear needs attention when false is passed`() {
+    fun `clears needs attention when false is passed`() {
       service.setOrganizationSplatNeedsAttention(organizationId, orgFileId, true)
       service.setOrganizationSplatNeedsAttention(organizationId, orgFileId, false)
 
       val record = dslContext.fetchOne(SPLATS, SPLATS.FILE_ID.eq(orgFileId))!!
-      assertEquals(true, record.needsAttention)
+      assertEquals(false, record.needsAttention)
     }
 
     @Test


### PR DESCRIPTION
The requirements originally said we only had to support setting this flag, but
they've since been updated to say we also need to support clearing it. The API
endpoints were already designed in anticipation of this change, so only the
service layer needs to change.