### PR TITLE
SW-8274 APIs to delete splats

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/splat/SplatService.kt
+++ b/src/main/kotlin/com/terraformation/backend/splat/SplatService.kt
@@ -21,6 +21,7 @@ import com.terraformation.backend.file.S3FileStore
 import com.terraformation.backend.file.SizedInputStream
 import com.terraformation.backend.file.event.FileDeletionStartedEvent
 import com.terraformation.backend.log.perClassLogger
+import com.terraformation.backend.splat.event.SplatDeletedEvent
 import com.terraformation.backend.splat.event.SplatGenerationCompletedEvent
 import com.terraformation.backend.splat.event.SplatGenerationFailedEvent
 import com.terraformation.backend.splat.event.SplatMarkedNeedsAttentionEvent
@@ -212,6 +213,46 @@ class SplatService(
           )
       )
     }
+  }
+
+  fun deleteObservationSplat(observationId: ObservationId, fileId: FileId) {
+    requirePermissions { updateObservation(observationId) }
+    ensureObservationFile(observationId, fileId)
+    ensureSplat(fileId)
+
+    val organizationId =
+        parentStore.getOrganizationId(observationId)
+            ?: throw ObservationNotFoundException(observationId)
+
+    deleteSplatRows(fileId, organizationId)
+  }
+
+  fun deleteOrganizationSplat(organizationId: OrganizationId, fileId: FileId) {
+    requirePermissions { updateOrganizationMedia(organizationId) }
+    ensureOrganizationMediaFile(organizationId, fileId)
+    ensureSplat(fileId)
+
+    deleteSplatRows(fileId, organizationId)
+  }
+
+  private fun deleteSplatRows(fileId: FileId, organizationId: OrganizationId) {
+    val splatRecord = dslContext.fetchSingle(SPLATS, SPLATS.FILE_ID.eq(fileId))
+
+    dslContext.transaction { _ ->
+      dslContext.deleteFrom(SPLAT_ANNOTATIONS).where(SPLAT_ANNOTATIONS.FILE_ID.eq(fileId)).execute()
+      dslContext.deleteFrom(BIRDNET_RESULTS).where(BIRDNET_RESULTS.FILE_ID.eq(fileId)).execute()
+      dslContext.deleteFrom(SPLATS).where(SPLATS.FILE_ID.eq(fileId)).execute()
+    }
+
+    eventPublisher.publishEvent(
+        SplatDeletedEvent(
+            deletedByUserId = currentUser().userId,
+            fileId = fileId,
+            organizationId = organizationId,
+            uploadedByUserId = splatRecord.createdBy!!,
+            videoUploadedTime = splatRecord.createdTime!!,
+        )
+    )
   }
 
   fun recordSplatError(fileId: FileId, errorMessage: String) {

--- a/src/main/kotlin/com/terraformation/backend/splat/api/SplatsController.kt
+++ b/src/main/kotlin/com/terraformation/backend/splat/api/SplatsController.kt
@@ -31,6 +31,7 @@ import jakarta.ws.rs.ServiceUnavailableException
 import java.math.BigDecimal
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
@@ -151,6 +152,20 @@ class SplatsController(
     val infoModel = splatService.getObservationSplatInfo(observationId, fileId)
 
     return GetObservationSplatInfoResponsePayload(infoModel)
+  }
+
+  @ApiResponse200
+  @ApiResponse404(
+      "The plot observation does not exist, or does not have a splat for the requested file ID."
+  )
+  @DeleteMapping("/api/v1/tracking/observations/{observationId}/splats/{fileId}")
+  @Operation(summary = "Deletes a 3D Gaussian splat model from an observation.")
+  fun deleteObservationSplat(
+      @PathVariable observationId: ObservationId,
+      @PathVariable fileId: FileId,
+  ): SimpleSuccessResponsePayload {
+    splatService.deleteObservationSplat(observationId, fileId)
+    return SimpleSuccessResponsePayload()
   }
 
   @ApiResponse200

--- a/src/main/kotlin/com/terraformation/backend/splat/event/SplatDeletedEvent.kt
+++ b/src/main/kotlin/com/terraformation/backend/splat/event/SplatDeletedEvent.kt
@@ -1,0 +1,15 @@
+package com.terraformation.backend.splat.event
+
+import com.terraformation.backend.db.default_schema.FileId
+import com.terraformation.backend.db.default_schema.OrganizationId
+import com.terraformation.backend.db.default_schema.UserId
+import java.time.Instant
+
+/** Published when a user deletes an organization or observation splat. */
+data class SplatDeletedEvent(
+    val deletedByUserId: UserId,
+    val fileId: FileId,
+    val organizationId: OrganizationId,
+    val uploadedByUserId: UserId,
+    val videoUploadedTime: Instant,
+)

--- a/src/main/kotlin/com/terraformation/backend/tracking/api/OrganizationSplatsController.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/api/OrganizationSplatsController.kt
@@ -22,6 +22,7 @@ import io.swagger.v3.oas.annotations.Operation
 import jakarta.ws.rs.ServiceUnavailableException
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
@@ -73,6 +74,18 @@ class OrganizationSplatsController(
       @RequestBody payload: GenerateSplatRequestPayload,
   ): SimpleSuccessResponsePayload {
     splatService.generateOrganizationMediaSplat(organizationId, payload.fileId)
+    return SimpleSuccessResponsePayload()
+  }
+
+  @ApiResponse200
+  @ApiResponse404("The media file does not exist in this organization, or has no splat.")
+  @DeleteMapping("/{fileId}")
+  @Operation(summary = "Deletes a 3D Gaussian splat model for an organization video.")
+  fun deleteOrganizationSplat(
+      @PathVariable organizationId: OrganizationId,
+      @PathVariable fileId: FileId,
+  ): SimpleSuccessResponsePayload {
+    splatService.deleteOrganizationSplat(organizationId, fileId)
     return SimpleSuccessResponsePayload()
   }
 

--- a/src/test/kotlin/com/terraformation/backend/splat/SplatServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/splat/SplatServiceTest.kt
@@ -26,6 +26,7 @@ import com.terraformation.backend.file.S3FileStore
 import com.terraformation.backend.file.SizedInputStream
 import com.terraformation.backend.file.event.FileDeletionStartedEvent
 import com.terraformation.backend.point
+import com.terraformation.backend.splat.event.SplatDeletedEvent
 import com.terraformation.backend.splat.event.SplatGenerationCompletedEvent
 import com.terraformation.backend.splat.event.SplatGenerationFailedEvent
 import com.terraformation.backend.splat.event.SplatMarkedNeedsAttentionEvent
@@ -172,7 +173,6 @@ class SplatServiceTest : DatabaseTest(), RunsAsDatabaseUser {
 
   @Nested
   inner class SetObservationSplatAnnotations {
-
     @BeforeEach
     fun setUp() {
       insertSplat()
@@ -488,6 +488,131 @@ class SplatServiceTest : DatabaseTest(), RunsAsDatabaseUser {
 
       assertThrows<FileNotFoundException> {
         service.setObservationSplatAnnotations(observationId, fileWithoutSplat, emptyList())
+      }
+    }
+  }
+
+  @Nested
+  inner class DeleteObservationSplat {
+    @BeforeEach
+    fun setUp() {
+      insertSplat()
+      insertBirdnetResult()
+      insertSplatAnnotation()
+    }
+
+    @Test
+    fun `removes splat, birdnet result, and annotations from database`() {
+      service.deleteObservationSplat(observationId, fileId)
+
+      assertTableEmpty(SPLATS)
+      assertTableEmpty(BIRDNET_RESULTS)
+      assertTableEmpty(SPLAT_ANNOTATIONS)
+
+      verify(exactly = 0) { fileStore.delete(any()) }
+
+      eventPublisher.assertEventPublished(
+          SplatDeletedEvent(
+              deletedByUserId = user.userId,
+              fileId = fileId,
+              organizationId = organizationId,
+              uploadedByUserId = user.userId,
+              videoUploadedTime = Instant.EPOCH,
+          )
+      )
+    }
+
+    @Test
+    fun `throws exception if splat does not exist for file`() {
+      val fileWithoutSplat = insertFile()
+      insertObservationMediaFile(fileId = fileWithoutSplat)
+
+      assertThrows<FileNotFoundException> {
+        service.deleteObservationSplat(observationId, fileWithoutSplat)
+      }
+    }
+
+    @Test
+    fun `throws exception if file is not associated with observation`() {
+      val otherFileId = insertFile()
+      insertSplat(fileId = otherFileId)
+
+      assertThrows<FileNotFoundException> {
+        service.deleteObservationSplat(observationId, otherFileId)
+      }
+    }
+
+    @Test
+    fun `throws exception if user does not have permission to update observation`() {
+      deleteOrganizationUser()
+
+      assertThrows<ObservationNotFoundException> {
+        service.deleteObservationSplat(observationId, fileId)
+      }
+    }
+  }
+
+  @Nested
+  inner class DeleteOrganizationSplat {
+    private lateinit var orgFileId: FileId
+
+    @BeforeEach
+    fun setUp() {
+      orgFileId = insertOrganizationMediaFile()
+      insertSplat(fileId = orgFileId)
+      insertBirdnetResult(fileId = orgFileId)
+      insertSplatAnnotation(fileId = orgFileId)
+    }
+
+    @Test
+    fun `removes splat, birdnet result, and annotations from database`() {
+      service.deleteOrganizationSplat(organizationId, orgFileId)
+
+      assertTableEmpty(SPLATS)
+      assertTableEmpty(BIRDNET_RESULTS)
+      assertTableEmpty(SPLAT_ANNOTATIONS)
+
+      verify(exactly = 0) { fileStore.delete(any()) }
+
+      eventPublisher.assertEventPublished(
+          SplatDeletedEvent(
+              deletedByUserId = user.userId,
+              fileId = orgFileId,
+              organizationId = organizationId,
+              uploadedByUserId = user.userId,
+              videoUploadedTime = Instant.EPOCH,
+          )
+      )
+    }
+
+    @Test
+    fun `throws exception if file does not belong to organization`() {
+      val unassociatedFileId = insertFile()
+      insertSplat(fileId = unassociatedFileId)
+
+      assertThrows<FileNotFoundException> {
+        service.deleteOrganizationSplat(organizationId, unassociatedFileId)
+      }
+    }
+
+    @Test
+    fun `throws exception if splat does not exist`() {
+      val fileWithoutSplat = insertOrganizationMediaFile(fileId = insertFile())
+
+      assertThrows<FileNotFoundException> {
+        service.deleteOrganizationSplat(organizationId, fileWithoutSplat)
+      }
+    }
+
+    @Test
+    fun `throws exception if user does not have permission`() {
+      val otherOrgId = insertOrganization()
+      val otherFileId = insertFile()
+      insertOrganizationMediaFile(fileId = otherFileId, organizationId = otherOrgId)
+      insertSplat(fileId = otherFileId, organizationId = otherOrgId)
+
+      assertThrows<OrganizationNotFoundException> {
+        service.deleteOrganizationSplat(otherOrgId, otherFileId)
       }
     }
   }


### PR DESCRIPTION
Add DELETE endpoints for observation and organization splats.
This just deletes the splats (and BirdNet results) from the
database; the model file is left alone on S3 and the video
is still listed in the appropriate media-files table.