### PR TITLE
SW-8218 Increase area-in-hectares precision

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/tracking/model/Constants.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/model/Constants.kt
@@ -3,7 +3,7 @@ package com.terraformation.backend.tracking.model
 import java.math.BigDecimal
 
 /** Number of digits after the decimal point to retain in area (hectares) calculations. */
-const val HECTARES_SCALE = 1
+const val HECTARES_SCALE = 3
 
 /** The maximum size of the envelope (bounding box) of a site. */
 val MAX_SITE_ENVELOPE_AREA_HA = BigDecimal(20000)

--- a/src/test/kotlin/com/terraformation/backend/accelerator/ApplicationServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/ApplicationServiceTest.kt
@@ -272,7 +272,7 @@ class ApplicationServiceTest : DatabaseTest(), RunsAsUser {
 
       val updatedVariableValues =
           ProjectAcceleratorVariableValuesModel(
-              applicationReforestableLand = BigDecimal("100.0"),
+              applicationReforestableLand = BigDecimal("99.950"),
               countryCode = "KE",
               dealName = internalName,
               landUseModelTypes = setOf(LandUseModelType.Mangroves, LandUseModelType.NativeForest),
@@ -296,7 +296,7 @@ class ApplicationServiceTest : DatabaseTest(), RunsAsUser {
 
       assertEquals(
           ProjectAcceleratorDetailsModel(
-              applicationReforestableLand = BigDecimal("100.0"),
+              applicationReforestableLand = BigDecimal("99.950"),
               countryCode = "KE",
               dealName = internalName,
               fileNaming = internalName,

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/plantingSiteStore/PlantingSiteStoreApplyEditTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/plantingSiteStore/PlantingSiteStoreApplyEditTest.kt
@@ -158,17 +158,17 @@ internal class PlantingSiteStoreApplyEditTest : BasePlantingSiteStoreTest() {
               newSite { exclusion = rectangle(width = 200, height = 500) },
           )
 
-      assertEquals(BigDecimal("20.0"), existing.areaHa, "Site area before edit")
-      assertEquals(BigDecimal("15.0"), edited.areaHa, "Site area after edit")
-      assertEquals(BigDecimal("20.0"), existing.strata[0].areaHa, "Stratum area before edit")
-      assertEquals(BigDecimal("15.0"), edited.strata[0].areaHa, "Stratum area after edit")
+      assertEquals(BigDecimal("20.008"), existing.areaHa, "Site area before edit")
+      assertEquals(BigDecimal("15.006"), edited.areaHa, "Site area after edit")
+      assertEquals(BigDecimal("20.008"), existing.strata[0].areaHa, "Stratum area before edit")
+      assertEquals(BigDecimal("15.006"), edited.strata[0].areaHa, "Stratum area after edit")
       assertEquals(
-          BigDecimal("20.0"),
+          BigDecimal("20.008"),
           existing.strata[0].substrata[0].areaHa,
           "Substratum area before edit",
       )
       assertEquals(
-          BigDecimal("15.0"),
+          BigDecimal("15.006"),
           edited.strata[0].substrata[0].areaHa,
           "Substratum area after edit",
       )

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/plantingSiteStore/PlantingSiteStoreCreateSiteTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/plantingSiteStore/PlantingSiteStoreCreateSiteTest.kt
@@ -97,7 +97,7 @@ internal class PlantingSiteStoreCreateSiteTest : BasePlantingSiteStoreTest() {
       assertEquals(
           listOf(
               PlantingSitesRow(
-                  areaHa = BigDecimal("2.3"),
+                  areaHa = BigDecimal("2.251"),
                   boundary = boundary,
                   createdBy = user.userId,
                   createdTime = Instant.EPOCH,
@@ -203,7 +203,7 @@ internal class PlantingSiteStoreCreateSiteTest : BasePlantingSiteStoreTest() {
       assertGeometryEquals(gridOrigin, plantingSitesRow.gridOrigin, "Planting site grid origin")
       assertEquals(
           PlantingSitesRow(
-              areaHa = BigDecimal("3.0"),
+              areaHa = BigDecimal("3.001"),
               countryCode = "GB",
               createdBy = user.userId,
               createdTime = Instant.EPOCH,
@@ -220,7 +220,7 @@ internal class PlantingSiteStoreCreateSiteTest : BasePlantingSiteStoreTest() {
 
       val commonStrataRow =
           StrataRow(
-              areaHa = BigDecimal("1.5"),
+              areaHa = BigDecimal("1.500"),
               boundaryModifiedBy = user.userId,
               boundaryModifiedTime = Instant.EPOCH,
               createdBy = user.userId,
@@ -273,7 +273,7 @@ internal class PlantingSiteStoreCreateSiteTest : BasePlantingSiteStoreTest() {
 
       val commonSubstrataRow =
           SubstrataRow(
-              areaHa = BigDecimal("0.8"),
+              areaHa = BigDecimal("0.750"),
               createdBy = user.userId,
               createdTime = Instant.EPOCH,
               modifiedBy = user.userId,
@@ -356,7 +356,7 @@ internal class PlantingSiteStoreCreateSiteTest : BasePlantingSiteStoreTest() {
       assertEquals(
           listOf(
               PlantingSiteHistoriesRow(
-                  areaHa = BigDecimal("2.2"),
+                  areaHa = BigDecimal("2.241"),
                   boundary = boundary,
                   createdBy = user.userId,
                   createdTime = clock.instant,
@@ -409,7 +409,7 @@ internal class PlantingSiteStoreCreateSiteTest : BasePlantingSiteStoreTest() {
       assertEquals(
           listOf(
               PlantingSiteHistoriesRow(
-                  areaHa = BigDecimal("4.0"),
+                  areaHa = BigDecimal("3.999"),
                   boundary = siteBoundary,
                   createdBy = user.userId,
                   createdTime = clock.instant,
@@ -427,7 +427,7 @@ internal class PlantingSiteStoreCreateSiteTest : BasePlantingSiteStoreTest() {
       assertEquals(
           listOf(
               StratumHistoriesRow(
-                  areaHa = BigDecimal("4.0"),
+                  areaHa = BigDecimal("3.995"),
                   boundary = stratumBoundary,
                   name = "stratum",
                   plantingSiteHistoryId = model.historyId,
@@ -442,7 +442,7 @@ internal class PlantingSiteStoreCreateSiteTest : BasePlantingSiteStoreTest() {
       assertEquals(
           listOf(
               SubstratumHistoriesRow(
-                  areaHa = BigDecimal("4.0"),
+                  areaHa = BigDecimal("3.991"),
                   boundary = substratumBoundary,
                   fullName = "stratum-substratum",
                   name = "substratum",

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/plantingSiteStore/PlantingSiteStoreUpdateSiteTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/plantingSiteStore/PlantingSiteStoreUpdateSiteTest.kt
@@ -55,7 +55,7 @@ internal class PlantingSiteStoreUpdateSiteTest : BasePlantingSiteStoreTest() {
       assertEquals(
           listOf(
               PlantingSitesRow(
-                  areaHa = BigDecimal("4.0"),
+                  areaHa = BigDecimal("4.002"),
                   boundary = newBoundary,
                   gridOrigin = initialModel.gridOrigin,
                   id = initialModel.id,
@@ -77,7 +77,7 @@ internal class PlantingSiteStoreUpdateSiteTest : BasePlantingSiteStoreTest() {
       assertSetEquals(
           setOf(
               PlantingSiteHistoriesRow(
-                  areaHa = BigDecimal("1.0"),
+                  areaHa = BigDecimal("1.002"),
                   boundary = initialModel.boundary,
                   createdBy = user.userId,
                   createdTime = createdTime,
@@ -85,7 +85,7 @@ internal class PlantingSiteStoreUpdateSiteTest : BasePlantingSiteStoreTest() {
                   plantingSiteId = initialModel.id,
               ),
               PlantingSiteHistoriesRow(
-                  areaHa = BigDecimal("4.0"),
+                  areaHa = BigDecimal("4.002"),
                   boundary = newBoundary,
                   createdBy = user.userId,
                   createdTime = clock.instant,

--- a/src/test/kotlin/com/terraformation/backend/tracking/edit/PlantingSiteEditCalculatorTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/edit/PlantingSiteEditCalculatorTest.kt
@@ -29,7 +29,7 @@ class PlantingSiteEditCalculatorTest {
 
     assertEditResult(
         PlantingSiteEdit(
-            areaHaDifference = BigDecimal("12.5"),
+            areaHaDifference = BigDecimal("12.505"),
             desiredModel = desired,
             existingModel = existing,
             stratumEdits =
@@ -75,14 +75,14 @@ class PlantingSiteEditCalculatorTest {
 
     assertEditResult(
         PlantingSiteEdit(
-            areaHaDifference = BigDecimal("12.5"),
+            areaHaDifference = BigDecimal("12.505"),
             desiredModel = desired,
             existingModel = existing,
             stratumEdits =
                 listOf(
                     StratumEdit.Update(
                         addedRegion = newSubstratumBoundary,
-                        areaHaDifference = BigDecimal("12.5"),
+                        areaHaDifference = BigDecimal("12.505"),
                         desiredModel = desired.strata[0],
                         existingModel = existing.strata[0],
                         monitoringPlotEdits =
@@ -171,14 +171,14 @@ class PlantingSiteEditCalculatorTest {
 
     assertEditResult(
         PlantingSiteEdit(
-            areaHaDifference = BigDecimal("5.0"),
+            areaHaDifference = BigDecimal("5.002"),
             desiredModel = desired,
             existingModel = existing,
             stratumEdits =
                 listOf(
                     StratumEdit.Update(
                         addedRegion = rectangle(x = 500, width = 200, height = 500),
-                        areaHaDifference = BigDecimal("5.0"),
+                        areaHaDifference = BigDecimal("5.002"),
                         desiredModel = desired.strata[0],
                         existingModel = existing.strata[0],
                         monitoringPlotEdits =
@@ -192,7 +192,7 @@ class PlantingSiteEditCalculatorTest {
                             listOf(
                                 SubstratumEdit.Update(
                                     addedRegion = rectangle(x = 500, width = 200, height = 500),
-                                    areaHaDifference = BigDecimal("5.0"),
+                                    areaHaDifference = BigDecimal("5.002"),
                                     desiredModel = desired.strata[0].substrata[0],
                                     existingModel = existing.strata[0].substrata[0],
                                     removedRegion = rectangle(x = 0, width = 100, height = 500),
@@ -230,7 +230,7 @@ class PlantingSiteEditCalculatorTest {
                     // Stratum B moves to west edge of site and grows from 200m to 500m wide
                     StratumEdit.Update(
                         addedRegion = rectangle(x = 0, width = 500, height = 500),
-                        areaHaDifference = BigDecimal(15),
+                        areaHaDifference = BigDecimal("15.007"),
                         desiredModel = desired.strata[0],
                         existingModel = existing.strata[1],
                         monitoringPlotEdits = emptyList(),
@@ -238,7 +238,7 @@ class PlantingSiteEditCalculatorTest {
                             listOf(
                                 SubstratumEdit.Update(
                                     addedRegion = rectangle(x = 0, width = 500, height = 500),
-                                    areaHaDifference = BigDecimal(15),
+                                    areaHaDifference = BigDecimal("15.007"),
                                     desiredModel = desired.strata[0].substrata[0],
                                     existingModel = existing.strata[1].substrata[0],
                                     monitoringPlotEdits =
@@ -253,7 +253,7 @@ class PlantingSiteEditCalculatorTest {
                     // Stratum A moves to east edge of site and shrinks from 800m to 500m wide
                     StratumEdit.Update(
                         addedRegion = rectangle(x = 800, width = 200, height = 500),
-                        areaHaDifference = BigDecimal(-15),
+                        areaHaDifference = BigDecimal("-15.007"),
                         desiredModel = desired.strata[1],
                         existingModel = existing.strata[0],
                         monitoringPlotEdits =
@@ -269,7 +269,7 @@ class PlantingSiteEditCalculatorTest {
                             listOf(
                                 SubstratumEdit.Update(
                                     addedRegion = rectangle(x = 800, width = 200, height = 500),
-                                    areaHaDifference = BigDecimal(-15),
+                                    areaHaDifference = BigDecimal("-15.007"),
                                     desiredModel = desired.strata[1].substrata[0],
                                     existingModel = existing.strata[0].substrata[0],
                                     monitoringPlotEdits =
@@ -340,7 +340,7 @@ class PlantingSiteEditCalculatorTest {
                     // Stratum A shrinks
                     StratumEdit.Update(
                         addedRegion = rectangle(0),
-                        areaHaDifference = BigDecimal("-12.5"),
+                        areaHaDifference = BigDecimal("-12.506"),
                         desiredModel = desired.strata[0],
                         existingModel = existing.strata[0],
                         monitoringPlotEdits = emptyList(),
@@ -391,7 +391,7 @@ class PlantingSiteEditCalculatorTest {
                     // Stratum A shrinks
                     StratumEdit.Update(
                         addedRegion = rectangle(0),
-                        areaHaDifference = BigDecimal("-12.5"),
+                        areaHaDifference = BigDecimal("-12.506"),
                         desiredModel = desired.strata[0],
                         existingModel = existing.strata[0],
                         monitoringPlotEdits = emptyList(),
@@ -400,7 +400,7 @@ class PlantingSiteEditCalculatorTest {
                     ),
                     StratumEdit.Update(
                         addedRegion = rectangle(x = 250, width = 250, height = 500),
-                        areaHaDifference = BigDecimal("12.5"),
+                        areaHaDifference = BigDecimal("12.506"),
                         desiredModel = desired.strata[1],
                         existingModel = existing.strata[1],
                         monitoringPlotEdits = emptyList(),
@@ -475,7 +475,7 @@ class PlantingSiteEditCalculatorTest {
                     ),
                     StratumEdit.Update(
                         addedRegion = rectangle(0),
-                        areaHaDifference = BigDecimal(-25),
+                        areaHaDifference = BigDecimal("-25.010"),
                         desiredModel = desired.strata[0],
                         existingModel = existing.strata[0],
                         monitoringPlotEdits =
@@ -489,7 +489,7 @@ class PlantingSiteEditCalculatorTest {
                             listOf(
                                 SubstratumEdit.Update(
                                     addedRegion = rectangle(0),
-                                    areaHaDifference = BigDecimal(-25),
+                                    areaHaDifference = BigDecimal("-25.010"),
                                     desiredModel = desired.strata[0].substrata[0],
                                     existingModel = existing.strata[0].substrata[0],
                                     monitoringPlotEdits = emptyList(),
@@ -536,14 +536,14 @@ class PlantingSiteEditCalculatorTest {
 
     assertEditResult(
         PlantingSiteEdit(
-            areaHaDifference = BigDecimal("-25.0"),
+            areaHaDifference = BigDecimal("-25.011"),
             desiredModel = desired,
             existingModel = existing,
             stratumEdits =
                 listOf(
                     StratumEdit.Update(
                         addedRegion = rectangle(x = 500, width = 280, height = 500),
-                        areaHaDifference = BigDecimal.ZERO,
+                        areaHaDifference = BigDecimal("-0.001"),
                         desiredModel = desired.strata[0],
                         existingModel = existing.strata[0],
                         monitoringPlotEdits =
@@ -557,7 +557,7 @@ class PlantingSiteEditCalculatorTest {
                             listOf(
                                 SubstratumEdit.Update(
                                     addedRegion = rectangle(x = 500, width = 280, height = 500),
-                                    areaHaDifference = BigDecimal.ZERO,
+                                    areaHaDifference = BigDecimal("-0.001"),
                                     desiredModel = desired.strata[0].substrata[0],
                                     existingModel = existing.strata[0].substrata[0],
                                     monitoringPlotEdits =
@@ -636,14 +636,14 @@ class PlantingSiteEditCalculatorTest {
 
     assertEditResult(
         PlantingSiteEdit(
-            areaHaDifference = BigDecimal(25),
+            areaHaDifference = BigDecimal("25.011"),
             desiredModel = desired,
             existingModel = existing,
             stratumEdits =
                 listOf(
                     StratumEdit.Update(
                         addedRegion = rectangle(x = 100, width = 500, height = 500),
-                        areaHaDifference = BigDecimal(25),
+                        areaHaDifference = BigDecimal("25.011"),
                         desiredModel = desired.strata[0],
                         existingModel = existing.strata[0],
                         monitoringPlotEdits = emptyList(),
@@ -651,7 +651,7 @@ class PlantingSiteEditCalculatorTest {
                             listOf(
                                 SubstratumEdit.Update(
                                     addedRegion = rectangle(x = 100, width = 500, height = 500),
-                                    areaHaDifference = BigDecimal(25),
+                                    areaHaDifference = BigDecimal("25.011"),
                                     desiredModel = desired.strata[0].substrata[0],
                                     existingModel = existing.strata[0].substrata[0],
                                     monitoringPlotEdits =
@@ -689,13 +689,13 @@ class PlantingSiteEditCalculatorTest {
 
     assertEditResult(
         PlantingSiteEdit(
-            areaHaDifference = BigDecimal(5),
+            areaHaDifference = BigDecimal("5.003"),
             desiredModel = desired,
             existingModel = existing,
             stratumEdits =
                 listOf(
                     StratumEdit.Update(
-                        areaHaDifference = BigDecimal(5),
+                        areaHaDifference = BigDecimal("5.003"),
                         addedRegion = rectangle(x = 400, width = 100, height = 500),
                         desiredModel = desired.strata[0],
                         existingModel = existing.strata[0],
@@ -707,7 +707,7 @@ class PlantingSiteEditCalculatorTest {
                             listOf(
                                 SubstratumEdit.Update(
                                     addedRegion = rectangle(x = 400, width = 100, height = 500),
-                                    areaHaDifference = BigDecimal(5),
+                                    areaHaDifference = BigDecimal("5.003"),
                                     desiredModel = desired.strata[0].substrata[0],
                                     existingModel = existing.strata[0].substrata[0],
                                     // The unqualified plots are already in the correct substratum
@@ -742,14 +742,14 @@ class PlantingSiteEditCalculatorTest {
 
     assertEditResult(
         PlantingSiteEdit(
-            areaHaDifference = BigDecimal("10.0"),
+            areaHaDifference = BigDecimal("10.004"),
             desiredModel = desired,
             existingModel = existing,
             stratumEdits =
                 listOf(
                     StratumEdit.Update(
                         addedRegion = addedRegion,
-                        areaHaDifference = BigDecimal("10.0"),
+                        areaHaDifference = BigDecimal("10.004"),
                         desiredModel = desired.strata[0],
                         existingModel = existing.strata[0],
                         monitoringPlotEdits =
@@ -772,7 +772,7 @@ class PlantingSiteEditCalculatorTest {
                             listOf(
                                 SubstratumEdit.Update(
                                     addedRegion = addedRegion,
-                                    areaHaDifference = BigDecimal("10.0"),
+                                    areaHaDifference = BigDecimal("10.004"),
                                     desiredModel = desired.strata[0].substrata[0],
                                     existingModel = existing.strata[0].substrata[0],
                                     monitoringPlotEdits = emptyList(),
@@ -882,7 +882,7 @@ class PlantingSiteEditCalculatorTest {
 
     assertEditResult(
         PlantingSiteEdit(
-            areaHaDifference = BigDecimal("-12.5"),
+            areaHaDifference = BigDecimal("-12.505"),
             desiredModel = desired,
             existingModel = existing,
             stratumEdits =
@@ -918,14 +918,14 @@ class PlantingSiteEditCalculatorTest {
 
     assertEditResult(
         PlantingSiteEdit(
-            areaHaDifference = BigDecimal(-25),
+            areaHaDifference = BigDecimal("-25.010"),
             desiredModel = desired,
             existingModel = existing,
             stratumEdits =
                 listOf(
                     StratumEdit.Update(
                         addedRegion = rectangle(0),
-                        areaHaDifference = BigDecimal(-25),
+                        areaHaDifference = BigDecimal("-25.010"),
                         desiredModel = desired.strata[0],
                         existingModel = existing.strata[0],
                         monitoringPlotEdits =
@@ -1086,14 +1086,14 @@ class PlantingSiteEditCalculatorTest {
 
     assertEditResult(
         PlantingSiteEdit(
-            areaHaDifference = BigDecimal("-0.1"),
+            areaHaDifference = BigDecimal("-0.063"),
             desiredModel = desired,
             existingModel = existing,
             stratumEdits =
                 listOf(
                     StratumEdit.Update(
                         addedRegion = rectangle(0),
-                        areaHaDifference = BigDecimal("-0.1"),
+                        areaHaDifference = BigDecimal("-0.063"),
                         desiredModel = desired.strata[0],
                         existingModel = existing.strata[0],
                         monitoringPlotEdits = emptyList(),
@@ -1101,7 +1101,7 @@ class PlantingSiteEditCalculatorTest {
                             listOf(
                                 SubstratumEdit.Update(
                                     addedRegion = rectangle(0),
-                                    areaHaDifference = BigDecimal("-0.1"),
+                                    areaHaDifference = BigDecimal("-0.063"),
                                     desiredModel = desired.strata[0].substrata[0],
                                     existingModel = existing.strata[0].substrata[0],
                                     monitoringPlotEdits =

--- a/src/test/kotlin/com/terraformation/backend/util/ExtensionsTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/util/ExtensionsTest.kt
@@ -45,7 +45,7 @@ class ExtensionsTest {
               )
           )
 
-      assertEquals(BigDecimal("101.8"), geometry.calculateAreaHectares())
+      assertEquals(BigDecimal("101.816"), geometry.calculateAreaHectares())
     }
 
     @Test
@@ -66,7 +66,7 @@ class ExtensionsTest {
               )
           )
 
-      assertEquals(BigDecimal("101.8"), geometry.calculateAreaHectares())
+      assertEquals(BigDecimal("101.816"), geometry.calculateAreaHectares())
     }
 
     @Test
@@ -87,7 +87,7 @@ class ExtensionsTest {
               )
           )
 
-      assertEquals(BigDecimal("101.8"), geometry.calculateAreaHectares())
+      assertEquals(BigDecimal("101.816"), geometry.calculateAreaHectares())
     }
 
     @Test


### PR DESCRIPTION
The web app adds together the areas of substrata to get the total planting area.
Since the backend calculates areas to 1 decimal place, that means that the total
shown in the app can differ meaningfully from the actual total area of the
substrata, especially at sites with large numbers of substrata.

Completely getting rid of the discrepancy would require doing geometry
calculations that aren't practical to do in the web app, so instead, increase
the precision of the areas to 3 decimal places. That should cause the total area
to sufficiently match the areas that customers expect to see based on their maps.

This doesn't update any areas that are already in the database; that'll be covered
by another change.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>