### PR TITLE
SW-8218 Add admin UI function to recalculate areas

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/admin/AdminController.kt
+++ b/src/main/kotlin/com/terraformation/backend/admin/AdminController.kt
@@ -89,6 +89,10 @@ class AdminController(
         GlobalRole.SuperAdmin in currentUser().globalRoles,
     )
     model.addAttribute(
+        "canRecalculatePlantingSiteAreas",
+        GlobalRole.SuperAdmin in currentUser().globalRoles,
+    )
+    model.addAttribute(
         "canRemoveOrganizationUser",
         GlobalRole.SuperAdmin in currentUser().globalRoles,
     )

--- a/src/main/kotlin/com/terraformation/backend/admin/AdminPlantingSitesController.kt
+++ b/src/main/kotlin/com/terraformation/backend/admin/AdminPlantingSitesController.kt
@@ -754,6 +754,32 @@ class AdminPlantingSitesController(
     return redirectToAdminHome()
   }
 
+  @PostMapping("/recalculatePlantingSiteAreas")
+  @RequireGlobalRole([GlobalRole.SuperAdmin])
+  fun recalculatePlantingSiteAreas(redirectAttributes: RedirectAttributes): String {
+    val successDetails = mutableListOf<String>()
+    val failureDetails = mutableListOf<String>()
+
+    try {
+      systemUser.run {
+        plantingSiteStore.recalculatePlantingSiteAreas(successDetails::add, failureDetails::add)
+      }
+
+      redirectAttributes.successMessage = "Recalculated planting site areas"
+      redirectAttributes.successDetails = successDetails
+
+      if (failureDetails.isNotEmpty()) {
+        redirectAttributes.failureMessage = "Failed to recalculate some planting site areas"
+        redirectAttributes.failureDetails = failureDetails
+      }
+    } catch (e: Exception) {
+      log.error("Failed to recalculate planting site areas", e)
+      redirectAttributes.failureMessage = "Failed to recalculate planting site areas: ${e.message}"
+    }
+
+    return redirectToAdminHome()
+  }
+
   @PostMapping("/migrateSimplePlantingSites")
   @RequireGlobalRole([GlobalRole.SuperAdmin])
   fun migrateSimplePlantingSites(redirectAttributes: RedirectAttributes): String {

--- a/src/main/kotlin/com/terraformation/backend/tracking/db/PlantingSiteStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/db/PlantingSiteStore.kt
@@ -99,6 +99,7 @@ import com.terraformation.backend.tracking.model.SubstratumHistoryModel
 import com.terraformation.backend.tracking.model.UpdatedPlantingSeasonModel
 import com.terraformation.backend.util.Turtle
 import com.terraformation.backend.util.calculateAreaHectares
+import com.terraformation.backend.util.differenceNullable
 import com.terraformation.backend.util.equalsIgnoreScale
 import com.terraformation.backend.util.equalsOrBothNull
 import com.terraformation.backend.util.toInstant
@@ -2062,6 +2063,96 @@ class PlantingSiteStore(
                 .execute()
 
         log.info("Inserted $rowsInserted substratum populations")
+      }
+    }
+  }
+
+  /**
+   * Recomputes the `area_ha` columns for every planting site that has a boundary, along with all of
+   * its strata and substrata.
+   *
+   * Each site is processed in its own transaction; a failure on one site is logged and reported but
+   * does not stop the migration. `modified_by` and `modified_time` columns are intentionally left
+   * untouched, as this is a precision correction rather than a user-driven edit. History tables are
+   * also left alone.
+   */
+  fun recalculatePlantingSiteAreas(
+      addSuccessMessage: (String) -> Unit,
+      addFailureMessage: (String) -> Unit,
+  ) {
+    val siteIds =
+        dslContext
+            .select(PLANTING_SITES.ID)
+            .from(PLANTING_SITES)
+            .where(PLANTING_SITES.BOUNDARY.isNotNull)
+            .orderBy(PLANTING_SITES.ID)
+            .fetch(PLANTING_SITES.ID.asNonNullable())
+
+    siteIds.forEach { siteId ->
+      try {
+        dslContext.transaction { _ ->
+          val site = fetchSiteById(siteId, PlantingSiteDepth.Substratum)
+          val boundary = site.boundary ?: return@transaction
+          val exclusion = site.exclusion
+
+          val newSiteArea =
+              boundary.differenceNullable(exclusion).calculateAreaHectares().let { area ->
+                if (area.signum() > 0) area else null
+              }
+
+          val siteChanged = !newSiteArea.equalsIgnoreScale(site.areaHa)
+          if (siteChanged) {
+            dslContext
+                .update(PLANTING_SITES)
+                .set(PLANTING_SITES.AREA_HA, newSiteArea)
+                .where(PLANTING_SITES.ID.eq(siteId))
+                .execute()
+          }
+
+          var stratumChanges = 0
+          var substratumChanges = 0
+
+          site.strata.forEach { stratum ->
+            val newStratumArea =
+                stratum.boundary.differenceNullable(exclusion).calculateAreaHectares()
+            if (!newStratumArea.equalsIgnoreScale(stratum.areaHa)) {
+              dslContext
+                  .update(STRATA)
+                  .set(STRATA.AREA_HA, newStratumArea)
+                  .where(STRATA.ID.eq(stratum.id))
+                  .execute()
+              stratumChanges++
+            }
+
+            stratum.substrata.forEach { substratum ->
+              val newSubstratumArea =
+                  substratum.boundary.differenceNullable(exclusion).calculateAreaHectares()
+              if (!newSubstratumArea.equalsIgnoreScale(substratum.areaHa)) {
+                dslContext
+                    .update(SUBSTRATA)
+                    .set(SUBSTRATA.AREA_HA, newSubstratumArea)
+                    .where(SUBSTRATA.ID.eq(substratum.id))
+                    .execute()
+                substratumChanges++
+              }
+            }
+          }
+
+          if (siteChanged || stratumChanges > 0 || substratumChanges > 0) {
+            val parts =
+                listOfNotNull(
+                    if (siteChanged) "site (${site.areaHa} -> $newSiteArea)" else null,
+                    if (stratumChanges > 0) "$stratumChanges strata" else null,
+                    if (substratumChanges > 0) "$substratumChanges substrata" else null,
+                )
+            addSuccessMessage(
+                "Recalculated planting site $siteId (${site.name}): ${parts.joinToString(", ")}"
+            )
+          }
+        }
+      } catch (e: Exception) {
+        log.error("Unable to recalculate areas for planting site $siteId", e)
+        addFailureMessage("Unable to recalculate planting site $siteId: ${e.message}")
       }
     }
   }

--- a/src/main/resources/templates/admin/index.html
+++ b/src/main/resources/templates/admin/index.html
@@ -278,6 +278,20 @@
             <input type="submit" value="Recalculate"/>
         </form>
     </th:block>
+
+    <th:block th:if="${canRecalculatePlantingSiteAreas}">
+        <h3>Recalculate Planting Site Areas</h3>
+
+        <p>
+            This recomputes the area in hectares for every planting site, stratum, and substratum.
+            Use this once to upgrade areas that were calculated before the precision was increased
+            to three decimal places.
+        </p>
+
+        <form method="POST" action="/admin/recalculatePlantingSiteAreas">
+            <input type="submit" value="Recalculate Planting Site Areas"/>
+        </form>
+    </th:block>
 </details>
 
 <details id="sendTestEmail" class="section" th:if="${canSendTestEmail}">

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/plantingSiteStore/PlantingSiteStoreRecalculateAreasTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/plantingSiteStore/PlantingSiteStoreRecalculateAreasTest.kt
@@ -1,0 +1,115 @@
+package com.terraformation.backend.tracking.db.plantingSiteStore
+
+import com.terraformation.backend.db.tracking.PlantingSiteId
+import com.terraformation.backend.db.tracking.StratumId
+import com.terraformation.backend.db.tracking.SubstratumId
+import com.terraformation.backend.db.tracking.tables.references.PLANTING_SITES
+import com.terraformation.backend.db.tracking.tables.references.STRATA
+import com.terraformation.backend.db.tracking.tables.references.SUBSTRATA
+import com.terraformation.backend.point
+import com.terraformation.backend.util.Turtle
+import com.terraformation.backend.util.calculateAreaHectares
+import com.terraformation.backend.util.differenceNullable
+import io.mockk.every
+import java.math.BigDecimal
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.locationtech.jts.geom.MultiPolygon
+
+internal class PlantingSiteStoreRecalculateAreasTest : BasePlantingSiteStoreTest() {
+  private val gridOrigin = point(1)
+  private val siteBoundary: MultiPolygon = Turtle(gridOrigin).makeMultiPolygon { square(150) }
+  private val exclusion: MultiPolygon =
+      Turtle(gridOrigin).makeMultiPolygon {
+        east(50)
+        north(50)
+        square(50)
+      }
+
+  private val successMessages = mutableListOf<String>()
+  private val failureMessages = mutableListOf<String>()
+
+  @Test
+  fun `recalculates site stratum and substratum areas at higher precision`() {
+    val siteId =
+        insertPlantingSite(
+            boundary = siteBoundary,
+            exclusion = exclusion,
+            gridOrigin = gridOrigin,
+            areaHa = BigDecimal("2.0"),
+        )
+    val stratumId = insertStratum(boundary = siteBoundary, areaHa = BigDecimal("2.0"))
+    val substratumId = insertSubstratum(boundary = siteBoundary, areaHa = BigDecimal("2.0"))
+
+    store.recalculatePlantingSiteAreas(successMessages::add, failureMessages::add)
+
+    val expectedArea = siteBoundary.differenceNullable(exclusion).calculateAreaHectares()
+
+    assertEquals(expectedArea, fetchSiteArea(siteId), "Site area")
+    assertEquals(expectedArea, fetchStratumArea(stratumId), "Stratum area")
+    assertEquals(expectedArea, fetchSubstratumArea(substratumId), "Substratum area")
+    assertTrue(
+        expectedArea < siteBoundary.calculateAreaHectares(),
+        "Exclusion should reduce the recalculated area",
+    )
+    assertEquals(emptyList<String>(), failureMessages)
+  }
+
+  @Test
+  fun `skips sites without a boundary`() {
+    val siteId = insertPlantingSite(areaHa = null)
+
+    store.recalculatePlantingSiteAreas(successMessages::add, failureMessages::add)
+
+    assertNull(fetchSiteArea(siteId), "Site without boundary should be unchanged")
+    assertEquals(emptyList<String>(), successMessages)
+    assertEquals(emptyList<String>(), failureMessages)
+  }
+
+  @Test
+  fun `continues processing other sites after a failure`() {
+    val failingSiteId = insertPlantingSite(boundary = siteBoundary, gridOrigin = gridOrigin)
+    val succeedingSiteId =
+        insertPlantingSite(
+            boundary = siteBoundary,
+            gridOrigin = gridOrigin,
+            areaHa = BigDecimal("2.3"),
+        )
+
+    every { user.canReadPlantingSite(failingSiteId) } returns false
+
+    store.recalculatePlantingSiteAreas(successMessages::add, failureMessages::add)
+
+    assertEquals(siteBoundary.calculateAreaHectares(), fetchSiteArea(succeedingSiteId))
+    assertEquals(1, failureMessages.size, "One failure message expected")
+    assertTrue(
+        failureMessages.single().contains("$failingSiteId"),
+        "Failure message should mention failing site ID: ${failureMessages.single()}",
+    )
+    assertNotNull(successMessages.firstOrNull { it.contains("$succeedingSiteId") })
+  }
+
+  private fun fetchSiteArea(siteId: PlantingSiteId): BigDecimal? =
+      dslContext
+          .select(PLANTING_SITES.AREA_HA)
+          .from(PLANTING_SITES)
+          .where(PLANTING_SITES.ID.eq(siteId))
+          .fetchOne(PLANTING_SITES.AREA_HA)
+
+  private fun fetchStratumArea(stratumId: StratumId): BigDecimal? =
+      dslContext
+          .select(STRATA.AREA_HA)
+          .from(STRATA)
+          .where(STRATA.ID.eq(stratumId))
+          .fetchOne(STRATA.AREA_HA)
+
+  private fun fetchSubstratumArea(substratumId: SubstratumId): BigDecimal? =
+      dslContext
+          .select(SUBSTRATA.AREA_HA)
+          .from(SUBSTRATA)
+          .where(SUBSTRATA.ID.eq(substratumId))
+          .fetchOne(SUBSTRATA.AREA_HA)
+}


### PR DESCRIPTION
Add a button to the "Migrations" section of the admin UI to go through all the
planting sites and recalculate their site, stratum, and substratum areas with the
new 3-digit scale.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>