### PR TITLE
SW-8277 Implemented admin UI to see simplification metrics and backfill data

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/admin/AdminSimplifyPlantingSitesController.kt
+++ b/src/main/kotlin/com/terraformation/backend/admin/AdminSimplifyPlantingSitesController.kt
@@ -1,0 +1,232 @@
+package com.terraformation.backend.admin
+
+import com.terraformation.backend.api.RequireGlobalRole
+import com.terraformation.backend.db.default_schema.GlobalRole
+import com.terraformation.backend.db.default_schema.OrganizationId
+import com.terraformation.backend.db.tracking.PlantingSiteHistoryId
+import com.terraformation.backend.db.tracking.PlantingSiteId
+import com.terraformation.backend.db.tracking.tables.references.PLANTING_SITES
+import com.terraformation.backend.db.tracking.tables.references.PLANTING_SITE_HISTORIES
+import com.terraformation.backend.db.tracking.tables.references.SIMPLIFIED_PLANTING_SITES
+import com.terraformation.backend.db.tracking.tables.references.SIMPLIFIED_PLANTING_SITE_HISTORIES
+import com.terraformation.backend.log.perClassLogger
+import com.terraformation.backend.tracking.db.PlantingSiteStore
+import org.jooq.DSLContext
+import org.jooq.Field
+import org.jooq.impl.DSL
+import org.jooq.impl.SQLDataType
+import org.locationtech.jts.geom.Geometry
+import org.springframework.stereotype.Controller
+import org.springframework.ui.Model
+import org.springframework.validation.annotation.Validated
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.servlet.mvc.support.RedirectAttributes
+
+@Controller
+@RequestMapping("/admin")
+@RequireGlobalRole([GlobalRole.SuperAdmin])
+@Validated
+class AdminSimplifyPlantingSitesController(
+    private val dslContext: DSLContext,
+    private val plantingSiteStore: PlantingSiteStore,
+) {
+  private val log = perClassLogger()
+
+  @GetMapping("/organization/{organizationId}/simplifyPlantingSites")
+  fun getSimplifyPlantingSites(
+      @PathVariable organizationId: OrganizationId,
+      model: Model,
+  ): String {
+    val numPointsOriginal = numVerticesField(PLANTING_SITES.BOUNDARY)
+    val numPointsSimplified = numVerticesField(SIMPLIFIED_PLANTING_SITES.BOUNDARY)
+    val reductionRatio =
+        reductionRatioField(PLANTING_SITES.BOUNDARY, SIMPLIFIED_PLANTING_SITES.BOUNDARY)
+    val jaccardSimilarity =
+        jaccardSimilarityField(PLANTING_SITES.BOUNDARY, SIMPLIFIED_PLANTING_SITES.BOUNDARY)
+
+    val plantingSites =
+        dslContext
+            .select(
+                PLANTING_SITES.ID,
+                PLANTING_SITES.NAME,
+                numPointsOriginal,
+                numPointsSimplified,
+                reductionRatio,
+                jaccardSimilarity,
+            )
+            .from(PLANTING_SITES)
+            .leftJoin(SIMPLIFIED_PLANTING_SITES)
+            .on(PLANTING_SITES.ID.eq(SIMPLIFIED_PLANTING_SITES.PLANTING_SITE_ID))
+            .where(PLANTING_SITES.ORGANIZATION_ID.eq(organizationId))
+            .fetch { record ->
+              PlantingSiteSimplificationModel(
+                  id = record[PLANTING_SITES.ID]!!,
+                  name = record[PLANTING_SITES.NAME]!!,
+                  numVerticesOriginal = record[numPointsOriginal],
+                  numVerticesSimplified = record[numPointsSimplified],
+                  reductionRatio = record[reductionRatio],
+                  jaccardSimilarity = record[jaccardSimilarity],
+              )
+            }
+
+    model.addAttribute("organizationId", organizationId)
+    model.addAttribute("plantingSites", plantingSites)
+
+    return "/admin/simplifyPlantingSites"
+  }
+
+  @GetMapping("/organization/{organizationId}/simplifyPlantingSites/{plantingSiteId}/histories")
+  fun getSimplifyPlantingSiteHistories(
+      @PathVariable organizationId: OrganizationId,
+      @PathVariable plantingSiteId: PlantingSiteId,
+      model: Model,
+  ): String {
+    val numPointsOriginal = numVerticesField(PLANTING_SITE_HISTORIES.BOUNDARY)
+    val numPointsSimplified = numVerticesField(SIMPLIFIED_PLANTING_SITE_HISTORIES.BOUNDARY)
+    val reductionRatio =
+        reductionRatioField(
+            PLANTING_SITE_HISTORIES.BOUNDARY,
+            SIMPLIFIED_PLANTING_SITE_HISTORIES.BOUNDARY,
+        )
+    val jaccardSimilarity =
+        jaccardSimilarityField(
+            PLANTING_SITE_HISTORIES.BOUNDARY,
+            SIMPLIFIED_PLANTING_SITE_HISTORIES.BOUNDARY,
+        )
+
+    val histories =
+        dslContext
+            .select(
+                PLANTING_SITE_HISTORIES.ID,
+                PLANTING_SITE_HISTORIES.CREATED_TIME,
+                numPointsOriginal,
+                numPointsSimplified,
+                reductionRatio,
+                jaccardSimilarity,
+            )
+            .from(PLANTING_SITE_HISTORIES)
+            .leftJoin(SIMPLIFIED_PLANTING_SITE_HISTORIES)
+            .on(
+                PLANTING_SITE_HISTORIES.ID.eq(
+                    SIMPLIFIED_PLANTING_SITE_HISTORIES.PLANTING_SITE_HISTORY_ID
+                )
+            )
+            .where(PLANTING_SITE_HISTORIES.PLANTING_SITE_ID.eq(plantingSiteId))
+            .orderBy(PLANTING_SITE_HISTORIES.ID.desc())
+            .fetch { record ->
+              PlantingSiteHistorySimplificationModel(
+                  id = record[PLANTING_SITE_HISTORIES.ID]!!,
+                  createdTime = record[PLANTING_SITE_HISTORIES.CREATED_TIME]!!,
+                  numVerticesOriginal = record[numPointsOriginal],
+                  numVerticesSimplified = record[numPointsSimplified],
+                  reductionRatio = record[reductionRatio],
+                  jaccardSimilarity = record[jaccardSimilarity],
+              )
+            }
+
+    model.addAttribute("organizationId", organizationId)
+    model.addAttribute("plantingSiteId", plantingSiteId)
+    model.addAttribute("histories", histories)
+
+    return "/admin/simplifyPlantingSiteHistories"
+  }
+
+  @PostMapping("/organization/{organizationId}/simplifyPlantingSite/{plantingSiteId}")
+  fun simplifyPlantingSite(
+      @PathVariable organizationId: OrganizationId,
+      @PathVariable plantingSiteId: PlantingSiteId,
+      @RequestParam(required = false) tolerance: Double?,
+      redirectAttributes: RedirectAttributes,
+  ): String {
+    try {
+      plantingSiteStore.upsertSimplifiedPlantingSite(plantingSiteId, tolerance)
+      redirectAttributes.successMessage = "Simplified planting site $plantingSiteId."
+    } catch (e: Exception) {
+      log.warn("Failed to simplify planting site $plantingSiteId", e)
+      redirectAttributes.failureMessage = "Failed to simplify planting site: ${e.message}"
+    }
+
+    return redirectToSimplifyPlantingSites(organizationId)
+  }
+
+  @PostMapping(
+      "/organization/{organizationId}/simplifyPlantingSites/{plantingSiteId}/histories/{historyId}"
+  )
+  fun simplifyPlantingSiteHistory(
+      @PathVariable organizationId: OrganizationId,
+      @PathVariable plantingSiteId: PlantingSiteId,
+      @PathVariable historyId: PlantingSiteHistoryId,
+      @RequestParam(required = false) tolerance: Double?,
+      redirectAttributes: RedirectAttributes,
+  ): String {
+    try {
+      plantingSiteStore.upsertSimplifiedPlantingSiteHistory(plantingSiteId, historyId, tolerance)
+      redirectAttributes.successMessage = "Simplified planting site history $historyId."
+    } catch (e: Exception) {
+      log.warn("Failed to simplify planting site history $historyId", e)
+      redirectAttributes.failureMessage = "Failed to simplify planting site history: ${e.message}"
+    }
+
+    return redirectToSimplifyPlantingSiteHistories(organizationId, plantingSiteId)
+  }
+
+  private fun numVerticesField(boundary: Field<Geometry?>): Field<Int> =
+      DSL.field("ST_NPoints({0})", SQLDataType.INTEGER, boundary)
+
+  private fun reductionRatioField(
+      original: Field<Geometry?>,
+      simplified: Field<Geometry?>,
+  ): Field<Double> =
+      DSL.field(
+          "CASE WHEN ST_NPoints({0}) > 0 AND {1} IS NOT NULL " +
+              "THEN 1.0 - ST_NPoints({1})::float / ST_NPoints({0})::float " +
+              "ELSE NULL END",
+          SQLDataType.DOUBLE,
+          original,
+          simplified,
+      )
+
+  private fun jaccardSimilarityField(
+      original: Field<Geometry?>,
+      simplified: Field<Geometry?>,
+  ): Field<Double> =
+      DSL.field(
+          "CASE WHEN {1} IS NOT NULL " +
+              "THEN ST_Area(ST_Intersection({0}, {1})::geography) / " +
+              "NULLIF(ST_Area(ST_Union({0}, {1})::geography), 0) " +
+              "ELSE NULL END",
+          SQLDataType.DOUBLE,
+          original,
+          simplified,
+      )
+
+  private fun redirectToSimplifyPlantingSites(organizationId: OrganizationId) =
+      "redirect:/admin/organization/$organizationId/simplifyPlantingSites"
+
+  private fun redirectToSimplifyPlantingSiteHistories(
+      organizationId: OrganizationId,
+      plantingSiteId: PlantingSiteId,
+  ) = "redirect:/admin/organization/$organizationId/simplifyPlantingSites/$plantingSiteId/histories"
+}
+
+data class PlantingSiteSimplificationModel(
+    val id: PlantingSiteId,
+    val name: String,
+    val numVerticesOriginal: Int?,
+    val numVerticesSimplified: Int?,
+    val reductionRatio: Double?,
+    val jaccardSimilarity: Double?,
+)
+
+data class PlantingSiteHistorySimplificationModel(
+    val id: PlantingSiteHistoryId,
+    val createdTime: java.time.Instant,
+    val numVerticesOriginal: Int?,
+    val numVerticesSimplified: Int?,
+    val reductionRatio: Double?,
+    val jaccardSimilarity: Double?,
+)

--- a/src/main/kotlin/com/terraformation/backend/tracking/db/PlantingSiteStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/db/PlantingSiteStore.kt
@@ -731,25 +731,25 @@ class PlantingSiteStore(
     dslContext.transaction { _ ->
       if (site.boundary != null) {
         simplifyAndUpsertRow(
-            SIMPLIFIED_PLANTING_SITES.PLANTING_SITE_ID,
-            plantingSiteId,
-            site.boundary,
-            site.exclusion,
-            tolerance,
+            idField = SIMPLIFIED_PLANTING_SITES.PLANTING_SITE_ID,
+            id = plantingSiteId,
+            boundary = site.boundary,
+            exclusion = site.exclusion,
+            tolerance = tolerance,
         )
 
         site.strata.forEach { stratum ->
           simplifyAndUpsertRow(
-              SIMPLIFIED_STRATA.STRATUM_ID,
-              stratum.id,
-              stratum.boundary,
+              idField = SIMPLIFIED_STRATA.STRATUM_ID,
+              id = stratum.id,
+              boundary = stratum.boundary,
               tolerance = tolerance,
           )
           stratum.substrata.forEach { substratum ->
             simplifyAndUpsertRow(
-                SIMPLIFIED_SUBSTRATA.SUBSTRATUM_ID,
-                substratum.id,
-                substratum.boundary,
+                idField = SIMPLIFIED_SUBSTRATA.SUBSTRATUM_ID,
+                id = substratum.id,
+                boundary = substratum.boundary,
                 tolerance = tolerance,
             )
           }
@@ -770,25 +770,25 @@ class PlantingSiteStore(
 
     dslContext.transaction { _ ->
       simplifyAndUpsertRow(
-          SIMPLIFIED_PLANTING_SITE_HISTORIES.PLANTING_SITE_HISTORY_ID,
-          siteHistory.id,
-          siteHistory.boundary,
-          siteHistory.exclusion,
-          tolerance,
+          idField = SIMPLIFIED_PLANTING_SITE_HISTORIES.PLANTING_SITE_HISTORY_ID,
+          id = siteHistory.id,
+          boundary = siteHistory.boundary,
+          exclusion = siteHistory.exclusion,
+          tolerance = tolerance,
       )
 
       siteHistory.strata.forEach { stratumHistory ->
         simplifyAndUpsertRow(
-            SIMPLIFIED_STRATUM_HISTORIES.STRATUM_HISTORY_ID,
-            stratumHistory.id,
-            stratumHistory.boundary,
+            idField = SIMPLIFIED_STRATUM_HISTORIES.STRATUM_HISTORY_ID,
+            id = stratumHistory.id,
+            boundary = stratumHistory.boundary,
             tolerance = tolerance,
         )
         stratumHistory.substrata.forEach { substratumHistory ->
           simplifyAndUpsertRow(
-              SIMPLIFIED_SUBSTRATUM_HISTORIES.SUBSTRATUM_HISTORY_ID,
-              substratumHistory.id,
-              substratumHistory.boundary,
+              idField = SIMPLIFIED_SUBSTRATUM_HISTORIES.SUBSTRATUM_HISTORY_ID,
+              id = substratumHistory.id,
+              boundary = substratumHistory.boundary,
               tolerance = tolerance,
           )
         }

--- a/src/main/kotlin/com/terraformation/backend/tracking/db/PlantingSiteStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/db/PlantingSiteStore.kt
@@ -720,7 +720,10 @@ class PlantingSiteStore(
     }
   }
 
-  fun upsertSimplifiedPlantingSite(plantingSiteId: PlantingSiteId) {
+  fun upsertSimplifiedPlantingSite(
+      plantingSiteId: PlantingSiteId,
+      tolerance: Double? = null,
+  ) {
     requirePermissions { updatePlantingSite(plantingSiteId) }
 
     val site = fetchSiteById(plantingSiteId, PlantingSiteDepth.Substratum)
@@ -732,15 +735,22 @@ class PlantingSiteStore(
             plantingSiteId,
             site.boundary,
             site.exclusion,
+            tolerance,
         )
 
         site.strata.forEach { stratum ->
-          simplifyAndUpsertRow(SIMPLIFIED_STRATA.STRATUM_ID, stratum.id, stratum.boundary)
+          simplifyAndUpsertRow(
+              SIMPLIFIED_STRATA.STRATUM_ID,
+              stratum.id,
+              stratum.boundary,
+              tolerance = tolerance,
+          )
           stratum.substrata.forEach { substratum ->
             simplifyAndUpsertRow(
                 SIMPLIFIED_SUBSTRATA.SUBSTRATUM_ID,
                 substratum.id,
                 substratum.boundary,
+                tolerance = tolerance,
             )
           }
         }
@@ -751,6 +761,7 @@ class PlantingSiteStore(
   fun upsertSimplifiedPlantingSiteHistory(
       plantingSiteId: PlantingSiteId,
       plantingSiteHistoryId: PlantingSiteHistoryId,
+      tolerance: Double? = null,
   ) {
     requirePermissions { updatePlantingSite(plantingSiteId) }
 
@@ -763,6 +774,7 @@ class PlantingSiteStore(
           siteHistory.id,
           siteHistory.boundary,
           siteHistory.exclusion,
+          tolerance,
       )
 
       siteHistory.strata.forEach { stratumHistory ->
@@ -770,12 +782,14 @@ class PlantingSiteStore(
             SIMPLIFIED_STRATUM_HISTORIES.STRATUM_HISTORY_ID,
             stratumHistory.id,
             stratumHistory.boundary,
+            tolerance = tolerance,
         )
         stratumHistory.substrata.forEach { substratumHistory ->
           simplifyAndUpsertRow(
               SIMPLIFIED_SUBSTRATUM_HISTORIES.SUBSTRATUM_HISTORY_ID,
               substratumHistory.id,
               substratumHistory.boundary,
+              tolerance = tolerance,
           )
         }
       }
@@ -3142,11 +3156,12 @@ class PlantingSiteStore(
       id: ID,
       boundary: Geometry,
       exclusion: Geometry? = null,
+      tolerance: Double? = null,
   ) {
     val table = idField.table!!
 
-    val simplifiedBoundary = GeometrySimplifier.simplify(boundary)
-    val simplifiedExclusion = exclusion?.let { GeometrySimplifier.simplify(it) }
+    val simplifiedBoundary = GeometrySimplifier.simplify(boundary, tolerance)
+    val simplifiedExclusion = exclusion?.let { GeometrySimplifier.simplify(it, tolerance) }
 
     val boundaryField = table.field("boundary", Geometry::class.java)!!
     val exclusionField = exclusion?.let { table.field("exclusion", Geometry::class.java)!! }

--- a/src/main/kotlin/com/terraformation/backend/util/GeometrySimplifier.kt
+++ b/src/main/kotlin/com/terraformation/backend/util/GeometrySimplifier.kt
@@ -13,15 +13,16 @@ import org.locationtech.jts.simplify.TopologyPreservingSimplifier
  */
 class GeometrySimplifier {
   companion object {
-    val TOLERANCE_M: Double = 0.5
+    const val DEFAULT_TOLERANCE_M: Double = 0.5
 
     /**
      * Simplifies geometry within a tolerance of 0.5 meter. The simplification will be performed in
      * the Web Mercator CRS. The results will be projected back to the original CRS
      */
-    fun simplify(geometry: Geometry): Geometry {
+    fun simplify(geometry: Geometry, tolerance: Double? = null): Geometry {
       val geometryMercator = project(geometry, geometry.srid, SRID.SPHERICAL_MERCATOR)
-      val simplifiedGeometry = TopologyPreservingSimplifier.simplify(geometryMercator, TOLERANCE_M)
+      val simplifiedGeometry =
+          TopologyPreservingSimplifier.simplify(geometryMercator, tolerance ?: DEFAULT_TOLERANCE_M)
       return project(simplifiedGeometry, SRID.SPHERICAL_MERCATOR, geometry.srid)
     }
 

--- a/src/main/resources/templates/admin/organization.html
+++ b/src/main/resources/templates/admin/organization.html
@@ -232,6 +232,8 @@
     </li>
 </ol>
 
+<a th:href="|/admin/organization/${organization.id}/simplifyPlantingSites|">Manage Simplified Planting Sites</a>
+
 <form method="POST" enctype="multipart/form-data" action="/admin/createPlantingSite"
       th:if="${canCreatePlantingSite}">
     <h4>Create Planting Site from Shapefiles</h4>

--- a/src/main/resources/templates/admin/simplifyPlantingSiteHistories.html
+++ b/src/main/resources/templates/admin/simplifyPlantingSiteHistories.html
@@ -1,0 +1,68 @@
+<!DOCTYPE HTML>
+<html xmlns:th="http://www.thymeleaf.org">
+<head th:replace="~{/admin/header :: head}"/>
+<style>
+    table td, table th {
+        padding: 0.1em 1.2em;
+    }
+</style>
+<body>
+
+<span th:replace="~{/admin/header :: top}"/>
+
+<a href="/admin/">Home</a>
+-
+<a th:href="|/admin/organization/${organizationId}|">Organization <th:block th:text="${organizationId}"/></a>
+-
+<a th:href="|/admin/organization/${organizationId}/simplifyPlantingSites|">Simplify Planting Sites</a>
+
+<h2>Simplify Planting Site Histories</h2>
+
+<p>
+    Regenerate simplified geometry for planting site histories. An optional tolerance (in meters)
+    controls how aggressively the geometry is simplified; leave blank to use the default.
+</p>
+
+<h3>Histories for Planting Site <th:block th:text="${plantingSiteId}"/></h3>
+
+<p th:if="${histories.isEmpty()}">No histories found for this planting site.</p>
+
+<div th:if="${!histories.isEmpty()}">
+    <label for="sharedTolerance">Tolerance (meters)</label>
+    <input type="number" id="sharedTolerance" step="any" min="0" value="0.5"
+           oninput="document.querySelectorAll('.historyToleranceInput').forEach(i => i.value = this.value)"/>
+
+    <table>
+        <thead>
+        <tr>
+            <th>History ID</th>
+            <th>Created Time</th>
+            <th>Original Vertices</th>
+            <th>Simplified Vertices</th>
+            <th>Reduction Ratio</th>
+            <th>Jaccard Similarity</th>
+            <th>Action</th>
+        </tr>
+        </thead>
+        <tbody>
+        <tr th:each="history : ${histories}" class="striped">
+            <td th:text="${history.id}">1</td>
+            <td th:text="${history.createdTime}">2024-01-01T00:00:00Z</td>
+            <td th:text="${history.numVerticesOriginal} ?: '-'">-</td>
+            <td th:text="${history.numVerticesSimplified} ?: '-'">-</td>
+            <td th:text="${history.reductionRatio != null} ? ${#numbers.formatDecimal(history.reductionRatio, 1, 4)} : '-'">-</td>
+            <td th:text="${history.jaccardSimilarity != null} ? ${#numbers.formatDecimal(history.jaccardSimilarity, 1, 4)} : '-'">-</td>
+            <td>
+                <form method="POST"
+                      th:action="|/admin/organization/${organizationId}/simplifyPlantingSites/${plantingSiteId}/histories/${history.id}|">
+                    <input type="hidden" name="tolerance" class="historyToleranceInput" value="0.5"/>
+                    <input type="submit" value="Simplify"/>
+                </form>
+            </td>
+        </tr>
+        </tbody>
+    </table>
+</div>
+
+</body>
+</html>

--- a/src/main/resources/templates/admin/simplifyPlantingSites.html
+++ b/src/main/resources/templates/admin/simplifyPlantingSites.html
@@ -18,7 +18,7 @@
 
 <p>
     Regenerate simplified geometry for planting sites. Simplified geometry is used by the API to
-    reduce data transfer sizes. An optional tolerance (in degrees) controls how aggressively the
+    reduce data transfer sizes. An optional tolerance (in meters) controls how aggressively the
     geometry is simplified; leave blank to use the default.
 </p>
 

--- a/src/main/resources/templates/admin/simplifyPlantingSites.html
+++ b/src/main/resources/templates/admin/simplifyPlantingSites.html
@@ -1,0 +1,71 @@
+<!DOCTYPE HTML>
+<html xmlns:th="http://www.thymeleaf.org">
+<head th:replace="~{/admin/header :: head}"/>
+<style>
+    table td, table th {
+        padding: 0.1em 1.2em;
+    }
+</style>
+<body>
+
+<span th:replace="~{/admin/header :: top}"/>
+
+<a href="/admin/">Home</a>
+-
+<a th:href="|/admin/organization/${organizationId}|">Organization <th:block th:text="${organizationId}"/></a>
+
+<h2>Simplify Planting Sites</h2>
+
+<p>
+    Regenerate simplified geometry for planting sites. Simplified geometry is used by the API to
+    reduce data transfer sizes. An optional tolerance (in degrees) controls how aggressively the
+    geometry is simplified; leave blank to use the default.
+</p>
+
+<h3>Planting Sites</h3>
+
+<p th:if="${plantingSites.isEmpty()}">No planting sites found for this organization.</p>
+
+<div th:if="${!plantingSites.isEmpty()}">
+    <label for="sharedTolerance">Tolerance (meters)</label>
+    <input type="number" id="sharedTolerance" step="any" min="0" value="0.5"
+           oninput="document.querySelectorAll('.siteToleranceInput').forEach(i => i.value = this.value)"/>
+
+    <table>
+        <thead>
+        <tr>
+            <th>ID</th>
+            <th>Name</th>
+            <th>Original Vertices</th>
+            <th>Simplified Vertices</th>
+            <th>Reduction Ratio</th>
+            <th>Jaccard Similarity</th>
+            <th>Action</th>
+            <th></th>
+        </tr>
+        </thead>
+        <tbody>
+        <tr th:each="site : ${plantingSites}" class="striped">
+            <td th:text="${site.id}">1</td>
+            <td th:text="${site.name}">Site Name</td>
+            <td th:text="${site.numVerticesOriginal} ?: '-'">-</td>
+            <td th:text="${site.numVerticesSimplified} ?: '-'">-</td>
+            <td th:text="${site.reductionRatio != null} ? ${#numbers.formatDecimal(site.reductionRatio, 1, 4)} : '-'">-</td>
+            <td th:text="${site.jaccardSimilarity != null} ? ${#numbers.formatDecimal(site.jaccardSimilarity, 1, 4)} : '-'">-</td>
+            <td style="display: flex; align-items: center; gap: 0.5em;">
+                <form method="POST"
+                      th:action="|/admin/organization/${organizationId}/simplifyPlantingSite/${site.id}|">
+                    <input type="hidden" name="tolerance" class="siteToleranceInput" value="0.5"/>
+                    <input type="submit" value="Simplify"/>
+                </form>
+            </td>
+            <td>
+                <a th:href="|/admin/organization/${organizationId}/simplifyPlantingSites/${site.id}/histories|">Site Histories</a>
+            </td>
+        </tr>
+        </tbody>
+    </table>
+</div>
+
+</body>
+</html>

--- a/src/test/kotlin/com/terraformation/backend/util/GeometrySimplifierTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/util/GeometrySimplifierTest.kt
@@ -1,6 +1,7 @@
 package com.terraformation.backend.util
 
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.terraformation.backend.assertGeometryEquals
 import com.terraformation.backend.db.GeometryModule
 import com.terraformation.backend.db.SRID
 import com.terraformation.backend.gis.GeometryFileParser
@@ -8,7 +9,10 @@ import org.geotools.geometry.jts.JTS
 import org.geotools.referencing.CRS
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.Test
+import org.locationtech.jts.geom.Coordinate
 import org.locationtech.jts.geom.Geometry
+import org.locationtech.jts.geom.GeometryFactory
+import org.locationtech.jts.geom.PrecisionModel
 
 class GeometrySimplifierTest {
   private val objectMapper = jacksonObjectMapper().registerModule(GeometryModule())
@@ -22,6 +26,69 @@ class GeometrySimplifierTest {
   @Test
   fun `simplifies geometry for a multi-polygon`() {
     runGeoJson("/gis/simplification/multipolygon.geojson")
+  }
+
+  @Test
+  fun `smooths line by removing points according to distance tolerances`() {
+    val geometryFactory = GeometryFactory(PrecisionModel(), SRID.SPHERICAL_MERCATOR)
+    val originalPolygon =
+        geometryFactory.createPolygon(
+            arrayOf(
+                Coordinate(0.0, 0.0),
+                Coordinate(6.0, 0.6), // divot of 0.6m
+                Coordinate(12.0, 0.0),
+                Coordinate(12.0, 10.0),
+                Coordinate(6.0, 11.1), // divot of 1.1m
+                Coordinate(0.0, 10.0),
+                Coordinate(0.0, 0.0),
+            )
+        )
+
+    val expectedSimplifiedPolygon2 =
+        geometryFactory.createPolygon(
+            arrayOf(
+                Coordinate(0.0, 0.0),
+                // 0.6m divot removed
+                Coordinate(12.0, 0.0),
+                Coordinate(12.0, 10.0),
+                Coordinate(6.0, 11.1), // divot of 1.1m
+                Coordinate(0.0, 10.0),
+                Coordinate(0.0, 0.0),
+            )
+        )
+
+    val expectedSimplifiedPolygon3 =
+        geometryFactory.createPolygon(
+            arrayOf(
+                Coordinate(0.0, 0.0),
+                // 0.6m divot removed
+                Coordinate(12.0, 0.0),
+                Coordinate(12.0, 10.0),
+                // 1.1m divot removed
+                Coordinate(0.0, 10.0),
+                Coordinate(0.0, 0.0),
+            )
+        )
+
+    val actualSimplifiedPolygon1 = GeometrySimplifier.simplify(originalPolygon, 0.5)
+    val actualSimplifiedPolygon2 = GeometrySimplifier.simplify(originalPolygon, 1.0)
+    val actualSimplifiedPolygon3 = GeometrySimplifier.simplify(originalPolygon, 1.5)
+
+    assertGeometryEquals(
+        originalPolygon,
+        actualSimplifiedPolygon1,
+        "Simplified polygon with tolerance of 0.5m",
+    )
+    assertGeometryEquals(
+        expectedSimplifiedPolygon2,
+        actualSimplifiedPolygon2,
+        "Simplified polygon with tolerance of 1.0m",
+    )
+    assertGeometryEquals(
+        expectedSimplifiedPolygon3,
+        actualSimplifiedPolygon3,
+        "Simplified polygon with tolerance of 1.5m",
+    )
   }
 
   private fun runGeoJson(path: String) {


### PR DESCRIPTION
![Screenshot 2026-04-21 at 7.00.27 PM.png](https://app.graphite.com/user-attachments/assets/4219c120-af9d-43ef-9e6e-2dc8c623eafb.png)

1. Added customization options for testing with various tolerance options
2. Added tests that account for tolerances, deterministically remove points.
3. Added triggers from the admin UI to backfill certain sites/site histories

Bulk backfill will be implemented in the future, once some small-scale testing is completed.

Claude was used to generate the html templates as well as the structure of the AdminController classes. Claude conveted the calculations of Jaccard and reduction ratio into SQL, from the original test code as well to improvement performances.