### PR TITLE
Ensure files for splats are also observation media files

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/splat/SplatService.kt
+++ b/src/main/kotlin/com/terraformation/backend/splat/SplatService.kt
@@ -36,6 +36,7 @@ import java.time.InstantSource
 import kotlin.io.path.Path
 import kotlin.io.path.pathString
 import org.jooq.DSLContext
+import org.jooq.impl.DSL
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.context.ApplicationEventPublisher
 import org.springframework.context.event.EventListener
@@ -142,6 +143,9 @@ class SplatService(
     val organizationId =
         parentStore.getOrganizationId(observationId)
             ?: throw ObservationNotFoundException(observationId)
+
+    // Ensure that an observation media file used for splats is also an organization media file
+    insertOrganizationMediaFileFromObservationFile(observationId, fileId)
 
     generateSplat(organizationId, fileId, force, params, runBirdnet)
   }
@@ -712,6 +716,41 @@ class SplatService(
 
     if (!associationExists) {
       throw FileNotFoundException(fileId)
+    }
+  }
+
+  private fun insertOrganizationMediaFileFromObservationFile(
+      observationId: ObservationId,
+      fileId: FileId,
+  ) {
+    val organizationId =
+        parentStore.getOrganizationId(observationId)
+            ?: throw ObservationNotFoundException(observationId)
+
+    requirePermissions {
+      readObservation(observationId)
+      createOrganizationMedia(organizationId)
+    }
+
+    ensureObservationFile(observationId, fileId)
+
+    with(ORGANIZATION_MEDIA_FILES) {
+      dslContext
+          .insertInto(ORGANIZATION_MEDIA_FILES, ORGANIZATION_ID, FILE_ID, CAPTION)
+          .select(
+              DSL.select(
+                      DSL.value(organizationId),
+                      OBSERVATION_MEDIA_FILES.FILE_ID,
+                      OBSERVATION_MEDIA_FILES.CAPTION,
+                  )
+                  .from(OBSERVATION_MEDIA_FILES)
+                  .where(
+                      OBSERVATION_MEDIA_FILES.OBSERVATION_ID.eq(observationId)
+                          .and(OBSERVATION_MEDIA_FILES.FILE_ID.eq(fileId))
+                  )
+          )
+          .onConflictDoNothing()
+          .execute()
     }
   }
 

--- a/src/main/resources/db/migration/0450/V477__BackfillOrganizationMediaSplats.sql
+++ b/src/main/resources/db/migration/0450/V477__BackfillOrganizationMediaSplats.sql
@@ -1,0 +1,9 @@
+INSERT INTO organization_media_files (file_id, organization_id, caption)
+    SELECT splats.file_id, sites.organization_id, obmf.caption
+    FROM splats
+    JOIN tracking.observation_media_files AS obmf
+    ON obmf.file_id = splats.file_id
+    JOIN tracking.observations as obs
+    ON obmf.observation_id = obs.id
+    JOIN tracking.planting_sites as sites
+    ON obs.planting_site_id = sites.id;

--- a/src/test/kotlin/com/terraformation/backend/splat/SplatServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/splat/SplatServiceTest.kt
@@ -15,6 +15,7 @@ import com.terraformation.backend.db.default_schema.FileId
 import com.terraformation.backend.db.default_schema.OrganizationId
 import com.terraformation.backend.db.default_schema.Role
 import com.terraformation.backend.db.default_schema.tables.records.BirdnetResultsRecord
+import com.terraformation.backend.db.default_schema.tables.records.OrganizationMediaFilesRecord
 import com.terraformation.backend.db.default_schema.tables.records.SplatAnnotationsRecord
 import com.terraformation.backend.db.default_schema.tables.records.SplatsRecord
 import com.terraformation.backend.db.default_schema.tables.references.BIRDNET_RESULTS
@@ -947,6 +948,14 @@ class SplatServiceTest : DatabaseTest(), RunsAsDatabaseUser {
       )
 
       assertTableEquals(
+          OrganizationMediaFilesRecord(
+              fileId = fileId,
+              organizationId = organizationId,
+          ),
+          "Organization media files table",
+      )
+
+      assertTableEquals(
           SplatsRecord(
               fileId = fileId,
               createdBy = user.userId,
@@ -955,7 +964,8 @@ class SplatServiceTest : DatabaseTest(), RunsAsDatabaseUser {
               splatStorageUrl = URI("s3://bucket/video.sog"),
               organizationId = organizationId,
               needsAttention = false,
-          )
+          ),
+          "Splats table",
       )
     }
 


### PR DESCRIPTION
This PR guarantees that an observation file used to generate splats is also an organization media file. This is to support organization media files APIs and features for splats are available. 