### PR TITLE
Remove sphere init from splats admin page

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/admin/AdminSplatsController.kt
+++ b/src/main/kotlin/com/terraformation/backend/admin/AdminSplatsController.kt
@@ -50,9 +50,6 @@ class AdminSplatsController(
       @RequestParam maxSteps: Int?,
       @RequestParam restartAt: String?,
       @RequestParam runBirdNet: Boolean?,
-      @RequestParam sphereInit: Boolean?,
-      @RequestParam sphereInitNumPoints: Int?,
-      @RequestParam sphereInitRadiusScale: Int?,
       @RequestParam ssimLambda: Double?,
       @RequestParam tailPruning: Boolean?,
       payload: AdminProcessSplatRequestPayload,
@@ -74,16 +71,6 @@ class AdminSplatsController(
                   },
                   maxSize?.let { "extract" to listOf("--max-size", "$maxSize") },
                   maxSteps?.let { "gsplat" to listOf("--max_steps", "$maxSteps") },
-                  if (sphereInit == true)
-                      "sphere-init" to
-                          listOfNotNull(
-                              "--sphere-init",
-                              sphereInitNumPoints?.let { "--num-points" },
-                              sphereInitNumPoints?.let { "$it" },
-                              sphereInitRadiusScale?.let { "--radius-scale" },
-                              sphereInitRadiusScale?.let { "$it" },
-                          )
-                  else null,
                   ssimLambda?.let { "gsplat" to listOf("--ssim_lambda", "$ssimLambda") },
                   tailPruning?.let {
                     if (tailPruning) {
@@ -145,9 +132,6 @@ class AdminSplatsController(
     redirectAttributes.addFlashAttribute("maxSteps", maxSteps)
     redirectAttributes.addFlashAttribute("restartAt", restartAt)
     redirectAttributes.addFlashAttribute("runBirdNet", runBirdNet)
-    redirectAttributes.addFlashAttribute("sphereInit", sphereInit)
-    redirectAttributes.addFlashAttribute("sphereInitNumPoints", sphereInitNumPoints)
-    redirectAttributes.addFlashAttribute("sphereInitRadiusScale", sphereInitRadiusScale)
     redirectAttributes.addFlashAttribute("ssimLambda", ssimLambda)
     redirectAttributes.addFlashAttribute("tailPruning", tailPruning)
     redirectAttributes.addFlashAttribute("stepArgs", payload.stepArgs)

--- a/src/main/resources/templates/admin/splats.html
+++ b/src/main/resources/templates/admin/splats.html
@@ -357,41 +357,6 @@
 
         <tbody>
         <tr>
-            <td rowspan="3">sphere-init</td>
-            <td>Sphere Init</td>
-            <td><input type="checkbox" name="sphereInit" th:checked="${sphereInit}"/></td>
-            <td>
-                Enable sphere initialization to initialize the sparse point clouse with a sphere of
-                points.
-            </td>
-        </tr>
-        <tr>
-            <td>Num Points</td>
-            <td><input type="text" name="sphereInitNumPoints" placeholder="10000"
-                       th:value="${sphereInitNumPoints}"/></td>
-            <td>
-                Number of points to use when initializing the sphere.
-            </td>
-        </tr>
-        <tr>
-            <td>Radius Scale</td>
-            <td><input type="text" name="sphereInitRadiusScale" placeholder="10"
-                       th:value="${sphereInitRadiusScale}"/></td>
-            <td>
-                Scale factor for the sphere radius (this is multiplied by the average position of
-                all the points from SfM).
-            </td>
-        </tr>
-        </tbody>
-
-        <tr>
-            <td colspan="4">
-                <hr/>
-            </td>
-        </tr>
-
-        <tbody>
-        <tr>
             <td rowspan="5">gsplat</td>
             <td>Densification Strategy</td>
             <td>


### PR DESCRIPTION
Now that sphere init is a part of the `gsplat` step, it no longer needs an admin section so remove it. All params of it can now be controlled with the `Other Args` input.