### PR TITLE
Convert all splat points to PostGIS points

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/splat/Models.kt
+++ b/src/main/kotlin/com/terraformation/backend/splat/Models.kt
@@ -11,7 +11,15 @@ import com.terraformation.backend.db.tracking.ObservationId
 import com.terraformation.backend.db.tracking.tables.references.OBSERVATION_MEDIA_FILES
 import java.math.BigDecimal
 import java.net.URI
+import org.jooq.Field
 import org.jooq.Record
+import org.jooq.impl.DSL
+import org.jooq.impl.SQLDataType
+import org.locationtech.jts.geom.Coordinate
+import org.locationtech.jts.geom.Geometry
+import org.locationtech.jts.geom.GeometryFactory
+import org.locationtech.jts.geom.Point
+import org.locationtech.jts.geom.PrecisionModel
 
 data class ObservationSplatModel(
     val assetStatus: AssetStatus,
@@ -61,7 +69,30 @@ data class CoordinateModel(val x: BigDecimal, val y: BigDecimal, val z: BigDecim
       y: Double,
       z: Double,
   ) : this(BigDecimal.valueOf(x), BigDecimal.valueOf(y), BigDecimal.valueOf(z))
+
+  fun toPoint(): Point =
+      cartesianGeometryFactory.createPoint(Coordinate(x.toDouble(), y.toDouble(), z.toDouble()))
+
+  companion object {
+    fun of(point: Point): CoordinateModel = CoordinateModel(point.x, point.y, point.coordinate.z)
+  }
 }
+
+private val cartesianGeometryFactory = GeometryFactory(PrecisionModel(), 0)
+
+@Suppress("UNCHECKED_CAST")
+fun CoordinateModel?.toPointZField(): Field<Geometry?> =
+    if (this == null) {
+      DSL.castNull(SQLDataType.GEOMETRY) as Field<Geometry?>
+    } else {
+      DSL.field(
+          "ST_MakePoint({0}, {1}, {2})",
+          SQLDataType.GEOMETRY,
+          DSL.value(x),
+          DSL.value(y),
+          DSL.value(z),
+      ) as Field<Geometry?>
+    }
 
 data class SplatAnnotationModel<AnnotationId : SplatAnnotationId?>(
     val id: AnnotationId,
@@ -78,22 +109,10 @@ data class SplatAnnotationModel<AnnotationId : SplatAnnotationId?>(
           ExistingSplatAnnotationModel(
               id = record[ID]!!,
               bodyText = record[BODY_TEXT],
-              cameraPosition =
-                  record[CAMERA_POSITION_X]?.let {
-                    CoordinateModel(
-                        it,
-                        record[CAMERA_POSITION_Y]!!,
-                        record[CAMERA_POSITION_Z]!!,
-                    )
-                  },
+              cameraPosition = (record[CAMERA_POSITION] as Point?)?.let { CoordinateModel.of(it) },
               fileId = record[FILE_ID]!!,
               label = record[LABEL],
-              position =
-                  CoordinateModel(
-                      record[POSITION_X]!!,
-                      record[POSITION_Y]!!,
-                      record[POSITION_Z]!!,
-                  ),
+              position = CoordinateModel.of(record[POSITION] as Point),
               title = record[TITLE]!!,
           )
         }

--- a/src/main/kotlin/com/terraformation/backend/splat/Models.kt
+++ b/src/main/kotlin/com/terraformation/backend/splat/Models.kt
@@ -74,7 +74,8 @@ data class CoordinateModel(val x: BigDecimal, val y: BigDecimal, val z: BigDecim
       cartesianGeometryFactory.createPoint(Coordinate(x.toDouble(), y.toDouble(), z.toDouble()))
 
   companion object {
-    fun of(point: Point): CoordinateModel = CoordinateModel(point.x, point.y, point.coordinate.z)
+    fun of(record: Record?, pointField: Field<Geometry?>): CoordinateModel? =
+        (record?.get(pointField) as Point?)?.let { CoordinateModel(it.x, it.y, it.coordinate.z) }
   }
 }
 
@@ -109,10 +110,10 @@ data class SplatAnnotationModel<AnnotationId : SplatAnnotationId?>(
           ExistingSplatAnnotationModel(
               id = record[ID]!!,
               bodyText = record[BODY_TEXT],
-              cameraPosition = (record[CAMERA_POSITION] as Point?)?.let { CoordinateModel.of(it) },
+              cameraPosition = CoordinateModel.of(record, CAMERA_POSITION),
               fileId = record[FILE_ID]!!,
               label = record[LABEL],
-              position = CoordinateModel.of(record[POSITION] as Point),
+              position = CoordinateModel.of(record, POSITION)!!,
               title = record[TITLE]!!,
           )
         }

--- a/src/main/kotlin/com/terraformation/backend/splat/SplatService.kt
+++ b/src/main/kotlin/com/terraformation/backend/splat/SplatService.kt
@@ -36,6 +36,7 @@ import java.time.InstantSource
 import kotlin.io.path.Path
 import kotlin.io.path.pathString
 import org.jooq.DSLContext
+import org.locationtech.jts.geom.Point
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.context.ApplicationEventPublisher
 import org.springframework.context.event.EventListener
@@ -529,35 +530,13 @@ class SplatService(
     with(SPLATS) {
       val record =
           dslContext
-              .select(
-                  CAMERA_POSITION_X,
-                  CAMERA_POSITION_Y,
-                  CAMERA_POSITION_Z,
-                  ORIGIN_POSITION_X,
-                  ORIGIN_POSITION_Y,
-                  ORIGIN_POSITION_Z,
-              )
+              .select(CAMERA_POSITION, ORIGIN_POSITION)
               .from(SPLATS)
               .where(FILE_ID.eq(fileId))
               .fetchOne()
 
-      val cameraPosition =
-          record?.get(CAMERA_POSITION_X)?.let {
-            CoordinateModel(
-                it,
-                record[CAMERA_POSITION_Y]!!,
-                record[CAMERA_POSITION_Z]!!,
-            )
-          }
-
-      val originPosition =
-          record?.get(ORIGIN_POSITION_X)?.let {
-            CoordinateModel(
-                it,
-                record[ORIGIN_POSITION_Y]!!,
-                record[ORIGIN_POSITION_Z]!!,
-            )
-          }
+      val cameraPosition = (record?.get(CAMERA_POSITION) as Point?)?.let { CoordinateModel.of(it) }
+      val originPosition = (record?.get(ORIGIN_POSITION) as Point?)?.let { CoordinateModel.of(it) }
 
       return Pair(originPosition, cameraPosition)
     }
@@ -568,19 +547,7 @@ class SplatService(
   ): List<ExistingSplatAnnotationModel> {
     with(SPLAT_ANNOTATIONS) {
       return dslContext
-          .select(
-              ID,
-              FILE_ID,
-              TITLE,
-              BODY_TEXT,
-              LABEL,
-              POSITION_X,
-              POSITION_Y,
-              POSITION_Z,
-              CAMERA_POSITION_X,
-              CAMERA_POSITION_Y,
-              CAMERA_POSITION_Z,
-          )
+          .select(ID, FILE_ID, TITLE, BODY_TEXT, LABEL, POSITION, CAMERA_POSITION)
           .from(SPLAT_ANNOTATIONS)
           .where(FILE_ID.eq(fileId))
           .fetch { record -> SplatAnnotationModel.of(record) }
@@ -607,12 +574,8 @@ class SplatService(
               .set(TITLE, annotation.title)
               .set(BODY_TEXT, annotation.bodyText)
               .set(LABEL, annotation.label)
-              .set(POSITION_X, annotation.position.x)
-              .set(POSITION_Y, annotation.position.y)
-              .set(POSITION_Z, annotation.position.z)
-              .set(CAMERA_POSITION_X, annotation.cameraPosition?.x)
-              .set(CAMERA_POSITION_Y, annotation.cameraPosition?.y)
-              .set(CAMERA_POSITION_Z, annotation.cameraPosition?.z)
+              .set(POSITION, annotation.position.toPointZField())
+              .set(CAMERA_POSITION, annotation.cameraPosition.toPointZField())
               .where(ID.eq(id).and(FILE_ID.eq(fileId)))
               .execute()
         }
@@ -628,47 +591,21 @@ class SplatService(
         dslContext.deleteFrom(SPLAT_ANNOTATIONS).where(deleteCondition).execute()
       }
 
-      if (annotationsWithoutIds.isNotEmpty()) {
+      annotationsWithoutIds.forEach { annotation ->
         with(SPLAT_ANNOTATIONS) {
-          val insertQuery =
-              dslContext.insertInto(
-                  SPLAT_ANNOTATIONS,
-                  FILE_ID,
-                  CREATED_BY,
-                  CREATED_TIME,
-                  MODIFIED_BY,
-                  MODIFIED_TIME,
-                  TITLE,
-                  BODY_TEXT,
-                  LABEL,
-                  POSITION_X,
-                  POSITION_Y,
-                  POSITION_Z,
-                  CAMERA_POSITION_X,
-                  CAMERA_POSITION_Y,
-                  CAMERA_POSITION_Z,
-              )
-
-          annotationsWithoutIds.forEach { annotation ->
-            insertQuery.values(
-                fileId,
-                userId,
-                now,
-                userId,
-                now,
-                annotation.title,
-                annotation.bodyText,
-                annotation.label,
-                annotation.position.x,
-                annotation.position.y,
-                annotation.position.z,
-                annotation.cameraPosition?.x,
-                annotation.cameraPosition?.y,
-                annotation.cameraPosition?.z,
-            )
-          }
-
-          insertQuery.execute()
+          dslContext
+              .insertInto(SPLAT_ANNOTATIONS)
+              .set(FILE_ID, fileId)
+              .set(CREATED_BY, userId)
+              .set(CREATED_TIME, now)
+              .set(MODIFIED_BY, userId)
+              .set(MODIFIED_TIME, now)
+              .set(TITLE, annotation.title)
+              .set(BODY_TEXT, annotation.bodyText)
+              .set(LABEL, annotation.label)
+              .set(POSITION, annotation.position.toPointZField())
+              .set(CAMERA_POSITION, annotation.cameraPosition.toPointZField())
+              .execute()
         }
       }
     }

--- a/src/main/kotlin/com/terraformation/backend/splat/SplatService.kt
+++ b/src/main/kotlin/com/terraformation/backend/splat/SplatService.kt
@@ -36,7 +36,6 @@ import java.time.InstantSource
 import kotlin.io.path.Path
 import kotlin.io.path.pathString
 import org.jooq.DSLContext
-import org.locationtech.jts.geom.Point
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.context.ApplicationEventPublisher
 import org.springframework.context.event.EventListener
@@ -535,8 +534,8 @@ class SplatService(
               .where(FILE_ID.eq(fileId))
               .fetchOne()
 
-      val cameraPosition = (record?.get(CAMERA_POSITION) as Point?)?.let { CoordinateModel.of(it) }
-      val originPosition = (record?.get(ORIGIN_POSITION) as Point?)?.let { CoordinateModel.of(it) }
+      val cameraPosition = CoordinateModel.of(record, CAMERA_POSITION)
+      val originPosition = CoordinateModel.of(record, ORIGIN_POSITION)
 
       return Pair(originPosition, cameraPosition)
     }

--- a/src/main/resources/db/migration/0450/V477__SplatPoints.sql
+++ b/src/main/resources/db/migration/0450/V477__SplatPoints.sql
@@ -1,0 +1,44 @@
+ALTER TABLE splats
+    ADD COLUMN origin_position GEOMETRY(PointZ, 0),
+    ADD COLUMN camera_position GEOMETRY(PointZ, 0);
+
+UPDATE splats
+SET origin_position = CASE
+    WHEN origin_position_x IS NOT NULL
+        THEN ST_MakePoint(origin_position_x, origin_position_y, origin_position_z)
+    END,
+    camera_position = CASE
+        WHEN camera_position_x IS NOT NULL
+            THEN ST_MakePoint(camera_position_x, camera_position_y, camera_position_z)
+        END;
+
+ALTER TABLE splats
+    DROP CONSTRAINT origin_position_all_or_none,
+    DROP CONSTRAINT camera_position_all_or_none,
+    DROP COLUMN origin_position_x,
+    DROP COLUMN origin_position_y,
+    DROP COLUMN origin_position_z,
+    DROP COLUMN camera_position_x,
+    DROP COLUMN camera_position_y,
+    DROP COLUMN camera_position_z;
+
+ALTER TABLE splat_annotations
+    ADD COLUMN position        GEOMETRY(PointZ, 0),
+    ADD COLUMN camera_position GEOMETRY(PointZ, 0);
+
+UPDATE splat_annotations
+SET position        = ST_MakePoint(position_x, position_y, position_z),
+    camera_position = CASE
+        WHEN camera_position_x IS NOT NULL
+            THEN ST_MakePoint(camera_position_x, camera_position_y, camera_position_z)
+        END;
+
+ALTER TABLE splat_annotations
+    ALTER COLUMN position SET NOT NULL,
+    DROP CONSTRAINT camera_position_all_or_none,
+    DROP COLUMN position_x,
+    DROP COLUMN position_y,
+    DROP COLUMN position_z,
+    DROP COLUMN camera_position_x,
+    DROP COLUMN camera_position_y,
+    DROP COLUMN camera_position_z;

--- a/src/main/resources/db/migration/R__Comments.sql
+++ b/src/main/resources/db/migration/R__Comments.sql
@@ -224,10 +224,12 @@ COMMENT ON TABLE species_problem_types IS '(Enum) Specific types of problems tha
 COMMENT ON TABLE species_problems IS 'Problems found in species data. Rows are deleted from this table when the problem is marked as ignored by the user or the user accepts the suggested fix.';
 
 COMMENT ON TABLE splats IS 'Information about 3D Gaussian splatting models generated from video files.';
-COMMENT ON COLUMN splats.camera_position_x IS 'Starting location of the camera (along with y and z).';
-COMMENT ON COLUMN splats.origin_position_x IS 'Center point of the splat (along with y and z).';
+COMMENT ON COLUMN splats.camera_position IS 'Starting location of the camera in cartesian coordinates.';
+COMMENT ON COLUMN splats.origin_position IS 'Center point of the splat in cartesian coordinates.';
 
 COMMENT ON TABLE splat_annotations IS 'Annotations that should be displayed inside splat models.';
+COMMENT ON COLUMN splat_annotations.camera_position IS 'Starting location of the camera in cartesian coordinates.';
+COMMENT ON COLUMN splat_annotations.position IS 'Position of the annotation in cartesian coordinates.';
 COMMENT ON COLUMN splat_annotations.label IS 'The text that displays over the annotations while it''s floating in space.';
 COMMENT ON COLUMN splat_annotations.title IS 'The text that displays at the top of the annotation box after it is clicked.';
 COMMENT ON COLUMN splat_annotations.body_text IS 'The text that displays in the annotation box after it is clicked.';

--- a/src/test/kotlin/com/terraformation/backend/db/DatabaseBackedTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/db/DatabaseBackedTest.kt
@@ -245,6 +245,8 @@ import com.terraformation.backend.db.default_schema.tables.references.SPECIES_EC
 import com.terraformation.backend.db.default_schema.tables.references.SPECIES_GROWTH_FORMS
 import com.terraformation.backend.db.default_schema.tables.references.SPECIES_PLANT_MATERIAL_SOURCING_METHODS
 import com.terraformation.backend.db.default_schema.tables.references.SPECIES_SUCCESSIONAL_GROUPS
+import com.terraformation.backend.db.default_schema.tables.references.SPLATS
+import com.terraformation.backend.db.default_schema.tables.references.SPLAT_ANNOTATIONS
 import com.terraformation.backend.db.default_schema.tables.references.SUB_LOCATIONS
 import com.terraformation.backend.db.default_schema.tables.references.TIMESERIES_VALUES
 import com.terraformation.backend.db.default_schema.tables.references.UPLOADS
@@ -518,6 +520,7 @@ import com.terraformation.backend.point
 import com.terraformation.backend.rectangle
 import com.terraformation.backend.rectanglePolygon
 import com.terraformation.backend.splat.CoordinateModel
+import com.terraformation.backend.splat.toPointZField
 import com.terraformation.backend.toBigDecimal
 import com.terraformation.backend.tracking.model.MONITORING_PLOT_SIZE
 import com.terraformation.backend.tracking.model.MONITORING_PLOT_SIZE_INT
@@ -3235,38 +3238,30 @@ abstract class DatabaseBackedTest {
       row: SplatsRow = SplatsRow(),
       fileId: FileId = row.fileId ?: inserted.fileId,
       assetStatus: AssetStatus = row.assetStatusId ?: AssetStatus.Ready,
-      originPosition: CoordinateModel? =
-          row.originPositionX?.let {
-            CoordinateModel(it, row.originPositionY!!, row.originPositionZ!!)
-          },
-      cameraPosition: CoordinateModel? =
-          row.cameraPositionX?.let {
-            CoordinateModel(it, row.cameraPositionY!!, row.cameraPositionZ!!)
-          },
+      originPosition: CoordinateModel? = null,
+      cameraPosition: CoordinateModel? = null,
       createdBy: UserId = row.createdBy ?: currentUser().userId,
       createdTime: Instant = row.createdTime ?: Instant.EPOCH,
       organizationId: OrganizationId = row.organizationId ?: inserted.organizationId,
       splatStorageUrl: URI = row.splatStorageUrl ?: URI("s3://bucket/splat"),
       needsAttention: Boolean = row.needsAttention ?: false,
   ) {
-    val rowWithDefaults =
-        row.copy(
-            assetStatusId = assetStatus,
-            cameraPositionX = cameraPosition?.x,
-            cameraPositionY = cameraPosition?.y,
-            cameraPositionZ = cameraPosition?.z,
-            createdBy = createdBy,
-            createdTime = createdTime,
-            fileId = fileId,
-            needsAttention = needsAttention,
-            organizationId = organizationId,
-            originPositionX = originPosition?.x,
-            originPositionY = originPosition?.y,
-            originPositionZ = originPosition?.z,
-            splatStorageUrl = splatStorageUrl,
-        )
-
-    splatsDao.insert(rowWithDefaults)
+    with(SPLATS) {
+      dslContext
+          .insertInto(SPLATS)
+          .set(FILE_ID, fileId)
+          .set(ASSET_STATUS_ID, assetStatus)
+          .set(CREATED_BY, createdBy)
+          .set(CREATED_TIME, createdTime)
+          .set(ORGANIZATION_ID, organizationId)
+          .set(SPLAT_STORAGE_URL, splatStorageUrl)
+          .set(NEEDS_ATTENTION, needsAttention)
+          .set(COMPLETED_TIME, row.completedTime)
+          .set(ERROR_MESSAGE, row.errorMessage)
+          .set(ORIGIN_POSITION, originPosition.toPointZField())
+          .set(CAMERA_POSITION, cameraPosition.toPointZField())
+          .execute()
+    }
   }
 
   fun insertBirdnetResult(
@@ -3301,41 +3296,34 @@ abstract class DatabaseBackedTest {
       title: String = row.title ?: "Annotation ${nextAnnotationNumber.getOrDefault(fileId, 1)}",
       bodyText: String? = row.bodyText,
       label: String? = row.label,
-      position: CoordinateModel =
-          row.positionX?.let { CoordinateModel(it, row.positionY!!, row.positionZ!!) }
-              ?: CoordinateModel(1.0, 2.0, 3.0),
-      cameraPosition: CoordinateModel? =
-          row.cameraPositionX?.let {
-            CoordinateModel(it, row.cameraPositionY!!, row.cameraPositionZ!!)
-          },
+      position: CoordinateModel = CoordinateModel(1.0, 2.0, 3.0),
+      cameraPosition: CoordinateModel? = null,
       createdBy: UserId = row.createdBy ?: currentUser().userId,
       createdTime: Instant = row.createdTime ?: Instant.EPOCH,
       modifiedBy: UserId = row.modifiedBy ?: createdBy,
       modifiedTime: Instant = row.modifiedTime ?: createdTime,
   ): SplatAnnotationId {
-    val rowWithDefaults =
-        row.copy(
-            fileId = fileId,
-            title = title,
-            bodyText = bodyText,
-            label = label,
-            positionX = position.x,
-            positionY = position.y,
-            positionZ = position.z,
-            cameraPositionX = cameraPosition?.x,
-            cameraPositionY = cameraPosition?.y,
-            cameraPositionZ = cameraPosition?.z,
-            createdBy = createdBy,
-            createdTime = createdTime,
-            modifiedBy = modifiedBy,
-            modifiedTime = modifiedTime,
-        )
-
-    splatAnnotationsDao.insert(rowWithDefaults)
+    val id =
+        with(SPLAT_ANNOTATIONS) {
+          dslContext
+              .insertInto(SPLAT_ANNOTATIONS)
+              .set(FILE_ID, fileId)
+              .set(TITLE, title)
+              .set(BODY_TEXT, bodyText)
+              .set(LABEL, label)
+              .set(POSITION, position.toPointZField())
+              .set(CAMERA_POSITION, cameraPosition.toPointZField())
+              .set(CREATED_BY, createdBy)
+              .set(CREATED_TIME, createdTime)
+              .set(MODIFIED_BY, modifiedBy)
+              .set(MODIFIED_TIME, modifiedTime)
+              .returning(ID)
+              .fetchOne(ID)!!
+        }
 
     nextAnnotationNumber[fileId] = nextAnnotationNumber.getOrDefault(fileId, 1) + 1
 
-    return rowWithDefaults.id!!.also { inserted.splatAnnotationIds.add(it) }
+    return id.also { inserted.splatAnnotationIds.add(it) }
   }
 
   fun insertObservationPlot(

--- a/src/test/kotlin/com/terraformation/backend/splat/SplatServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/splat/SplatServiceTest.kt
@@ -216,12 +216,8 @@ class SplatServiceTest : DatabaseTest(), RunsAsDatabaseUser {
                   title = "New Annotation 1",
                   bodyText = "Description 1",
                   label = "Label 1",
-                  positionX = position1.x,
-                  positionY = position1.y,
-                  positionZ = position1.z,
-                  cameraPositionX = cameraPosition1.x,
-                  cameraPositionY = cameraPosition1.y,
-                  cameraPositionZ = cameraPosition1.z,
+                  position = position1.toPoint(),
+                  cameraPosition = cameraPosition1.toPoint(),
               ),
               SplatAnnotationsRecord(
                   fileId = fileId,
@@ -230,9 +226,7 @@ class SplatServiceTest : DatabaseTest(), RunsAsDatabaseUser {
                   modifiedBy = user.userId,
                   modifiedTime = clock.instant(),
                   title = "New Annotation 2",
-                  positionX = position2.x,
-                  positionY = position2.y,
-                  positionZ = position2.z,
+                  position = position2.toPoint(),
               ),
           )
       )
@@ -276,12 +270,8 @@ class SplatServiceTest : DatabaseTest(), RunsAsDatabaseUser {
               title = "Updated Title",
               bodyText = "Updated Text",
               label = "Updated Label",
-              positionX = updatedPosition.x,
-              positionY = updatedPosition.y,
-              positionZ = updatedPosition.z,
-              cameraPositionX = updatedCameraPosition.x,
-              cameraPositionY = updatedCameraPosition.y,
-              cameraPositionZ = updatedCameraPosition.z,
+              position = updatedPosition.toPoint(),
+              cameraPosition = updatedCameraPosition.toPoint(),
           )
       )
     }
@@ -324,9 +314,7 @@ class SplatServiceTest : DatabaseTest(), RunsAsDatabaseUser {
                   modifiedBy = user.userId,
                   modifiedTime = clock.instant(),
                   title = "Annotation 1",
-                  positionX = position1.x,
-                  positionY = position1.y,
-                  positionZ = position1.z,
+                  position = position1.toPoint(),
               ),
               SplatAnnotationsRecord(
                   id = id2,
@@ -336,9 +324,7 @@ class SplatServiceTest : DatabaseTest(), RunsAsDatabaseUser {
                   modifiedBy = user.userId,
                   modifiedTime = clock.instant(),
                   title = "Annotation 2",
-                  positionX = position2.x,
-                  positionY = position2.y,
-                  positionZ = position2.z,
+                  position = position2.toPoint(),
               ),
           )
       )
@@ -380,9 +366,7 @@ class SplatServiceTest : DatabaseTest(), RunsAsDatabaseUser {
                   modifiedBy = user.userId,
                   modifiedTime = clock.instant(),
                   title = "Updated Title",
-                  positionX = position1.x,
-                  positionY = position1.y,
-                  positionZ = position1.z,
+                  position = position1.toPoint(),
               ),
               SplatAnnotationsRecord(
                   fileId = fileId,
@@ -391,9 +375,7 @@ class SplatServiceTest : DatabaseTest(), RunsAsDatabaseUser {
                   modifiedBy = user.userId,
                   modifiedTime = clock.instant(),
                   title = "New Annotation",
-                  positionX = position3.x,
-                  positionY = position3.y,
-                  positionZ = position3.z,
+                  position = position3.toPoint(),
               ),
           )
       )
@@ -452,9 +434,7 @@ class SplatServiceTest : DatabaseTest(), RunsAsDatabaseUser {
                   modifiedBy = user.userId,
                   modifiedTime = clock.instant(),
                   title = "Updated Annotation 1",
-                  positionX = position1.x,
-                  positionY = position1.y,
-                  positionZ = position1.z,
+                  position = position1.toPoint(),
               ),
               SplatAnnotationsRecord(
                   id = id2,
@@ -464,9 +444,7 @@ class SplatServiceTest : DatabaseTest(), RunsAsDatabaseUser {
                   modifiedBy = user.userId,
                   modifiedTime = clock.instant(),
                   title = "Annotation 2", // not updated
-                  positionX = position2.x,
-                  positionY = position2.y,
-                  positionZ = position2.z,
+                  position = position2.toPoint(),
               ),
           )
       )
@@ -1382,12 +1360,8 @@ class SplatServiceTest : DatabaseTest(), RunsAsDatabaseUser {
                   title = "Annotation 1",
                   bodyText = "Body",
                   label = "Label",
-                  positionX = position.x,
-                  positionY = position.y,
-                  positionZ = position.z,
-                  cameraPositionX = cameraPos.x,
-                  cameraPositionY = cameraPos.y,
-                  cameraPositionZ = cameraPos.z,
+                  position = position.toPoint(),
+                  cameraPosition = cameraPos.toPoint(),
               )
           )
       )


### PR DESCRIPTION
When splat points were originally implemented, it was preferred to spread them out since there was no benefit to using PostGIS Geometry classes. We are eventually wanting to store the bounding box and ground plane for a model, so it makes more sense to use Geometry classes moving forward. Change all splat usages to PostGIS Geometry, using cartesian points (SRID 0), by utilizing the `ST_MakePoint` function.

This commit shows an alternative approach that was taken when this was originally implemented, using the `ST_Force3DZ` function. We can also take that approach if preferred.

https://github.com/terraware/terraware-server/pull/3857/changes/637eaa67809b2a8feb60ab1826d63c0c5e8c41e1

(The GeometryBinding automatically convets all points to SRID 4326 right now, so it can't be used)