### PR TITLE
Receive and store model metadata colors

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/splat/Models.kt
+++ b/src/main/kotlin/com/terraformation/backend/splat/Models.kt
@@ -63,6 +63,11 @@ data class ObservationBirdnetResultModel(
   }
 }
 
+data class ModelMetadataModel(
+    val skyColor: String?,
+    val groundColor: String?,
+)
+
 data class CoordinateModel(val x: BigDecimal, val y: BigDecimal, val z: BigDecimal) {
   constructor(
       x: Double,

--- a/src/main/kotlin/com/terraformation/backend/splat/SplatService.kt
+++ b/src/main/kotlin/com/terraformation/backend/splat/SplatService.kt
@@ -278,7 +278,7 @@ class SplatService(
     )
   }
 
-  fun recordSplatSuccess(fileId: FileId) {
+  fun recordSplatSuccess(fileId: FileId, modelMetadata: ModelMetadataModel? = null) {
     log.info("Splat generation completed for file $fileId")
 
     val splatRecord = dslContext.fetchOne(SPLATS, SPLATS.FILE_ID.eq(fileId))
@@ -291,6 +291,10 @@ class SplatService(
 
     splatRecord.assetStatusId = AssetStatus.Ready
     splatRecord.completedTime = clock.instant()
+    if (modelMetadata != null) {
+      splatRecord.skyColor = modelMetadata.skyColor
+      splatRecord.groundColor = modelMetadata.groundColor
+    }
     splatRecord.update()
 
     eventPublisher.publishEvent(

--- a/src/main/kotlin/com/terraformation/backend/splat/sqs/SplatsSqsListener.kt
+++ b/src/main/kotlin/com/terraformation/backend/splat/sqs/SplatsSqsListener.kt
@@ -44,11 +44,17 @@ data class SplatterResponseOutputPayload(
 )
 
 data class SplatterResponsePayload(
+    val birdnetErrorMessage: String? = null,
+    val birdnetOutput: SplatterResponseOutputPayload? = null,
+    val birdnetSuccess: Boolean? = null,
     val errorMessage: String?,
     val jobId: FileId,
+    val modelMetadata: SplatterResponseModelMetadataPayload? = null,
     val output: SplatterResponseOutputPayload?,
     val success: Boolean,
-    val birdnetSuccess: Boolean? = null,
-    val birdnetOutput: SplatterResponseOutputPayload? = null,
-    val birdnetErrorMessage: String? = null,
+)
+
+data class SplatterResponseModelMetadataPayload(
+    val skyColor: String?,
+    val groundColor: String?,
 )

--- a/src/main/kotlin/com/terraformation/backend/splat/sqs/SplatsSqsListener.kt
+++ b/src/main/kotlin/com/terraformation/backend/splat/sqs/SplatsSqsListener.kt
@@ -2,6 +2,7 @@ package com.terraformation.backend.splat.sqs
 
 import com.terraformation.backend.db.default_schema.FileId
 import com.terraformation.backend.log.perClassLogger
+import com.terraformation.backend.splat.ModelMetadataModel
 import com.terraformation.backend.splat.SplatService
 import io.awspring.cloud.sqs.annotation.SqsListener
 import jakarta.inject.Named
@@ -17,7 +18,7 @@ class SplatsSqsListener(private val splatService: SplatService) {
     log.info("Got response from Splatter service: $payload")
 
     if (payload.success) {
-      splatService.recordSplatSuccess(payload.jobId)
+      splatService.recordSplatSuccess(payload.jobId, payload.modelMetadata?.toModel())
     } else {
       splatService.recordSplatError(
           payload.jobId,
@@ -57,4 +58,10 @@ data class SplatterResponsePayload(
 data class SplatterResponseModelMetadataPayload(
     val skyColor: String?,
     val groundColor: String?,
-)
+) {
+  fun toModel() =
+      ModelMetadataModel(
+          skyColor = skyColor,
+          groundColor = groundColor,
+      )
+}

--- a/src/main/resources/db/migration/0450/V478__SplatModelMetadata.sql
+++ b/src/main/resources/db/migration/0450/V478__SplatModelMetadata.sql
@@ -1,0 +1,5 @@
+ALTER TABLE splats
+    ADD COLUMN sky_color TEXT,
+    ADD COLUMN ground_color TEXT,
+    ADD COLUMN ground_plane GEOMETRY(POLYGON, 0),
+    ADD COLUMN scene_bounds GEOMETRY(POINTZM, 0);

--- a/src/main/resources/db/migration/0450/V478__SplatModelMetadata.sql
+++ b/src/main/resources/db/migration/0450/V478__SplatModelMetadata.sql
@@ -2,4 +2,6 @@ ALTER TABLE splats
     ADD COLUMN sky_color TEXT,
     ADD COLUMN ground_color TEXT,
     ADD COLUMN ground_plane GEOMETRY(POLYGON, 0),
-    ADD COLUMN scene_bounds GEOMETRY(POINTZM, 0);
+    ADD COLUMN scene_bounds GEOMETRY(POINTZM, 0),
+    ADD COLUMN sky_radius NUMERIC
+;

--- a/src/main/resources/db/migration/R__Comments.sql
+++ b/src/main/resources/db/migration/R__Comments.sql
@@ -225,7 +225,11 @@ COMMENT ON TABLE species_problems IS 'Problems found in species data. Rows are d
 
 COMMENT ON TABLE splats IS 'Information about 3D Gaussian splatting models generated from video files.';
 COMMENT ON COLUMN splats.camera_position IS 'Starting location of the camera in cartesian coordinates.';
+COMMENT ON COLUMN splats.ground_color IS 'Average color of the ground.';
+COMMENT ON COLUMN splats.ground_plane IS 'Ground plane of the splat in cartesian coordinates.';
 COMMENT ON COLUMN splats.origin_position IS 'Center point of the splat in cartesian coordinates.';
+COMMENT ON COLUMN splats.scene_bounds IS 'Bounding perimeter of the splat in cartesian coordinates, defined as a PointZM such that XYZ is the center of the circle, and M is the radius. The circle lies on the ground plane.';
+COMMENT ON COLUMN splats.sky_color IS 'Average color of the sky.';
 
 COMMENT ON TABLE splat_annotations IS 'Annotations that should be displayed inside splat models.';
 COMMENT ON COLUMN splat_annotations.camera_position IS 'Starting location of the camera in cartesian coordinates.';

--- a/src/main/resources/db/migration/R__Comments.sql
+++ b/src/main/resources/db/migration/R__Comments.sql
@@ -230,6 +230,7 @@ COMMENT ON COLUMN splats.ground_plane IS 'Ground plane of the splat in cartesian
 COMMENT ON COLUMN splats.origin_position IS 'Center point of the splat in cartesian coordinates.';
 COMMENT ON COLUMN splats.scene_bounds IS 'Bounding perimeter of the splat in cartesian coordinates, defined as a PointZM such that XYZ is the center of the circle, and M is the radius. The circle lies on the ground plane.';
 COMMENT ON COLUMN splats.sky_color IS 'Average color of the sky.';
+COMMENT ON COLUMN splats.sky_radius IS 'Size of the sky sphere.';
 
 COMMENT ON TABLE splat_annotations IS 'Annotations that should be displayed inside splat models.';
 COMMENT ON COLUMN splat_annotations.camera_position IS 'Starting location of the camera in cartesian coordinates.';

--- a/src/test/kotlin/com/terraformation/backend/splat/SplatServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/splat/SplatServiceTest.kt
@@ -873,6 +873,67 @@ class SplatServiceTest : DatabaseTest(), RunsAsDatabaseUser {
           )
       )
     }
+
+    @Test
+    fun `updates status to Ready and sets completed time`() {
+      service.recordSplatSuccess(fileId)
+
+      assertTableEquals(
+          SplatsRecord(
+              fileId = fileId,
+              createdBy = user.userId,
+              createdTime = clock.instant(),
+              assetStatusId = AssetStatus.Ready,
+              completedTime = clock.instant(),
+              organizationId = organizationId,
+              needsAttention = false,
+              splatStorageUrl = URI("s3://bucket/splat"),
+          )
+      )
+    }
+
+    @Test
+    fun `saves sky and ground color when model metadata is provided`() {
+      service.recordSplatSuccess(
+          fileId,
+          ModelMetadataModel(skyColor = "#87CEEB", groundColor = "#8B4513"),
+      )
+
+      assertTableEquals(
+          SplatsRecord(
+              fileId = fileId,
+              createdBy = user.userId,
+              createdTime = clock.instant(),
+              assetStatusId = AssetStatus.Ready,
+              completedTime = clock.instant(),
+              organizationId = organizationId,
+              needsAttention = false,
+              splatStorageUrl = URI("s3://bucket/splat"),
+              skyColor = "#87CEEB",
+              groundColor = "#8B4513",
+          )
+      )
+    }
+
+    @Test
+    fun `does not save sky and ground color when model metadata is null`() {
+      service.recordSplatSuccess(fileId, null)
+
+      assertTableEquals(
+          SplatsRecord(
+              fileId = fileId,
+              createdBy = user.userId,
+              createdTime = clock.instant(),
+              assetStatusId = AssetStatus.Ready,
+              completedTime = clock.instant(),
+              organizationId = organizationId,
+              needsAttention = false,
+              splatStorageUrl = URI("s3://bucket/splat"),
+              skyColor = null,
+              groundColor = null,
+          )
+      )
+    }
   }
 
   @Nested

--- a/src/test/kotlin/com/terraformation/backend/splat/sqs/SplatsSqsListenerTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/splat/sqs/SplatsSqsListenerTest.kt
@@ -1,6 +1,7 @@
 package com.terraformation.backend.splat.sqs
 
 import com.terraformation.backend.db.default_schema.FileId
+import com.terraformation.backend.splat.ModelMetadataModel
 import com.terraformation.backend.splat.SplatService
 import io.mockk.Runs
 import io.mockk.every
@@ -19,7 +20,7 @@ class SplatsSqsListenerTest {
 
   @BeforeEach
   fun setUp() {
-    every { splatService.recordSplatSuccess(any()) } just Runs
+    every { splatService.recordSplatSuccess(any(), any()) } just Runs
     every { splatService.recordSplatError(any(), any()) } just Runs
     every { splatService.recordBirdnetSuccess(any()) } just Runs
     every { splatService.recordBirdnetError(any(), any()) } just Runs
@@ -56,7 +57,7 @@ class SplatsSqsListenerTest {
       listener.receiveSplatterResponse(payload)
 
       verify { splatService.recordSplatError(fileId, "Test error") }
-      verify(exactly = 0) { splatService.recordSplatSuccess(any()) }
+      verify(exactly = 0) { splatService.recordSplatSuccess(any(), any()) }
     }
 
     @Test
@@ -72,6 +73,46 @@ class SplatsSqsListenerTest {
       listener.receiveSplatterResponse(payload)
 
       verify { splatService.recordSplatError(fileId, "No error message received") }
+    }
+
+    @Test
+    fun `passes model metadata to recordSplatSuccess when present`() {
+      val payload =
+          SplatterResponsePayload(
+              errorMessage = null,
+              jobId = fileId,
+              output = SplatterResponseOutputPayload("bucket", "key"),
+              success = true,
+              modelMetadata =
+                  SplatterResponseModelMetadataPayload(
+                      skyColor = "#AABBCC",
+                      groundColor = "#112233",
+                  ),
+          )
+
+      listener.receiveSplatterResponse(payload)
+
+      verify {
+        splatService.recordSplatSuccess(
+            fileId,
+            ModelMetadataModel(skyColor = "#AABBCC", groundColor = "#112233"),
+        )
+      }
+    }
+
+    @Test
+    fun `passes null metadata to recordSplatSuccess when absent`() {
+      val payload =
+          SplatterResponsePayload(
+              errorMessage = null,
+              jobId = fileId,
+              output = SplatterResponseOutputPayload("bucket", "key"),
+              success = true,
+          )
+
+      listener.receiveSplatterResponse(payload)
+
+      verify { splatService.recordSplatSuccess(fileId, null) }
     }
   }
 


### PR DESCRIPTION
Add columns for all planned model metadata items to `splats` table.

Receive and store `skyColor` and `groundColor` from the response message on success. Other metadata items will come in later PRs.