### PR TITLE
Expose sky and ground colors in splat info endpoint

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/splat/Models.kt
+++ b/src/main/kotlin/com/terraformation/backend/splat/Models.kt
@@ -41,7 +41,9 @@ data class ObservationSplatModel(
 data class SplatInfoModel(
     val annotations: List<SplatAnnotationModel<SplatAnnotationId>>,
     val cameraPosition: CoordinateModel?,
+    val groundColor: String?,
     val originPosition: CoordinateModel?,
+    val skyColor: String?,
 )
 
 data class ObservationBirdnetResultModel(
@@ -79,8 +81,8 @@ data class CoordinateModel(val x: BigDecimal, val y: BigDecimal, val z: BigDecim
       cartesianGeometryFactory.createPoint(Coordinate(x.toDouble(), y.toDouble(), z.toDouble()))
 
   companion object {
-    fun of(record: Record?, pointField: Field<Geometry?>): CoordinateModel? =
-        (record?.get(pointField) as Point?)?.let { CoordinateModel(it.x, it.y, it.coordinate.z) }
+    fun of(record: Record, pointField: Field<Geometry?>): CoordinateModel? =
+        (record.get(pointField) as Point?)?.let { CoordinateModel(it.x, it.y, it.coordinate.z) }
   }
 }
 

--- a/src/main/kotlin/com/terraformation/backend/splat/SplatService.kt
+++ b/src/main/kotlin/com/terraformation/backend/splat/SplatService.kt
@@ -520,28 +520,27 @@ class SplatService(
     ensureSplat(fileId)
 
     val annotations = listSplatAnnotations(fileId)
-    val (originPosition, cameraPosition) = getSplatPositions(fileId)
 
-    return SplatInfoModel(
-        annotations = annotations,
-        cameraPosition = cameraPosition,
-        originPosition = originPosition,
-    )
-  }
-
-  private fun getSplatPositions(fileId: FileId): Pair<CoordinateModel?, CoordinateModel?> {
     with(SPLATS) {
       val record =
           dslContext
-              .select(CAMERA_POSITION, ORIGIN_POSITION)
+              .select(CAMERA_POSITION, GROUND_COLOR, ORIGIN_POSITION, SKY_COLOR)
               .from(SPLATS)
               .where(FILE_ID.eq(fileId))
-              .fetchOne()
+              .fetchOne()!!
 
       val cameraPosition = CoordinateModel.of(record, CAMERA_POSITION)
       val originPosition = CoordinateModel.of(record, ORIGIN_POSITION)
+      val skyColor = record[SKY_COLOR]
+      val groundColor = record[GROUND_COLOR]
 
-      return Pair(originPosition, cameraPosition)
+      return SplatInfoModel(
+          annotations = annotations,
+          cameraPosition = cameraPosition,
+          groundColor = groundColor,
+          originPosition = originPosition,
+          skyColor = skyColor,
+      )
     }
   }
 

--- a/src/main/kotlin/com/terraformation/backend/splat/api/SplatsController.kt
+++ b/src/main/kotlin/com/terraformation/backend/splat/api/SplatsController.kt
@@ -262,14 +262,18 @@ data class SplatAnnotationPayload(
 data class GetObservationSplatInfoResponsePayload(
     val annotations: List<SplatAnnotationPayload>,
     val cameraPosition: CoordinatePayload?,
+    val groundColor: String?,
     val originPosition: CoordinatePayload?,
+    val skyColor: String?,
 ) : SuccessResponsePayload {
   constructor(
       model: SplatInfoModel
   ) : this(
       annotations = model.annotations.map { SplatAnnotationPayload.of(it) },
       cameraPosition = model.cameraPosition?.let { CoordinatePayload.of(it) },
+      groundColor = model.groundColor,
       originPosition = model.originPosition?.let { CoordinatePayload.of(it) },
+      skyColor = model.skyColor,
   )
 }
 

--- a/src/test/kotlin/com/terraformation/backend/db/DatabaseBackedTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/db/DatabaseBackedTest.kt
@@ -3245,21 +3245,25 @@ abstract class DatabaseBackedTest {
       organizationId: OrganizationId = row.organizationId ?: inserted.organizationId,
       splatStorageUrl: URI = row.splatStorageUrl ?: URI("s3://bucket/splat"),
       needsAttention: Boolean = row.needsAttention ?: false,
+      groundColor: String? = null,
+      skyColor: String? = null,
   ) {
     with(SPLATS) {
       dslContext
           .insertInto(SPLATS)
-          .set(FILE_ID, fileId)
           .set(ASSET_STATUS_ID, assetStatus)
+          .set(CAMERA_POSITION, cameraPosition.toPointZField())
+          .set(COMPLETED_TIME, row.completedTime)
           .set(CREATED_BY, createdBy)
           .set(CREATED_TIME, createdTime)
-          .set(ORGANIZATION_ID, organizationId)
-          .set(SPLAT_STORAGE_URL, splatStorageUrl)
-          .set(NEEDS_ATTENTION, needsAttention)
-          .set(COMPLETED_TIME, row.completedTime)
           .set(ERROR_MESSAGE, row.errorMessage)
+          .set(FILE_ID, fileId)
+          .set(GROUND_COLOR, groundColor)
+          .set(NEEDS_ATTENTION, needsAttention)
+          .set(ORGANIZATION_ID, organizationId)
           .set(ORIGIN_POSITION, originPosition.toPointZField())
-          .set(CAMERA_POSITION, cameraPosition.toPointZField())
+          .set(SKY_COLOR, skyColor)
+          .set(SPLAT_STORAGE_URL, splatStorageUrl)
           .execute()
     }
   }

--- a/src/test/kotlin/com/terraformation/backend/splat/SplatServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/splat/SplatServiceTest.kt
@@ -617,7 +617,9 @@ class SplatServiceTest : DatabaseTest(), RunsAsDatabaseUser {
                       ),
                   ),
               cameraPosition = null,
+              groundColor = null,
               originPosition = originPosition,
+              skyColor = null,
           )
 
       assertEquals(expected, service.getObservationSplatInfo(observationId, fileId))
@@ -641,7 +643,9 @@ class SplatServiceTest : DatabaseTest(), RunsAsDatabaseUser {
                       ),
                   ),
               cameraPosition = null,
+              groundColor = null,
               originPosition = null,
+              skyColor = null,
           )
 
       assertEquals(expected, service.getObservationSplatInfo(observationId, fileId))
@@ -666,7 +670,9 @@ class SplatServiceTest : DatabaseTest(), RunsAsDatabaseUser {
                       ),
                   ),
               cameraPosition = null,
+              groundColor = null,
               originPosition = null,
+              skyColor = null,
           )
 
       assertEquals(expected, service.getObservationSplatInfo(observationId, fileId))
@@ -712,7 +718,9 @@ class SplatServiceTest : DatabaseTest(), RunsAsDatabaseUser {
                       ),
                   ),
               cameraPosition = null,
+              groundColor = null,
               originPosition = originPosition,
+              skyColor = null,
           )
 
       assertEquals(expected, service.getObservationSplatInfo(observationId, fileId))
@@ -727,7 +735,9 @@ class SplatServiceTest : DatabaseTest(), RunsAsDatabaseUser {
           SplatInfoModel(
               annotations = emptyList(),
               cameraPosition = null,
+              groundColor = null,
               originPosition = originPosition,
+              skyColor = null,
           )
 
       assertEquals(expected, service.getObservationSplatInfo(observationId, fileId))
@@ -742,7 +752,9 @@ class SplatServiceTest : DatabaseTest(), RunsAsDatabaseUser {
           SplatInfoModel(
               annotations = emptyList(),
               cameraPosition = cameraPosition,
+              groundColor = null,
               originPosition = null,
+              skyColor = null,
           )
 
       assertEquals(expected, service.getObservationSplatInfo(observationId, fileId))
@@ -758,7 +770,25 @@ class SplatServiceTest : DatabaseTest(), RunsAsDatabaseUser {
           SplatInfoModel(
               annotations = emptyList(),
               cameraPosition = cameraPosition,
+              groundColor = null,
               originPosition = originPosition,
+              skyColor = null,
+          )
+
+      assertEquals(expected, service.getObservationSplatInfo(observationId, fileId))
+    }
+
+    @Test
+    fun `returns both sky and ground colors when they exist`() {
+      insertSplat(groundColor = "#FF0000", skyColor = "#00FF00")
+
+      val expected =
+          SplatInfoModel(
+              annotations = emptyList(),
+              cameraPosition = null,
+              groundColor = "#FF0000",
+              originPosition = null,
+              skyColor = "#00FF00",
           )
 
       assertEquals(expected, service.getObservationSplatInfo(observationId, fileId))
@@ -1337,7 +1367,9 @@ class SplatServiceTest : DatabaseTest(), RunsAsDatabaseUser {
                       ),
                   ),
               cameraPosition = cameraPosition,
+              groundColor = null,
               originPosition = originPosition,
+              skyColor = null,
           )
 
       assertEquals(expected, result)
@@ -1349,7 +1381,16 @@ class SplatServiceTest : DatabaseTest(), RunsAsDatabaseUser {
 
       val result = service.getOrganizationSplatInfo(organizationId, orgFileId)
 
-      assertEquals(SplatInfoModel(emptyList(), null, null), result)
+      assertEquals(
+          SplatInfoModel(
+              annotations = emptyList(),
+              cameraPosition = null,
+              groundColor = null,
+              originPosition = null,
+              skyColor = null,
+          ),
+          result,
+      )
     }
 
     @Test


### PR DESCRIPTION
Add `skyColor` and `groundColor` hex values to the get splat info endpoint. 