### PR TITLE
Log warning and set colors to null for invalid hex strings

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/splat/SplatService.kt
+++ b/src/main/kotlin/com/terraformation/backend/splat/SplatService.kt
@@ -292,8 +292,18 @@ class SplatService(
     splatRecord.assetStatusId = AssetStatus.Ready
     splatRecord.completedTime = clock.instant()
     if (modelMetadata != null) {
-      splatRecord.skyColor = modelMetadata.skyColor
-      splatRecord.groundColor = modelMetadata.groundColor
+      if (isValidHexColor(modelMetadata.skyColor)) {
+        splatRecord.skyColor = modelMetadata.skyColor
+      } else {
+        log.warn("Invalid sky color ${modelMetadata.skyColor} for file $fileId")
+        splatRecord.skyColor = null
+      }
+      if (isValidHexColor(modelMetadata.groundColor)) {
+        splatRecord.groundColor = modelMetadata.groundColor
+      } else {
+        log.warn("Invalid ground color ${modelMetadata.groundColor} for file $fileId")
+        splatRecord.groundColor = null
+      }
     }
     splatRecord.update()
 
@@ -306,6 +316,9 @@ class SplatService(
         )
     )
   }
+
+  private fun isValidHexColor(color: String?): Boolean =
+      color == null || color.matches(Regex("^#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})$"))
 
   fun getObservationSplatInfo(
       observationId: ObservationId,

--- a/src/test/kotlin/com/terraformation/backend/splat/SplatServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/splat/SplatServiceTest.kt
@@ -946,6 +946,36 @@ class SplatServiceTest : DatabaseTest(), RunsAsDatabaseUser {
     }
 
     @Test
+    fun `invalid sky and ground colors are set to null`() {
+      dslContext.deleteFrom(SPLATS).where(SPLATS.FILE_ID.eq(fileId)).execute()
+      insertSplat(
+          fileId = fileId,
+          assetStatus = AssetStatus.Preparing,
+          skyColor = "#87CEEB",
+          groundColor = "#8B4513",
+      )
+      service.recordSplatSuccess(
+          fileId,
+          ModelMetadataModel(skyColor = "#FFFFFFFF", groundColor = "#0000"),
+      )
+
+      assertTableEquals(
+          SplatsRecord(
+              fileId = fileId,
+              createdBy = user.userId,
+              createdTime = clock.instant(),
+              assetStatusId = AssetStatus.Ready,
+              completedTime = clock.instant(),
+              organizationId = organizationId,
+              needsAttention = false,
+              splatStorageUrl = URI("s3://bucket/splat"),
+              skyColor = null,
+              groundColor = null,
+          )
+      )
+    }
+
+    @Test
     fun `does not save sky and ground color when model metadata is null`() {
       service.recordSplatSuccess(fileId, null)
 


### PR DESCRIPTION
We don't want to store invalid colors, so show a warning and set to null in those cases.