### PR TITLE
Don't localize parsing of raw numeric search values

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/search/field/BigDecimalField.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/field/BigDecimalField.kt
@@ -22,7 +22,8 @@ class BigDecimalField(
         localize = localize,
         exportable = exportable,
     ) {
-  override fun fromString(value: String) = numberFormat.parseObject(value) as BigDecimal
+  override fun fromString(value: String) =
+      if (localize) numberFormat.parseObject(value) as BigDecimal else BigDecimal(value)
 
   override fun makeNumberFormat(): NumberFormat {
     return (NumberFormat.getNumberInstance(currentLocale()) as DecimalFormat).apply {

--- a/src/main/kotlin/com/terraformation/backend/search/field/CoordinateField.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/field/CoordinateField.kt
@@ -42,7 +42,8 @@ class CoordinateField(
     throw IllegalArgumentException("Filters not supported for geometry fields")
   }
 
-  override fun fromString(value: String) = numberFormat.parseObject(value) as BigDecimal
+  override fun fromString(value: String) =
+      if (localize) numberFormat.parseObject(value) as BigDecimal else BigDecimal(value)
 
   override fun makeNumberFormat(): NumberFormat {
     return (NumberFormat.getNumberInstance(currentLocale()) as DecimalFormat).apply {

--- a/src/main/kotlin/com/terraformation/backend/search/field/DoubleField.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/field/DoubleField.kt
@@ -13,7 +13,8 @@ class DoubleField(
     localize: Boolean = true,
     exportable: Boolean = true,
 ) : NumericSearchField<Double>(fieldName, databaseField, table, localize, exportable) {
-  override fun fromString(value: String) = numberFormat.parse(value).toDouble()
+  override fun fromString(value: String) =
+      if (localize) numberFormat.parse(value).toDouble() else value.toDouble()
 
   override fun makeNumberFormat(): NumberFormat {
     return NumberFormat.getNumberInstance(currentLocale()).apply {

--- a/src/main/kotlin/com/terraformation/backend/search/field/LongField.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/field/LongField.kt
@@ -13,7 +13,8 @@ class LongField(
     localize: Boolean = true,
     exportable: Boolean = true,
 ) : NumericSearchField<Long>(fieldName, databaseField, table, localize, exportable) {
-  override fun fromString(value: String) = numberFormat.parse(value).toLong()
+  override fun fromString(value: String) =
+      if (localize) numberFormat.parse(value).toLong() else value.toLong()
 
   override fun makeNumberFormat(): NumberFormat = NumberFormat.getIntegerInstance(currentLocale())
 


### PR DESCRIPTION
Raw search fields are supposed to use the default number format for both
rendering and parsing, rather than the user's localized number format. This was
happening correctly for integer and age fields, but the other numeric field
types were always using localized parsing. Update them to pay attention to
whether the field is localized or not.