### PR TITLE
Receive and store average camera height from sqs, expose it in splat info

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/splat/Models.kt
+++ b/src/main/kotlin/com/terraformation/backend/splat/Models.kt
@@ -41,6 +41,7 @@ data class ObservationSplatModel(
 
 data class SplatInfoModel(
     val annotations: List<SplatAnnotationModel<SplatAnnotationId>>,
+    val averageCameraHeight: BigDecimal? = null,
     val cameraPosition: CoordinateModel?,
     val groundColor: String?,
     val groundPlane: List<CoordinateModel>? = null,
@@ -69,6 +70,7 @@ data class ObservationBirdnetResultModel(
 }
 
 data class ModelMetadataModel(
+    val averageCameraHeight: BigDecimal? = null,
     val groundColor: String? = null,
     val groundPlane: List<CoordinateModel>? = null,
     val sceneBounds: CoordinateModel? = null,

--- a/src/main/kotlin/com/terraformation/backend/splat/SplatService.kt
+++ b/src/main/kotlin/com/terraformation/backend/splat/SplatService.kt
@@ -313,7 +313,11 @@ class SplatService(
           .set(ASSET_STATUS_ID, AssetStatus.Ready)
           .set(COMPLETED_TIME, clock.instant())
           .let { step ->
-            if (modelMetadata != null) step.set(SKY_COLOR, skyColor).set(GROUND_COLOR, groundColor)
+            if (modelMetadata != null)
+                step
+                    .set(AVERAGE_CAMERA_HEIGHT, modelMetadata.averageCameraHeight)
+                    .set(SKY_COLOR, skyColor)
+                    .set(GROUND_COLOR, groundColor)
             else step
           }
           .let { step ->
@@ -561,6 +565,7 @@ class SplatService(
       val record =
           dslContext
               .select(
+                  AVERAGE_CAMERA_HEIGHT,
                   CAMERA_POSITION,
                   GROUND_COLOR,
                   GROUND_PLANE,
@@ -578,9 +583,11 @@ class SplatService(
       val groundPlane = CoordinateModel.ofList(record, GROUND_PLANE)
       val skyColor = record[SKY_COLOR]
       val groundColor = record[GROUND_COLOR]
+      val averageCameraHeight = record[AVERAGE_CAMERA_HEIGHT]
 
       return SplatInfoModel(
           annotations = annotations,
+          averageCameraHeight = averageCameraHeight,
           cameraPosition = cameraPosition,
           groundColor = groundColor,
           groundPlane = groundPlane,

--- a/src/main/kotlin/com/terraformation/backend/splat/api/SplatsController.kt
+++ b/src/main/kotlin/com/terraformation/backend/splat/api/SplatsController.kt
@@ -267,6 +267,7 @@ data class SplatAnnotationPayload(
 
 data class GetObservationSplatInfoResponsePayload(
     val annotations: List<SplatAnnotationPayload>,
+    val averageCameraHeight: BigDecimal?,
     val cameraPosition: CoordinatePayload?,
     val groundColor: String?,
     val groundPlane: List<CoordinatePayload>?,
@@ -278,6 +279,7 @@ data class GetObservationSplatInfoResponsePayload(
       model: SplatInfoModel
   ) : this(
       annotations = model.annotations.map { SplatAnnotationPayload.of(it) },
+      averageCameraHeight = model.averageCameraHeight,
       cameraPosition = model.cameraPosition?.let { CoordinatePayload.of(it) },
       groundColor = model.groundColor,
       groundPlane = model.groundPlane?.map { CoordinatePayload.of(it) },

--- a/src/main/kotlin/com/terraformation/backend/splat/sqs/SplatsSqsListener.kt
+++ b/src/main/kotlin/com/terraformation/backend/splat/sqs/SplatsSqsListener.kt
@@ -9,6 +9,7 @@ import com.terraformation.backend.splat.ModelMetadataModel
 import com.terraformation.backend.splat.SplatService
 import io.awspring.cloud.sqs.annotation.SqsListener
 import jakarta.inject.Named
+import java.math.BigDecimal
 import org.locationtech.jts.geom.MultiPoint
 import org.locationtech.jts.geom.Point
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
@@ -61,6 +62,7 @@ data class SplatterResponsePayload(
 )
 
 data class SplatterResponseModelMetadataPayload(
+    val averageCameraHeight: BigDecimal? = null,
     val groundColor: String?,
     val groundPlane: MultiPoint? = null,
     @JsonDeserialize(using = PointWithMDeserializer::class) //
@@ -101,6 +103,7 @@ data class SplatterResponseModelMetadataPayload(
     }
 
     return ModelMetadataModel(
+        averageCameraHeight = averageCameraHeight,
         groundColor = groundColor,
         groundPlane = parsedGroundPlane,
         sceneBounds = parsedSceneBounds,

--- a/src/test/kotlin/com/terraformation/backend/db/DatabaseBackedTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/db/DatabaseBackedTest.kt
@@ -3301,6 +3301,7 @@ abstract class DatabaseBackedTest {
       groundPlane: List<CoordinateModel>? = null,
       sceneBounds: CoordinateModel? = null,
       skyColor: String? = null,
+      averageCameraHeight: BigDecimal? = null,
   ) {
     with(SPLATS) {
       dslContext
@@ -3319,6 +3320,7 @@ abstract class DatabaseBackedTest {
           .set(ORIGIN_POSITION, originPosition.toPointField())
           .set(SCENE_BOUNDS, sceneBounds.toPointField())
           .set(SKY_COLOR, skyColor)
+          .set(AVERAGE_CAMERA_HEIGHT, averageCameraHeight)
           .set(SPLAT_STORAGE_URL, splatStorageUrl)
           .execute()
     }

--- a/src/test/kotlin/com/terraformation/backend/splat/SplatServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/splat/SplatServiceTest.kt
@@ -39,6 +39,7 @@ import io.mockk.just
 import io.mockk.mockk
 import io.mockk.verify
 import java.io.ByteArrayInputStream
+import java.math.BigDecimal
 import java.net.URI
 import java.nio.file.NoSuchFileException
 import java.time.Instant
@@ -836,6 +837,23 @@ class SplatServiceTest : DatabaseTest(), RunsAsDatabaseUser {
     }
 
     @Test
+    fun `returns average camera height when present`() {
+      insertSplat(averageCameraHeight = BigDecimal("7.25"))
+
+      val expected =
+          SplatInfoModel(
+              annotations = emptyList(),
+              averageCameraHeight = BigDecimal("7.25"),
+              cameraPosition = null,
+              groundColor = null,
+              originPosition = null,
+              skyColor = null,
+          )
+
+      assertEquals(expected, service.getObservationSplatInfo(observationId, fileId))
+    }
+
+    @Test
     fun `throws exception if file is not associated with observation`() {
       val otherFileId = insertFile()
 
@@ -982,6 +1000,54 @@ class SplatServiceTest : DatabaseTest(), RunsAsDatabaseUser {
               splatStorageUrl = URI("s3://bucket/splat"),
               skyColor = "#87CEEB",
               groundColor = "#8B4513",
+          )
+      )
+    }
+
+    @Test
+    fun `saves average camera height when model metadata is provided`() {
+      service.recordSplatSuccess(
+          fileId,
+          ModelMetadataModel(averageCameraHeight = BigDecimal("5.75")),
+      )
+
+      assertTableEquals(
+          SplatsRecord(
+              fileId = fileId,
+              createdBy = user.userId,
+              createdTime = clock.instant(),
+              assetStatusId = AssetStatus.Ready,
+              completedTime = clock.instant(),
+              organizationId = organizationId,
+              needsAttention = false,
+              splatStorageUrl = URI("s3://bucket/splat"),
+              averageCameraHeight = BigDecimal("5.75"),
+          )
+      )
+    }
+
+    @Test
+    fun `does not overwrite average camera height when modelMetadata is null`() {
+      dslContext.deleteFrom(SPLATS).where(SPLATS.FILE_ID.eq(fileId)).execute()
+      insertSplat(
+          fileId = fileId,
+          assetStatus = AssetStatus.Preparing,
+          averageCameraHeight = BigDecimal("3.0"),
+      )
+
+      service.recordSplatSuccess(fileId, null)
+
+      assertTableEquals(
+          SplatsRecord(
+              fileId = fileId,
+              createdBy = user.userId,
+              createdTime = clock.instant(),
+              assetStatusId = AssetStatus.Ready,
+              completedTime = clock.instant(),
+              organizationId = organizationId,
+              needsAttention = false,
+              splatStorageUrl = URI("s3://bucket/splat"),
+              averageCameraHeight = BigDecimal("3.0"),
           )
       )
     }

--- a/src/test/kotlin/com/terraformation/backend/splat/sqs/SplatsSqsListenerTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/splat/sqs/SplatsSqsListenerTest.kt
@@ -9,6 +9,7 @@ import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
 import io.mockk.verify
+import java.math.BigDecimal
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
@@ -251,6 +252,52 @@ class SplatsSqsListenerTest {
 
     @Test
     fun `passes null ground plane when absent from metadata`() {
+      val payload =
+          SplatterResponsePayload(
+              errorMessage = null,
+              jobId = fileId,
+              output = SplatterResponseOutputPayload("bucket", "key"),
+              success = true,
+              modelMetadata =
+                  SplatterResponseModelMetadataPayload(
+                      groundColor = null,
+                      skyColor = null,
+                  ),
+          )
+
+      listener.receiveSplatterResponse(payload)
+
+      verify { splatService.recordSplatSuccess(fileId, ModelMetadataModel()) }
+    }
+
+    @Test
+    fun `passes average camera height to recordSplatSuccess when present`() {
+      val payload =
+          SplatterResponsePayload(
+              errorMessage = null,
+              jobId = fileId,
+              output = SplatterResponseOutputPayload("bucket", "key"),
+              success = true,
+              modelMetadata =
+                  SplatterResponseModelMetadataPayload(
+                      averageCameraHeight = BigDecimal("12.5"),
+                      groundColor = null,
+                      skyColor = null,
+                  ),
+          )
+
+      listener.receiveSplatterResponse(payload)
+
+      verify {
+        splatService.recordSplatSuccess(
+            fileId,
+            ModelMetadataModel(averageCameraHeight = BigDecimal("12.5")),
+        )
+      }
+    }
+
+    @Test
+    fun `passes null average camera height when absent from metadata`() {
       val payload =
           SplatterResponsePayload(
               errorMessage = null,


### PR DESCRIPTION
Receive and save average camera height from splatter response sqs messages. Add this to splat info endpoint.