### PR TITLE
SW-8359 Return observation-specific activity media data

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/accelerator/api/ActivitiesController.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/api/ActivitiesController.kt
@@ -23,6 +23,8 @@ import com.terraformation.backend.db.accelerator.ActivityStatus
 import com.terraformation.backend.db.accelerator.ActivityType
 import com.terraformation.backend.db.default_schema.FileId
 import com.terraformation.backend.db.default_schema.ProjectId
+import com.terraformation.backend.db.tracking.ObservationMediaType
+import com.terraformation.backend.db.tracking.ObservationPlotPosition
 import com.terraformation.backend.file.SUPPORTED_MEDIA_TYPES
 import com.terraformation.backend.file.api.GetMuxStreamResponsePayload
 import com.terraformation.backend.file.model.FileMetadata
@@ -211,6 +213,20 @@ class ActivitiesController(
   }
 }
 
+data class ObservationActivityMediaFilePayload(
+    val monitoringPlotNumber: Long,
+    val position: ObservationPlotPosition?,
+    val type: ObservationMediaType,
+) {
+  constructor(
+      observation: ActivityMediaModel.Observation
+  ) : this(
+      monitoringPlotNumber = observation.monitoringPlotNumber,
+      position = observation.position,
+      type = observation.type,
+  )
+}
+
 data class ActivityMediaFilePayload(
     val caption: String?,
     val capturedDate: LocalDate,
@@ -220,6 +236,11 @@ data class ActivityMediaFilePayload(
     val isCoverPhoto: Boolean,
     val isHiddenOnMap: Boolean,
     val listPosition: Int,
+    @Schema(
+        description =
+            "If this file is from an observation, additional observation-specific data about it."
+    )
+    val observation: ObservationActivityMediaFilePayload? = null,
     val type: ActivityMediaType,
 ) {
   constructor(
@@ -233,6 +254,7 @@ data class ActivityMediaFilePayload(
       isCoverPhoto = model.isCoverPhoto,
       isHiddenOnMap = model.isHiddenOnMap,
       listPosition = model.listPosition,
+      observation = model.observation?.let { ObservationActivityMediaFilePayload(it) },
       type = model.type,
   )
 }

--- a/src/main/kotlin/com/terraformation/backend/accelerator/db/ActivityMediaStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/db/ActivityMediaStore.kt
@@ -14,6 +14,8 @@ import com.terraformation.backend.db.default_schema.FileId
 import com.terraformation.backend.db.default_schema.OrganizationId
 import com.terraformation.backend.db.default_schema.ProjectId
 import com.terraformation.backend.db.default_schema.tables.references.FILES
+import com.terraformation.backend.db.tracking.tables.references.MONITORING_PLOTS
+import com.terraformation.backend.db.tracking.tables.references.OBSERVATION_MEDIA_FILES
 import com.terraformation.backend.file.event.FileReferenceDeletedEvent
 import jakarta.inject.Named
 import java.time.InstantSource
@@ -212,10 +214,18 @@ class ActivityMediaStore(
             FILES.CREATED_TIME,
             FILES.GEOLOCATION,
             FILES.STORAGE_URL,
+            OBSERVATION_MEDIA_FILES.OBSERVATION_ID,
+            OBSERVATION_MEDIA_FILES.POSITION_ID,
+            OBSERVATION_MEDIA_FILES.TYPE_ID,
+            MONITORING_PLOTS.PLOT_NUMBER,
         )
         .from(ACTIVITY_MEDIA_FILES)
         .join(FILES)
         .on(ACTIVITY_MEDIA_FILES.FILE_ID.eq(FILES.ID))
+        .leftJoin(OBSERVATION_MEDIA_FILES)
+        .on(ACTIVITY_MEDIA_FILES.FILE_ID.eq(OBSERVATION_MEDIA_FILES.FILE_ID))
+        .leftJoin(MONITORING_PLOTS)
+        .on(OBSERVATION_MEDIA_FILES.MONITORING_PLOT_ID.eq(MONITORING_PLOTS.ID))
         .where(condition)
         .orderBy(ACTIVITY_MEDIA_FILES.FILE_ID)
         .fetch { ActivityMediaModel.of(it) }

--- a/src/main/kotlin/com/terraformation/backend/accelerator/db/ActivityStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/db/ActivityStore.kt
@@ -17,6 +17,8 @@ import com.terraformation.backend.db.default_schema.ProjectId
 import com.terraformation.backend.db.default_schema.tables.references.FILES
 import com.terraformation.backend.db.forMultiset
 import com.terraformation.backend.db.funder.tables.references.PUBLISHED_ACTIVITIES
+import com.terraformation.backend.db.tracking.tables.references.MONITORING_PLOTS
+import com.terraformation.backend.db.tracking.tables.references.OBSERVATION_MEDIA_FILES
 import jakarta.inject.Named
 import java.time.InstantSource
 import org.jooq.Condition
@@ -208,10 +210,18 @@ class ActivityStore(
                       FILES.CREATED_TIME,
                       FILES.STORAGE_URL,
                       geolocationField,
+                      OBSERVATION_MEDIA_FILES.OBSERVATION_ID,
+                      OBSERVATION_MEDIA_FILES.POSITION_ID,
+                      OBSERVATION_MEDIA_FILES.TYPE_ID,
+                      MONITORING_PLOTS.PLOT_NUMBER,
                   )
                   .from(ACTIVITY_MEDIA_FILES)
                   .join(FILES)
                   .on(ACTIVITY_MEDIA_FILES.FILE_ID.eq(FILES.ID))
+                  .leftJoin(OBSERVATION_MEDIA_FILES)
+                  .on(ACTIVITY_MEDIA_FILES.FILE_ID.eq(OBSERVATION_MEDIA_FILES.FILE_ID))
+                  .leftJoin(MONITORING_PLOTS)
+                  .on(OBSERVATION_MEDIA_FILES.MONITORING_PLOT_ID.eq(MONITORING_PLOTS.ID))
                   .where(ACTIVITY_MEDIA_FILES.ACTIVITY_ID.eq(ACTIVITIES.ID))
                   .and(condition)
                   .orderBy(ACTIVITY_MEDIA_FILES.LIST_POSITION)

--- a/src/main/kotlin/com/terraformation/backend/accelerator/model/ActivityMediaModel.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/model/ActivityMediaModel.kt
@@ -6,6 +6,11 @@ import com.terraformation.backend.db.accelerator.tables.references.ACTIVITY_MEDI
 import com.terraformation.backend.db.default_schema.FileId
 import com.terraformation.backend.db.default_schema.UserId
 import com.terraformation.backend.db.default_schema.tables.references.FILES
+import com.terraformation.backend.db.tracking.ObservationId
+import com.terraformation.backend.db.tracking.ObservationMediaType
+import com.terraformation.backend.db.tracking.ObservationPlotPosition
+import com.terraformation.backend.db.tracking.tables.references.MONITORING_PLOTS
+import com.terraformation.backend.db.tracking.tables.references.OBSERVATION_MEDIA_FILES
 import java.time.Instant
 import java.time.LocalDate
 import java.time.LocalDateTime
@@ -26,10 +31,18 @@ data class ActivityMediaModel(
     val isCoverPhoto: Boolean,
     val isHiddenOnMap: Boolean,
     val listPosition: Int,
+    val observation: Observation? = null,
     val type: ActivityMediaType,
 ) {
   val capturedDate: LocalDate
     get() = capturedLocalTime.toLocalDate()
+
+  data class Observation(
+      val monitoringPlotNumber: Long,
+      val observationId: ObservationId,
+      val position: ObservationPlotPosition?,
+      val type: ObservationMediaType,
+  )
 
   companion object {
     fun of(
@@ -48,6 +61,15 @@ data class ActivityMediaModel(
           isCoverPhoto = record[ACTIVITY_MEDIA_FILES.IS_COVER_PHOTO]!!,
           isHiddenOnMap = record[ACTIVITY_MEDIA_FILES.IS_HIDDEN_ON_MAP]!!,
           listPosition = record[ACTIVITY_MEDIA_FILES.LIST_POSITION]!!,
+          observation =
+              record[OBSERVATION_MEDIA_FILES.OBSERVATION_ID]?.let { observationId ->
+                Observation(
+                    monitoringPlotNumber = record[MONITORING_PLOTS.PLOT_NUMBER]!!,
+                    observationId = observationId,
+                    position = record[OBSERVATION_MEDIA_FILES.POSITION_ID],
+                    type = record[OBSERVATION_MEDIA_FILES.TYPE_ID]!!,
+                )
+              },
           type = record[ACTIVITY_MEDIA_FILES.ACTIVITY_MEDIA_TYPE_ID]!!,
       )
     }

--- a/src/test/kotlin/com/terraformation/backend/accelerator/db/ActivityMediaStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/db/ActivityMediaStoreTest.kt
@@ -3,10 +3,12 @@ package com.terraformation.backend.accelerator.db
 import com.terraformation.backend.RunsAsDatabaseUser
 import com.terraformation.backend.TestClock
 import com.terraformation.backend.TestEventPublisher
+import com.terraformation.backend.accelerator.model.ActivityMediaModel
 import com.terraformation.backend.customer.model.TerrawareUser
 import com.terraformation.backend.db.DatabaseTest
 import com.terraformation.backend.db.accelerator.ActivityId
 import com.terraformation.backend.db.accelerator.ActivityMediaType
+import com.terraformation.backend.db.accelerator.ActivityType
 import com.terraformation.backend.db.accelerator.tables.references.ACTIVITIES
 import com.terraformation.backend.db.accelerator.tables.references.ACTIVITY_MEDIA_FILES
 import com.terraformation.backend.db.default_schema.FileId
@@ -14,12 +16,15 @@ import com.terraformation.backend.db.default_schema.OrganizationId
 import com.terraformation.backend.db.default_schema.Role
 import com.terraformation.backend.db.default_schema.UserId
 import com.terraformation.backend.db.default_schema.tables.references.FILES
+import com.terraformation.backend.db.tracking.ObservationMediaType
+import com.terraformation.backend.db.tracking.ObservationPlotPosition
 import java.time.Instant
 import java.time.LocalDate
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertNull
 import org.junit.jupiter.api.assertThrows
 
 class ActivityMediaStoreTest : DatabaseTest(), RunsAsDatabaseUser {
@@ -43,6 +48,51 @@ class ActivityMediaStoreTest : DatabaseTest(), RunsAsDatabaseUser {
     activityId = insertActivity(createdBy = createdBy, projectId = projectId)
 
     insertOrganizationUser(role = Role.Admin)
+  }
+
+  @Nested
+  inner class FetchByActivityId {
+    @Test
+    fun `does not return observation metadata for non-observation media files`() {
+      insertFileForActivity()
+      insertActivityMediaFile()
+
+      val files = store.fetchByActivityId(activityId)
+      assertNull(files.single().observation)
+    }
+
+    @Test
+    fun `returns observation metadata for observation media files`() {
+      insertPlantingSite(x = 0, width = 11)
+      insertStratum()
+      insertSubstratum()
+      insertMonitoringPlot(plotNumber = 123)
+      insertObservation(completedTime = Instant.EPOCH)
+      insertObservationPlot(completedBy = user.userId, completedTime = Instant.EPOCH)
+      insertFileForActivity()
+      insertObservationMediaFile(
+          position = ObservationPlotPosition.SoutheastCorner,
+          type = ObservationMediaType.Plot,
+      )
+
+      activitiesDao.update(
+          activitiesDao.fetchOneById(activityId)!!.copy(activityTypeId = ActivityType.Monitoring)
+      )
+      insertActivityMediaFile()
+
+      val files = store.fetchByActivityId(activityId)
+      assertEquals(
+          listOf(
+              ActivityMediaModel.Observation(
+                  observationId = inserted.observationId,
+                  monitoringPlotNumber = 123,
+                  position = ObservationPlotPosition.SoutheastCorner,
+                  type = ObservationMediaType.Plot,
+              )
+          ),
+          files.map { it.observation },
+      )
+    }
   }
 
   @Nested

--- a/src/test/kotlin/com/terraformation/backend/accelerator/db/ActivityStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/db/ActivityStoreTest.kt
@@ -25,6 +25,8 @@ import com.terraformation.backend.db.default_schema.GlobalRole
 import com.terraformation.backend.db.default_schema.ProjectId
 import com.terraformation.backend.db.default_schema.Role
 import com.terraformation.backend.db.default_schema.tables.references.PROJECTS
+import com.terraformation.backend.db.tracking.ObservationMediaType
+import com.terraformation.backend.db.tracking.ObservationPlotPosition
 import com.terraformation.backend.point
 import java.time.Instant
 import java.time.LocalDate
@@ -265,6 +267,12 @@ class ActivityStoreTest : DatabaseTest(), RunsAsDatabaseUser {
     @Test
     fun `includes activity media`() {
       insertOrganizationUser(role = Role.Admin)
+      insertPlantingSite(x = 0, width = 11)
+      insertStratum()
+      insertSubstratum()
+      insertMonitoringPlot(plotNumber = 321)
+      insertObservation(completedTime = Instant.EPOCH)
+      insertObservationPlot()
 
       val activityId =
           insertActivity(
@@ -277,6 +285,10 @@ class ActivityStoreTest : DatabaseTest(), RunsAsDatabaseUser {
               capturedLocalTime = LocalDate.of(2024, 2, 19).atStartOfDay(),
               storageUrl = "s3://x/y/my-file.jpg",
           )
+      insertObservationMediaFile(
+          position = null,
+          type = ObservationMediaType.Soil,
+      )
       insertActivityMediaFile(
           caption = "Caption 1",
           isCoverPhoto = true,
@@ -287,6 +299,10 @@ class ActivityStoreTest : DatabaseTest(), RunsAsDatabaseUser {
               createdTime = Instant.ofEpochSecond(1),
               geolocation = point(1),
           )
+      insertObservationMediaFile(
+          position = ObservationPlotPosition.SouthwestCorner,
+          type = ObservationMediaType.Plot,
+      )
       insertActivityMediaFile(
           caption = "Caption 2",
           isHiddenOnMap = true,
@@ -321,6 +337,13 @@ class ActivityStoreTest : DatabaseTest(), RunsAsDatabaseUser {
                           isCoverPhoto = true,
                           isHiddenOnMap = false,
                           listPosition = 1,
+                          observation =
+                              ActivityMediaModel.Observation(
+                                  monitoringPlotNumber = 321,
+                                  observationId = inserted.observationId,
+                                  position = null,
+                                  type = ObservationMediaType.Soil,
+                              ),
                           type = ActivityMediaType.Photo,
                       ),
                       ActivityMediaModel(
@@ -335,6 +358,13 @@ class ActivityStoreTest : DatabaseTest(), RunsAsDatabaseUser {
                           isCoverPhoto = false,
                           isHiddenOnMap = true,
                           listPosition = 2,
+                          observation =
+                              ActivityMediaModel.Observation(
+                                  monitoringPlotNumber = 321,
+                                  observationId = inserted.observationId,
+                                  position = ObservationPlotPosition.SouthwestCorner,
+                                  type = ObservationMediaType.Plot,
+                              ),
                           type = ActivityMediaType.Video,
                       ),
                   ),

--- a/src/test/kotlin/com/terraformation/backend/db/DatabaseBackedTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/db/DatabaseBackedTest.kt
@@ -3253,7 +3253,8 @@ abstract class DatabaseBackedTest {
       isOriginal: Boolean = row.isOriginal ?: true,
       observationId: ObservationId = row.observationId ?: inserted.observationId,
       monitoringPlotId: MonitoringPlotId = row.monitoringPlotId ?: inserted.monitoringPlotId,
-      position: ObservationPlotPosition = row.positionId ?: ObservationPlotPosition.SouthwestCorner,
+      position: ObservationPlotPosition? =
+          row.positionId ?: ObservationPlotPosition.SouthwestCorner,
       type: ObservationMediaType = row.typeId ?: ObservationMediaType.Plot,
   ) {
     val rowWithDefaults =


### PR DESCRIPTION
When we have activities created from observations, the client will need additional
information about the photos in order to label the photos correctly. Extend the
activity media files API to include an optional child object to hold observation
data. We'll be able to follow a similar pattern if/when we add more activity types
that are linked to existing Terraware entities.

Currently, there's no way to create an activity that's linked to an observation,
so the new child object will always be absent; this just defines the API so client
developers can reference it.

The published-activity API will be updated separately.