### PR TITLE
SW-8352 Fixed incorrect primary keys in observation results search tables

### DIFF
--- a/jooq/src/main/kotlin/com/terraformation/backend/jooq/Config.kt
+++ b/jooq/src/main/kotlin/com/terraformation/backend/jooq/Config.kt
@@ -608,6 +608,10 @@ val EMBEDDABLES =
                 "biomass_species_id",
             ),
         EmbeddableDefinitionType()
+            .withName("observation_plot_history_id")
+            .withTables("tracking.observation_plot_results")
+            .withColumns("observation_id", "monitoring_plot_history_id"),
+        EmbeddableDefinitionType()
             .withName("observation_plot_id")
             .withTables(
                 listOf(
@@ -622,6 +626,18 @@ val EMBEDDABLES =
                     .joinToString("|", prefix = "tracking.")
             )
             .withColumns("observation_id", "monitoring_plot_id"),
+        EmbeddableDefinitionType()
+            .withName("observation_site_history_id")
+            .withTables("tracking.observation_site_results")
+            .withColumns("observation_id", "planting_site_history_id"),
+        EmbeddableDefinitionType()
+            .withName("observation_stratum_history_id")
+            .withTables("tracking.observation_stratum_results")
+            .withColumns("observation_id", "stratum_history_id"),
+        EmbeddableDefinitionType()
+            .withName("observation_substratum_history_id")
+            .withTables("tracking.observation_substratum_results")
+            .withColumns("observation_id", "substratum_history_id"),
         EmbeddableDefinitionType()
             .withName("organization_internal_tag_id")
             .withTables("public.organization_internal_tags")

--- a/src/main/kotlin/com/terraformation/backend/search/table/ObservationPlotResultTable.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/table/ObservationPlotResultTable.kt
@@ -15,7 +15,7 @@ import org.jooq.TableField
 
 class ObservationPlotResultTable(private val tables: SearchTables) : SearchTable() {
   override val primaryKey: TableField<out Record, out Any?>
-    get() = OBSERVATION_PLOT_RESULTS.OBSERVATION_ID
+    get() = OBSERVATION_PLOT_RESULTS.OBSERVATION_PLOT_HISTORY_ID
 
   override val sublists: List<SublistField> by lazy {
     with(tables) {

--- a/src/main/kotlin/com/terraformation/backend/search/table/ObservationSiteResultTable.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/table/ObservationSiteResultTable.kt
@@ -16,7 +16,7 @@ import org.jooq.impl.DSL
 
 class ObservationSiteResultTable(private val tables: SearchTables) : SearchTable() {
   override val primaryKey: TableField<out Record, out Any?>
-    get() = OBSERVATION_SITE_RESULTS.OBSERVATION_ID
+    get() = OBSERVATION_SITE_RESULTS.OBSERVATION_SITE_HISTORY_ID
 
   override val sublists: List<SublistField> by lazy {
     with(tables) {

--- a/src/main/kotlin/com/terraformation/backend/search/table/ObservationStratumResultTable.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/table/ObservationStratumResultTable.kt
@@ -17,7 +17,7 @@ import org.jooq.impl.DSL
 
 class ObservationStratumResultTable(private val tables: SearchTables) : SearchTable() {
   override val primaryKey: TableField<out Record, out Any?>
-    get() = OBSERVATION_STRATUM_RESULTS.OBSERVATION_ID
+    get() = OBSERVATION_STRATUM_RESULTS.OBSERVATION_STRATUM_HISTORY_ID
 
   override val sublists: List<SublistField> by lazy {
     with(tables) {

--- a/src/main/kotlin/com/terraformation/backend/search/table/ObservationSubstratumResultTable.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/table/ObservationSubstratumResultTable.kt
@@ -17,7 +17,7 @@ import org.jooq.impl.DSL
 
 class ObservationSubstratumResultTable(private val tables: SearchTables) : SearchTable() {
   override val primaryKey: TableField<out Record, out Any?>
-    get() = OBSERVATION_SUBSTRATUM_RESULTS.OBSERVATION_ID
+    get() = OBSERVATION_SUBSTRATUM_RESULTS.OBSERVATION_SUBSTRATUM_HISTORY_ID
 
   override val sublists: List<SublistField> by lazy {
     with(tables) {


### PR DESCRIPTION
Incorrect primary key was causing search results to be incorrect.