### PR TITLE
SW-8346 Publish event when observation is completed

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/tracking/db/ObservationStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/db/ObservationStore.kt
@@ -69,6 +69,7 @@ import com.terraformation.backend.db.tracking.tables.references.SUBSTRATUM_POPUL
 import com.terraformation.backend.log.perClassLogger
 import com.terraformation.backend.log.withMDC
 import com.terraformation.backend.tracking.event.MonitoringSpeciesTotalsEditedEvent
+import com.terraformation.backend.tracking.event.ObservationCompletedEvent
 import com.terraformation.backend.tracking.event.ObservationPlotCreatedEvent
 import com.terraformation.backend.tracking.event.ObservationPlotEditedEvent
 import com.terraformation.backend.tracking.event.ObservationStateUpdatedEvent
@@ -1574,6 +1575,8 @@ class ObservationStore(
       recalculateSurvivalRates(observationId, plantingSiteId)
       recalculateSurvivalRateResults(observationId, plantingSiteId)
     }
+
+    eventPublisher.publishEvent(ObservationCompletedEvent(observationId))
   }
 
   /**

--- a/src/main/kotlin/com/terraformation/backend/tracking/event/Events.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/event/Events.kt
@@ -75,6 +75,11 @@ data class ObservationRescheduledEvent(
     val rescheduledObservation: ExistingObservationModel,
 )
 
+/** Published when an observation is completed. */
+data class ObservationCompletedEvent(
+    val observationId: ObservationId,
+)
+
 interface ObservationSchedulingNotificationEvent
 
 /** Published when a site is ready to have observations scheduled */

--- a/src/test/kotlin/com/terraformation/backend/tracking/ObservationServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/ObservationServiceTest.kt
@@ -87,6 +87,7 @@ import com.terraformation.backend.tracking.edit.PlantingSiteEdit
 import com.terraformation.backend.tracking.edit.StratumEdit
 import com.terraformation.backend.tracking.event.MonitoringSpeciesTotalsEditedEvent
 import com.terraformation.backend.tracking.event.MonitoringSpeciesTotalsEditedEventValues
+import com.terraformation.backend.tracking.event.ObservationCompletedEvent
 import com.terraformation.backend.tracking.event.ObservationMediaFileDeletedEvent
 import com.terraformation.backend.tracking.event.ObservationMediaFileEditedEvent
 import com.terraformation.backend.tracking.event.ObservationMediaFileEditedEventValues
@@ -2708,6 +2709,8 @@ class ObservationServiceTest : DatabaseTest(), RunsAsDatabaseUser {
           ),
           "Totals after observation",
       )
+
+      eventPublisher.assertEventPublished(ObservationCompletedEvent(observationId))
     }
 
     @Test
@@ -2815,6 +2818,8 @@ class ObservationServiceTest : DatabaseTest(), RunsAsDatabaseUser {
           ),
           "Biomass details table",
       )
+
+      eventPublisher.assertEventPublished(ObservationCompletedEvent(observationId))
     }
 
     @Test

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/observationStore/ObservationStoreCompletePlotTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/observationStore/ObservationStoreCompletePlotTest.kt
@@ -38,6 +38,7 @@ import com.terraformation.backend.db.tracking.tables.references.RECORDED_PLANTS
 import com.terraformation.backend.point
 import com.terraformation.backend.tracking.db.PlotAlreadyCompletedException
 import com.terraformation.backend.tracking.db.PlotNotInObservationException
+import com.terraformation.backend.tracking.event.ObservationCompletedEvent
 import com.terraformation.backend.util.toPlantsPerHectare
 import io.mockk.every
 import java.math.BigDecimal
@@ -1048,6 +1049,8 @@ class ObservationStoreCompletePlotTest : BaseObservationStoreTest() {
         substratumPopulationsDao.findAll(),
         "Substratum plants since last observation should have been reset",
     )
+
+    eventPublisher.assertEventPublished(ObservationCompletedEvent(observationId))
   }
 
   @Test


### PR DESCRIPTION
Add an event that gets published when an observation is completed. This will be
used in later changes to trigger additional actions.