### PR TITLE
SW-8375 Add post-observation media to activities

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/accelerator/ObservationActivityService.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/ObservationActivityService.kt
@@ -20,9 +20,11 @@ import com.terraformation.backend.tracking.db.ObservationStore
 import com.terraformation.backend.tracking.db.PlantingSiteStore
 import com.terraformation.backend.tracking.event.ObservationCompletedEvent
 import com.terraformation.backend.tracking.event.ObservationMediaFileEditedEvent
+import com.terraformation.backend.tracking.event.ObservationMediaFileUploadedEvent
 import com.terraformation.backend.tracking.model.PlantingSiteDepth
 import jakarta.inject.Named
 import org.jooq.DSLContext
+import org.jooq.impl.DSL
 import org.springframework.context.event.EventListener
 
 @Named
@@ -151,12 +153,7 @@ class ObservationActivityService(
                     }
 
             mediaFiles.forEach { file ->
-              val activityMediaTypeId =
-                  if (file.contentType.startsWith("video/")) {
-                    ActivityMediaType.Video
-                  } else {
-                    ActivityMediaType.Photo
-                  }
+              val activityMediaTypeId = activityMediaTypeFor(file.contentType)
 
               with(ACTIVITY_MEDIA_FILES) {
                 dslContext
@@ -195,4 +192,42 @@ class ObservationActivityService(
       log.error("Unable to propagate observation media edit to activity media", e)
     }
   }
+
+  @EventListener
+  fun on(event: ObservationMediaFileUploadedEvent) {
+    try {
+      val activityId =
+          dslContext.fetchValue(
+              ACTIVITY_OBSERVATIONS.ACTIVITY_ID,
+              ACTIVITY_OBSERVATIONS.OBSERVATION_ID.eq(event.observationId),
+          ) ?: return
+
+      with(ACTIVITY_MEDIA_FILES) {
+        dslContext
+            .insertInto(ACTIVITY_MEDIA_FILES)
+            .set(ACTIVITY_ID, activityId)
+            .set(ACTIVITY_MEDIA_TYPE_ID, activityMediaTypeFor(event.contentType))
+            .set(CAPTION, event.caption)
+            .set(FILE_ID, event.fileId)
+            .set(IS_COVER_PHOTO, false)
+            .set(IS_HIDDEN_ON_MAP, false)
+            .set(
+                LIST_POSITION,
+                DSL.select(DSL.coalesce(DSL.max(LIST_POSITION).plus(1), 1))
+                    .from(ACTIVITY_MEDIA_FILES)
+                    .where(ACTIVITY_ID.eq(activityId)),
+            )
+            .execute()
+      }
+    } catch (e: Exception) {
+      log.error("Unable to propagate new observation media file to activity media", e)
+    }
+  }
+
+  private fun activityMediaTypeFor(contentType: String): ActivityMediaType =
+      if (contentType.startsWith("video/")) {
+        ActivityMediaType.Video
+      } else {
+        ActivityMediaType.Photo
+      }
 }

--- a/src/main/kotlin/com/terraformation/backend/accelerator/ObservationActivityService.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/ObservationActivityService.kt
@@ -202,22 +202,24 @@ class ObservationActivityService(
               ACTIVITY_OBSERVATIONS.OBSERVATION_ID.eq(event.observationId),
           ) ?: return
 
-      with(ACTIVITY_MEDIA_FILES) {
-        dslContext
-            .insertInto(ACTIVITY_MEDIA_FILES)
-            .set(ACTIVITY_ID, activityId)
-            .set(ACTIVITY_MEDIA_TYPE_ID, activityMediaTypeFor(event.contentType))
-            .set(CAPTION, event.caption)
-            .set(FILE_ID, event.fileId)
-            .set(IS_COVER_PHOTO, false)
-            .set(IS_HIDDEN_ON_MAP, false)
-            .set(
-                LIST_POSITION,
-                DSL.select(DSL.coalesce(DSL.max(LIST_POSITION).plus(1), 1))
-                    .from(ACTIVITY_MEDIA_FILES)
-                    .where(ACTIVITY_ID.eq(activityId)),
-            )
-            .execute()
+      activityStore.withLockedActivity(activityId) {
+        with(ACTIVITY_MEDIA_FILES) {
+          dslContext
+              .insertInto(ACTIVITY_MEDIA_FILES)
+              .set(ACTIVITY_ID, activityId)
+              .set(ACTIVITY_MEDIA_TYPE_ID, activityMediaTypeFor(event.contentType))
+              .set(CAPTION, event.caption)
+              .set(FILE_ID, event.fileId)
+              .set(IS_COVER_PHOTO, false)
+              .set(IS_HIDDEN_ON_MAP, false)
+              .set(
+                  LIST_POSITION,
+                  DSL.select(DSL.coalesce(DSL.max(LIST_POSITION).plus(1), 1))
+                      .from(ACTIVITY_MEDIA_FILES)
+                      .where(ACTIVITY_ID.eq(activityId)),
+              )
+              .execute()
+        }
       }
     } catch (e: Exception) {
       log.error("Unable to propagate new observation media file to activity media", e)

--- a/src/main/kotlin/com/terraformation/backend/accelerator/db/ActivityStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/db/ActivityStore.kt
@@ -205,6 +205,24 @@ class ActivityStore(
     return fetchByCondition(ACTIVITIES.PROJECT_ID.eq(projectId), mediaDepth)
   }
 
+  fun <T> withLockedActivity(activityId: ActivityId, func: () -> T): T {
+    return dslContext.transactionResult { _ ->
+      val exists =
+          dslContext
+              .selectOne()
+              .from(ACTIVITIES)
+              .where(ACTIVITIES.ID.eq(activityId))
+              .forUpdate()
+              .fetchOne() != null
+
+      if (!exists) {
+        throw ActivityNotFoundException(activityId)
+      }
+
+      func()
+    }
+  }
+
   private val geolocationField = FILES.GEOLOCATION.forMultiset()
 
   private fun mediaMultiset(condition: Condition) =

--- a/src/test/kotlin/com/terraformation/backend/accelerator/ObservationActivityServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/ObservationActivityServiceTest.kt
@@ -31,6 +31,7 @@ import com.terraformation.backend.db.tracking.PlantingSiteId
 import com.terraformation.backend.db.tracking.tables.records.ObservationMediaFilesRecord
 import com.terraformation.backend.db.tracking.tables.references.OBSERVATION_MEDIA_FILES
 import com.terraformation.backend.gis.CountryDetector
+import com.terraformation.backend.point
 import com.terraformation.backend.tracking.ObservationService
 import com.terraformation.backend.tracking.db.BiomassStore
 import com.terraformation.backend.tracking.db.ObservationLocker
@@ -40,6 +41,7 @@ import com.terraformation.backend.tracking.db.PlantingSiteStore
 import com.terraformation.backend.tracking.event.ObservationCompletedEvent
 import com.terraformation.backend.tracking.event.ObservationMediaFileEditedEvent
 import com.terraformation.backend.tracking.event.ObservationMediaFileEditedEventValues
+import com.terraformation.backend.tracking.event.ObservationMediaFileUploadedEvent
 import io.mockk.mockk
 import java.time.Instant
 import java.time.LocalDate
@@ -421,6 +423,85 @@ class ObservationActivityServiceTest : DatabaseTest(), RunsAsDatabaseUser {
       assertTableEmpty(ACTIVITY_MEDIA_FILES)
 
       eventPublisher.assertEventNotPublished<ActivityMediaUpdatedEvent>()
+    }
+  }
+
+  @Nested
+  inner class OnObservationMediaFileUploadedEvent {
+    @Test
+    fun `creates activity media file for new observation media file`() {
+      val activityId = insertActivity(activityType = ActivityType.Monitoring)
+      insertActivityObservation()
+      val existingFileId = insertFile()
+      insertObservationMediaFile()
+      insertActivityMediaFile(caption = "Existing", type = ActivityMediaType.Video)
+      val fileId = insertFile(capturedLocalTime = LocalDateTime.of(2026, 1, 2, 3, 4))
+      insertObservationMediaFile(caption = "Caption", isOriginal = false, position = null)
+
+      val event =
+          ObservationMediaFileUploadedEvent(
+              "Caption",
+              "image/jpeg",
+              fileId,
+              point(1),
+              false,
+              monitoringPlotId,
+              observationId,
+              organizationId,
+              plantingSiteId,
+              null,
+              ObservationMediaType.Plot,
+          )
+
+      service.on(event)
+
+      assertTableEquals(
+          setOf(
+              ActivityMediaFilesRecord(
+                  existingFileId,
+                  activityId,
+                  ActivityMediaType.Video,
+                  false,
+                  "Existing",
+                  false,
+                  1,
+              ),
+              ActivityMediaFilesRecord(
+                  fileId,
+                  activityId,
+                  ActivityMediaType.Photo,
+                  false,
+                  "Caption",
+                  false,
+                  2,
+              ),
+          )
+      )
+    }
+
+    @Test
+    fun `ignores uploaded files for observations without activities`() {
+      val fileId = insertFile(capturedLocalTime = LocalDateTime.of(2026, 1, 2, 3, 4))
+      insertObservationMediaFile(caption = "Caption", isOriginal = false, position = null)
+
+      val event =
+          ObservationMediaFileUploadedEvent(
+              "Caption",
+              "image/jpeg",
+              fileId,
+              point(1),
+              false,
+              monitoringPlotId,
+              observationId,
+              organizationId,
+              plantingSiteId,
+              null,
+              ObservationMediaType.Plot,
+          )
+
+      service.on(event)
+
+      assertTableEmpty(ACTIVITY_MEDIA_FILES)
     }
   }
 }


### PR DESCRIPTION
If photos or videos are uploaded for an observation after it's completed, add them
to the media files list for the observation's activity, if any.

There is no syncing in the other direction, since activity media uploads lack the
necessary metadata (plot ID, etc.) to add them to observations. The expectation is
that clients will use the observation media upload endpoint to add files to
observation activities.