### PR TITLE
SW-8359 Delete deleted observation files from activity

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/accelerator/ActivityMediaService.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/ActivityMediaService.kt
@@ -1,6 +1,7 @@
 package com.terraformation.backend.accelerator
 
 import com.terraformation.backend.accelerator.db.ActivityMediaStore
+import com.terraformation.backend.accelerator.db.CannotDeleteObservationActivityMediaException
 import com.terraformation.backend.accelerator.event.ActivityDeletionStartedEvent
 import com.terraformation.backend.accelerator.model.ActivityMediaModel
 import com.terraformation.backend.customer.db.ParentStore
@@ -10,6 +11,7 @@ import com.terraformation.backend.customer.model.requirePermissions
 import com.terraformation.backend.db.accelerator.ActivityId
 import com.terraformation.backend.db.accelerator.ActivityMediaType
 import com.terraformation.backend.db.accelerator.tables.pojos.ActivityMediaFilesRow
+import com.terraformation.backend.db.accelerator.tables.references.ACTIVITY_OBSERVATIONS
 import com.terraformation.backend.db.default_schema.FileId
 import com.terraformation.backend.file.FileService
 import com.terraformation.backend.file.SizedInputStream
@@ -22,6 +24,7 @@ import jakarta.inject.Named
 import java.io.InputStream
 import java.time.InstantSource
 import java.time.LocalDateTime
+import org.jooq.DSLContext
 import org.springframework.context.event.EventListener
 import org.springframework.web.reactive.function.UnsupportedMediaTypeException
 
@@ -29,6 +32,7 @@ import org.springframework.web.reactive.function.UnsupportedMediaTypeException
 class ActivityMediaService(
     private val activityMediaStore: ActivityMediaStore,
     private val clock: InstantSource,
+    private val dslContext: DSLContext,
     private val fileService: FileService,
     private val muxService: MuxService,
     private val parentStore: ParentStore,
@@ -118,6 +122,10 @@ class ActivityMediaService(
   fun deleteMedia(activityId: ActivityId, fileId: FileId) {
     requirePermissions { updateActivity(activityId) }
 
+    if (isObservation(activityId)) {
+      throw CannotDeleteObservationActivityMediaException(activityId)
+    }
+
     activityMediaStore.deleteFromDatabase(activityId, fileId)
   }
 
@@ -149,4 +157,10 @@ class ActivityMediaService(
   /** Returns the current date in the time zone of the organization associated with an activity. */
   private fun getCurrentTime(activityId: ActivityId): LocalDateTime =
       LocalDateTime.ofInstant(clock.instant(), parentStore.getEffectiveTimeZone(activityId))
+
+  private fun isObservation(activityId: ActivityId): Boolean =
+      dslContext.fetchExists(
+          ACTIVITY_OBSERVATIONS,
+          ACTIVITY_OBSERVATIONS.ACTIVITY_ID.eq(activityId),
+      )
 }

--- a/src/main/kotlin/com/terraformation/backend/accelerator/ObservationActivityService.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/ObservationActivityService.kt
@@ -19,6 +19,7 @@ import com.terraformation.backend.tracking.db.ObservationResultsStoreV2
 import com.terraformation.backend.tracking.db.ObservationStore
 import com.terraformation.backend.tracking.db.PlantingSiteStore
 import com.terraformation.backend.tracking.event.ObservationCompletedEvent
+import com.terraformation.backend.tracking.event.ObservationMediaFileDeletedEvent
 import com.terraformation.backend.tracking.event.ObservationMediaFileEditedEvent
 import com.terraformation.backend.tracking.event.ObservationMediaFileUploadedEvent
 import com.terraformation.backend.tracking.model.PlantingSiteDepth
@@ -173,6 +174,16 @@ class ObservationActivityService(
       } catch (e: Exception) {
         log.error("Unable to create activity for completed observation", e)
       }
+    }
+  }
+
+  @EventListener
+  fun on(event: ObservationMediaFileDeletedEvent) {
+    try {
+      // This will be a no-op if the observation had no activity.
+      activityMediaStore.deleteForTrigger(event.fileId)
+    } catch (e: Exception) {
+      log.error("Unable to delete activity media file for observation", e)
     }
   }
 

--- a/src/main/kotlin/com/terraformation/backend/accelerator/db/ActivityMediaStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/db/ActivityMediaStore.kt
@@ -11,7 +11,6 @@ import com.terraformation.backend.db.accelerator.tables.pojos.ActivityMediaFiles
 import com.terraformation.backend.db.accelerator.tables.records.ActivitiesRecord
 import com.terraformation.backend.db.accelerator.tables.references.ACTIVITIES
 import com.terraformation.backend.db.accelerator.tables.references.ACTIVITY_MEDIA_FILES
-import com.terraformation.backend.db.accelerator.tables.references.ACTIVITY_OBSERVATIONS
 import com.terraformation.backend.db.asNonNullable
 import com.terraformation.backend.db.default_schema.FileId
 import com.terraformation.backend.db.default_schema.OrganizationId
@@ -192,10 +191,6 @@ class ActivityMediaStore(
     withLockedActivity(activityId) {
       ensureFileExists(activityId, fileId)
 
-      if (isObservation(activityId)) {
-        throw CannotDeleteObservationActivityMediaException(activityId)
-      }
-
       dslContext
           .deleteFrom(ACTIVITY_MEDIA_FILES)
           .where(ACTIVITY_MEDIA_FILES.FILE_ID.eq(fileId))
@@ -319,12 +314,6 @@ class ActivityMediaStore(
           .execute()
     }
   }
-
-  private fun isObservation(activityId: ActivityId): Boolean =
-      dslContext.fetchExists(
-          ACTIVITY_OBSERVATIONS,
-          ACTIVITY_OBSERVATIONS.ACTIVITY_ID.eq(activityId),
-      )
 
   private fun markActivityModified(activityId: ActivityId) {
     with(ACTIVITIES) {

--- a/src/main/kotlin/com/terraformation/backend/accelerator/db/ActivityMediaStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/db/ActivityMediaStore.kt
@@ -11,6 +11,7 @@ import com.terraformation.backend.db.accelerator.tables.pojos.ActivityMediaFiles
 import com.terraformation.backend.db.accelerator.tables.records.ActivitiesRecord
 import com.terraformation.backend.db.accelerator.tables.references.ACTIVITIES
 import com.terraformation.backend.db.accelerator.tables.references.ACTIVITY_MEDIA_FILES
+import com.terraformation.backend.db.accelerator.tables.references.ACTIVITY_OBSERVATIONS
 import com.terraformation.backend.db.asNonNullable
 import com.terraformation.backend.db.default_schema.FileId
 import com.terraformation.backend.db.default_schema.OrganizationId
@@ -191,6 +192,10 @@ class ActivityMediaStore(
     withLockedActivity(activityId) {
       ensureFileExists(activityId, fileId)
 
+      if (isObservation(activityId)) {
+        throw CannotDeleteObservationActivityMediaException(activityId)
+      }
+
       dslContext
           .deleteFrom(ACTIVITY_MEDIA_FILES)
           .where(ACTIVITY_MEDIA_FILES.FILE_ID.eq(fileId))
@@ -201,6 +206,35 @@ class ActivityMediaStore(
       markActivityModified(activityId)
 
       eventPublisher.publishEvent(FileReferenceDeletedEvent(fileId))
+    }
+  }
+
+  /**
+   * Deletes an activity media file from the database as part of a higher-level operation. The
+   * higher-level operation is assumed to have done the necessary permission checks and is assumed
+   * to publish [FileReferenceDeletedEvent] after calling this.
+   *
+   * Returns silently if the file doesn't exist on the activity.
+   */
+  fun deleteForTrigger(fileId: FileId) {
+    val activityId =
+        dslContext.fetchValue(
+            ACTIVITY_MEDIA_FILES.ACTIVITY_ID,
+            ACTIVITY_MEDIA_FILES.FILE_ID.eq(fileId),
+        ) ?: return
+
+    withLockedActivity(activityId) {
+      val rowsDeleted =
+          dslContext
+              .deleteFrom(ACTIVITY_MEDIA_FILES)
+              .where(ACTIVITY_MEDIA_FILES.FILE_ID.eq(fileId))
+              .execute()
+
+      if (rowsDeleted > 0) {
+        updateListPositions(activityId, fetchFileIds(activityId))
+
+        markActivityModified(activityId)
+      }
     }
   }
 
@@ -285,6 +319,12 @@ class ActivityMediaStore(
           .execute()
     }
   }
+
+  private fun isObservation(activityId: ActivityId): Boolean =
+      dslContext.fetchExists(
+          ACTIVITY_OBSERVATIONS,
+          ACTIVITY_OBSERVATIONS.ACTIVITY_ID.eq(activityId),
+      )
 
   private fun markActivityModified(activityId: ActivityId) {
     with(ACTIVITIES) {

--- a/src/main/kotlin/com/terraformation/backend/accelerator/db/Exceptions.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/db/Exceptions.kt
@@ -18,6 +18,11 @@ class ActivityNotFoundException(id: ActivityId) : EntityNotFoundException("Activ
 class ApplicationNotFoundException(id: ApplicationId) :
     EntityNotFoundException("Application $id not found")
 
+class CannotDeleteObservationActivityMediaException(activityId: ActivityId) :
+    MismatchedStateException(
+        "Activity $activityId is an observation; media files can only be deleted from the observation"
+    )
+
 class CannotDeletePublishedActivityException(activityId: ActivityId) :
     MismatchedStateException("Activity $activityId has been published and cannot be deleted")
 

--- a/src/test/kotlin/com/terraformation/backend/accelerator/ActivityMediaServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/ActivityMediaServiceTest.kt
@@ -5,6 +5,7 @@ import com.terraformation.backend.TestClock
 import com.terraformation.backend.TestEventPublisher
 import com.terraformation.backend.accelerator.db.ActivityMediaStore
 import com.terraformation.backend.accelerator.db.ActivityNotFoundException
+import com.terraformation.backend.accelerator.db.CannotDeleteObservationActivityMediaException
 import com.terraformation.backend.accelerator.event.ActivityDeletionStartedEvent
 import com.terraformation.backend.assertGeometryEquals
 import com.terraformation.backend.assertIsEventListener
@@ -372,6 +373,24 @@ internal class ActivityMediaServiceTest : DatabaseTest(), RunsAsDatabaseUser {
       val fileId = storeMedia("pixel.png", pngMetadata)
 
       assertThrows<FileNotFoundException> { service.deleteMedia(otherActivityId, fileId) }
+    }
+
+    @Test
+    fun `throws exception if activity is an observation`() {
+      insertPlantingSite(x = 0, width = 10)
+      insertStratum()
+      insertSubstratum()
+      insertMonitoringPlot()
+      insertObservation()
+      insertObservationPlot()
+      insertActivityObservation()
+      val fileId = insertFile()
+      insertActivityMediaFile()
+      insertObservationMediaFile()
+
+      assertThrows<CannotDeleteObservationActivityMediaException> {
+        service.deleteMedia(activityId, fileId)
+      }
     }
 
     @Test

--- a/src/test/kotlin/com/terraformation/backend/accelerator/ActivityMediaServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/ActivityMediaServiceTest.kt
@@ -77,6 +77,7 @@ internal class ActivityMediaServiceTest : DatabaseTest(), RunsAsDatabaseUser {
     ActivityMediaService(
         ActivityMediaStore(clock, dslContext, eventPublisher),
         clock,
+        dslContext,
         fileService,
         muxService,
         ParentStore(dslContext),

--- a/src/test/kotlin/com/terraformation/backend/accelerator/ObservationActivityServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/ObservationActivityServiceTest.kt
@@ -39,6 +39,7 @@ import com.terraformation.backend.tracking.db.ObservationResultsStoreV2
 import com.terraformation.backend.tracking.db.ObservationStore
 import com.terraformation.backend.tracking.db.PlantingSiteStore
 import com.terraformation.backend.tracking.event.ObservationCompletedEvent
+import com.terraformation.backend.tracking.event.ObservationMediaFileDeletedEvent
 import com.terraformation.backend.tracking.event.ObservationMediaFileEditedEvent
 import com.terraformation.backend.tracking.event.ObservationMediaFileEditedEventValues
 import com.terraformation.backend.tracking.event.ObservationMediaFileUploadedEvent
@@ -356,6 +357,35 @@ class ObservationActivityServiceTest : DatabaseTest(), RunsAsDatabaseUser {
       service.on(ObservationCompletedEvent(observationId))
 
       assertTableEmpty(ACTIVITIES)
+    }
+  }
+
+  @Nested
+  inner class OnObservationMediaFileDeletedEvent {
+    @Test
+    fun `removes activity media file`() {
+      insertActivity(activityType = ActivityType.Monitoring)
+      insertActivityObservation()
+      insertFile(capturedLocalTime = LocalDateTime.of(2026, 2, 3, 4, 5))
+      insertActivityMediaFile(caption = "Retained file", listPosition = 2)
+      val retainedFileRecord = dslContext.fetchSingle(ACTIVITY_MEDIA_FILES)
+      val fileId = insertFile(capturedLocalTime = LocalDateTime.of(2026, 1, 2, 3, 4))
+      insertActivityMediaFile(caption = "Old caption", listPosition = 1)
+
+      val event =
+          ObservationMediaFileDeletedEvent(
+              fileId,
+              monitoringPlotId,
+              observationId,
+              organizationId,
+              plantingSiteId,
+          )
+      service.on(event)
+
+      // Should update list positions of remaining files
+      retainedFileRecord.listPosition = 1
+
+      assertTableEquals(retainedFileRecord)
     }
   }
 


### PR DESCRIPTION
If the user deletes a media file from an observation, we also want to delete it
from the corresponding activity, if any.

Media files must be deleted from the observation, not from the activity, because
we need to enforce rules such as not allowing deletion of corner photos.