### PR TITLE
SW-8370 Include season targets when fetching planting seasons

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/plantingmanagement/Models.kt
+++ b/src/main/kotlin/com/terraformation/backend/plantingmanagement/Models.kt
@@ -19,6 +19,7 @@ data class ExistingPlantingSeasonModel(
     val id: PlantingSeasonId,
     val name: String,
     val plantingSiteId: PlantingSiteId,
+    val speciesTargets: List<PlantingSeasonSpeciesTargetModel> = emptyList(),
     val startDate: LocalDate,
     val status: PlantingSeasonStatus,
 )

--- a/src/main/kotlin/com/terraformation/backend/plantingmanagement/api/PlantingSeasonsController.kt
+++ b/src/main/kotlin/com/terraformation/backend/plantingmanagement/api/PlantingSeasonsController.kt
@@ -141,6 +141,7 @@ data class PlantingSeasonPayload(
     val id: PlantingSeasonId,
     val name: String,
     val plantingSiteId: PlantingSiteId,
+    val speciesTargets: List<SpeciesTargetPayload> = emptyList(),
     val startDate: LocalDate,
     val status: PlantingSeasonStatus,
 ) {
@@ -151,6 +152,7 @@ data class PlantingSeasonPayload(
       id = model.id,
       name = model.name,
       plantingSiteId = model.plantingSiteId,
+      speciesTargets = model.speciesTargets.map { SpeciesTargetPayload(it) },
       startDate = model.startDate,
       status = model.status,
   )

--- a/src/main/kotlin/com/terraformation/backend/plantingmanagement/db/PlantingSeasonStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/plantingmanagement/db/PlantingSeasonStore.kt
@@ -6,8 +6,8 @@ import com.terraformation.backend.customer.model.requirePermissions
 import com.terraformation.backend.db.tracking.PlantingSeasonId
 import com.terraformation.backend.db.tracking.PlantingSeasonStatus
 import com.terraformation.backend.db.tracking.PlantingSiteId
-import com.terraformation.backend.db.tracking.tables.references.PLANTING_SEASON_SPECIES_TARGETS
 import com.terraformation.backend.db.tracking.tables.references.PLANTING_SEASONS
+import com.terraformation.backend.db.tracking.tables.references.PLANTING_SEASON_SPECIES_TARGETS
 import com.terraformation.backend.plantingmanagement.ExistingPlantingSeasonModel
 import com.terraformation.backend.plantingmanagement.NewPlantingSeasonModel
 import com.terraformation.backend.plantingmanagement.PlantingSeasonSpeciesTargetModel

--- a/src/main/kotlin/com/terraformation/backend/plantingmanagement/db/PlantingSeasonStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/plantingmanagement/db/PlantingSeasonStore.kt
@@ -6,14 +6,17 @@ import com.terraformation.backend.customer.model.requirePermissions
 import com.terraformation.backend.db.tracking.PlantingSeasonId
 import com.terraformation.backend.db.tracking.PlantingSeasonStatus
 import com.terraformation.backend.db.tracking.PlantingSiteId
+import com.terraformation.backend.db.tracking.tables.references.PLANTING_SEASON_SPECIES_TARGETS
 import com.terraformation.backend.db.tracking.tables.references.PLANTING_SEASONS
 import com.terraformation.backend.plantingmanagement.ExistingPlantingSeasonModel
 import com.terraformation.backend.plantingmanagement.NewPlantingSeasonModel
+import com.terraformation.backend.plantingmanagement.PlantingSeasonSpeciesTargetModel
 import jakarta.inject.Named
 import java.time.InstantSource
 import java.time.LocalDate
 import org.jooq.Condition
 import org.jooq.DSLContext
+import org.jooq.impl.DSL
 
 @Named
 class PlantingSeasonStore(
@@ -119,17 +122,44 @@ class PlantingSeasonStore(
   }
 
   private fun fetchByCondition(condition: Condition): List<ExistingPlantingSeasonModel> {
+    val targetsMultiset =
+        DSL.multiset(
+                DSL.select(
+                        PLANTING_SEASON_SPECIES_TARGETS.SUBSTRATUM_ID,
+                        PLANTING_SEASON_SPECIES_TARGETS.SPECIES_ID,
+                        PLANTING_SEASON_SPECIES_TARGETS.QUANTITY,
+                    )
+                    .from(PLANTING_SEASON_SPECIES_TARGETS)
+                    .where(
+                        PLANTING_SEASON_SPECIES_TARGETS.PLANTING_SEASON_ID.eq(PLANTING_SEASONS.ID)
+                    )
+            )
+            .convertFrom { result ->
+              result.map { record ->
+                PlantingSeasonSpeciesTargetModel(
+                    substratumId = record[PLANTING_SEASON_SPECIES_TARGETS.SUBSTRATUM_ID]!!,
+                    speciesId = record[PLANTING_SEASON_SPECIES_TARGETS.SPECIES_ID]!!,
+                    quantity = record[PLANTING_SEASON_SPECIES_TARGETS.QUANTITY]!!,
+                )
+              }
+            }
+
     return with(PLANTING_SEASONS) {
-      dslContext.selectFrom(PLANTING_SEASONS).where(condition).fetch { record ->
-        ExistingPlantingSeasonModel(
-            endDate = record[END_DATE]!!,
-            id = record[ID]!!,
-            name = record[NAME]!!,
-            plantingSiteId = record[PLANTING_SITE_ID]!!,
-            startDate = record[START_DATE]!!,
-            status = record[STATUS_ID]!!,
-        )
-      }
+      dslContext
+          .select(PLANTING_SEASONS.asterisk(), targetsMultiset)
+          .from(PLANTING_SEASONS)
+          .where(condition)
+          .fetch { record ->
+            ExistingPlantingSeasonModel(
+                endDate = record[END_DATE]!!,
+                id = record[ID]!!,
+                name = record[NAME]!!,
+                plantingSiteId = record[PLANTING_SITE_ID]!!,
+                speciesTargets = record[targetsMultiset],
+                startDate = record[START_DATE]!!,
+                status = record[STATUS_ID]!!,
+            )
+          }
     }
   }
 }

--- a/src/test/kotlin/com/terraformation/backend/plantingmanagement/db/PlantingSeasonStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/plantingmanagement/db/PlantingSeasonStoreTest.kt
@@ -268,7 +268,7 @@ internal class PlantingSeasonStoreTest : DatabaseTest(), RunsAsDatabaseUser {
       val substratumId = insertSubstratum()
       val speciesId = insertSpecies()
       insertPlantingSeasonSpeciesTarget(plantingSeasonId = id1, quantity = 10)
-      insertPlantingSeasonSpeciesTarget(plantingSeasonId = id2, quantity = 10)
+      insertPlantingSeasonSpeciesTarget(plantingSeasonId = id2, quantity = 20)
 
       val result = store.fetchList(plantingSiteId)
 

--- a/src/test/kotlin/com/terraformation/backend/plantingmanagement/db/PlantingSeasonStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/plantingmanagement/db/PlantingSeasonStoreTest.kt
@@ -12,6 +12,7 @@ import com.terraformation.backend.db.tracking.PlantingSiteId
 import com.terraformation.backend.db.tracking.tables.records.PlantingSeasonsRecord
 import com.terraformation.backend.plantingmanagement.ExistingPlantingSeasonModel
 import com.terraformation.backend.plantingmanagement.NewPlantingSeasonModel
+import com.terraformation.backend.plantingmanagement.PlantingSeasonSpeciesTargetModel
 import com.terraformation.backend.tracking.db.PlantingSiteNotFoundException
 import java.time.Instant
 import java.time.LocalDate
@@ -29,6 +30,9 @@ internal class PlantingSeasonStoreTest : DatabaseTest(), RunsAsDatabaseUser {
   private val clock = TestClock()
   private val store: PlantingSeasonStore by lazy {
     PlantingSeasonStore(clock, dslContext, ParentStore(dslContext))
+  }
+  private val targetsStore: PlantingSeasonSpeciesTargetsStore by lazy {
+    PlantingSeasonSpeciesTargetsStore(clock, dslContext)
   }
 
   private lateinit var plantingSiteId: PlantingSiteId
@@ -248,6 +252,69 @@ internal class PlantingSeasonStoreTest : DatabaseTest(), RunsAsDatabaseUser {
     }
 
     @Test
+    fun `returns species targets for each season`() {
+      val id1 =
+          insertPlantingSeason(
+              name = "Spring 2025",
+              startDate = LocalDate.of(2025, 1, 1),
+              endDate = LocalDate.of(2025, 3, 31),
+              status = PlantingSeasonStatus.Upcoming,
+          )
+      val id2 =
+          insertPlantingSeason(
+              name = "Fall 2025",
+              startDate = LocalDate.of(2025, 9, 1),
+              endDate = LocalDate.of(2025, 11, 30),
+              status = PlantingSeasonStatus.Upcoming,
+          )
+      insertStratum()
+      val substratumId = insertSubstratum()
+      val speciesId = insertSpecies()
+      targetsStore.upsert(id1, substratumId, speciesId, quantity = 10)
+      targetsStore.upsert(id2, substratumId, speciesId, quantity = 20)
+
+      val result = store.fetchList(plantingSiteId)
+
+      assertEquals(
+          listOf(
+              ExistingPlantingSeasonModel(
+                  endDate = LocalDate.of(2025, 3, 31),
+                  id = id1,
+                  name = "Spring 2025",
+                  plantingSiteId = plantingSiteId,
+                  speciesTargets =
+                      listOf(
+                          PlantingSeasonSpeciesTargetModel(
+                              substratumId = substratumId,
+                              speciesId = speciesId,
+                              quantity = 10,
+                          )
+                      ),
+                  startDate = LocalDate.of(2025, 1, 1),
+                  status = PlantingSeasonStatus.Upcoming,
+              ),
+              ExistingPlantingSeasonModel(
+                  endDate = LocalDate.of(2025, 11, 30),
+                  id = id2,
+                  name = "Fall 2025",
+                  plantingSiteId = plantingSiteId,
+                  speciesTargets =
+                      listOf(
+                          PlantingSeasonSpeciesTargetModel(
+                              substratumId = substratumId,
+                              speciesId = speciesId,
+                              quantity = 20,
+                          )
+                      ),
+                  startDate = LocalDate.of(2025, 9, 1),
+                  status = PlantingSeasonStatus.Upcoming,
+              ),
+          ),
+          result,
+      )
+    }
+
+    @Test
     fun `throws PlantingSiteNotFoundException when user is not a member of the organization`() {
       deleteOrganizationUser()
 
@@ -277,6 +344,45 @@ internal class PlantingSeasonStoreTest : DatabaseTest(), RunsAsDatabaseUser {
               id = id,
               name = "Spring 2025",
               plantingSiteId = plantingSiteId,
+              startDate = startDate,
+              status = PlantingSeasonStatus.Upcoming,
+          ),
+          result,
+      )
+    }
+
+    @Test
+    fun `returns species targets when they exist`() {
+      val startDate = LocalDate.of(2025, 1, 1)
+      val endDate = LocalDate.of(2025, 3, 31)
+      val id =
+          insertPlantingSeason(
+              name = "Spring 2025",
+              startDate = startDate,
+              endDate = endDate,
+              status = PlantingSeasonStatus.Upcoming,
+          )
+      insertStratum()
+      val substratumId = insertSubstratum()
+      val speciesId = insertSpecies()
+      targetsStore.upsert(id, substratumId, speciesId, quantity = 42)
+
+      val result = store.fetchById(id)
+
+      assertEquals(
+          ExistingPlantingSeasonModel(
+              endDate = endDate,
+              id = id,
+              name = "Spring 2025",
+              plantingSiteId = plantingSiteId,
+              speciesTargets =
+                  listOf(
+                      PlantingSeasonSpeciesTargetModel(
+                          substratumId = substratumId,
+                          speciesId = speciesId,
+                          quantity = 42,
+                      )
+                  ),
               startDate = startDate,
               status = PlantingSeasonStatus.Upcoming,
           ),

--- a/src/test/kotlin/com/terraformation/backend/plantingmanagement/db/PlantingSeasonStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/plantingmanagement/db/PlantingSeasonStoreTest.kt
@@ -31,9 +31,6 @@ internal class PlantingSeasonStoreTest : DatabaseTest(), RunsAsDatabaseUser {
   private val store: PlantingSeasonStore by lazy {
     PlantingSeasonStore(clock, dslContext, ParentStore(dslContext))
   }
-  private val targetsStore: PlantingSeasonSpeciesTargetsStore by lazy {
-    PlantingSeasonSpeciesTargetsStore(clock, dslContext)
-  }
 
   private lateinit var plantingSiteId: PlantingSiteId
 
@@ -270,8 +267,8 @@ internal class PlantingSeasonStoreTest : DatabaseTest(), RunsAsDatabaseUser {
       insertStratum()
       val substratumId = insertSubstratum()
       val speciesId = insertSpecies()
-      targetsStore.upsert(id1, substratumId, speciesId, quantity = 10)
-      targetsStore.upsert(id2, substratumId, speciesId, quantity = 20)
+      insertPlantingSeasonSpeciesTarget(plantingSeasonId = id1, quantity = 10)
+      insertPlantingSeasonSpeciesTarget(plantingSeasonId = id2, quantity = 10)
 
       val result = store.fetchList(plantingSiteId)
 
@@ -365,7 +362,7 @@ internal class PlantingSeasonStoreTest : DatabaseTest(), RunsAsDatabaseUser {
       insertStratum()
       val substratumId = insertSubstratum()
       val speciesId = insertSpecies()
-      targetsStore.upsert(id, substratumId, speciesId, quantity = 42)
+      insertPlantingSeasonSpeciesTarget(plantingSeasonId = id, quantity = 42)
 
       val result = store.fetchById(id)
 


### PR DESCRIPTION
Add a multiset when fetching planting seasons to include their species targets.

Claude wrote the multiset.

Co-authored-by: Claude Sonnet 4.6 [noreply@anthropic.com](mailto:noreply@anthropic.com)