### PR TITLE
SW-8370 Update create api endpoint to copy a planting season's species targets

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/plantingmanagement/Models.kt
+++ b/src/main/kotlin/com/terraformation/backend/plantingmanagement/Models.kt
@@ -9,6 +9,7 @@ import java.time.LocalDate
 
 data class NewPlantingSeasonModel(
     val endDate: LocalDate,
+    val fromPlantingSeasonId: PlantingSeasonId? = null,
     val name: String,
     val plantingSiteId: PlantingSiteId,
     val startDate: LocalDate,

--- a/src/main/kotlin/com/terraformation/backend/plantingmanagement/PlantingSeasonService.kt
+++ b/src/main/kotlin/com/terraformation/backend/plantingmanagement/PlantingSeasonService.kt
@@ -1,0 +1,28 @@
+package com.terraformation.backend.plantingmanagement
+
+import com.terraformation.backend.db.tracking.PlantingSeasonId
+import com.terraformation.backend.plantingmanagement.db.PlantingSeasonSpeciesTargetsStore
+import com.terraformation.backend.plantingmanagement.db.PlantingSeasonStore
+import jakarta.inject.Named
+import org.jooq.DSLContext
+
+@Named
+class PlantingSeasonService(
+    private val dslContext: DSLContext,
+    private val plantingSeasonStore: PlantingSeasonStore,
+    private val plantingSeasonSpeciesTargetsStore: PlantingSeasonSpeciesTargetsStore,
+) {
+  fun create(newModel: NewPlantingSeasonModel): PlantingSeasonId {
+    return dslContext.transactionResult { _ ->
+      val newSeasonId = plantingSeasonStore.create(newModel)
+
+      if (newModel.fromPlantingSeasonId != null) {
+        plantingSeasonSpeciesTargetsStore.copySpeciesTargets(
+            newModel.fromPlantingSeasonId,
+            newSeasonId,
+        )
+      }
+      newSeasonId
+    }
+  }
+}

--- a/src/main/kotlin/com/terraformation/backend/plantingmanagement/api/PlantingSeasonsController.kt
+++ b/src/main/kotlin/com/terraformation/backend/plantingmanagement/api/PlantingSeasonsController.kt
@@ -11,6 +11,7 @@ import com.terraformation.backend.db.tracking.PlantingSeasonStatus
 import com.terraformation.backend.db.tracking.PlantingSiteId
 import com.terraformation.backend.plantingmanagement.ExistingPlantingSeasonModel
 import com.terraformation.backend.plantingmanagement.NewPlantingSeasonModel
+import com.terraformation.backend.plantingmanagement.PlantingSeasonService
 import com.terraformation.backend.plantingmanagement.db.PlantingSeasonStore
 import io.swagger.v3.oas.annotations.Operation
 import java.time.LocalDate
@@ -28,18 +29,23 @@ import org.springframework.web.bind.annotation.RestController
 @RequestMapping("/api/v1/planting-seasons")
 @RestController
 class PlantingSeasonsController(
+    private val plantingSeasonService: PlantingSeasonService,
     private val plantingSeasonStore: PlantingSeasonStore,
 ) {
 
   @ApiResponse200
-  @Operation(summary = "Creates a new planting season.")
+  @Operation(
+      summary = "Creates a new planting season.",
+      description =
+          "If fromPlantingSeasonId is specified, copy all species/substrata over to the new season (with quantities of 0).",
+  )
   @PostMapping
   fun createPlantingSeason(
       @RequestBody payload: CreatePlantingSeasonRequestPayload
   ): CreatePlantingSeasonResponsePayload {
     payload.validate()
 
-    val plantingSeasonId = plantingSeasonStore.create(payload.toModel())
+    val plantingSeasonId = plantingSeasonService.create(payload.toModel())
     return CreatePlantingSeasonResponsePayload(plantingSeasonId)
   }
 
@@ -97,6 +103,7 @@ private fun validateDateRange(startDate: LocalDate, endDate: LocalDate) {
 
 data class CreatePlantingSeasonRequestPayload(
     val endDate: LocalDate,
+    val fromPlantingSeasonId: PlantingSeasonId? = null,
     val name: String,
     val plantingSiteId: PlantingSiteId,
     val startDate: LocalDate,
@@ -108,6 +115,7 @@ data class CreatePlantingSeasonRequestPayload(
   fun toModel(): NewPlantingSeasonModel =
       NewPlantingSeasonModel(
           endDate = endDate,
+          fromPlantingSeasonId = fromPlantingSeasonId,
           name = name,
           plantingSiteId = plantingSiteId,
           startDate = startDate,

--- a/src/main/kotlin/com/terraformation/backend/plantingmanagement/db/PlantingSeasonSpeciesTargetsStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/plantingmanagement/db/PlantingSeasonSpeciesTargetsStore.kt
@@ -11,6 +11,7 @@ import jakarta.inject.Named
 import java.time.InstantSource
 import org.jooq.Condition
 import org.jooq.DSLContext
+import org.jooq.impl.DSL
 
 @Named
 class PlantingSeasonSpeciesTargetsStore(
@@ -51,6 +52,41 @@ class PlantingSeasonSpeciesTargetsStore(
           .set(QUANTITY, quantity)
           .set(MODIFIED_BY, userId)
           .set(MODIFIED_TIME, now)
+          .execute()
+    }
+  }
+
+  fun copySpeciesTargets(
+      fromPlantingSeasonId: PlantingSeasonId,
+      toPlantingSeasonId: PlantingSeasonId,
+  ) {
+    requirePermissions {
+      updatePlantingSeason(toPlantingSeasonId)
+      readPlantingSeason(fromPlantingSeasonId)
+    }
+
+    val userId = currentUser().userId
+    val now = clock.instant()
+
+    with(PLANTING_SEASON_SPECIES_TARGETS) {
+      dslContext
+          .insertInto(PLANTING_SEASON_SPECIES_TARGETS)
+          .select(
+              DSL.select(
+                      DSL.`val`(toPlantingSeasonId),
+                      SUBSTRATUM_ID,
+                      SPECIES_ID,
+                      DSL.`val`(0), // quantity
+                      DSL.`val`(userId), // created_by
+                      DSL.`val`(now), // created_time
+                      DSL.`val`(userId), // modified_by
+                      DSL.`val`(now), // modified_time
+                  )
+                  .from(PLANTING_SEASON_SPECIES_TARGETS)
+                  .where(
+                      PLANTING_SEASON_ID.eq(fromPlantingSeasonId),
+                  )
+          )
           .execute()
     }
   }

--- a/src/main/kotlin/com/terraformation/backend/plantingmanagement/db/PlantingSeasonSpeciesTargetsStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/plantingmanagement/db/PlantingSeasonSpeciesTargetsStore.kt
@@ -70,22 +70,30 @@ class PlantingSeasonSpeciesTargetsStore(
 
     with(PLANTING_SEASON_SPECIES_TARGETS) {
       dslContext
-          .insertInto(PLANTING_SEASON_SPECIES_TARGETS)
+          .insertInto(
+              PLANTING_SEASON_SPECIES_TARGETS,
+              PLANTING_SEASON_ID,
+              SUBSTRATUM_ID,
+              SPECIES_ID,
+              QUANTITY,
+              CREATED_BY,
+              CREATED_TIME,
+              MODIFIED_BY,
+              MODIFIED_TIME,
+          )
           .select(
               DSL.select(
                       DSL.`val`(toPlantingSeasonId),
                       SUBSTRATUM_ID,
                       SPECIES_ID,
-                      DSL.`val`(0), // quantity
-                      DSL.`val`(userId), // created_by
-                      DSL.`val`(now), // created_time
-                      DSL.`val`(userId), // modified_by
-                      DSL.`val`(now), // modified_time
+                      DSL.`val`(0),
+                      DSL.`val`(userId),
+                      DSL.`val`(now),
+                      DSL.`val`(userId),
+                      DSL.`val`(now),
                   )
                   .from(PLANTING_SEASON_SPECIES_TARGETS)
-                  .where(
-                      PLANTING_SEASON_ID.eq(fromPlantingSeasonId),
-                  )
+                  .where(PLANTING_SEASON_ID.eq(fromPlantingSeasonId))
           )
           .execute()
     }

--- a/src/test/kotlin/com/terraformation/backend/plantingmanagement/PlantingSeasonServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/plantingmanagement/PlantingSeasonServiceTest.kt
@@ -1,0 +1,120 @@
+package com.terraformation.backend.plantingmanagement
+
+import com.terraformation.backend.RunsAsDatabaseUser
+import com.terraformation.backend.TestClock
+import com.terraformation.backend.customer.db.ParentStore
+import com.terraformation.backend.customer.model.TerrawareUser
+import com.terraformation.backend.db.DatabaseTest
+import com.terraformation.backend.db.default_schema.Role
+import com.terraformation.backend.db.default_schema.SpeciesId
+import com.terraformation.backend.db.tracking.PlantingSeasonId
+import com.terraformation.backend.db.tracking.PlantingSiteId
+import com.terraformation.backend.db.tracking.SubstratumId
+import com.terraformation.backend.db.tracking.tables.records.PlantingSeasonSpeciesTargetsRecord
+import com.terraformation.backend.db.tracking.tables.references.PLANTING_SEASON_SPECIES_TARGETS
+import com.terraformation.backend.plantingmanagement.db.PlantingSeasonSpeciesTargetsStore
+import com.terraformation.backend.plantingmanagement.db.PlantingSeasonStore
+import java.time.Instant
+import java.time.LocalDate
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+internal class PlantingSeasonServiceTest : DatabaseTest(), RunsAsDatabaseUser {
+  override lateinit var user: TerrawareUser
+
+  private val clock = TestClock()
+  private val plantingSeasonSpeciesTargetsStore: PlantingSeasonSpeciesTargetsStore by lazy {
+    PlantingSeasonSpeciesTargetsStore(clock, dslContext)
+  }
+  private val plantingSeasonStore: PlantingSeasonStore by lazy {
+    PlantingSeasonStore(clock, dslContext, ParentStore(dslContext))
+  }
+  private val service: PlantingSeasonService by lazy {
+    PlantingSeasonService(dslContext, plantingSeasonStore, plantingSeasonSpeciesTargetsStore)
+  }
+
+  private lateinit var plantingSeasonId: PlantingSeasonId
+  private lateinit var plantingSiteId: PlantingSiteId
+  private lateinit var substratumId: SubstratumId
+  private lateinit var speciesId: SpeciesId
+
+  @BeforeEach
+  fun setUp() {
+    insertOrganization()
+    plantingSiteId = insertPlantingSite()
+    insertOrganizationUser(role = Role.Manager)
+    insertStratum()
+    plantingSeasonId = insertPlantingSeason()
+    substratumId = insertSubstratum()
+    speciesId = insertSpecies()
+  }
+
+  @Nested
+  inner class Create {
+    private val startDate = LocalDate.of(2025, 1, 1)
+    private val endDate = LocalDate.of(2025, 3, 31)
+
+    @Test
+    fun `copies species targets from source season when fromPlantingSeasonId is specified`() {
+      insertPlantingSeasonSpeciesTarget(speciesId = speciesId, quantity = 5)
+
+      val newSeasonId =
+          service.create(
+              NewPlantingSeasonModel(
+                  endDate = endDate,
+                  fromPlantingSeasonId = plantingSeasonId,
+                  name = "Spring 2025",
+                  plantingSiteId = plantingSiteId,
+                  startDate = startDate,
+              )
+          )
+
+      assertTableEquals(
+          listOf(
+              PlantingSeasonSpeciesTargetsRecord(
+                  plantingSeasonId = plantingSeasonId,
+                  substratumId = substratumId,
+                  speciesId = speciesId,
+                  quantity = 5,
+                  createdBy = user.userId,
+                  createdTime = Instant.EPOCH,
+                  modifiedBy = user.userId,
+                  modifiedTime = Instant.EPOCH,
+              ),
+              PlantingSeasonSpeciesTargetsRecord(
+                  plantingSeasonId = newSeasonId,
+                  substratumId = substratumId,
+                  speciesId = speciesId,
+                  quantity = 0,
+                  createdBy = user.userId,
+                  createdTime = Instant.EPOCH,
+                  modifiedBy = user.userId,
+                  modifiedTime = Instant.EPOCH,
+              ),
+          )
+      )
+    }
+
+    @Test
+    fun `does not copy species targets when fromPlantingSeasonId is null`() {
+      insertPlantingSeason()
+      insertPlantingSeasonSpeciesTarget(speciesId = speciesId, quantity = 5)
+
+      val newSeasonId =
+          service.create(
+              NewPlantingSeasonModel(
+                  endDate = endDate,
+                  name = "Spring 2025",
+                  plantingSiteId = plantingSiteId,
+                  startDate = startDate,
+              )
+          )
+
+      assertTableEmpty(
+          PLANTING_SEASON_SPECIES_TARGETS,
+          where = PLANTING_SEASON_SPECIES_TARGETS.PLANTING_SEASON_ID.eq(newSeasonId),
+      )
+    }
+  }
+}

--- a/src/test/kotlin/com/terraformation/backend/plantingmanagement/db/PlantingSeasonSpeciesTargetsStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/plantingmanagement/db/PlantingSeasonSpeciesTargetsStoreTest.kt
@@ -163,6 +163,80 @@ internal class PlantingSeasonSpeciesTargetsStoreTest : DatabaseTest(), RunsAsDat
   }
 
   @Nested
+  inner class CopySpeciesTargets {
+    @Test
+    fun `throws AccessDeniedException when user lacks permission`() {
+      val otherPlantingSeasonId = insertPlantingSeason()
+
+      deleteOrganizationUser()
+      insertOrganizationUser(role = Role.Contributor)
+
+      assertThrows<AccessDeniedException> {
+        store.copySpeciesTargets(otherPlantingSeasonId, plantingSeasonId)
+      }
+    }
+
+    @Test
+    fun `copies all species targets from another planting season`() {
+      val otherPlantingSeasonId = insertPlantingSeason()
+      val speciesId2 = insertSpecies()
+      val initialTime = Instant.EPOCH
+      clock.instant = initialTime
+      insertPlantingSeasonSpeciesTarget(speciesId = speciesId, quantity = 5)
+      insertPlantingSeasonSpeciesTarget(speciesId = speciesId2, quantity = 10)
+
+      val laterTime = initialTime.plusSeconds(86400)
+      clock.instant = laterTime
+      store.copySpeciesTargets(otherPlantingSeasonId, plantingSeasonId)
+
+      assertTableEquals(
+          listOf(
+              PlantingSeasonSpeciesTargetsRecord(
+                  plantingSeasonId = otherPlantingSeasonId,
+                  substratumId = substratumId,
+                  speciesId = speciesId,
+                  quantity = 5,
+                  createdBy = user.userId,
+                  createdTime = initialTime,
+                  modifiedBy = user.userId,
+                  modifiedTime = initialTime,
+              ),
+              PlantingSeasonSpeciesTargetsRecord(
+                  plantingSeasonId = otherPlantingSeasonId,
+                  substratumId = substratumId,
+                  speciesId = speciesId2,
+                  quantity = 10,
+                  createdBy = user.userId,
+                  createdTime = initialTime,
+                  modifiedBy = user.userId,
+                  modifiedTime = initialTime,
+              ),
+              PlantingSeasonSpeciesTargetsRecord(
+                  plantingSeasonId = plantingSeasonId,
+                  substratumId = substratumId,
+                  speciesId = speciesId,
+                  quantity = 0,
+                  createdBy = user.userId,
+                  createdTime = laterTime,
+                  modifiedBy = user.userId,
+                  modifiedTime = laterTime,
+              ),
+              PlantingSeasonSpeciesTargetsRecord(
+                  plantingSeasonId = plantingSeasonId,
+                  substratumId = substratumId,
+                  speciesId = speciesId2,
+                  quantity = 0,
+                  createdBy = user.userId,
+                  createdTime = laterTime,
+                  modifiedBy = user.userId,
+                  modifiedTime = laterTime,
+              ),
+          )
+      )
+    }
+  }
+
+  @Nested
   inner class Delete {
     @Test
     fun `deletes the species target row`() {


### PR DESCRIPTION
Add an optional `fromPlantingSeasonId` to the create planting season endpoint that copies the species targets with zero'd quantities.