### PR TITLE
Run backfill observations as system user in the Admin UI

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/admin/AdminPlantingSitesController.kt
+++ b/src/main/kotlin/com/terraformation/backend/admin/AdminPlantingSitesController.kt
@@ -740,7 +740,7 @@ class AdminPlantingSitesController(
   @RequireGlobalRole([GlobalRole.SuperAdmin])
   fun backfillObservationResults(redirectAttributes: RedirectAttributes): String {
     try {
-      val count = observationService.backfillObservationResults()
+      val count = systemUser.run { observationService.backfillObservationResults() }
       redirectAttributes.successMessage =
           "Backfilled observation_*_results rows for $count completed observations."
     } catch (e: Exception) {


### PR DESCRIPTION
This is to ensure that all observations are back-filled.