### PR TITLE
Rename some leftover variables in tests from zones to strata

### DIFF
--- a/src/test/kotlin/com/terraformation/backend/accelerator/db/ReportStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/db/ReportStoreTest.kt
@@ -6021,8 +6021,8 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
         speciesId = speciesId,
         permanentLive = 6,
         // total live at a site level can be lower than substratum level because of disjoint
-        // substrata
-        // set this to 0 to ensure that tests use substratum level for temp plots in survival rates
+        // substrata. set this to 0 to ensure that tests use substratum level for temp plots in
+        // survival rates
         totalLive = 0,
     )
     insertObservedSubstratumSpeciesTotals(

--- a/src/test/kotlin/com/terraformation/backend/accelerator/db/ReportStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/db/ReportStoreTest.kt
@@ -5652,7 +5652,7 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
     val site1oldHistory = insertPlantingSiteHistory()
     val site1newHistory = insertPlantingSiteHistory()
     insertStratum(insertHistory = false)
-    val site1zoneOldHistory = insertStratumHistory(plantingSiteHistoryId = site1oldHistory)
+    val site1stratumOldHistory = insertStratumHistory(plantingSiteHistoryId = site1oldHistory)
     insertStratumHistory()
     insertStratumT0TempDensity(
         speciesId = speciesId,
@@ -5662,21 +5662,21 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
         speciesId = otherSpeciesId,
         stratumDensity = BigDecimal.valueOf(110).toPlantsPerHectare(),
     )
-    val subzoneId1 =
+    val substratumId1 =
         insertSubstratum(
             areaHa = BigDecimal(10),
             plantingCompletedTime = plantingCompletedDate1.atStartOfDay().toInstant(ZoneOffset.UTC),
             insertHistory = false,
         )
-    val subzone1oldHistory = insertSubstratumHistory(stratumHistoryId = site1zoneOldHistory)
+    val substratum1oldHistory = insertSubstratumHistory(stratumHistoryId = site1stratumOldHistory)
     insertSubstratumHistory()
-    val subzone1plot1 = insertMonitoringPlot(permanentIndex = 1, insertHistory = false)
-    val subzone1plot1OldHist =
+    val substratum1plot1 = insertMonitoringPlot(permanentIndex = 1, insertHistory = false)
+    val substratum1plot1OldHist =
         insertMonitoringPlotHistory(
-            substratumHistoryId = subzone1oldHistory,
+            substratumHistoryId = substratum1oldHistory,
             plantingSiteHistoryId = site1oldHistory,
         )
-    val subzone1plot1Hist = insertMonitoringPlotHistory()
+    val substratum1plot1Hist = insertMonitoringPlotHistory()
     insertPlotT0Density(
         speciesId = speciesId,
         plotDensity = BigDecimal.valueOf(10).toPlantsPerHectare(),
@@ -5685,13 +5685,13 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
         speciesId = otherSpeciesId,
         plotDensity = BigDecimal.valueOf(11).toPlantsPerHectare(),
     )
-    val subzone1plot2 = insertMonitoringPlot(permanentIndex = null, insertHistory = false)
-    val subzone1plot2OldHist =
+    val substratum1plot2 = insertMonitoringPlot(permanentIndex = null, insertHistory = false)
+    val substratum1plot2OldHist =
         insertMonitoringPlotHistory(
-            substratumHistoryId = subzone1oldHistory,
+            substratumHistoryId = substratum1oldHistory,
             plantingSiteHistoryId = site1oldHistory,
         )
-    val subzone1plot2Hist = insertMonitoringPlotHistory()
+    val substratum1plot2Hist = insertMonitoringPlotHistory()
     // these old densities from when the plot was permanent should be excluded
     insertPlotT0Density(
         speciesId = speciesId,
@@ -5703,14 +5703,14 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
     )
 
     // Not counted towards hectares planted, planting completed before report period
-    val subzoneId2 =
+    val substratumId2 =
         insertSubstratum(
             areaHa = BigDecimal(20),
             plantingCompletedTime =
                 pastPlantingCompletedDate.atStartOfDay().toInstant(ZoneOffset.UTC),
             insertHistory = false,
         )
-    val subzone2oldHistory = insertSubstratumHistory(stratumHistoryId = site1zoneOldHistory)
+    val substratum2oldHistory = insertSubstratumHistory(stratumHistoryId = site1stratumOldHistory)
     insertSubstratumHistory()
     // this plot was in observation1 but was reassigned from observation2
     val reassignedPlot = insertMonitoringPlot(permanentIndex = 2)
@@ -5727,7 +5727,7 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
     val newlyPermanentPlot = insertMonitoringPlot(permanentIndex = 3, insertHistory = false)
     val newlyPermanentPlotOldHist =
         insertMonitoringPlotHistory(
-            substratumHistoryId = subzone2oldHistory,
+            substratumHistoryId = substratum2oldHistory,
             plantingSiteHistoryId = site1oldHistory,
         )
     val newlyPermanentPlotHist = insertMonitoringPlotHistory()
@@ -5743,7 +5743,7 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
     val newlyTemporaryPlot = insertMonitoringPlot(permanentIndex = null, insertHistory = false)
     val newlyTemporaryPlotOldHist =
         insertMonitoringPlotHistory(
-            substratumHistoryId = subzone2oldHistory,
+            substratumHistoryId = substratum2oldHistory,
             plantingSiteHistoryId = site1oldHistory,
         )
     insertMonitoringPlotHistory()
@@ -5755,12 +5755,12 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
         speciesId = otherSpeciesId,
         plotDensity = BigDecimal.valueOf(106).toPlantsPerHectare(),
     )
-    // this plot used to be in a subzone but is no longer
-    val plotNotInSubzone =
+    // this plot used to be in a substratum but is no longer
+    val plotNotInSubstratum =
         insertMonitoringPlot(permanentIndex = 4, insertHistory = false, substratumId = null)
-    val plotNotInSubzoneOldHist =
+    val plotNotInSubstratumOldHist =
         insertMonitoringPlotHistory(
-            substratumHistoryId = subzone2oldHistory,
+            substratumHistoryId = substratum2oldHistory,
             plantingSiteHistoryId = site1oldHistory,
         )
     insertMonitoringPlotHistory(substratumId = null, substratumHistoryId = null)
@@ -5777,24 +5777,24 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
         insertMonitoringPlot(permanentIndex = null, insertHistory = false)
     val previouslyObservedTempPlotOldHist =
         insertMonitoringPlotHistory(
-            substratumHistoryId = subzone2oldHistory,
+            substratumHistoryId = substratum2oldHistory,
             plantingSiteHistoryId = site1oldHistory,
         )
     insertMonitoringPlotHistory()
     // Not counted towards hectares planted, not completed
-    val incompleteSubzone =
+    val incompleteSubstratum =
         insertSubstratum(
             areaHa = BigDecimal(1000),
             plantingCompletedTime = null,
         )
-    // plot was in a different subzone previously
-    val incompleteSubzonePlot1 = insertMonitoringPlot(permanentIndex = 5, insertHistory = false)
-    val incompleteSubzonePlot1OldHist =
+    // plot was in a different substratum previously
+    val incompleteSubstratumPlot1 = insertMonitoringPlot(permanentIndex = 5, insertHistory = false)
+    val incompleteSubstratumPlot1OldHist =
         insertMonitoringPlotHistory(
-            substratumHistoryId = subzone2oldHistory,
+            substratumHistoryId = substratum2oldHistory,
             plantingSiteHistoryId = site1oldHistory,
         )
-    val incompleteSubzonePlot1Hist = insertMonitoringPlotHistory()
+    val incompleteSubstratumPlot1Hist = insertMonitoringPlotHistory()
     insertPlotT0Density(
         speciesId = speciesId,
         plotDensity = BigDecimal.valueOf(40).toPlantsPerHectare(),
@@ -5804,22 +5804,22 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
         plotDensity = BigDecimal.valueOf(41).toPlantsPerHectare(),
     )
     // Not counted towards hectares planted, after reporting period
-    val futureSubzone =
+    val futureSubstratum =
         insertSubstratum(
             areaHa = BigDecimal(3000),
             plantingCompletedTime =
                 futurePlantingCompletedDate.atStartOfDay().toInstant(ZoneOffset.UTC),
             insertHistory = false,
         )
-    val futureSubzoneOldHist = insertSubstratumHistory(stratumHistoryId = site1zoneOldHistory)
+    val futureSubstratumOldHist = insertSubstratumHistory(stratumHistoryId = site1stratumOldHistory)
     insertSubstratumHistory()
-    val futureSubzonePlot1 = insertMonitoringPlot(permanentIndex = 6, insertHistory = false)
-    val futureSubzonePlot1OldHist =
+    val futureSubstratumPlot1 = insertMonitoringPlot(permanentIndex = 6, insertHistory = false)
+    val futureSubstratumPlot1OldHist =
         insertMonitoringPlotHistory(
-            substratumHistoryId = futureSubzoneOldHist,
+            substratumHistoryId = futureSubstratumOldHist,
             plantingSiteHistoryId = site1oldHistory,
         )
-    val futureSubzonePlot1Hist = insertMonitoringPlotHistory()
+    val futureSubstratumPlot1Hist = insertMonitoringPlotHistory()
     insertPlotT0Density(
         speciesId = speciesId,
         plotDensity = BigDecimal.valueOf(50).toPlantsPerHectare(),
@@ -5836,13 +5836,13 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
         speciesId = speciesId,
         stratumDensity = BigDecimal.valueOf(200).toPlantsPerHectare(),
     )
-    val site2Subzone1 =
+    val site2Substratum1 =
         insertSubstratum(
             areaHa = BigDecimal(30),
             plantingCompletedTime = plantingCompletedDate2.atStartOfDay().toInstant(ZoneOffset.UTC),
         )
-    val subzone3plot1 = insertMonitoringPlot(permanentIndex = 1)
-    val subzone3plot1Hist = inserted.monitoringPlotHistoryId
+    val substratum3plot1 = insertMonitoringPlot(permanentIndex = 1)
+    val substratum3plot1Hist = inserted.monitoringPlotHistoryId
     insertPlotT0Density(
         speciesId = speciesId,
         plotDensity = BigDecimal.valueOf(65).toPlantsPerHectare(),
@@ -5862,7 +5862,7 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
         stratumDensity = BigDecimal.valueOf(310).toPlantsPerHectare(),
     )
     // Not counted towards hectares planted, outside of project site
-    val otherSiteSubzoneId =
+    val otherSiteSubstratumId =
         insertSubstratum(
             areaHa = BigDecimal(5000),
             plantingCompletedTime = plantingCompletedDate2.atStartOfDay().toInstant(ZoneOffset.UTC),
@@ -5880,49 +5880,49 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
 
     val allPlotsOldHist =
         mapOf(
-            subzone1plot1 to subzone1plot1OldHist,
-            subzone1plot2 to subzone1plot2OldHist,
+            substratum1plot1 to substratum1plot1OldHist,
+            substratum1plot2 to substratum1plot2OldHist,
             newlyPermanentPlot to newlyPermanentPlotOldHist,
             newlyTemporaryPlot to newlyTemporaryPlotOldHist,
-            incompleteSubzonePlot1 to incompleteSubzonePlot1OldHist,
-            futureSubzonePlot1 to futureSubzonePlot1OldHist,
-            plotNotInSubzone to plotNotInSubzoneOldHist,
+            incompleteSubstratumPlot1 to incompleteSubstratumPlot1OldHist,
+            futureSubstratumPlot1 to futureSubstratumPlot1OldHist,
+            plotNotInSubstratum to plotNotInSubstratumOldHist,
             previouslyObservedTempPlot to previouslyObservedTempPlotOldHist,
             reassignedPlot to reassignedPlotHist,
         )
     val allPlotsObs2 =
         mapOf(
             newlyPermanentPlot to newlyPermanentPlotHist,
-            incompleteSubzonePlot1 to incompleteSubzonePlot1Hist,
-            futureSubzonePlot1 to futureSubzonePlot1Hist,
+            incompleteSubstratumPlot1 to incompleteSubstratumPlot1Hist,
+            futureSubstratumPlot1 to futureSubstratumPlot1Hist,
         )
     val allPlots =
         mapOf(
-            subzone1plot1 to subzone1plot1Hist,
-            subzone1plot2 to subzone1plot2Hist,
+            substratum1plot1 to substratum1plot1Hist,
+            substratum1plot2 to substratum1plot2Hist,
             newlyPermanentPlot to newlyPermanentPlotHist,
-            incompleteSubzonePlot1 to incompleteSubzonePlot1Hist,
-            futureSubzonePlot1 to futureSubzonePlot1Hist,
+            incompleteSubstratumPlot1 to incompleteSubstratumPlot1Hist,
+            futureSubstratumPlot1 to futureSubstratumPlot1Hist,
             previouslyObservedTempPlot to previouslyObservedTempPlotOldHist,
-            subzone3plot1 to subzone3plot1Hist,
+            substratum3plot1 to substratum3plot1Hist,
             excludedPlot to excludedPlotHist,
         )
-    val site2plots = mapOf(subzone3plot1 to subzone3plot1Hist)
-    val allSubzonesInSite1 =
+    val site2plots = mapOf(substratum3plot1 to substratum3plot1Hist)
+    val allSubstrataInSite1 =
         listOf(
-            subzoneId1,
-            subzoneId2,
-            incompleteSubzone,
-            futureSubzone,
+            substratumId1,
+            substratumId2,
+            incompleteSubstratum,
+            futureSubstratum,
         )
-    val site1subzonesObservation2 =
+    val site1substrataObservation2 =
         listOf(
-            subzoneId2,
-            incompleteSubzone,
-            futureSubzone,
+            substratumId2,
+            incompleteSubstratum,
+            futureSubstratum,
         )
 
-    val tempPlots = listOf(subzone1plot2, previouslyObservedTempPlot)
+    val tempPlots = listOf(substratum1plot2, previouslyObservedTempPlot)
 
     val deliveryId =
         insertDelivery(
@@ -5931,7 +5931,7 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
         )
     insertPlanting(
         plantingSiteId = plantingSiteId1,
-        substratumId = subzoneId1,
+        substratumId = substratumId1,
         deliveryId = deliveryId,
         numPlants = 27, // This should match up with the number of seedlings withdrawn
     )
@@ -5944,7 +5944,7 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
         )
     insertPlanting(
         plantingSiteId = plantingSiteId1,
-        substratumId = subzoneId1,
+        substratumId = substratumId1,
         deliveryId = undoneDeliveryId,
         numPlants = 200,
     )
@@ -5955,7 +5955,7 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
         )
     insertPlanting(
         plantingSiteId = plantingSiteId1,
-        substratumId = subzoneId1,
+        substratumId = substratumId1,
         plantingTypeId = PlantingType.Undo,
         deliveryId = undoDeliveryId,
         numPlants = -200,
@@ -5969,7 +5969,7 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
         )
     insertPlanting(
         plantingSiteId = otherPlantingSiteId,
-        substratumId = otherSiteSubzoneId,
+        substratumId = otherSiteSubstratumId,
         deliveryId = otherDeliveryId,
         numPlants = 6,
     )
@@ -5982,7 +5982,7 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
         )
     insertPlanting(
         plantingSiteId = plantingSiteId1,
-        substratumId = subzoneId1,
+        substratumId = substratumId1,
         deliveryId = futureDeliveryId,
         numPlants = 9,
     )
@@ -6005,10 +6005,10 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
           completedTime = observationTime,
       )
     }
-    allSubzonesInSite1.forEach { insertObservationRequestedSubstratum(substratumId = it) }
+    allSubstrataInSite1.forEach { insertObservationRequestedSubstratum(substratumId = it) }
     insertObservedSubstratumSpeciesTotals(
         observationId = site1OldObservationId,
-        substratumId = subzoneId1,
+        substratumId = substratumId1,
         certainty = RecordedSpeciesCertainty.Known,
         speciesId = speciesId,
         permanentLive = 6,
@@ -6020,13 +6020,14 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
         certainty = RecordedSpeciesCertainty.Known,
         speciesId = speciesId,
         permanentLive = 6,
-        // total live at a site level can be lower than subzone level because of disjoint subzones
-        // set this to 0 to ensure that tests use subzone level for temp plots in survival rates
+        // total live at a site level can be lower than substratum level because of disjoint
+        // substrata
+        // set this to 0 to ensure that tests use substratum level for temp plots in survival rates
         totalLive = 0,
     )
     insertObservedSubstratumSpeciesTotals(
         observationId = site1OldObservationId,
-        substratumId = subzoneId1,
+        substratumId = substratumId1,
         certainty = RecordedSpeciesCertainty.Known,
         speciesId = otherSpeciesId,
         permanentLive = 11,
@@ -6042,7 +6043,7 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
     )
     insertObservedSubstratumSpeciesTotals(
         observationId = site1OldObservationId,
-        substratumId = subzoneId1,
+        substratumId = substratumId1,
         certainty = RecordedSpeciesCertainty.Other,
         speciesName = "Other",
         permanentLive = 6,
@@ -6072,10 +6073,10 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
           completedTime = observationTime,
       )
     }
-    site1subzonesObservation2.forEach { insertObservationRequestedSubstratum(substratumId = it) }
+    site1substrataObservation2.forEach { insertObservationRequestedSubstratum(substratumId = it) }
     insertObservedSubstratumSpeciesTotals(
         observationId = site1observation2,
-        substratumId = subzoneId1,
+        substratumId = substratumId1,
         certainty = RecordedSpeciesCertainty.Known,
         speciesId = speciesId,
         permanentLive = 6,
@@ -6091,7 +6092,7 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
     )
     insertObservedSubstratumSpeciesTotals(
         observationId = site1observation2,
-        substratumId = subzoneId1,
+        substratumId = substratumId1,
         certainty = RecordedSpeciesCertainty.Known,
         speciesId = otherSpeciesId,
         permanentLive = 11,
@@ -6107,7 +6108,7 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
     )
     insertObservedSubstratumSpeciesTotals(
         observationId = site1observation2,
-        substratumId = subzoneId1,
+        substratumId = substratumId1,
         certainty = RecordedSpeciesCertainty.Other,
         speciesName = "Other",
         permanentLive = 6,
@@ -6124,7 +6125,7 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
     // Unknown plants are not counted towards survival rates
     insertObservedSubstratumSpeciesTotals(
         observationId = site1observation2,
-        substratumId = subzoneId1,
+        substratumId = substratumId1,
         certainty = RecordedSpeciesCertainty.Unknown,
         permanentLive = 0,
         totalLive = 0,
@@ -6146,7 +6147,7 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
             state = ObservationState.Completed,
             completedTime = futureObservationDate.atStartOfDay().toInstant(ZoneOffset.UTC),
         )
-    site1subzonesObservation2.forEach { insertObservationRequestedSubstratum(substratumId = it) }
+    site1substrataObservation2.forEach { insertObservationRequestedSubstratum(substratumId = it) }
     allPlots.forEach { (plotId, histId) ->
       insertObservationPlot(
           monitoringPlotId = plotId,
@@ -6157,7 +6158,7 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
     }
     insertObservedSubstratumSpeciesTotals(
         observationId = site1FutureObservationId,
-        substratumId = subzoneId1,
+        substratumId = substratumId1,
         certainty = RecordedSpeciesCertainty.Known,
         speciesId = otherSpeciesId,
         permanentLive = 12,
@@ -6173,7 +6174,7 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
     )
     insertObservedSubstratumSpeciesTotals(
         observationId = site1FutureObservationId,
-        substratumId = subzoneId1,
+        substratumId = substratumId1,
         certainty = RecordedSpeciesCertainty.Known,
         speciesId = speciesId,
         permanentLive = 7,
@@ -6189,7 +6190,7 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
     )
     insertObservedSubstratumSpeciesTotals(
         observationId = site1FutureObservationId,
-        substratumId = subzoneId1,
+        substratumId = substratumId1,
         certainty = RecordedSpeciesCertainty.Other,
         speciesName = "Other",
         permanentLive = 7,
@@ -6206,7 +6207,7 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
     // Unknown plants are not counted towards survival rate
     insertObservedSubstratumSpeciesTotals(
         observationId = site1FutureObservationId,
-        substratumId = subzoneId1,
+        substratumId = substratumId1,
         certainty = RecordedSpeciesCertainty.Unknown,
         permanentLive = 1,
         totalLive = 1,
@@ -6236,10 +6237,10 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
           completedTime = site2ObservationTime,
       )
     }
-    insertObservationRequestedSubstratum(substratumId = site2Subzone1)
+    insertObservationRequestedSubstratum(substratumId = site2Substratum1)
     insertObservedSubstratumSpeciesTotals(
         observationId = site2ObservationId,
-        substratumId = site2Subzone1,
+        substratumId = site2Substratum1,
         certainty = RecordedSpeciesCertainty.Known,
         speciesId = speciesId,
         permanentLive = 7,
@@ -6273,10 +6274,10 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
           completedTime = observationTime,
       )
     }
-    insertObservationRequestedSubstratum(substratumId = otherSiteSubzoneId)
+    insertObservationRequestedSubstratum(substratumId = otherSiteSubstratumId)
     insertObservedSubstratumSpeciesTotals(
         observationId = otherSiteObservationId,
-        substratumId = otherSiteSubzoneId,
+        substratumId = otherSiteSubstratumId,
         certainty = RecordedSpeciesCertainty.Known,
         speciesId = speciesId,
         permanentLive = 0,
@@ -6361,7 +6362,7 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
     val site3Substratum1History = inserted.substratumHistoryId
     val site3perm1 = insertMonitoringPlot(permanentIndex = 1) // missing plot t0
     val site3perm1Hist = inserted.monitoringPlotHistoryId
-    val site3temp1 = insertMonitoringPlot(permanentIndex = null) // missing zone t0
+    val site3temp1 = insertMonitoringPlot(permanentIndex = null) // missing stratum t0
     val site3temp1Hist = inserted.monitoringPlotHistoryId
     insertStratum()
     insertStratumT0TempDensity(stratumDensity = BigDecimal.valueOf(100).toPlantsPerHectare())

--- a/src/test/kotlin/com/terraformation/backend/daily/PlantingSeasonSchedulerTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/daily/PlantingSeasonSchedulerTest.kt
@@ -69,7 +69,7 @@ class PlantingSeasonSchedulerTest : DatabaseTest(), RunsAsUser {
   inner class FirstPlantingSeasonNotification {
     @Test
     fun `sends reminders after correct numbers of weeks have passed since site creation`() {
-      val plantingSiteId = insertPlantingSiteWithSubzone()
+      val plantingSiteId = insertPlantingSiteWithSubstratum()
 
       assertEventsAtWeekNumber(0, PlantingSeasonNotScheduledNotificationEvent(plantingSiteId, 1))
       assertEventsAtWeekNumber(4, PlantingSeasonNotScheduledNotificationEvent(plantingSiteId, 2))
@@ -85,7 +85,7 @@ class PlantingSeasonSchedulerTest : DatabaseTest(), RunsAsUser {
 
     @Test
     fun `does not send multiple reminders if several reminder deadlines have passed`() {
-      val plantingSiteId = insertPlantingSiteWithSubzone()
+      val plantingSiteId = insertPlantingSiteWithSubstratum()
 
       clock.instant = initialDate.plusWeeks(52).toInstant(timeZone)
       scheduler.transitionPlantingSeasons()
@@ -103,7 +103,7 @@ class PlantingSeasonSchedulerTest : DatabaseTest(), RunsAsUser {
     }
 
     @Test
-    fun `does not send reminders about sites without subzones`() {
+    fun `does not send reminders about sites without substrata`() {
       insertPlantingSite(createdTime = initialInstant)
 
       assertNoEventsAtWeekNumber(52)
@@ -111,7 +111,7 @@ class PlantingSeasonSchedulerTest : DatabaseTest(), RunsAsUser {
 
     @Test
     fun `sends reminders about partially-planted sites`() {
-      val plantingSiteId = insertPlantingSiteWithSubzone()
+      val plantingSiteId = insertPlantingSiteWithSubstratum()
       insertSubstratum(plantingCompletedTime = initialInstant)
 
       assertEventsAtWeekNumber(0, PlantingSeasonNotScheduledNotificationEvent(plantingSiteId, 1))
@@ -131,7 +131,7 @@ class PlantingSeasonSchedulerTest : DatabaseTest(), RunsAsUser {
     @Test
     fun `sends support notifications for accelerator planting sites`() {
       insertProject(phase = AcceleratorPhase.Phase2PlanAndScale)
-      val plantingSiteId = insertPlantingSiteWithSubzone(inserted.projectId)
+      val plantingSiteId = insertPlantingSiteWithSubstratum(inserted.projectId)
 
       assertNoEventsBeforeWeekNumber(
           6,
@@ -192,8 +192,8 @@ class PlantingSeasonSchedulerTest : DatabaseTest(), RunsAsUser {
     }
 
     @Test
-    fun `does not send reminders about sites without subzones`() {
-      insertPlantingSiteWithSeason(subzone = false)
+    fun `does not send reminders about sites without substrata`() {
+      insertPlantingSiteWithSeason(substratum = false)
 
       assertNoEventsAtWeekNumber(52)
     }
@@ -277,7 +277,7 @@ class PlantingSeasonSchedulerTest : DatabaseTest(), RunsAsUser {
     eventPublisher.assertNoEventsPublished("Sent duplicate $weeks-weeks notification")
   }
 
-  private fun insertPlantingSiteWithSubzone(projectId: ProjectId? = null): PlantingSiteId {
+  private fun insertPlantingSiteWithSubstratum(projectId: ProjectId? = null): PlantingSiteId {
     val plantingSiteId = insertPlantingSite(createdTime = clock.instant, projectId = projectId)
     insertStratum()
     insertSubstratum()
@@ -286,12 +286,12 @@ class PlantingSeasonSchedulerTest : DatabaseTest(), RunsAsUser {
   }
 
   private fun insertPlantingSiteWithSeason(
-      subzone: Boolean = true,
+      substratum: Boolean = true,
       projectId: ProjectId? = null,
   ): PlantingSiteId {
     val plantingSiteId =
-        if (subzone) {
-          insertPlantingSiteWithSubzone(projectId)
+        if (substratum) {
+          insertPlantingSiteWithSubstratum(projectId)
         } else {
           insertPlantingSite(createdTime = clock.instant, projectId = projectId)
         }

--- a/src/test/kotlin/com/terraformation/backend/notification/NotificationServiceEmailTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/notification/NotificationServiceEmailTest.kt
@@ -348,25 +348,25 @@ internal class NotificationServiceEmailTest {
           sizeMeters = 30,
           elevationMeters = BigDecimal.ONE,
       )
-  private val plantingSubzone =
+  private val substratum =
       SubstratumModel(
           id = SubstratumId(1),
           areaHa = BigDecimal.ONE,
           boundary = multiPolygon(1),
-          name = "My Zone",
-          fullName = "My Zone",
-          stableId = StableId("stableSubzone"),
+          name = "My Stratum",
+          fullName = "My Stratum",
+          stableId = StableId("stableSubstratum"),
           monitoringPlots = listOf(monitoringPlot),
       )
-  private val plantingZone =
+  private val stratum =
       StratumModel(
           id = StratumId(1),
           areaHa = BigDecimal.ONE,
           boundary = multiPolygon(1),
           boundaryModifiedTime = Instant.EPOCH,
-          name = "My Zone",
-          stableId = StableId("stableZone"),
-          substrata = listOf(plantingSubzone),
+          name = "My Stratum",
+          stableId = StableId("stableStratum"),
+          substrata = listOf(substratum),
       )
 
   private val plantingSite =
@@ -376,7 +376,7 @@ internal class NotificationServiceEmailTest {
           id = PlantingSiteId(1),
           organizationId = organization.id,
           name = "My Site",
-          strata = listOf(plantingZone),
+          strata = listOf(stratum),
           timeZone = ZoneId.of("Asia/Tokyo"),
       )
   private val project =
@@ -1439,8 +1439,8 @@ internal class NotificationServiceEmailTest {
             strata =
                 listOf(
                     StratumT0DensityChangedEventModel(
-                        plantingZone.id,
-                        stratumName = "This Zone",
+                        stratum.id,
+                        stratumName = "This Stratum",
                         speciesDensityChanges =
                             listOf(
                                 SpeciesDensityChangedEventModel(
@@ -1463,7 +1463,7 @@ internal class NotificationServiceEmailTest {
     assertBodyContains(species.scientificName, message = message)
     assertBodyContains("10.123", message = message)
     assertBodyContains("20.456", message = message)
-    assertBodyContains("This Zone:", message = message)
+    assertBodyContains("This Stratum:", message = message)
     assertBodyContains("OtherSpecies", message = message)
     assertBodyContains("100.5", message = message)
     assertBodyContains("200.6", message = message)
@@ -1550,7 +1550,7 @@ internal class NotificationServiceEmailTest {
   }
 
   @Test
-  fun `rateLimitedT0DataAssignedEvent doesn't send if no species changes in plots or zones`() {
+  fun `rateLimitedT0DataAssignedEvent doesn't send if no species changes in plots or strata`() {
     service.on(
         RateLimitedT0DataAssignedEvent(
             organizationId = organization.id,
@@ -1571,8 +1571,8 @@ internal class NotificationServiceEmailTest {
             strata =
                 listOf(
                     StratumT0DensityChangedEventModel(
-                        plantingZone.id,
-                        stratumName = plantingZone.name,
+                        stratum.id,
+                        stratumName = stratum.name,
                         speciesDensityChanges = emptyList(),
                     ),
                     StratumT0DensityChangedEventModel(
@@ -1588,7 +1588,7 @@ internal class NotificationServiceEmailTest {
   }
 
   @Test
-  fun `rateLimitedT0DataAssignedEvent doesn't send if no species changes in zones`() {
+  fun `rateLimitedT0DataAssignedEvent doesn't send if no species changes in strata`() {
     service.on(
         RateLimitedT0DataAssignedEvent(
             organizationId = organization.id,
@@ -1597,8 +1597,8 @@ internal class NotificationServiceEmailTest {
             strata =
                 listOf(
                     StratumT0DensityChangedEventModel(
-                        plantingZone.id,
-                        stratumName = plantingZone.name,
+                        stratum.id,
+                        stratumName = stratum.name,
                         speciesDensityChanges = emptyList(),
                     ),
                     StratumT0DensityChangedEventModel(
@@ -1614,7 +1614,7 @@ internal class NotificationServiceEmailTest {
   }
 
   @Test
-  fun `rateLimitedT0DataAssignedEvent doesn't send if no plots or zones`() {
+  fun `rateLimitedT0DataAssignedEvent doesn't send if no plots or strata`() {
     service.on(
         RateLimitedT0DataAssignedEvent(
             organizationId = organization.id,

--- a/src/test/kotlin/com/terraformation/backend/species/db/SpeciesStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/species/db/SpeciesStoreTest.kt
@@ -531,9 +531,9 @@ internal class SpeciesStoreTest : DatabaseTest(), RunsAsUser {
   }
 
   @Nested
-  inner class FetchSiteSpeciesByPlantingSubzoneId {
+  inner class FetchSiteSpeciesBySubstratumId {
     @Test
-    fun `returns species planted across entire site, not just requested subzone`() {
+    fun `returns species planted across entire site, not just requested substratum`() {
       val speciesId1 = insertSpecies(scientificName = "Species 1")
       val speciesId2 = insertSpecies(scientificName = "Species 2", commonName = "Common 2")
       val speciesId3 = insertSpecies(scientificName = "Species 3")
@@ -545,7 +545,7 @@ internal class SpeciesStoreTest : DatabaseTest(), RunsAsUser {
       insertPlantingSite()
       insertStratum()
 
-      val subzoneId = insertSubstratum()
+      val substratumId = insertSubstratum()
       insertNurseryWithdrawal()
       insertDelivery()
       insertPlanting(speciesId = speciesId1)
@@ -570,7 +570,7 @@ internal class SpeciesStoreTest : DatabaseTest(), RunsAsUser {
       insertDelivery()
       insertPlanting(speciesId = speciesId5)
 
-      every { user.canReadSubstratum(subzoneId) } returns true
+      every { user.canReadSubstratum(substratumId) } returns true
 
       val expected =
           listOf(
@@ -601,7 +601,7 @@ internal class SpeciesStoreTest : DatabaseTest(), RunsAsUser {
               ),
           )
 
-      val actual = store.fetchSiteSpeciesBySubstratumId(subzoneId)
+      val actual = store.fetchSiteSpeciesBySubstratumId(substratumId)
 
       assertEquals(expected, actual)
     }
@@ -616,7 +616,7 @@ internal class SpeciesStoreTest : DatabaseTest(), RunsAsUser {
       insertFacility(type = FacilityType.Nursery)
       insertPlantingSite(x = 0)
       insertStratum()
-      val subzoneId = insertSubstratum()
+      val substratumId = insertSubstratum()
       insertMonitoringPlot()
 
       insertNurseryWithdrawal()
@@ -642,7 +642,7 @@ internal class SpeciesStoreTest : DatabaseTest(), RunsAsUser {
             .insert()
       }
 
-      every { user.canReadSubstratum(subzoneId) } returns true
+      every { user.canReadSubstratum(substratumId) } returns true
 
       val expected =
           listOf(
@@ -672,20 +672,22 @@ internal class SpeciesStoreTest : DatabaseTest(), RunsAsUser {
               ),
           )
 
-      val actual = store.fetchSiteSpeciesBySubstratumId(subzoneId)
+      val actual = store.fetchSiteSpeciesBySubstratumId(substratumId)
 
       assertEquals(expected, actual)
     }
 
     @Test
-    fun `throws exception if no permission to read subzone`() {
+    fun `throws exception if no permission to read substratum`() {
       insertPlantingSite()
       insertStratum()
-      val subzoneId = insertSubstratum()
+      val substratumId = insertSubstratum()
 
-      every { user.canReadSubstratum(subzoneId) } returns false
+      every { user.canReadSubstratum(substratumId) } returns false
 
-      assertThrows<SubstratumNotFoundException> { store.fetchSiteSpeciesBySubstratumId(subzoneId) }
+      assertThrows<SubstratumNotFoundException> {
+        store.fetchSiteSpeciesBySubstratumId(substratumId)
+      }
     }
   }
 

--- a/src/test/kotlin/com/terraformation/backend/tracking/TrackingSearchTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/TrackingSearchTest.kt
@@ -52,9 +52,9 @@ class TrackingSearchTest : DatabaseTest(), RunsAsUser {
     val projectId = insertProject(name = "Project 1", description = "Project 1 description")
     val plantingSiteGeometry = multiPolygon(3.0)
     val exclusionGeometry = multiPolygon(0.5)
-    val plantingZoneGeometry = multiPolygon(2.0)
-    val plantingSubzoneGeometry3 = multiPolygon(1.0)
-    val plantingSubzoneGeometry4 = multiPolygon(1.0)
+    val stratumGeometry = multiPolygon(2.0)
+    val substratumGeometry3 = multiPolygon(1.0)
+    val substratumGeometry4 = multiPolygon(1.0)
     val monitoringPlotGeometry5 = polygon(5, 6, 7, 8)
     val monitoringPlotGeometry6 = polygon(6, 7, 8, 9)
     val monitoringPlotGeometry7 = polygon(7, 8, 9, 10)
@@ -81,17 +81,17 @@ class TrackingSearchTest : DatabaseTest(), RunsAsUser {
             endDate = LocalDate.of(1970, 6, 5),
         )
 
-    val plantingZoneId2 = insertStratum(boundary = plantingZoneGeometry, name = "S2")
-    val plantingZoneHistoryId2 = inserted.stratumHistoryId
+    val stratumId2 = insertStratum(boundary = stratumGeometry, name = "S2")
+    val stratumHistoryId2 = inserted.stratumHistoryId
 
-    val plantingSubzoneId3 =
+    val substratumId3 =
         insertSubstratum(
-            boundary = plantingSubzoneGeometry3,
+            boundary = substratumGeometry3,
             name = "3",
             observedTime = Instant.ofEpochSecond(1),
             stableId = "3",
         )
-    val plantingSubzoneHistoryId3 = inserted.substratumHistoryId
+    val substratumHistoryId3 = inserted.substratumHistoryId
 
     val monitoringPlotId5 = insertMonitoringPlot(boundary = monitoringPlotGeometry5)
     val monitoringPlotHistoryId5 = inserted.monitoringPlotHistoryId
@@ -99,14 +99,14 @@ class TrackingSearchTest : DatabaseTest(), RunsAsUser {
     val monitoringPlotId6 = insertMonitoringPlot(boundary = monitoringPlotGeometry6)
     val monitoringPlotHistoryId6 = inserted.monitoringPlotHistoryId
 
-    val plantingSubzoneId4 =
+    val substratumId4 =
         insertSubstratum(
-            boundary = plantingSubzoneGeometry4,
+            boundary = substratumGeometry4,
             plantingCompletedTime = Instant.ofEpochSecond(1),
             name = "4",
             stableId = "4",
         )
-    val plantingSubzoneHistoryId4 = inserted.substratumHistoryId
+    val substratumHistoryId4 = inserted.substratumHistoryId
 
     val monitoringPlotId7 = insertMonitoringPlot(boundary = monitoringPlotGeometry7)
     val monitoringPlotHistoryId7 = inserted.monitoringPlotHistoryId
@@ -130,7 +130,7 @@ class TrackingSearchTest : DatabaseTest(), RunsAsUser {
     val plantingId1 =
         insertPlanting(
             numPlants = 1,
-            substratumId = plantingSubzoneId3,
+            substratumId = substratumId3,
             speciesId = speciesId1,
         )
 
@@ -138,27 +138,27 @@ class TrackingSearchTest : DatabaseTest(), RunsAsUser {
         insertPlanting(
             numPlants = -2,
             plantingTypeId = PlantingType.ReassignmentFrom,
-            substratumId = plantingSubzoneId3,
+            substratumId = substratumId3,
             speciesId = speciesId1,
         )
     val plantingId4 =
         insertPlanting(
             numPlants = 2,
             plantingTypeId = PlantingType.ReassignmentTo,
-            substratumId = plantingSubzoneId4,
+            substratumId = substratumId4,
             speciesId = speciesId1,
         )
     val plantingId5 =
         insertPlanting(
             numPlants = 8,
-            substratumId = plantingSubzoneId4,
+            substratumId = substratumId4,
             speciesId = speciesId2,
         )
     val deliveryId2 = insertDelivery(plantingSiteId = plantingSiteId)
     val plantingId2 =
         insertPlanting(
             numPlants = 4,
-            substratumId = plantingSubzoneId3,
+            substratumId = substratumId3,
             speciesId = speciesId1,
         )
 
@@ -166,11 +166,11 @@ class TrackingSearchTest : DatabaseTest(), RunsAsUser {
     // searches are querying the right columns from the right tables.
     insertPlantingSitePopulation(plantingSiteId, speciesId1, 2, 1)
     insertPlantingSitePopulation(plantingSiteId, speciesId2, 4, 3)
-    insertStratumPopulation(plantingZoneId2, speciesId1, 6, 5)
-    insertStratumPopulation(plantingZoneId2, speciesId2, 8, 7)
-    insertSubstratumPopulation(plantingSubzoneId3, speciesId1, 10, 9)
-    insertSubstratumPopulation(plantingSubzoneId4, speciesId1, 12, 11)
-    insertSubstratumPopulation(plantingSubzoneId4, speciesId2, 14, 13)
+    insertStratumPopulation(stratumId2, speciesId1, 6, 5)
+    insertStratumPopulation(stratumId2, speciesId2, 8, 7)
+    insertSubstratumPopulation(substratumId3, speciesId1, 10, 9)
+    insertSubstratumPopulation(substratumId4, speciesId1, 12, 11)
+    insertSubstratumPopulation(substratumId4, speciesId2, 14, 13)
 
     val observationId1 =
         insertObservation(
@@ -263,8 +263,8 @@ class TrackingSearchTest : DatabaseTest(), RunsAsUser {
     )
     insertObservationStratumResult(
         observationId = observationId1,
-        stratumId = plantingZoneId2,
-        stratumHistoryId = plantingZoneHistoryId2,
+        stratumId = stratumId2,
+        stratumHistoryId = stratumHistoryId2,
         totalLive = 11,
         totalDead = 2,
         totalExisting = 3,
@@ -276,8 +276,8 @@ class TrackingSearchTest : DatabaseTest(), RunsAsUser {
     )
     insertObservationSubstratumResult(
         observationId = observationId1,
-        substratumId = plantingSubzoneId3,
-        substratumHistoryId = plantingSubzoneHistoryId3,
+        substratumId = substratumId3,
+        substratumHistoryId = substratumHistoryId3,
         totalLive = 7,
         totalDead = 1,
         totalExisting = 2,
@@ -466,7 +466,7 @@ class TrackingSearchTest : DatabaseTest(), RunsAsUser {
                                             "permanentLive" to "6",
                                             "plantDensity" to "110",
                                             "plantDensityStdDev" to "5",
-                                            "stratum" to mapOf("id" to "$plantingZoneId2"),
+                                            "stratum" to mapOf("id" to "$stratumId2"),
                                             "survivalRate" to "80",
                                             "survivalRateStdDev" to "4",
                                             "totalDead" to "2",
@@ -480,7 +480,7 @@ class TrackingSearchTest : DatabaseTest(), RunsAsUser {
                                             "permanentLive" to "4",
                                             "plantDensity" to "90",
                                             "plantDensityStdDev" to "3",
-                                            "substratum" to mapOf("id" to "$plantingSubzoneId3"),
+                                            "substratum" to mapOf("id" to "$substratumId3"),
                                             "survivalRate" to "75",
                                             "survivalRateStdDev" to "2",
                                             "totalDead" to "1",
@@ -605,26 +605,24 @@ class TrackingSearchTest : DatabaseTest(), RunsAsUser {
                     "strata" to
                         listOf(
                             mapOf(
-                                "boundary" to postgisRenderGeoJson(plantingZoneGeometry),
+                                "boundary" to postgisRenderGeoJson(stratumGeometry),
                                 "boundaryModifiedTime" to "1970-01-01T00:00:00Z",
                                 "createdTime" to "1970-01-01T00:00:00Z",
                                 "histories" to
                                     listOf(
                                         mapOf(
-                                            "boundary" to
-                                                postgisRenderGeoJson(plantingZoneGeometry),
-                                            "id" to "$plantingZoneHistoryId2",
+                                            "boundary" to postgisRenderGeoJson(stratumGeometry),
+                                            "id" to "$stratumHistoryId2",
                                             "name" to "S2",
                                         ),
                                     ),
-                                "id" to "$plantingZoneId2",
+                                "id" to "$stratumId2",
                                 "modifiedTime" to "1970-01-01T00:00:00Z",
                                 "name" to "S2",
                                 "substrata" to
                                     listOf(
                                         mapOf(
-                                            "boundary" to
-                                                postgisRenderGeoJson(plantingSubzoneGeometry3),
+                                            "boundary" to postgisRenderGeoJson(substratumGeometry3),
                                             "createdTime" to "1970-01-01T00:00:00Z",
                                             "fullName" to "S2-3",
                                             "histories" to
@@ -632,15 +630,15 @@ class TrackingSearchTest : DatabaseTest(), RunsAsUser {
                                                     mapOf(
                                                         "boundary" to
                                                             postgisRenderGeoJson(
-                                                                plantingSubzoneGeometry3,
+                                                                substratumGeometry3,
                                                             ),
                                                         "fullName" to "S2-3",
-                                                        "id" to "$plantingSubzoneHistoryId3",
+                                                        "id" to "$substratumHistoryId3",
                                                         "name" to "3",
                                                         "stableId" to "3",
                                                     ),
                                                 ),
-                                            "id" to "$plantingSubzoneId3",
+                                            "id" to "$substratumId3",
                                             "modifiedTime" to "1970-01-01T00:00:00Z",
                                             "name" to "3",
                                             "observedTime" to "1970-01-01T00:00:01Z",
@@ -702,8 +700,7 @@ class TrackingSearchTest : DatabaseTest(), RunsAsUser {
                                                 ),
                                         ),
                                         mapOf(
-                                            "boundary" to
-                                                postgisRenderGeoJson(plantingSubzoneGeometry4),
+                                            "boundary" to postgisRenderGeoJson(substratumGeometry4),
                                             "createdTime" to "1970-01-01T00:00:00Z",
                                             "fullName" to "S2-4",
                                             "histories" to
@@ -711,15 +708,15 @@ class TrackingSearchTest : DatabaseTest(), RunsAsUser {
                                                     mapOf(
                                                         "boundary" to
                                                             postgisRenderGeoJson(
-                                                                plantingSubzoneGeometry4,
+                                                                substratumGeometry4,
                                                             ),
                                                         "fullName" to "S2-4",
-                                                        "id" to "$plantingSubzoneHistoryId4",
+                                                        "id" to "$substratumHistoryId4",
                                                         "name" to "4",
                                                         "stableId" to "4",
                                                     ),
                                                 ),
-                                            "id" to "$plantingSubzoneId4",
+                                            "id" to "$substratumId4",
                                             "modifiedTime" to "1970-01-01T00:00:00Z",
                                             "name" to "4",
                                             "plantingCompletedTime" to "1970-01-01T00:00:01Z",


### PR DESCRIPTION
Not sure if this was from merge conflicts or what, but there were some leftover test variables still referencing zones. Update these to strata.

Updates to Observation related tests will be in a separate PR since those require updating google sheets and many csv's.