### PR TITLE
SW-8376 Publish observation-specific activity data

### DIFF
--- a/jooq/src/main/kotlin/com/terraformation/backend/jooq/Config.kt
+++ b/jooq/src/main/kotlin/com/terraformation/backend/jooq/Config.kt
@@ -285,10 +285,19 @@ val ENUM_TABLES =
                 ),
                 EnumTable(
                     "observation_media_types",
-                    listOf("observation_media_files\\.type_id"),
+                    listOf(
+                        "observation_media_files\\.type_id",
+                        "funder\\.published_activity_observation_media_files\\.type_id",
+                    ),
                     isLocalizable = false,
                 ),
-                EnumTable("observation_plot_positions", listOf("tracking\\..*\\.position_id")),
+                EnumTable(
+                    "observation_plot_positions",
+                    listOf(
+                        "tracking\\..*\\.position_id",
+                        "funder\\.published_activity_observation_media_files\\.position_id",
+                    ),
+                ),
                 EnumTable(
                     "observation_plot_statuses",
                     listOf("observation_plots\\.status_id"),

--- a/src/main/kotlin/com/terraformation/backend/funder/db/PublishedActivityStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/funder/db/PublishedActivityStore.kt
@@ -8,6 +8,7 @@ import com.terraformation.backend.db.accelerator.ActivityId
 import com.terraformation.backend.db.accelerator.ActivityStatus
 import com.terraformation.backend.db.accelerator.tables.references.ACTIVITIES
 import com.terraformation.backend.db.accelerator.tables.references.ACTIVITY_MEDIA_FILES
+import com.terraformation.backend.db.accelerator.tables.references.ACTIVITY_OBSERVATIONS
 import com.terraformation.backend.db.asNonNullable
 import com.terraformation.backend.db.default_schema.FileId
 import com.terraformation.backend.db.default_schema.OrganizationId
@@ -16,6 +17,10 @@ import com.terraformation.backend.db.default_schema.tables.references.FILES
 import com.terraformation.backend.db.forMultiset
 import com.terraformation.backend.db.funder.tables.references.PUBLISHED_ACTIVITIES
 import com.terraformation.backend.db.funder.tables.references.PUBLISHED_ACTIVITY_MEDIA_FILES
+import com.terraformation.backend.db.funder.tables.references.PUBLISHED_ACTIVITY_OBSERVATIONS
+import com.terraformation.backend.db.funder.tables.references.PUBLISHED_ACTIVITY_OBSERVATION_MEDIA_FILES
+import com.terraformation.backend.db.tracking.tables.references.OBSERVATION_MEDIA_FILES
+import com.terraformation.backend.db.tracking.tables.references.OBSERVATION_SITE_RESULTS
 import com.terraformation.backend.file.event.FileReferenceDeletedEvent
 import com.terraformation.backend.funder.model.PublishedActivityMediaModel
 import com.terraformation.backend.funder.model.PublishedActivityModel
@@ -188,6 +193,40 @@ class PublishedActivityStore(
           .set(PUBLISHED_TIME, DSL.excluded(PUBLISHED_TIME))
           .execute()
     }
+
+    with(PUBLISHED_ACTIVITY_OBSERVATIONS) {
+      dslContext
+          .insertInto(
+              PUBLISHED_ACTIVITY_OBSERVATIONS,
+              ACTIVITY_ID,
+              OBSERVATION_ID,
+              LIVE_PLANTS,
+              PLANT_DENSITY,
+              SURVIVAL_RATE,
+          )
+          .select(
+              DSL.select(
+                      ACTIVITY_OBSERVATIONS.ACTIVITY_ID,
+                      ACTIVITY_OBSERVATIONS.OBSERVATION_ID,
+                      OBSERVATION_SITE_RESULTS.TOTAL_LIVE,
+                      OBSERVATION_SITE_RESULTS.PLANT_DENSITY,
+                      OBSERVATION_SITE_RESULTS.SURVIVAL_RATE,
+                  )
+                  .from(ACTIVITY_OBSERVATIONS)
+                  .leftJoin(OBSERVATION_SITE_RESULTS)
+                  .on(
+                      ACTIVITY_OBSERVATIONS.OBSERVATION_ID.eq(
+                          OBSERVATION_SITE_RESULTS.OBSERVATION_ID
+                      )
+                  )
+                  .where(ACTIVITY_OBSERVATIONS.ACTIVITY_ID.eq(activityId))
+          )
+          .onDuplicateKeyUpdate()
+          .set(LIVE_PLANTS, DSL.excluded(LIVE_PLANTS))
+          .set(PLANT_DENSITY, DSL.excluded(PLANT_DENSITY))
+          .set(SURVIVAL_RATE, DSL.excluded(SURVIVAL_RATE))
+          .execute()
+    }
   }
 
   /**
@@ -240,6 +279,34 @@ class PublishedActivityStore(
           .set(IS_COVER_PHOTO, DSL.excluded(IS_COVER_PHOTO))
           .set(IS_HIDDEN_ON_MAP, DSL.excluded(IS_HIDDEN_ON_MAP))
           .set(LIST_POSITION, DSL.excluded(LIST_POSITION))
+          .execute()
+    }
+
+    with(PUBLISHED_ACTIVITY_OBSERVATION_MEDIA_FILES) {
+      dslContext
+          .insertInto(
+              PUBLISHED_ACTIVITY_OBSERVATION_MEDIA_FILES,
+              ACTIVITY_ID,
+              FILE_ID,
+              MONITORING_PLOT_ID,
+              POSITION_ID,
+              TYPE_ID,
+          )
+          .select(
+              DSL.select(
+                      ACTIVITY_MEDIA_FILES.ACTIVITY_ID,
+                      ACTIVITY_MEDIA_FILES.FILE_ID,
+                      OBSERVATION_MEDIA_FILES.MONITORING_PLOT_ID,
+                      OBSERVATION_MEDIA_FILES.POSITION_ID,
+                      OBSERVATION_MEDIA_FILES.TYPE_ID,
+                  )
+                  .from(ACTIVITY_MEDIA_FILES)
+                  .join(OBSERVATION_MEDIA_FILES)
+                  .on(ACTIVITY_MEDIA_FILES.FILE_ID.eq(OBSERVATION_MEDIA_FILES.FILE_ID))
+                  .where(ACTIVITY_MEDIA_FILES.ACTIVITY_ID.eq(activityId))
+          )
+          .onConflict(FILE_ID)
+          .doNothing() // None of the properties is editable, so no point updating them.
           .execute()
     }
   }

--- a/src/main/resources/db/migration/0450/V486__PublishedActivityObservationMediaFiles.sql
+++ b/src/main/resources/db/migration/0450/V486__PublishedActivityObservationMediaFiles.sql
@@ -1,0 +1,10 @@
+CREATE TABLE funder.published_activity_observation_media_files (
+    file_id BIGINT PRIMARY KEY REFERENCES files,
+    activity_id BIGINT NOT NULL REFERENCES funder.published_activities,
+    monitoring_plot_id BIGINT NOT NULL REFERENCES tracking.monitoring_plots,
+    position_id INTEGER REFERENCES tracking.observation_plot_positions,
+    type_id INTEGER NOT NULL REFERENCES tracking.observation_media_types
+);
+
+CREATE INDEX ON funder.published_activity_observation_media_files (activity_id);
+CREATE INDEX ON funder.published_activity_observation_media_files (monitoring_plot_id);

--- a/src/main/resources/db/migration/R__Comments.sql
+++ b/src/main/resources/db/migration/R__Comments.sql
@@ -866,6 +866,8 @@ COMMENT ON TABLE funder.published_activities IS 'Published project activities vi
 
 COMMENT ON TABLE funder.published_activity_media_files IS 'Media files for published project activities visible to funders. It is possible for a file to continue to appear here after it has been removed from the activity if the removal has not been published yet.';
 
+COMMENT ON TABLE funder.published_activity_observation_media_files IS 'Observation-specific details about media files in published activities.';
+
 COMMENT ON TABLE funder.published_activity_observations IS 'Which published activities represent which observations. Top-level observation results are copied here as well since the underlying results could change after publication.';
 
 COMMENT ON TABLE funder.published_auto_calculated_indicator_baselines IS 'Published project-level baseline and end-of-project target values for auto-calculated indicators.';

--- a/src/test/kotlin/com/terraformation/backend/db/SchemaDocsGenerator.kt
+++ b/src/test/kotlin/com/terraformation/backend/db/SchemaDocsGenerator.kt
@@ -241,6 +241,7 @@ class SchemaDocsGenerator : DatabaseTest() {
                   "funding_entity_projects" to setOf(ALL, FUNDER),
                   "published_activities" to setOf(ALL, FUNDER),
                   "published_activity_media_files" to setOf(ALL, FUNDER),
+                  "published_activity_observation_media_files" to setOf(ALL, FUNDER),
                   "published_activity_observations" to setOf(ALL, FUNDER),
                   "published_auto_calculated_indicator_baselines" to setOf(ALL, FUNDER),
                   "published_auto_calculated_indicator_targets" to setOf(ALL, FUNDER),

--- a/src/test/kotlin/com/terraformation/backend/funder/db/PublishedActivityStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/funder/db/PublishedActivityStoreTest.kt
@@ -21,7 +21,11 @@ import com.terraformation.backend.db.default_schema.tables.references.FILES
 import com.terraformation.backend.db.default_schema.tables.references.USERS
 import com.terraformation.backend.db.funder.tables.records.PublishedActivitiesRecord
 import com.terraformation.backend.db.funder.tables.records.PublishedActivityMediaFilesRecord
+import com.terraformation.backend.db.funder.tables.records.PublishedActivityObservationMediaFilesRecord
+import com.terraformation.backend.db.funder.tables.records.PublishedActivityObservationsRecord
 import com.terraformation.backend.db.funder.tables.references.FUNDING_ENTITY_PROJECTS
+import com.terraformation.backend.db.tracking.ObservationMediaType
+import com.terraformation.backend.db.tracking.ObservationPlotPosition
 import com.terraformation.backend.file.event.FileReferenceDeletedEvent
 import com.terraformation.backend.funder.model.PublishedActivityMediaModel
 import com.terraformation.backend.funder.model.PublishedActivityModel
@@ -87,7 +91,8 @@ class PublishedActivityStoreTest : DatabaseTest(), RunsAsDatabaseUser {
       val activity1FileId2 = insertFile(capturedLocalTime = LocalDate.EPOCH.atStartOfDay())
       insertActivityMediaFile()
       insertPublishedActivityMediaFile()
-      val activityId2 = insertActivity(verifiedBy = user.userId)
+      val activityId2 =
+          insertActivity(activityType = ActivityType.Monitoring, verifiedBy = user.userId)
       insertPublishedActivity(
           activityDate = LocalDate.of(2025, 1, 2),
           activityType = ActivityType.Monitoring,
@@ -275,6 +280,74 @@ class PublishedActivityStoreTest : DatabaseTest(), RunsAsDatabaseUser {
                   isHiddenOnMap = true,
                   listPosition = 2,
               ),
+          )
+      )
+    }
+
+    @Test
+    fun `publishes observation-specific details for observation`() {
+      insertUserGlobalRole(role = GlobalRole.TFExpert)
+
+      activitiesDao.update(
+          activitiesDao.fetchOneById(activityId)!!.copy(activityTypeId = ActivityType.Monitoring)
+      )
+      insertPlantingSite(x = 0, width = 10)
+      insertStratum()
+      insertSubstratum()
+      val monitoringPlotId = insertMonitoringPlot()
+      val observationId = insertObservation()
+      insertObservationPlot(completedBy = user.userId)
+      insertObservationSiteResult(totalLive = 123, plantDensity = 4, survivalRate = 56)
+      insertActivityObservation()
+
+      val fileId1 = insertFile(capturedLocalTime = LocalDate.of(2024, 1, 10).atStartOfDay())
+      insertObservationMediaFile(position = ObservationPlotPosition.NorthwestCorner)
+      insertActivityMediaFile(caption = "Photo caption", isCoverPhoto = true)
+
+      store.publish(activityId)
+
+      assertTableEquals(
+          PublishedActivitiesRecord(
+              activityDate = LocalDate.of(2024, 1, 15),
+              activityId = activityId,
+              activityTypeId = ActivityType.Monitoring,
+              description = "Test activity",
+              isHighlight = true,
+              projectId = projectId,
+              publishedBy = user.userId,
+              publishedTime = Instant.EPOCH,
+          )
+      )
+
+      assertTableEquals(
+          PublishedActivityObservationsRecord(
+              activityId = activityId,
+              observationId = observationId,
+              livePlants = 123,
+              plantDensity = 4,
+              survivalRate = 56,
+          )
+      )
+
+      assertTableEquals(
+          PublishedActivityMediaFilesRecord(
+              activityId = activityId,
+              activityMediaTypeId = ActivityMediaType.Photo,
+              caption = "Photo caption",
+              fileId = fileId1,
+              isCoverPhoto = true,
+              isHiddenOnMap = false,
+              listPosition = 1,
+          )
+      )
+
+      assertTableEquals(
+          PublishedActivityObservationMediaFilesRecord(
+              activityId = activityId,
+              fileId = fileId1,
+              monitoringPlotId = monitoringPlotId,
+              positionId = ObservationPlotPosition.NorthwestCorner,
+              typeId = ObservationMediaType.Plot,
           )
       )
     }


### PR DESCRIPTION
When an activity created from an observation is published, copy its
observation-specific details to the published activities. This includes plant
statistics, since those can potentially change in the original observation
after publication. It also includes observation-specific details about media
files, since media files can be deleted from observations.