### PR TITLE
SW-8376 Delete observation data for published activities

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/funder/db/PublishedActivityStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/funder/db/PublishedActivityStore.kt
@@ -74,10 +74,7 @@ class PublishedActivityStore(
   fun deletePublishedActivity(activityId: ActivityId) {
     deletePublishedMediaFiles(PUBLISHED_ACTIVITY_MEDIA_FILES.ACTIVITY_ID.eq(activityId))
 
-    dslContext
-        .deleteFrom(PUBLISHED_ACTIVITIES)
-        .where(PUBLISHED_ACTIVITIES.ACTIVITY_ID.eq(activityId))
-        .execute()
+    deletePublishedActivities(PUBLISHED_ACTIVITIES.ACTIVITY_ID.eq(activityId))
   }
 
   @Deprecated("Do not call this except when handling deletion of the organization")
@@ -88,10 +85,7 @@ class PublishedActivityStore(
         )
     )
 
-    dslContext
-        .deleteFrom(PUBLISHED_ACTIVITIES)
-        .where(PUBLISHED_ACTIVITIES.projects.ORGANIZATION_ID.eq(organizationId))
-        .execute()
+    deletePublishedActivities(PUBLISHED_ACTIVITIES.projects.ORGANIZATION_ID.eq(organizationId))
   }
 
   @Deprecated("Do not call this except when handling deletion of the project")
@@ -100,10 +94,7 @@ class PublishedActivityStore(
         PUBLISHED_ACTIVITY_MEDIA_FILES.publishedActivities.PROJECT_ID.eq(projectId)
     )
 
-    dslContext
-        .deleteFrom(PUBLISHED_ACTIVITIES)
-        .where(PUBLISHED_ACTIVITIES.PROJECT_ID.eq(projectId))
-        .execute()
+    deletePublishedActivities(PUBLISHED_ACTIVITIES.PROJECT_ID.eq(projectId))
   }
 
   private val geolocationField = FILES.GEOLOCATION.forMultiset()
@@ -311,18 +302,41 @@ class PublishedActivityStore(
     }
   }
 
+  private fun deletePublishedActivities(condition: Condition) {
+    val activityIds =
+        dslContext
+            .select(PUBLISHED_ACTIVITIES.ACTIVITY_ID)
+            .from(PUBLISHED_ACTIVITIES)
+            .where(condition)
+            .fetch(PUBLISHED_ACTIVITIES.ACTIVITY_ID.asNonNullable())
+
+    dslContext
+        .deleteFrom(PUBLISHED_ACTIVITY_OBSERVATIONS)
+        .where(PUBLISHED_ACTIVITY_OBSERVATIONS.ACTIVITY_ID.`in`(activityIds))
+        .execute()
+
+    dslContext
+        .deleteFrom(PUBLISHED_ACTIVITIES)
+        .where(PUBLISHED_ACTIVITIES.ACTIVITY_ID.`in`(activityIds))
+        .execute()
+  }
+
   private fun deletePublishedMediaFiles(condition: Condition) {
     with(PUBLISHED_ACTIVITY_MEDIA_FILES) {
-      val deletedFileIds =
+      val fileIds =
           dslContext
-              .deleteFrom(PUBLISHED_ACTIVITY_MEDIA_FILES)
+              .select(FILE_ID)
+              .from(PUBLISHED_ACTIVITY_MEDIA_FILES)
               .where(condition)
-              .returning(FILE_ID)
               .fetch(FILE_ID.asNonNullable())
 
-      deletedFileIds.forEach { fileId ->
-        eventPublisher.publishEvent(FileReferenceDeletedEvent(fileId))
-      }
+      dslContext
+          .deleteFrom(PUBLISHED_ACTIVITY_OBSERVATION_MEDIA_FILES)
+          .where(PUBLISHED_ACTIVITY_OBSERVATION_MEDIA_FILES.FILE_ID.`in`(fileIds))
+          .execute()
+      dslContext.deleteFrom(PUBLISHED_ACTIVITY_MEDIA_FILES).where(FILE_ID.`in`(fileIds)).execute()
+
+      fileIds.forEach { fileId -> eventPublisher.publishEvent(FileReferenceDeletedEvent(fileId)) }
     }
   }
 

--- a/src/main/kotlin/com/terraformation/backend/funder/db/PublishedActivityStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/funder/db/PublishedActivityStore.kt
@@ -74,7 +74,10 @@ class PublishedActivityStore(
   fun deletePublishedActivity(activityId: ActivityId) {
     deletePublishedMediaFiles(PUBLISHED_ACTIVITY_MEDIA_FILES.ACTIVITY_ID.eq(activityId))
 
-    deletePublishedActivities(PUBLISHED_ACTIVITIES.ACTIVITY_ID.eq(activityId))
+    dslContext
+        .deleteFrom(PUBLISHED_ACTIVITIES)
+        .where(PUBLISHED_ACTIVITIES.ACTIVITY_ID.eq(activityId))
+        .execute()
   }
 
   @Deprecated("Do not call this except when handling deletion of the organization")
@@ -85,7 +88,10 @@ class PublishedActivityStore(
         )
     )
 
-    deletePublishedActivities(PUBLISHED_ACTIVITIES.projects.ORGANIZATION_ID.eq(organizationId))
+    dslContext
+        .deleteFrom(PUBLISHED_ACTIVITIES)
+        .where(PUBLISHED_ACTIVITIES.projects.ORGANIZATION_ID.eq(organizationId))
+        .execute()
   }
 
   @Deprecated("Do not call this except when handling deletion of the project")
@@ -94,7 +100,10 @@ class PublishedActivityStore(
         PUBLISHED_ACTIVITY_MEDIA_FILES.publishedActivities.PROJECT_ID.eq(projectId)
     )
 
-    deletePublishedActivities(PUBLISHED_ACTIVITIES.PROJECT_ID.eq(projectId))
+    dslContext
+        .deleteFrom(PUBLISHED_ACTIVITIES)
+        .where(PUBLISHED_ACTIVITIES.PROJECT_ID.eq(projectId))
+        .execute()
   }
 
   private val geolocationField = FILES.GEOLOCATION.forMultiset()
@@ -302,41 +311,27 @@ class PublishedActivityStore(
     }
   }
 
-  private fun deletePublishedActivities(condition: Condition) {
-    val activityIds =
-        dslContext
-            .select(PUBLISHED_ACTIVITIES.ACTIVITY_ID)
-            .from(PUBLISHED_ACTIVITIES)
-            .where(condition)
-            .fetch(PUBLISHED_ACTIVITIES.ACTIVITY_ID.asNonNullable())
-
-    dslContext
-        .deleteFrom(PUBLISHED_ACTIVITY_OBSERVATIONS)
-        .where(PUBLISHED_ACTIVITY_OBSERVATIONS.ACTIVITY_ID.`in`(activityIds))
-        .execute()
-
-    dslContext
-        .deleteFrom(PUBLISHED_ACTIVITIES)
-        .where(PUBLISHED_ACTIVITIES.ACTIVITY_ID.`in`(activityIds))
-        .execute()
-  }
-
   private fun deletePublishedMediaFiles(condition: Condition) {
     with(PUBLISHED_ACTIVITY_MEDIA_FILES) {
-      val fileIds =
-          dslContext
-              .select(FILE_ID)
-              .from(PUBLISHED_ACTIVITY_MEDIA_FILES)
-              .where(condition)
-              .fetch(FILE_ID.asNonNullable())
-
       dslContext
           .deleteFrom(PUBLISHED_ACTIVITY_OBSERVATION_MEDIA_FILES)
-          .where(PUBLISHED_ACTIVITY_OBSERVATION_MEDIA_FILES.FILE_ID.`in`(fileIds))
+          .where(
+              PUBLISHED_ACTIVITY_OBSERVATION_MEDIA_FILES.FILE_ID.`in`(
+                  DSL.select(FILE_ID).from(PUBLISHED_ACTIVITY_MEDIA_FILES).where(condition)
+              )
+          )
           .execute()
-      dslContext.deleteFrom(PUBLISHED_ACTIVITY_MEDIA_FILES).where(FILE_ID.`in`(fileIds)).execute()
 
-      fileIds.forEach { fileId -> eventPublisher.publishEvent(FileReferenceDeletedEvent(fileId)) }
+      val deletedFileIds =
+          dslContext
+              .deleteFrom(PUBLISHED_ACTIVITY_MEDIA_FILES)
+              .where(condition)
+              .returning(FILE_ID)
+              .fetch(FILE_ID.asNonNullable())
+
+      deletedFileIds.forEach { fileId ->
+        eventPublisher.publishEvent(FileReferenceDeletedEvent(fileId))
+      }
     }
   }
 

--- a/src/test/kotlin/com/terraformation/backend/db/DatabaseBackedTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/db/DatabaseBackedTest.kt
@@ -323,6 +323,8 @@ import com.terraformation.backend.db.funder.tables.daos.FundingEntityProjectsDao
 import com.terraformation.backend.db.funder.tables.daos.FundingEntityUsersDao
 import com.terraformation.backend.db.funder.tables.daos.PublishedActivitiesDao
 import com.terraformation.backend.db.funder.tables.daos.PublishedActivityMediaFilesDao
+import com.terraformation.backend.db.funder.tables.daos.PublishedActivityObservationMediaFilesDao
+import com.terraformation.backend.db.funder.tables.daos.PublishedActivityObservationsDao
 import com.terraformation.backend.db.funder.tables.daos.PublishedAutoCalculatedIndicatorBaselinesDao
 import com.terraformation.backend.db.funder.tables.daos.PublishedAutoCalculatedIndicatorTargetsDao
 import com.terraformation.backend.db.funder.tables.daos.PublishedCommonIndicatorBaselinesDao
@@ -342,6 +344,8 @@ import com.terraformation.backend.db.funder.tables.pojos.FundingEntityProjectsRo
 import com.terraformation.backend.db.funder.tables.pojos.FundingEntityUsersRow
 import com.terraformation.backend.db.funder.tables.pojos.PublishedActivitiesRow
 import com.terraformation.backend.db.funder.tables.pojos.PublishedActivityMediaFilesRow
+import com.terraformation.backend.db.funder.tables.pojos.PublishedActivityObservationMediaFilesRow
+import com.terraformation.backend.db.funder.tables.pojos.PublishedActivityObservationsRow
 import com.terraformation.backend.db.funder.tables.pojos.PublishedAutoCalculatedIndicatorBaselinesRow
 import com.terraformation.backend.db.funder.tables.pojos.PublishedAutoCalculatedIndicatorTargetsRow
 import com.terraformation.backend.db.funder.tables.pojos.PublishedCommonIndicatorBaselinesRow
@@ -754,6 +758,10 @@ abstract class DatabaseBackedTest {
   protected val projectVoteDecisionDao: ProjectVoteDecisionsDao by lazyDao()
   protected val projectVotesDao: ProjectVotesDao by lazyDao()
   protected val publishedActivitiesDao: PublishedActivitiesDao by lazyDao()
+  protected val publishedActivityObservationMediaFilesDao:
+      PublishedActivityObservationMediaFilesDao by
+      lazyDao()
+  protected val publishedActivityObservationsDao: PublishedActivityObservationsDao by lazyDao()
   protected val publishedActivityMediaFilesDao: PublishedActivityMediaFilesDao by lazyDao()
   protected val publishedAutoCalculatedIndicatorBaselinesDao:
       PublishedAutoCalculatedIndicatorBaselinesDao by
@@ -4659,6 +4667,25 @@ abstract class DatabaseBackedTest {
     publishedActivitiesDao.insert(row)
   }
 
+  protected fun insertPublishedActivityObservation(
+      activityId: ActivityId = inserted.activityId,
+      observationId: ObservationId = inserted.observationId,
+      livePlants: Int? = 100,
+      plantDensity: Int? = 20,
+      survivalRate: Int? = 90,
+  ) {
+    val row =
+        PublishedActivityObservationsRow(
+            activityId = activityId,
+            observationId = observationId,
+            livePlants = livePlants,
+            plantDensity = plantDensity,
+            survivalRate = survivalRate,
+        )
+
+    publishedActivityObservationsDao.insert(row)
+  }
+
   private var lastPublishedActivityMediaFileActivityId: ActivityId? = null
   private var nextPublishedActivityMediaFileListPosition = 1
 
@@ -4689,6 +4716,25 @@ abstract class DatabaseBackedTest {
 
     lastPublishedActivityMediaFileActivityId = activityId
     nextPublishedActivityMediaFileListPosition = listPosition + 1
+  }
+
+  protected fun insertPublishedActivityObservationMediaFile(
+      activityId: ActivityId = inserted.activityId,
+      fileId: FileId = inserted.fileId,
+      monitoringPlotId: MonitoringPlotId = inserted.monitoringPlotId,
+      position: ObservationPlotPosition? = ObservationPlotPosition.SouthwestCorner,
+      type: ObservationMediaType = ObservationMediaType.Plot,
+  ) {
+    val row =
+        PublishedActivityObservationMediaFilesRow(
+            activityId = activityId,
+            fileId = fileId,
+            monitoringPlotId = monitoringPlotId,
+            positionId = position,
+            typeId = type,
+        )
+
+    publishedActivityObservationMediaFilesDao.insert(row)
   }
 
   private var nextInternalTagNumber = 1

--- a/src/test/kotlin/com/terraformation/backend/funder/PublishedActivityServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/funder/PublishedActivityServiceTest.kt
@@ -22,6 +22,7 @@ import com.terraformation.backend.db.default_schema.UserType
 import com.terraformation.backend.db.default_schema.tables.references.USERS
 import com.terraformation.backend.db.funder.tables.references.PUBLISHED_ACTIVITIES
 import com.terraformation.backend.db.funder.tables.references.PUBLISHED_ACTIVITY_MEDIA_FILES
+import com.terraformation.backend.db.funder.tables.references.PUBLISHED_ACTIVITY_OBSERVATION_MEDIA_FILES
 import com.terraformation.backend.file.SizedInputStream
 import com.terraformation.backend.file.ThumbnailService
 import com.terraformation.backend.file.VideoStreamNotFoundException
@@ -132,6 +133,8 @@ class PublishedActivityServiceTest : DatabaseTest(), RunsAsDatabaseUser {
           setOf(otherActivityFileId, otherProjectActivityFileId, otherOrganizationActivityFileId)
       )
 
+      assertTableEmpty(PUBLISHED_ACTIVITY_OBSERVATION_MEDIA_FILES)
+
       assertIsEventListener<ActivityDeletionStartedEvent>(service)
     }
 
@@ -141,6 +144,8 @@ class PublishedActivityServiceTest : DatabaseTest(), RunsAsDatabaseUser {
 
       val publishedActivitiesBefore = dslContext.fetch(PUBLISHED_ACTIVITIES)
       val publishedActivityMediaBefore = dslContext.fetch(PUBLISHED_ACTIVITY_MEDIA_FILES)
+      val publishedActivityObservationMediaBefore =
+          dslContext.fetch(PUBLISHED_ACTIVITY_OBSERVATION_MEDIA_FILES)
 
       service.on(ActivityDeletionStartedEvent(unpublishedActivityId))
 
@@ -148,6 +153,7 @@ class PublishedActivityServiceTest : DatabaseTest(), RunsAsDatabaseUser {
 
       assertTableEquals(publishedActivitiesBefore)
       assertTableEquals(publishedActivityMediaBefore)
+      assertTableEquals(publishedActivityObservationMediaBefore)
     }
 
     @Test
@@ -166,6 +172,8 @@ class PublishedActivityServiceTest : DatabaseTest(), RunsAsDatabaseUser {
       )
       assertRemainingFileIds(setOf(otherProjectActivityFileId, otherOrganizationActivityFileId))
 
+      assertTableEmpty(PUBLISHED_ACTIVITY_OBSERVATION_MEDIA_FILES)
+
       assertIsEventListener<ProjectDeletionStartedEvent>(service)
     }
 
@@ -183,6 +191,8 @@ class PublishedActivityServiceTest : DatabaseTest(), RunsAsDatabaseUser {
 
       assertRemainingPublishedActivityIds(setOf(otherOrganizationActivityId))
       assertRemainingFileIds(setOf(otherOrganizationActivityFileId))
+
+      assertTableEmpty(PUBLISHED_ACTIVITY_OBSERVATION_MEDIA_FILES)
 
       assertIsEventListener<OrganizationDeletionStartedEvent>(service)
     }

--- a/src/test/kotlin/com/terraformation/backend/funder/PublishedActivityServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/funder/PublishedActivityServiceTest.kt
@@ -13,6 +13,7 @@ import com.terraformation.backend.customer.model.TerrawareUser
 import com.terraformation.backend.db.DatabaseTest
 import com.terraformation.backend.db.FileNotFoundException
 import com.terraformation.backend.db.accelerator.ActivityId
+import com.terraformation.backend.db.accelerator.ActivityType
 import com.terraformation.backend.db.default_schema.FileId
 import com.terraformation.backend.db.default_schema.OrganizationId
 import com.terraformation.backend.db.default_schema.ProjectId
@@ -64,6 +65,7 @@ class PublishedActivityServiceTest : DatabaseTest(), RunsAsDatabaseUser {
 
     activityId =
         insertActivity(
+            activityType = ActivityType.Monitoring,
             verifiedBy = user.userId,
             verifiedTime = clock.instant(),
         )
@@ -81,10 +83,18 @@ class PublishedActivityServiceTest : DatabaseTest(), RunsAsDatabaseUser {
 
     @BeforeEach
     fun setUp() {
+      insertPlantingSite(x = 0)
+      insertStratum()
+      insertSubstratum()
+      insertMonitoringPlot()
+      insertObservation()
+      insertActivityObservation()
+
       activityFileId = insertFile()
       insertActivityMediaFile()
       insertPublishedActivity()
       insertPublishedActivityMediaFile()
+      insertPublishedActivityObservationMediaFile()
 
       otherActivityId = insertActivity()
       otherActivityFileId = insertFile()


### PR DESCRIPTION
When a published activity is deleted, we need to delete any observation-specific
details about it and its media files.