### PR TITLE
Add planting management controllers to springdoc, add test to ensure this doesn't happen again

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -145,6 +145,7 @@ springdoc:
     - "com.terraformation.backend.i18n.api"
     - "com.terraformation.backend.nursery.api"
     - "com.terraformation.backend.report.api"
+    - "com.terraformation.backend.plantingmanagement.api"
     - "com.terraformation.backend.search.api"
     - "com.terraformation.backend.seedbank.api"
     - "com.terraformation.backend.species.api"

--- a/src/test/kotlin/com/terraformation/backend/api/OpenApiAnnotationTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/api/OpenApiAnnotationTest.kt
@@ -12,8 +12,13 @@ import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.MethodSource
+import org.springframework.boot.context.properties.bind.Bindable
+import org.springframework.boot.context.properties.bind.Binder
+import org.springframework.boot.env.YamlPropertySourceLoader
 import org.springframework.context.annotation.ClassPathScanningCandidateComponentProvider
 import org.springframework.core.annotation.MergedAnnotations
+import org.springframework.core.env.StandardEnvironment
+import org.springframework.core.io.ClassPathResource
 import org.springframework.core.type.filter.AnnotationTypeFilter
 import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
@@ -22,11 +27,6 @@ import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.PutMapping
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
-import org.springframework.boot.context.properties.bind.Bindable
-import org.springframework.boot.context.properties.bind.Binder
-import org.springframework.boot.env.YamlPropertySourceLoader
-import org.springframework.core.env.StandardEnvironment
-import org.springframework.core.io.ClassPathResource
 
 /**
  * Verifies that all our controller methods have the expected set of annotations to generate a good
@@ -86,14 +86,14 @@ class OpenApiAnnotationTest {
 
   companion object {
     /**
-     * Packages containing @RestController classes that are intentionally excluded from
-     * springdoc scanning (e.g., internal-only controllers that should not appear in the public
-     * API docs).
+     * Packages containing @RestController classes that are intentionally excluded from springdoc
+     * scanning (e.g., internal-only controllers that should not appear in the public API docs).
      */
     private val SPRINGDOC_PACKAGE_SCAN_BLACKLIST: Set<String> = setOf()
 
     private val springdocPackagesToScan: Set<String> by lazy {
-      val propertySources = YamlPropertySourceLoader().load("application", ClassPathResource("application.yaml"))
+      val propertySources =
+          YamlPropertySourceLoader().load("application", ClassPathResource("application.yaml"))
       val environment = StandardEnvironment()
       propertySources.forEach { environment.propertySources.addFirst(it) }
       Binder.get(environment)

--- a/src/test/kotlin/com/terraformation/backend/api/OpenApiAnnotationTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/api/OpenApiAnnotationTest.kt
@@ -22,6 +22,11 @@ import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.PutMapping
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
+import org.springframework.boot.context.properties.bind.Bindable
+import org.springframework.boot.context.properties.bind.Binder
+import org.springframework.boot.env.YamlPropertySourceLoader
+import org.springframework.core.env.StandardEnvironment
+import org.springframework.core.io.ClassPathResource
 
 /**
  * Verifies that all our controller methods have the expected set of annotations to generate a good
@@ -61,7 +66,42 @@ class OpenApiAnnotationTest {
     assertNotNull(operation.getString("summary"), "Operation annotation on $name missing summary")
   }
 
+  @MethodSource("findAllControllerPackages")
+  @ParameterizedTest(name = "{0}")
+  fun `all controller packages are in springdoc packages-to-scan`(packageName: String) {
+    val classNames =
+        controllerClasses()
+            .filter { it.packageName == packageName }
+            .map { it.simpleName }
+            .sorted()
+            .joinToString(", ")
+
+    assertTrue(
+        packageName in springdocPackagesToScan,
+        "Package '$packageName' has @RestController classes [$classNames] but is missing from " +
+            "springdoc.packages-to-scan in application.yaml. " +
+            "Add it, or add it to SPRINGDOC_PACKAGE_SCAN_BLACKLIST in this test if it should be excluded.",
+    )
+  }
+
   companion object {
+    /**
+     * Packages containing @RestController classes that are intentionally excluded from
+     * springdoc scanning (e.g., internal-only controllers that should not appear in the public
+     * API docs).
+     */
+    private val SPRINGDOC_PACKAGE_SCAN_BLACKLIST: Set<String> = setOf()
+
+    private val springdocPackagesToScan: Set<String> by lazy {
+      val propertySources = YamlPropertySourceLoader().load("application", ClassPathResource("application.yaml"))
+      val environment = StandardEnvironment()
+      propertySources.forEach { environment.propertySources.addFirst(it) }
+      Binder.get(environment)
+          .bind("springdoc.packages-to-scan", Bindable.listOf(String::class.java))
+          .orElse(emptyList())
+          .toSet()
+    }
+
     private val controllerMethodAnnotations =
         setOf(
             DeleteMapping::class,
@@ -86,6 +126,15 @@ class OpenApiAnnotationTest {
     @JvmStatic
     fun findAllControllerClasses(): Stream<Class<*>> {
       return controllerClasses().asStream()
+    }
+
+    @JvmStatic
+    fun findAllControllerPackages(): Stream<String> {
+      return controllerClasses()
+          .map { it.packageName }
+          .filter { it !in SPRINGDOC_PACKAGE_SCAN_BLACKLIST }
+          .distinct()
+          .asStream()
     }
 
     @JvmStatic


### PR DESCRIPTION
The `plantingmanagement` package was missing from the `springdoc.packages-to-scan` config. Add it, then add a unit test that ensures all controllers with `@RestController` are in the packages-to-scan so that this can't be missed again (with an optional ability to blacklist packages if needed).