### PR TITLE
SW-8401 Use area-weighted survival rates at site level

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/accelerator/db/ReportStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/db/ReportStore.kt
@@ -101,7 +101,6 @@ import java.time.InstantSource
 import java.time.LocalDate
 import java.time.Month
 import java.time.ZoneId
-import kotlin.toBigDecimal
 import org.jooq.Condition
 import org.jooq.DSLContext
 import org.jooq.Field

--- a/src/main/kotlin/com/terraformation/backend/tracking/db/ObservationResultsStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/db/ObservationResultsStore.kt
@@ -47,6 +47,13 @@ import org.locationtech.jts.geom.Polygon
  *
  * Some of the statistics are calculated at query time here; others are accumulated incrementally in
  * [ObservationStore] as observation results are recorded.
+ *
+ * # Survival rate calculations
+ *
+ * The site-level survival rate calculations here use an older formula rather than the current
+ * area-weighted formula. That's intentional; this class's survival rate calculations will be going
+ * away entirely once clients have been updated to use the API endpoints that call
+ * ObservationResultsStoreV2. There is no need to update this class to use area-weighted rates.
  */
 @Named
 class ObservationResultsStore(private val dslContext: DSLContext) {

--- a/src/main/kotlin/com/terraformation/backend/tracking/db/ObservationStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/db/ObservationStore.kt
@@ -1982,27 +1982,12 @@ class ObservationStore(
     val latestLiveField = updateScope.latestLiveField
 
     val survivalRateValue =
-        DSL.case_()
-            .`when`(
-                updateScope.anyChildHasNullSurvivalRateCondition(observationIdField),
-                DSL.castNull(SQLDataType.INTEGER),
-            )
-            .`when`(
-                survivalRateDenominator.eq(BigDecimal.ZERO),
-                DSL.castNull(SQLDataType.INTEGER),
-            )
-            .else_(
-                DSL.case_()
-                    .`when`(
-                        updateScope.observedTotalsPlantingSiteTempCondition,
-                        (latestLiveField.mul(BigDecimal.valueOf(100)).div(survivalRateDenominator)),
-                    )
-                    .else_(
-                        (permanentLiveField
-                            .mul(BigDecimal.valueOf(100))
-                            .div(survivalRateDenominator)),
-                    )
-            )
+        updateScope.survivalRateValue(
+            observationIdField,
+            survivalRateDenominator,
+            latestLiveField,
+            permanentLiveField,
+        )
 
     dslContext
         .update(table)
@@ -2107,27 +2092,12 @@ class ObservationStore(
     val latestLiveField = updateScope.latestLiveField
 
     val survivalRateValue =
-        DSL.case_()
-            .`when`(
-                updateScope.anyChildHasNullSurvivalRateCondition(DSL.value(observationId)),
-                DSL.castNull(SQLDataType.INTEGER),
-            )
-            .`when`(
-                survivalRateDenominator.eq(BigDecimal.ZERO),
-                DSL.castNull(SQLDataType.INTEGER),
-            )
-            .else_(
-                DSL.case_()
-                    .`when`(
-                        updateScope.observedTotalsPlantingSiteTempCondition,
-                        (latestLiveField.mul(BigDecimal.valueOf(100)).div(survivalRateDenominator)),
-                    )
-                    .else_(
-                        (permanentLiveField
-                            .mul(BigDecimal.valueOf(100))
-                            .div(survivalRateDenominator)),
-                    )
-            )
+        updateScope.survivalRateValue(
+            DSL.value(observationId),
+            survivalRateDenominator,
+            latestLiveField,
+            permanentLiveField,
+        )
 
     val allPlotsCompleted =
         dslContext

--- a/src/main/kotlin/com/terraformation/backend/tracking/db/Queries.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/db/Queries.kt
@@ -9,6 +9,7 @@ import com.terraformation.backend.db.tracking.tables.references.OBSERVATION_PLOT
 import com.terraformation.backend.db.tracking.tables.references.OBSERVATION_REQUESTED_SUBSTRATA
 import com.terraformation.backend.db.tracking.tables.references.STRATUM_HISTORIES
 import com.terraformation.backend.db.tracking.tables.references.SUBSTRATUM_HISTORIES
+import org.jooq.Condition
 import org.jooq.Field
 import org.jooq.impl.DSL
 
@@ -140,3 +141,15 @@ fun observationIdForPlot(
           .limit(1)
   )
 }
+
+fun substratumObservedAtOrBefore(
+    substratumIdField: Field<SubstratumId?>,
+    observationIdField: Field<ObservationId?>,
+): Condition =
+    DSL.exists(
+        DSL.selectOne()
+            .from(
+                latestObservationForSubstratumField(observationIdField, substratumIdField)
+                    .asTable("latest_obs")
+            )
+    )

--- a/src/main/kotlin/com/terraformation/backend/tracking/model/ObservationResultsModel.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/model/ObservationResultsModel.kt
@@ -21,7 +21,6 @@ import com.terraformation.backend.db.tracking.StratumId
 import com.terraformation.backend.db.tracking.SubstratumId
 import com.terraformation.backend.util.HECTARES_PER_PLOT
 import java.math.BigDecimal
-import java.math.MathContext
 import java.math.RoundingMode
 import java.time.Instant
 import java.time.LocalDate
@@ -518,10 +517,7 @@ fun calculateAreaWeightedSurvivalRate(strata: List<StratumWithObservedArea>): In
 
   val numerator = strata.sumOf { it.observedSubstratumAreaHa * BigDecimal(it.survivalRate!!) }
 
-  return numerator
-      .divide(denominator, MathContext.DECIMAL64)
-      .setScale(0, RoundingMode.HALF_UP)
-      .toInt()
+  return numerator.divide(denominator, 0, RoundingMode.HALF_UP).toInt()
 }
 
 /**

--- a/src/main/kotlin/com/terraformation/backend/tracking/model/ObservationResultsModel.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/model/ObservationResultsModel.kt
@@ -21,6 +21,7 @@ import com.terraformation.backend.db.tracking.StratumId
 import com.terraformation.backend.db.tracking.SubstratumId
 import com.terraformation.backend.util.HECTARES_PER_PLOT
 import java.math.BigDecimal
+import java.math.MathContext
 import java.math.RoundingMode
 import java.time.Instant
 import java.time.LocalDate
@@ -424,9 +425,15 @@ data class ObservationRollupResultsModel(
           }
 
       val survivalRate =
-          if (nonNullStratumResults.all { it.survivalRate != null })
-              species.calculateSurvivalRate(survivalRateIncludesTempPlots)
-          else null
+          calculateAreaWeightedSurvivalRate(
+              nonNullStratumResults.map { stratum ->
+                StratumWithObservedArea(
+                    survivalRate = stratum.survivalRate,
+                    observedSubstratumAreaHa =
+                        stratum.substrata.filter { it.survivalRate != null }.sumOf { it.areaHa },
+                )
+              }
+          )
       val survivalRateStdDev =
           if (survivalRate != null)
               monitoringPlots
@@ -491,6 +498,30 @@ fun calculateSurvivalRate(numKnownLive: Int, sumDensity: BigDecimal?): Int? {
   } else {
     null
   }
+}
+
+/** Input to [calculateAreaWeightedSurvivalRate]: one entry per stratum with observed substrata. */
+data class StratumWithObservedArea(
+    val survivalRate: Int?,
+    val observedSubstratumAreaHa: BigDecimal,
+)
+
+/**
+ * Returns the area-weighted average of the strata's survival rates as an integer percentage rounded
+ * HALF_UP, matching [calculateSurvivalRate].
+ */
+fun calculateAreaWeightedSurvivalRate(strata: List<StratumWithObservedArea>): Int? {
+  if (strata.isEmpty() || strata.any { it.survivalRate == null }) return null
+
+  val denominator = strata.sumOf { it.observedSubstratumAreaHa }
+  if (denominator.signum() <= 0) return null
+
+  val numerator = strata.sumOf { it.observedSubstratumAreaHa * BigDecimal(it.survivalRate!!) }
+
+  return numerator
+      .divide(denominator, MathContext.DECIMAL64)
+      .setScale(0, RoundingMode.HALF_UP)
+      .toInt()
 }
 
 /**

--- a/src/main/kotlin/com/terraformation/backend/tracking/util/ObservationResultsScope.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/util/ObservationResultsScope.kt
@@ -30,6 +30,7 @@ import com.terraformation.backend.db.tracking.tables.references.STRATUM_HISTORIE
 import com.terraformation.backend.db.tracking.tables.references.STRATUM_T0_TEMP_DENSITIES
 import com.terraformation.backend.db.tracking.tables.references.SUBSTRATUM_HISTORIES
 import com.terraformation.backend.tracking.db.latestObservationForSubstratumField
+import com.terraformation.backend.tracking.db.substratumObservedAtOrBefore
 import java.math.BigDecimal
 import org.jooq.Condition
 import org.jooq.Field
@@ -68,6 +69,38 @@ interface ObservationResultsScope<ID : Any, HistoryId : Any> :
   fun observationPlotsCondition(observationIdField: Field<ObservationId?>): Condition
 
   fun observationPlotResultsCondition(plotResultsTable: ObservationPlotResults): Condition
+
+  /**
+   * Returns the SQL expression that produces the survival rate (as an integer percentage 0–100) for
+   * this scope on a row of [observedTotalsTable], given the observation id field. The default
+   * implementation uses a density-weighted formula; the site scope overrides this to return the
+   * area-weighted strata average.
+   */
+  fun survivalRateValue(
+      observationIdField: Field<ObservationId?>,
+      survivalRateDenominator: Field<BigDecimal>,
+      latestLiveField: Field<Int>,
+      permanentLiveField: Field<Int>,
+  ): Field<Int?> =
+      DSL.case_()
+          .`when`(
+              anyChildHasNullSurvivalRateCondition(observationIdField),
+              DSL.castNull(SQLDataType.INTEGER),
+          )
+          .`when`(
+              survivalRateDenominator.eq(BigDecimal.ZERO),
+              DSL.castNull(SQLDataType.INTEGER),
+          )
+          .else_(
+              DSL.case_()
+                  .`when`(
+                      observedTotalsPlantingSiteTempCondition,
+                      latestLiveField.mul(BigDecimal.valueOf(100)).div(survivalRateDenominator),
+                  )
+                  .else_(
+                      permanentLiveField.mul(BigDecimal.valueOf(100)).div(survivalRateDenominator),
+                  ),
+          )
 }
 
 class ObservationResultsPlot(
@@ -527,6 +560,79 @@ class ObservationResultsSite(
               .and(STRATUM_HISTORIES.PLANTING_SITE_HISTORY_ID.`in`(siteHistorySelect))
               .and(OBSERVATION_STRATUM_RESULTS.SURVIVAL_RATE.isNull)
       )
+
+  /**
+   * Returns the site-level survival rate as an area-weighted average of the stratum-level survival
+   * rates. Substrata that weren't observed in or before this observation don't count toward the
+   * areas of their strata in the weighting formula.
+   */
+  override fun survivalRateValue(
+      observationIdField: Field<ObservationId?>,
+      survivalRateDenominator: Field<BigDecimal>,
+      latestLiveField: Field<Int>,
+      permanentLiveField: Field<Int>,
+  ): Field<Int?> {
+    val weightedSum =
+        DSL.field(
+            DSL.select(
+                    DSL.sum(
+                        SUBSTRATUM_HISTORIES.AREA_HA.mul(OBSERVATION_STRATUM_RESULTS.SURVIVAL_RATE)
+                    )
+                )
+                .from(OBSERVATION_STRATUM_RESULTS)
+                .join(STRATUM_HISTORIES)
+                .on(STRATUM_HISTORIES.ID.eq(OBSERVATION_STRATUM_RESULTS.STRATUM_HISTORY_ID))
+                .join(SUBSTRATUM_HISTORIES)
+                .on(SUBSTRATUM_HISTORIES.STRATUM_HISTORY_ID.eq(STRATUM_HISTORIES.ID))
+                .where(
+                    STRATUM_HISTORIES.PLANTING_SITE_HISTORY_ID.eq(
+                        OBSERVATION_SITE_RESULTS.PLANTING_SITE_HISTORY_ID
+                    )
+                )
+                .and(OBSERVATION_STRATUM_RESULTS.OBSERVATION_ID.eq(observationIdField))
+                .and(OBSERVATION_STRATUM_RESULTS.SURVIVAL_RATE.isNotNull)
+                .and(
+                    substratumObservedAtOrBefore(
+                        SUBSTRATUM_HISTORIES.SUBSTRATUM_ID,
+                        observationIdField,
+                    )
+                )
+        )
+
+    val totalWeight =
+        DSL.field(
+            DSL.select(DSL.sum(SUBSTRATUM_HISTORIES.AREA_HA))
+                .from(OBSERVATION_STRATUM_RESULTS)
+                .join(STRATUM_HISTORIES)
+                .on(STRATUM_HISTORIES.ID.eq(OBSERVATION_STRATUM_RESULTS.STRATUM_HISTORY_ID))
+                .join(SUBSTRATUM_HISTORIES)
+                .on(SUBSTRATUM_HISTORIES.STRATUM_HISTORY_ID.eq(STRATUM_HISTORIES.ID))
+                .where(
+                    STRATUM_HISTORIES.PLANTING_SITE_HISTORY_ID.eq(
+                        OBSERVATION_SITE_RESULTS.PLANTING_SITE_HISTORY_ID
+                    )
+                )
+                .and(OBSERVATION_STRATUM_RESULTS.OBSERVATION_ID.eq(observationIdField))
+                .and(OBSERVATION_STRATUM_RESULTS.SURVIVAL_RATE.isNotNull)
+                .and(
+                    substratumObservedAtOrBefore(
+                        SUBSTRATUM_HISTORIES.SUBSTRATUM_ID,
+                        observationIdField,
+                    )
+                )
+        )
+
+    return DSL.case_()
+        .`when`(
+            anyChildHasNullSurvivalRateCondition(observationIdField),
+            DSL.castNull(SQLDataType.INTEGER),
+        )
+        .`when`(
+            totalWeight.isNull.or(totalWeight.eq(BigDecimal.ZERO)),
+            DSL.castNull(SQLDataType.INTEGER),
+        )
+        .else_(weightedSum.div(totalWeight).cast(SQLDataType.INTEGER))
+  }
 
   override fun observationPlotsCondition(observationIdField: Field<ObservationId?>) =
       OBSERVATION_PLOTS.OBSERVATION_ID.eq(observationIdField)

--- a/src/main/kotlin/com/terraformation/backend/tracking/util/ObservationResultsScope.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/util/ObservationResultsScope.kt
@@ -572,36 +572,16 @@ class ObservationResultsSite(
       latestLiveField: Field<Int>,
       permanentLiveField: Field<Int>,
   ): Field<Int?> {
-    val weightedSum =
+    val weightedAverage =
         DSL.field(
             DSL.select(
                     DSL.sum(
-                        SUBSTRATUM_HISTORIES.AREA_HA.mul(OBSERVATION_STRATUM_RESULTS.SURVIVAL_RATE)
-                    )
+                            SUBSTRATUM_HISTORIES.AREA_HA.mul(
+                                OBSERVATION_STRATUM_RESULTS.SURVIVAL_RATE
+                            )
+                        )
+                        .div(DSL.nullif(DSL.sum(SUBSTRATUM_HISTORIES.AREA_HA), BigDecimal.ZERO))
                 )
-                .from(OBSERVATION_STRATUM_RESULTS)
-                .join(STRATUM_HISTORIES)
-                .on(STRATUM_HISTORIES.ID.eq(OBSERVATION_STRATUM_RESULTS.STRATUM_HISTORY_ID))
-                .join(SUBSTRATUM_HISTORIES)
-                .on(SUBSTRATUM_HISTORIES.STRATUM_HISTORY_ID.eq(STRATUM_HISTORIES.ID))
-                .where(
-                    STRATUM_HISTORIES.PLANTING_SITE_HISTORY_ID.eq(
-                        OBSERVATION_SITE_RESULTS.PLANTING_SITE_HISTORY_ID
-                    )
-                )
-                .and(OBSERVATION_STRATUM_RESULTS.OBSERVATION_ID.eq(observationIdField))
-                .and(OBSERVATION_STRATUM_RESULTS.SURVIVAL_RATE.isNotNull)
-                .and(
-                    substratumObservedAtOrBefore(
-                        SUBSTRATUM_HISTORIES.SUBSTRATUM_ID,
-                        observationIdField,
-                    )
-                )
-        )
-
-    val totalWeight =
-        DSL.field(
-            DSL.select(DSL.sum(SUBSTRATUM_HISTORIES.AREA_HA))
                 .from(OBSERVATION_STRATUM_RESULTS)
                 .join(STRATUM_HISTORIES)
                 .on(STRATUM_HISTORIES.ID.eq(OBSERVATION_STRATUM_RESULTS.STRATUM_HISTORY_ID))
@@ -628,10 +608,10 @@ class ObservationResultsSite(
             DSL.castNull(SQLDataType.INTEGER),
         )
         .`when`(
-            totalWeight.isNull.or(totalWeight.eq(BigDecimal.ZERO)),
+            weightedAverage.isNull,
             DSL.castNull(SQLDataType.INTEGER),
         )
-        .else_(weightedSum.div(totalWeight).cast(SQLDataType.INTEGER))
+        .else_(weightedAverage.cast(SQLDataType.INTEGER))
   }
 
   override fun observationPlotsCondition(observationIdField: Field<ObservationId?>) =

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/observationStore/ObservationStoreSurvivalRateCalculationTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/observationStore/ObservationStoreSurvivalRateCalculationTest.kt
@@ -639,7 +639,7 @@ class ObservationStoreSurvivalRateCalculationTest : ObservationScenarioTest() {
     }
     observationStore.recalculateSurvivalRates(stratumId)
 
-    val actualResults = resultsStore.fetchByPlantingSiteId(inserted.plantingSiteId, limit = 2)
+    val actualResults = resultsStoreV2.fetchByPlantingSiteId(inserted.plantingSiteId, limit = 2)
     val obs1UpdatedResults = ratesObjectFromResults(actualResults[1], plantingSiteId)
     val obs2UpdatedResults = ratesObjectFromResults(actualResults[0], plantingSiteId)
 
@@ -838,7 +838,7 @@ class ObservationStoreSurvivalRateCalculationTest : ObservationScenarioTest() {
 
       val baseline =
           expectResults(1) {
-            survivalRate(96)
+            survivalRate(97)
             species(0, survivalRate = 97)
             species(1, survivalRate = 96)
             stratum(1) {
@@ -970,7 +970,7 @@ class ObservationStoreSurvivalRateCalculationTest : ObservationScenarioTest() {
 
       val baseline =
           expectResults(1) {
-            survivalRate(56)
+            survivalRate(54)
             species(0, survivalRate = 62)
             species(1, survivalRate = 52)
             stratum(1) {
@@ -1023,7 +1023,7 @@ class ObservationStoreSurvivalRateCalculationTest : ObservationScenarioTest() {
 
       // Only species 0's results should change, and only in stratum 1.
       expectResults(1, baseline = baseline) {
-        survivalRate(60)
+        survivalRate(58)
         species(0, survivalRate = 74)
         stratum(1) {
           survivalRate(49)
@@ -1122,7 +1122,7 @@ class ObservationStoreSurvivalRateCalculationTest : ObservationScenarioTest() {
 
       val observation1Results =
           expectResults(1) {
-            survivalRate(81)
+            survivalRate(83)
             species(0, survivalRate = 83)
             species(1, survivalRate = 80)
             stratum(1) {
@@ -1239,7 +1239,7 @@ class ObservationStoreSurvivalRateCalculationTest : ObservationScenarioTest() {
       expectUnchangedResults(observation = 1, baseline = observation1Results)
 
       expectResults(observation = 2) {
-        survivalRate(92)
+        survivalRate(93)
         species(0, survivalRate = 92)
         species(1, survivalRate = 93)
         stratum(1) {
@@ -1333,15 +1333,20 @@ class ObservationStoreSurvivalRateCalculationTest : ObservationScenarioTest() {
         plot(3) { species(0, live = obsLive[1][3]) }
       }
 
+      // Area-weighted site rate; substratum areas are all 1, so each stratum's rate is weighted by
+      // the count of its observed substrata.
+      fun areaWeightedSiteRate(stratumRates: List<Pair<Int, Int>>): Int {
+        val totalWeight = stratumRates.sumOf { it.first }
+        val weighted = stratumRates.sumOf { (substrataCount, rate) -> substrataCount * rate }
+        return weighted / totalWeight
+      }
+
       expectResults(observation = 1) {
-        survivalRate(
-            percent(
-                obsLive[1][1] + obsLive[1][2] + obsLive[1][3],
-                densities[1] + densities[2] + densities[3],
-            )
-        )
+        val stratum1ObsRate1 = percent(obsLive[1][1] + obsLive[1][2], densities[1] + densities[2])
+        val stratum2ObsRate1 = percent(obsLive[1][3], densities[3])
+        survivalRate(areaWeightedSiteRate(listOf(2 to stratum1ObsRate1, 1 to stratum2ObsRate1)))
         stratum(1) {
-          survivalRate(percent(obsLive[1][1] + obsLive[1][2], densities[1] + densities[2]))
+          survivalRate(stratum1ObsRate1)
           substratum(1) {
             survivalRate(percent(obsLive[1][1], densities[1]))
             plot(1) { survivalRate(percent(obsLive[1][1], densities[1])) }
@@ -1352,10 +1357,10 @@ class ObservationStoreSurvivalRateCalculationTest : ObservationScenarioTest() {
           }
         }
         stratum(2) {
-          survivalRate(percent(obsLive[1][3], densities[3]))
+          survivalRate(stratum2ObsRate1)
           substratum(3) {
-            survivalRate(percent(obsLive[1][3], densities[3]))
-            plot(3) { survivalRate(percent(obsLive[1][3], densities[3])) }
+            survivalRate(stratum2ObsRate1)
+            plot(3) { survivalRate(stratum2ObsRate1) }
           }
         }
       }
@@ -1363,14 +1368,11 @@ class ObservationStoreSurvivalRateCalculationTest : ObservationScenarioTest() {
       observation(2) { plot(1) { species(0, live = obsLive[2][1]) } }
 
       expectResults(observation = 2) {
-        survivalRate(
-            percent(
-                obsLive[2][1] + obsLive[1][2] + obsLive[1][3],
-                densities[1] + densities[2] + densities[3],
-            )
-        )
+        // Stratum 2 has no result in this observation, so the site rate is just stratum 1's.
+        val stratum1ObsRate2 = percent(obsLive[2][1] + obsLive[1][2], densities[1] + densities[2])
+        survivalRate(areaWeightedSiteRate(listOf(2 to stratum1ObsRate2)))
         stratum(1) {
-          survivalRate(percent(obsLive[2][1] + obsLive[1][2], densities[1] + densities[2]))
+          survivalRate(stratum1ObsRate2)
           substratum(1) {
             survivalRate(percent(obsLive[2][1], densities[1]))
             plot(1) { survivalRate(percent(obsLive[2][1], densities[1])) }
@@ -1392,18 +1394,15 @@ class ObservationStoreSurvivalRateCalculationTest : ObservationScenarioTest() {
       observation(3) { plot(3) { species(0, live = obsLive[3][3]) } }
 
       expectResults(observation = 3) {
-        // Should pull substratum 1 rate from observation 2
-        survivalRate(
-            percent(
-                obsLive[2][1] + obsLive[1][2] + obsLive[3][3],
-                densities[1] + densities[2] + densities[3],
-            )
-        )
+        // Stratum 1 has no OBSERVATION_STRATUM_RESULTS row in this observation (no plot in it was
+        // observed), so the site SR only includes stratum 2's substrata.
+        val stratum2ObsRate3 = percent(obsLive[1][2] + obsLive[3][3], densities[2] + densities[3])
+        survivalRate(areaWeightedSiteRate(listOf(2 to stratum2ObsRate3)))
         noResultForStratum(1)
         stratum(2) {
           // Should pull substratum 2 rate from observation 1, but credit it to stratum 2
           // thanks to the map edit
-          survivalRate(percent(obsLive[1][2] + obsLive[3][3], densities[2] + densities[3]))
+          survivalRate(stratum2ObsRate3)
           noResultForSubstratum(2)
           substratum(3) { survivalRate(percent(obsLive[3][3], densities[3])) }
         }
@@ -1537,6 +1536,9 @@ class ObservationStoreSurvivalRateCalculationTest : ObservationScenarioTest() {
         ratesObjectFromResults(
             resultsStore.fetchByPlantingSiteId(inserted.plantingSiteId, limit = 2)[1],
             inserted.plantingSiteId,
+            resultsStoreV2
+                .fetchByPlantingSiteId(inserted.plantingSiteId, limit = 2)[1]
+                .survivalRate,
         )
     assertSurvivalRates(observation1Expected, observation1Actual, "Observation 1 shouldn't change")
   }
@@ -1681,7 +1683,12 @@ class ObservationStoreSurvivalRateCalculationTest : ObservationScenarioTest() {
       message: String,
   ) {
     val siteResults = resultsStore.fetchByPlantingSiteId(inserted.plantingSiteId, limit = 1)[0]
-    val actual = ratesObjectFromResults(siteResults, inserted.plantingSiteId)
+    // The v1 store's site-level survival rate uses the legacy density-weighted formula; for the
+    // overall site rate we use the v2 store (which reads the area-weighted DB column) so that the
+    // assertion matches the same value as the raw DB column check below.
+    val siteResultsV2 = resultsStoreV2.fetchOneById(siteResults.observationId)
+    val actual =
+        ratesObjectFromResults(siteResults, inserted.plantingSiteId, siteResultsV2.survivalRate)
     assertSurvivalRates(expected, actual, message)
     assertResultTablesSurvivalRates(expected, siteResults.observationId, message)
   }
@@ -1832,6 +1839,7 @@ class ObservationStoreSurvivalRateCalculationTest : ObservationScenarioTest() {
   private fun ratesObjectFromResults(
       siteResults: ObservationResultsModel,
       plantingSiteId: PlantingSiteId,
+      siteSurvivalRateOverride: Int? = siteResults.survivalRate,
   ): SurvivalRates {
     val siteMap = mutableMapOf<SpeciesId?, Int?>()
     val allStrataMap = mutableMapOf<Any, Map<SpeciesId?, Int?>>()
@@ -1840,7 +1848,7 @@ class ObservationStoreSurvivalRateCalculationTest : ObservationScenarioTest() {
     siteResults.species
         .filter { it.certainty == RecordedSpeciesCertainty.Known }
         .forEach { species -> siteMap[species.speciesId] = species.survivalRate }
-    siteResults.survivalRate?.let { siteMap[null] = it }
+    siteSurvivalRateOverride?.let { siteMap[null] = it }
 
     siteResults.strata.forEach { stratum ->
       val stratumMap = mutableMapOf<SpeciesId?, Int?>()

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/observationStore/ObservationStoreUpdateMonitoringSpeciesTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/observationStore/ObservationStoreUpdateMonitoringSpeciesTest.kt
@@ -6,6 +6,7 @@ import com.terraformation.backend.customer.model.TerrawareUser
 import com.terraformation.backend.db.DatabaseTest
 import com.terraformation.backend.db.default_schema.Role
 import com.terraformation.backend.db.tracking.RecordedSpeciesCertainty
+import com.terraformation.backend.toBigDecimal
 import com.terraformation.backend.tracking.event.MonitoringSpeciesTotalsEditedEvent
 import com.terraformation.backend.tracking.event.MonitoringSpeciesTotalsEditedEventValues
 import com.terraformation.backend.tracking.scenario.ObservationScenario
@@ -51,6 +52,21 @@ class ObservationStoreUpdateMonitoringSpeciesTest : DatabaseTest(), RunsAsDataba
   fun setUp() {
     insertOrganization()
     insertOrganizationUser(role = Role.Admin)
+  }
+
+  /**
+   * Models the area-weighted site survival rate over a list of (substratum count, stratum SR)
+   * pairs, where the substratum count is the number of substrata in the stratum that contribute to
+   * the site rate (carry-forward predicate applies). DSL default substratum area is 1 ha, so each
+   * substratum carries equal weight.
+   */
+  private fun areaWeightedSiteRate(stratumRates: List<Pair<Int, Int>>): Int {
+    val totalWeight = stratumRates.sumOf { it.first }
+    val weighted = stratumRates.sumOf { (substrataCount, rate) -> substrataCount * rate }
+    return weighted
+        .toBigDecimal()
+        .divide(totalWeight.toBigDecimal(), 0, java.math.RoundingMode.HALF_UP)
+        .toInt()
   }
 
   @Test
@@ -314,25 +330,32 @@ class ObservationStoreUpdateMonitoringSpeciesTest : DatabaseTest(), RunsAsDataba
       }
 
       fun assertResultsMatchNumbersFromObsLive() {
+        // Site-level survival rate is the area-weighted average across substrata of each stratum's
+        // SR (DSL default substratum area is 1 ha, so each substratum has equal weight).
+        val stratum1Live =
+            obsLive[111][0] +
+                obsLive[111][1] +
+                obsLive[112][0] +
+                obsLive[112][1] +
+                obsLive[211][0] +
+                obsLive[211][1]
+        val stratum1Density =
+            densities[111][0] +
+                densities[111][1] +
+                densities[112][0] +
+                densities[112][1] +
+                densities[211][0] +
+                densities[211][1]
+        val stratum2Live = obsLive[311][0] + obsLive[311][1]
+        val stratum2Density = densities[311][0] + densities[311][1]
+        // Stratum 1 has 2 substrata, stratum 2 has 1.
         expectResults(observation = 1) {
           survivalRate(
-              percent(
-                  obsLive[111][0] +
-                      obsLive[111][1] +
-                      obsLive[112][0] +
-                      obsLive[112][1] +
-                      obsLive[211][0] +
-                      obsLive[211][1] +
-                      obsLive[311][0] +
-                      obsLive[311][1],
-                  densities[111][0] +
-                      densities[111][1] +
-                      densities[112][0] +
-                      densities[112][1] +
-                      densities[211][0] +
-                      densities[211][1] +
-                      densities[311][0] +
-                      densities[311][1],
+              areaWeightedSiteRate(
+                  listOf(
+                      2 to percent(stratum1Live, stratum1Density),
+                      1 to percent(stratum2Live, stratum2Density),
+                  )
               )
           )
           species(
@@ -708,12 +731,9 @@ class ObservationStoreUpdateMonitoringSpeciesTest : DatabaseTest(), RunsAsDataba
         }
 
         expectResults(observation = 3) {
-          survivalRate(
-              percent(
-                  obsLive[1][111] + obsLive[2][121] + obsLive[3][211],
-                  densities[111] + densities[121] + densities[211],
-              )
-          )
+          // Stratum 1 has no OBSERVATION_STRATUM_RESULTS row in observation 3 (none of its plots
+          // were observed there), so the site SR only includes stratum 2's substrata.
+          survivalRate(percent(obsLive[3][211], densities[211]))
           stratum(2) {
             survivalRate(percent(obsLive[3][211], densities[211]))
             substratum(21) {
@@ -776,15 +796,15 @@ class ObservationStoreUpdateMonitoringSpeciesTest : DatabaseTest(), RunsAsDataba
       }
 
       fun assertResultsMatchNumbersFromObsLive() {
+        // Stratum 1 contains substrata 1 (plot 1) and 2 (plot 2); stratum 2 contains substratum 3.
         expectResults(observation = 1) {
-          survivalRate(
-              percent(
-                  obsLive[1][1] + obsLive[1][2] + obsLive[1][3],
-                  densities[1] + densities[2] + densities[3],
-              )
-          )
+          val stratum1SrObs1 = percent(obsLive[1][1] + obsLive[1][2], densities[1] + densities[2])
+          val stratum2SrObs1 = percent(obsLive[1][3], densities[3])
+
+          // Stratum 1 has 2 substrata, stratum 2 has 1.
+          survivalRate(areaWeightedSiteRate(listOf(2 to stratum1SrObs1, 1 to stratum2SrObs1)))
           stratum(1) {
-            survivalRate(percent(obsLive[1][1] + obsLive[1][2], densities[1] + densities[2]))
+            survivalRate(stratum1SrObs1)
             substratum(1) {
               survivalRate(percent(obsLive[1][1], densities[1]))
               plot(1) { survivalRate(percent(obsLive[1][1], densities[1])) }
@@ -795,23 +815,21 @@ class ObservationStoreUpdateMonitoringSpeciesTest : DatabaseTest(), RunsAsDataba
             }
           }
           stratum(2) {
-            survivalRate(percent(obsLive[1][3], densities[3]))
+            survivalRate(stratum2SrObs1)
             substratum(3) {
-              survivalRate(percent(obsLive[1][3], densities[3]))
-              plot(3) { survivalRate(percent(obsLive[1][3], densities[3])) }
+              survivalRate(stratum2SrObs1)
+              plot(3) { survivalRate(stratum2SrObs1) }
             }
           }
         }
 
+        // Observation 2: only plot 1 observed; stratum 2 has no OBSERVATION_STRATUM_RESULTS row,
+        // so the site SR includes only stratum 1's substrata.
         expectResults(observation = 2) {
-          survivalRate(
-              percent(
-                  obsLive[2][1] + obsLive[1][2] + obsLive[1][3],
-                  densities[1] + densities[2] + densities[3],
-              )
-          )
+          val stratum1SrObs2 = percent(obsLive[2][1] + obsLive[1][2], densities[1] + densities[2])
+          survivalRate(areaWeightedSiteRate(listOf(2 to stratum1SrObs2)))
           stratum(1) {
-            survivalRate(percent(obsLive[2][1] + obsLive[1][2], densities[1] + densities[2]))
+            survivalRate(stratum1SrObs2)
             substratum(1) {
               survivalRate(percent(obsLive[2][1], densities[1]))
               plot(1) { survivalRate(percent(obsLive[2][1], densities[1])) }
@@ -821,18 +839,15 @@ class ObservationStoreUpdateMonitoringSpeciesTest : DatabaseTest(), RunsAsDataba
           noResultForStratum(2)
         }
 
+        // Observation 3: only plot 3 observed; stratum 1 has no OBSERVATION_STRATUM_RESULTS row.
         expectResults(observation = 3) {
-          survivalRate(
-              percent(
-                  obsLive[2][1] + obsLive[1][2] + obsLive[3][3],
-                  densities[1] + densities[2] + densities[3],
-              )
-          )
+          val stratum2SrObs3 = percent(obsLive[3][3], densities[3])
+          survivalRate(areaWeightedSiteRate(listOf(1 to stratum2SrObs3)))
           noResultForStratum(1)
           stratum(2) {
-            survivalRate(percent(obsLive[3][3], densities[3]))
+            survivalRate(stratum2SrObs3)
             noResultForSubstratum(2)
-            substratum(3) { survivalRate(percent(obsLive[3][3], densities[3])) }
+            substratum(3) { survivalRate(stratum2SrObs3) }
           }
         }
       }
@@ -902,14 +917,13 @@ class ObservationStoreUpdateMonitoringSpeciesTest : DatabaseTest(), RunsAsDataba
 
       fun assertResultsMatchNumbersFromObsLive() {
         expectResults(observation = 1) {
-          survivalRate(
-              percent(
-                  obsLive[1][1] + obsLive[1][2] + obsLive[1][3],
-                  densities[1] + densities[2] + densities[3],
-              )
-          )
+          val stratum1SrObs1 = percent(obsLive[1][1] + obsLive[1][2], densities[1] + densities[2])
+          val stratum2SrObs1 = percent(obsLive[1][3], densities[3])
+
+          // Before the site edit, stratum 1 has 2 substrata and stratum 2 has 1.
+          survivalRate(areaWeightedSiteRate(listOf(2 to stratum1SrObs1, 1 to stratum2SrObs1)))
           stratum(1) {
-            survivalRate(percent(obsLive[1][1] + obsLive[1][2], densities[1] + densities[2]))
+            survivalRate(stratum1SrObs1)
             substratum(1) {
               survivalRate(percent(obsLive[1][1], densities[1]))
               plot(1) { survivalRate(percent(obsLive[1][1], densities[1])) }
@@ -920,23 +934,20 @@ class ObservationStoreUpdateMonitoringSpeciesTest : DatabaseTest(), RunsAsDataba
             }
           }
           stratum(2) {
-            survivalRate(percent(obsLive[1][3], densities[3]))
+            survivalRate(stratum2SrObs1)
             substratum(3) {
-              survivalRate(percent(obsLive[1][3], densities[3]))
-              plot(3) { survivalRate(percent(obsLive[1][3], densities[3])) }
+              survivalRate(stratum2SrObs1)
+              plot(3) { survivalRate(stratum2SrObs1) }
             }
           }
         }
 
         expectResults(observation = 2) {
-          survivalRate(
-              percent(
-                  obsLive[2][1] + obsLive[1][2] + obsLive[1][3],
-                  densities[1] + densities[2] + densities[3],
-              )
-          )
+          // Stratum 2 has no OBSERVATION_STRATUM_RESULTS row in observation 2.
+          val stratum1SrObs2 = percent(obsLive[2][1] + obsLive[1][2], densities[1] + densities[2])
+          survivalRate(areaWeightedSiteRate(listOf(2 to stratum1SrObs2)))
           stratum(1) {
-            survivalRate(percent(obsLive[2][1] + obsLive[1][2], densities[1] + densities[2]))
+            survivalRate(stratum1SrObs2)
             substratum(1) {
               survivalRate(percent(obsLive[2][1], densities[1]))
               plot(1) { survivalRate(percent(obsLive[2][1], densities[1])) }
@@ -947,17 +958,15 @@ class ObservationStoreUpdateMonitoringSpeciesTest : DatabaseTest(), RunsAsDataba
         }
 
         expectResults(observation = 3) {
-          survivalRate(
-              percent(
-                  obsLive[2][1] + obsLive[1][2] + obsLive[3][3],
-                  densities[1] + densities[2] + densities[3],
-              )
-          )
+          // After the map edit stratum 1 has 1 substratum (1) and stratum 2 has 2 (2 and 3).
+          // Stratum 1 has no OBSERVATION_STRATUM_RESULTS row in observation 3.
+          val stratum2SrObs3 = percent(obsLive[1][2] + obsLive[3][3], densities[2] + densities[3])
+          survivalRate(areaWeightedSiteRate(listOf(2 to stratum2SrObs3)))
           noResultForStratum(1)
           stratum(2) {
             // Should pull substratum 2 rate from observation 1, but credit it to stratum 2
             // thanks to the map edit
-            survivalRate(percent(obsLive[1][2] + obsLive[3][3], densities[2] + densities[3]))
+            survivalRate(stratum2SrObs3)
             noResultForSubstratum(2)
             substratum(3) { survivalRate(percent(obsLive[3][3], densities[3])) }
           }

--- a/src/test/kotlin/com/terraformation/backend/tracking/model/ObservationResultsModelTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/model/ObservationResultsModelTest.kt
@@ -1,0 +1,70 @@
+package com.terraformation.backend.tracking.model
+
+import java.math.BigDecimal
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Test
+
+class ObservationResultsModelTest {
+  @Test
+  fun `calculateAreaWeightedSurvivalRate uses area weighting`() {
+    // Values from Plant Tracking Math v2 spreadsheet — Site 1, Observation 2.
+    // Stratum SRs are stored as integer percentages, so the inputs here are pre-rounded
+    // (70/106/102), which gives 99 rather than the spreadsheet's full-precision 0.9963.
+    // Zone 1: SR 70%, observed substratum area 104.10 ha (subzone 1 only at obs 1)
+    // Zone 2: SR 106%, observed substratum area 328.07 ha (subzones 3+4 at obs 1)
+    // Zone 3: SR 102%, observed substratum area 340.69 ha (subzones 5+6 at obs 2)
+    val strata =
+        listOf(
+            StratumWithObservedArea(
+                survivalRate = 70,
+                observedSubstratumAreaHa = BigDecimal("104.1009464"),
+            ),
+            StratumWithObservedArea(
+                survivalRate = 106,
+                observedSubstratumAreaHa = BigDecimal("328.0757098"),
+            ),
+            StratumWithObservedArea(
+                survivalRate = 102,
+                observedSubstratumAreaHa = BigDecimal("340.6940063"),
+            ),
+        )
+
+    assertEquals(99, calculateAreaWeightedSurvivalRate(strata))
+  }
+
+  @Test
+  fun `calculateAreaWeightedSurvivalRate returns null if any stratum has null survival rate`() {
+    val strata =
+        listOf(
+            StratumWithObservedArea(
+                survivalRate = 80,
+                observedSubstratumAreaHa = BigDecimal("100"),
+            ),
+            StratumWithObservedArea(
+                survivalRate = null,
+                observedSubstratumAreaHa = BigDecimal("100"),
+            ),
+        )
+
+    assertNull(calculateAreaWeightedSurvivalRate(strata))
+  }
+
+  @Test
+  fun `calculateAreaWeightedSurvivalRate returns null if total observed area is zero`() {
+    val strata =
+        listOf(
+            StratumWithObservedArea(
+                survivalRate = 80,
+                observedSubstratumAreaHa = BigDecimal.ZERO,
+            ),
+        )
+
+    assertNull(calculateAreaWeightedSurvivalRate(strata))
+  }
+
+  @Test
+  fun `calculateAreaWeightedSurvivalRate returns null on empty input`() {
+    assertNull(calculateAreaWeightedSurvivalRate(emptyList()))
+  }
+}

--- a/src/test/kotlin/com/terraformation/backend/tracking/scenario/ExpectedObservationResult.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/scenario/ExpectedObservationResult.kt
@@ -39,7 +39,12 @@ abstract class ExpectedObservationResult<
   fun survivalRate(expected: Int?) {
     survivalRate = expected
     survivalRateSet = true
-    assertions.add { assertEquals(expected, actualResult.survivalRate, "$name survival rate") }
+    // The v1 store's site-level survival rate uses the legacy density-weighted formula and is
+    // being removed; only the v2 store (which reads the area-weighted DB column) is asserted at
+    // the site level.
+    if (name != "Site") {
+      assertions.add { assertEquals(expected, actualResult.survivalRate, "$name survival rate") }
+    }
     assertions.add {
       assertEquals(expected, actualResultV2.survivalRate, "$name survival rate [V2]")
     }

--- a/src/test/resources/tracking/observation/ObservationsSummaryTempPlots/SiteStatsSummary.csv
+++ b/src/test/resources/tracking/observation/ObservationsSummaryTempPlots/SiteStatsSummary.csv
@@ -1,3 +1,3 @@
 1,1,1,1,1,1,2,2,2,2,2,2,3,3,3,3,3,3
 Planting Density,Planting Density Std Dev,Estimated # Plants,# Species,Survival Rate,Survival Rate Std Dev,Planting Density,Planting Density Std Dev,Estimated # Plants,# Species,Survival Rate,Survival Rate Std Dev,Planting Density,Planting Density Std Dev,Estimated # Plants,# Species,Survival Rate,Survival Rate Std Dev
-762,309,,4,70%,35%,1053,496,2220000,4,,,1614,859,4571000,4,,
+762,309,,4,72%,35%,1053,496,2220000,4,,,1614,859,4571000,4,,

--- a/src/test/resources/tracking/observation/SurvivalRateNoObservations/SiteRates.csv
+++ b/src/test/resources/tracking/observation/SurvivalRateNoObservations/SiteRates.csv
@@ -1,2 +1,2 @@
 Site Name,Site Survival Rate,Species 0 Survival Rate,Species 1 Survival Rate
-Demo Site,96%,96%,96%
+Demo Site,95%,96%,96%

--- a/src/test/resources/tracking/observation/SurvivalRateNoObservations/SiteStatsSummary.csv
+++ b/src/test/resources/tracking/observation/SurvivalRateNoObservations/SiteStatsSummary.csv
@@ -1,3 +1,3 @@
 1,1,1,1,1,1
 Planting Density,Planting Density Std Dev,Estimated # Plants,# Species,Survival Rate,Survival Rate Std Dev
-1029,633,,2,96%,3%
+1029,633,,2,95%,3%

--- a/src/test/resources/tracking/observation/SurvivalRateNoRecorded/SiteRates.csv
+++ b/src/test/resources/tracking/observation/SurvivalRateNoRecorded/SiteRates.csv
@@ -1,2 +1,2 @@
 Site Name,Site Survival Rate,Species 0 Survival Rate,Species 1 Survival Rate
-Demo Site,43%,96%,0%
+Demo Site,42%,96%,0%

--- a/src/test/resources/tracking/observation/SurvivalRateSiteData/SiteRates.csv
+++ b/src/test/resources/tracking/observation/SurvivalRateSiteData/SiteRates.csv
@@ -1,2 +1,2 @@
 Site Name,Plot Survival Rate,Species 0 Survival Rate,Species 1 Survival Rate,Species 2 Survival Rate
-Demo Site,145%,184%,122%,135%
+Demo Site,151%,184%,122%,135%

--- a/src/test/resources/tracking/observation/SurvivalRateSiteGeometryChangeTemp/SiteRates.csv
+++ b/src/test/resources/tracking/observation/SurvivalRateSiteGeometryChangeTemp/SiteRates.csv
@@ -1,2 +1,2 @@
 Site Name,Site Survival Rate,Species A Survival Rate,Species B Survival Rate
-Demo Site,88%,87%,88%
+Demo Site,90%,87%,88%

--- a/src/test/resources/tracking/observation/SurvivalRateSiteTempData/SiteRates.csv
+++ b/src/test/resources/tracking/observation/SurvivalRateSiteTempData/SiteRates.csv
@@ -1,2 +1,2 @@
 Site Name,Site Survival Rate,Species 0 Survival Rate,Species 1 Survival Rate,Species 2 Survival Rate
-Demo Site,127%,216%,90%,115%
+Demo Site,128%,216%,90%,115%


### PR DESCRIPTION
Change the calculation of site-level survival rates so that it takes the weighted
average of the stratum-level survival rates, with the weights based on the total
areas of the observed substrata in each stratum.

This new number is written to the site-level observation results table, replacing
the old density-weighted number. Clients that pull results using
`ObservationResultsStoreV2` pick up the new number. The calculations in
`ObservationResultsStore` are left as-is since that class will be going away
soon.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>