### PR TITLE
SW-8399 Run T0 survival rate recalculations asynchronously via JobRunr

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/tracking/db/ObservationStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/db/ObservationStore.kt
@@ -2143,22 +2143,22 @@ class ObservationStore(
   @EventListener
   fun on(event: T0PlotDataAssignedEvent) {
     jobScheduler.enqueue<ObservationStore> {
-      runRecalculateSurvivalRatesForPlot(event.monitoringPlotId)
+      runRecalculateSurvivalRates(event.monitoringPlotId)
     }
   }
 
   @EventListener
   fun on(event: T0StratumDataAssignedEvent) {
     jobScheduler.enqueue<ObservationStore> {
-      runRecalculateSurvivalRatesForStratum(event.stratumId)
+      runRecalculateSurvivalRates(event.stratumId)
     }
   }
 
-  fun runRecalculateSurvivalRatesForPlot(monitoringPlotId: MonitoringPlotId) {
+  fun runRecalculateSurvivalRates(monitoringPlotId: MonitoringPlotId) {
     systemUser.run { recalculateSurvivalRates(monitoringPlotId) }
   }
 
-  fun runRecalculateSurvivalRatesForStratum(stratumId: StratumId) {
+  fun runRecalculateSurvivalRates(stratumId: StratumId) {
     systemUser.run { recalculateSurvivalRates(stratumId) }
   }
 

--- a/src/main/kotlin/com/terraformation/backend/tracking/db/ObservationStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/db/ObservationStore.kt
@@ -120,7 +120,6 @@ class ObservationStore(
     private val clock: InstantSource,
     private val dslContext: DSLContext,
     private val eventPublisher: ApplicationEventPublisher,
-    // JobRunr is disabled when generating OpenAPI docs from Gradle
     @Lazy private val jobScheduler: JobScheduler,
     private val observationLocker: ObservationLocker,
     private val observationsDao: ObservationsDao,
@@ -2143,6 +2142,7 @@ class ObservationStore(
   @EventListener
   fun on(event: T0PlotDataAssignedEvent) {
     jobScheduler.enqueue<ObservationStore> {
+      // Do the survival rate recalculation asynchronously to avoid delays on a T0 settings change.
       runRecalculateSurvivalRates(event.monitoringPlotId)
     }
   }
@@ -2150,6 +2150,7 @@ class ObservationStore(
   @EventListener
   fun on(event: T0StratumDataAssignedEvent) {
     jobScheduler.enqueue<ObservationStore> {
+      // Do the survival rate recalculation asynchronously to avoid delays on a T0 settings change.
       runRecalculateSurvivalRates(event.stratumId)
     }
   }

--- a/src/main/kotlin/com/terraformation/backend/tracking/db/ObservationStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/db/ObservationStore.kt
@@ -2,6 +2,7 @@ package com.terraformation.backend.tracking.db
 
 import com.terraformation.backend.auth.currentUser
 import com.terraformation.backend.customer.db.ParentStore
+import com.terraformation.backend.customer.model.SystemUser
 import com.terraformation.backend.customer.model.TerrawareUser
 import com.terraformation.backend.customer.model.requirePermissions
 import com.terraformation.backend.db.asNonNullable
@@ -103,6 +104,7 @@ import java.time.Instant
 import java.time.InstantSource
 import java.time.LocalDate
 import java.time.ZoneOffset
+import org.jobrunr.scheduling.JobScheduler
 import org.jooq.Condition
 import org.jooq.DSLContext
 import org.jooq.Field
@@ -110,6 +112,7 @@ import org.jooq.Record
 import org.jooq.impl.DSL
 import org.jooq.impl.SQLDataType
 import org.springframework.context.ApplicationEventPublisher
+import org.springframework.context.annotation.Lazy
 import org.springframework.context.event.EventListener
 
 @Named
@@ -117,12 +120,15 @@ class ObservationStore(
     private val clock: InstantSource,
     private val dslContext: DSLContext,
     private val eventPublisher: ApplicationEventPublisher,
+    // JobRunr is disabled when generating OpenAPI docs from Gradle
+    @Lazy private val jobScheduler: JobScheduler,
     private val observationLocker: ObservationLocker,
     private val observationsDao: ObservationsDao,
     private val observationPlotConditionsDao: ObservationPlotConditionsDao,
     private val observationPlotsDao: ObservationPlotsDao,
     private val observationRequestedSubstrataDao: ObservationRequestedSubstrataDao,
     private val parentStore: ParentStore,
+    private val systemUser: SystemUser,
 ) {
   companion object {
     val requestedSubstratumIdsField: Field<Set<SubstratumId>> =
@@ -2136,12 +2142,24 @@ class ObservationStore(
 
   @EventListener
   fun on(event: T0PlotDataAssignedEvent) {
-    recalculateSurvivalRates(event.monitoringPlotId)
+    jobScheduler.enqueue<ObservationStore> {
+      runRecalculateSurvivalRatesForPlot(event.monitoringPlotId)
+    }
   }
 
   @EventListener
   fun on(event: T0StratumDataAssignedEvent) {
-    recalculateSurvivalRates(event.stratumId)
+    jobScheduler.enqueue<ObservationStore> {
+      runRecalculateSurvivalRatesForStratum(event.stratumId)
+    }
+  }
+
+  fun runRecalculateSurvivalRatesForPlot(monitoringPlotId: MonitoringPlotId) {
+    systemUser.run { recalculateSurvivalRates(monitoringPlotId) }
+  }
+
+  fun runRecalculateSurvivalRatesForStratum(stratumId: StratumId) {
+    systemUser.run { recalculateSurvivalRates(stratumId) }
   }
 
   private fun deleteObservation(observationId: ObservationId) {

--- a/src/test/kotlin/com/terraformation/backend/accelerator/ObservationActivityServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/ObservationActivityServiceTest.kt
@@ -50,6 +50,7 @@ import io.mockk.mockk
 import java.time.Instant
 import java.time.LocalDate
 import java.time.LocalDateTime
+import org.jobrunr.scheduling.JobScheduler
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
@@ -63,17 +64,20 @@ class ObservationActivityServiceTest : DatabaseTest(), RunsAsDatabaseUser {
   private val parentStore: ParentStore by lazy { ParentStore(dslContext) }
   private val systemUser: SystemUser by lazy { SystemUser(usersDao) }
   private val observationLocker: ObservationLocker by lazy { ObservationLocker(dslContext) }
+  private val jobScheduler: JobScheduler = mockk()
   private val observationStore: ObservationStore by lazy {
     ObservationStore(
         clock,
         dslContext,
         eventPublisher,
+        jobScheduler,
         observationLocker,
         observationsDao,
         observationPlotConditionsDao,
         observationPlotsDao,
         observationRequestedSubstrataDao,
         parentStore,
+        systemUser,
     )
   }
   private val plantingSiteStore: PlantingSiteStore by lazy {

--- a/src/test/kotlin/com/terraformation/backend/tracking/ObservationServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/ObservationServiceTest.kt
@@ -122,6 +122,7 @@ import java.math.BigDecimal
 import java.time.Instant
 import java.time.LocalDate
 import java.time.temporal.ChronoUnit
+import org.jobrunr.scheduling.JobScheduler
 import org.junit.jupiter.api.Assertions.assertArrayEquals
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
@@ -156,17 +157,21 @@ class ObservationServiceTest : DatabaseTest(), RunsAsDatabaseUser {
   private val biomassStore: BiomassStore by lazy {
     BiomassStore(dslContext, eventPublisher, observationLocker, parentStore)
   }
+  private val jobScheduler: JobScheduler = mockk()
+  private val systemUser: SystemUser by lazy { SystemUser(usersDao) }
   private val observationStore: ObservationStore by lazy {
     ObservationStore(
         clock,
         dslContext,
         eventPublisher,
+        jobScheduler,
         observationLocker,
         observationsDao,
         observationPlotConditionsDao,
         observationPlotsDao,
         observationRequestedSubstrataDao,
         parentStore,
+        systemUser,
     )
   }
   private val plantingSiteStore: PlantingSiteStore by lazy {

--- a/src/test/kotlin/com/terraformation/backend/tracking/PlotAssignmentTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/PlotAssignmentTest.kt
@@ -24,6 +24,7 @@ import com.terraformation.backend.util.GeometrySimplifier
 import com.terraformation.backend.util.nearlyCoveredBy
 import io.mockk.every
 import io.mockk.mockk
+import org.jobrunr.scheduling.JobScheduler
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.RepeatedTest
@@ -37,17 +38,21 @@ class PlotAssignmentTest : DatabaseTest(), RunsAsUser {
   private val mockGeometrySimplifier = mockk<GeometrySimplifier>()
   private val parentStore: ParentStore by lazy { ParentStore(dslContext) }
   private val observationLocker: ObservationLocker by lazy { ObservationLocker(dslContext) }
+  private val jobScheduler: JobScheduler = mockk()
+  private val systemUser: SystemUser by lazy { SystemUser(usersDao) }
   private val observationStore: ObservationStore by lazy {
     ObservationStore(
         clock,
         dslContext,
         eventPublisher,
+        jobScheduler,
         observationLocker,
         observationsDao,
         observationPlotConditionsDao,
         observationPlotsDao,
         observationRequestedSubstrataDao,
         parentStore,
+        systemUser,
     )
   }
   private val plantingSiteStore: PlantingSiteStore by lazy {

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/ObservationScenarioTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/ObservationScenarioTest.kt
@@ -5,6 +5,7 @@ import com.terraformation.backend.RunsAsUser
 import com.terraformation.backend.TestClock
 import com.terraformation.backend.TestEventPublisher
 import com.terraformation.backend.customer.db.ParentStore
+import com.terraformation.backend.customer.model.SystemUser
 import com.terraformation.backend.customer.model.TerrawareUser
 import com.terraformation.backend.db.DatabaseTest
 import com.terraformation.backend.db.default_schema.OrganizationId
@@ -34,11 +35,13 @@ import com.terraformation.backend.tracking.scenario.ObservationScenario
 import com.terraformation.backend.util.calculateAreaHectares
 import com.terraformation.backend.util.toPlantsPerHectare
 import io.mockk.every
+import io.mockk.mockk
 import java.io.InputStreamReader
 import java.math.BigDecimal
 import java.nio.file.NoSuchFileException
 import java.time.Instant
 import kotlin.math.sqrt
+import org.jobrunr.scheduling.JobScheduler
 import org.jooq.impl.DSL
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
@@ -61,17 +64,21 @@ abstract class ObservationScenarioTest : DatabaseTest(), RunsAsUser {
 
   protected val clock = TestClock()
   protected val eventPublisher = TestEventPublisher()
+  protected val jobScheduler: JobScheduler = mockk()
+  protected val systemUser: SystemUser by lazy { SystemUser(usersDao) }
   protected val observationStore by lazy {
     ObservationStore(
         clock,
         dslContext,
         eventPublisher,
+        jobScheduler,
         ObservationLocker(dslContext),
         observationsDao,
         observationPlotConditionsDao,
         observationPlotsDao,
         observationRequestedSubstrataDao,
         ParentStore(dslContext),
+        systemUser,
     )
   }
   protected val resultsStore by lazy { ObservationResultsStore(dslContext) }

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/observationStore/BaseObservationStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/observationStore/BaseObservationStoreTest.kt
@@ -4,6 +4,7 @@ import com.terraformation.backend.RunsAsUser
 import com.terraformation.backend.TestClock
 import com.terraformation.backend.TestEventPublisher
 import com.terraformation.backend.customer.db.ParentStore
+import com.terraformation.backend.customer.model.SystemUser
 import com.terraformation.backend.customer.model.TerrawareUser
 import com.terraformation.backend.db.DatabaseTest
 import com.terraformation.backend.db.default_schema.OrganizationId
@@ -13,6 +14,8 @@ import com.terraformation.backend.tracking.db.ObservationLocker
 import com.terraformation.backend.tracking.db.ObservationStore
 import com.terraformation.backend.tracking.db.ObservationTestHelper
 import io.mockk.every
+import io.mockk.mockk
+import org.jobrunr.scheduling.JobScheduler
 import org.junit.jupiter.api.BeforeEach
 
 abstract class BaseObservationStoreTest : DatabaseTest(), RunsAsUser {
@@ -20,17 +23,21 @@ abstract class BaseObservationStoreTest : DatabaseTest(), RunsAsUser {
 
   protected val clock = TestClock()
   protected val eventPublisher = TestEventPublisher()
+  protected val jobScheduler: JobScheduler = mockk()
+  protected val systemUser: SystemUser by lazy { SystemUser(usersDao) }
   protected val store: ObservationStore by lazy {
     ObservationStore(
         clock,
         dslContext,
         eventPublisher,
+        jobScheduler,
         ObservationLocker(dslContext),
         observationsDao,
         observationPlotConditionsDao,
         observationPlotsDao,
         observationRequestedSubstrataDao,
         ParentStore(dslContext),
+        systemUser,
     )
   }
   protected val helper: ObservationTestHelper by lazy {

--- a/src/test/kotlin/com/terraformation/backend/tracking/scenario/ObservationScenario.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/scenario/ObservationScenario.kt
@@ -3,6 +3,7 @@ package com.terraformation.backend.tracking.scenario
 import com.terraformation.backend.TestClock
 import com.terraformation.backend.TestEventPublisher
 import com.terraformation.backend.customer.db.ParentStore
+import com.terraformation.backend.customer.model.SystemUser
 import com.terraformation.backend.db.DatabaseBackedTest
 import com.terraformation.backend.db.IdentifierGenerator
 import com.terraformation.backend.db.default_schema.SpeciesId
@@ -29,9 +30,12 @@ import com.terraformation.backend.tracking.db.PlantingSiteStore
 import com.terraformation.backend.tracking.db.T0Store
 import com.terraformation.backend.tracking.event.MonitoringSpeciesTotalsEditedEvent
 import com.terraformation.backend.tracking.event.T0PlotDataAssignedEvent
+import com.terraformation.backend.tracking.event.T0StratumDataAssignedEvent
 import com.terraformation.backend.tracking.model.ObservationResultsDepth
 import com.terraformation.backend.util.GeometrySimplifier
+import io.mockk.mockk
 import java.time.temporal.ChronoUnit
+import org.jobrunr.scheduling.JobScheduler
 import org.jooq.Configuration
 
 /**
@@ -83,17 +87,21 @@ class ObservationScenario(
         observationLocker: ObservationLocker = ObservationLocker(test.dslContext),
         parentStore: ParentStore = ParentStore(test.dslContext),
         configuration: Configuration = test.dslContext.configuration(),
+        jobScheduler: JobScheduler = mockk(),
+        systemUser: SystemUser = mockk(relaxed = true),
         observationStore: ObservationStore =
             ObservationStore(
                 clock,
                 test.dslContext,
                 eventPublisher,
+                jobScheduler,
                 observationLocker,
                 ObservationsDao(configuration),
                 ObservationPlotConditionsDao(configuration),
                 ObservationPlotsDao(configuration),
                 ObservationRequestedSubstrataDao(configuration),
                 parentStore,
+                systemUser,
             ),
         plantingSiteStore: PlantingSiteStore =
             PlantingSiteStore(
@@ -114,7 +122,14 @@ class ObservationScenario(
     ): ObservationScenario {
       if (registerListeners) {
         eventPublisher.register<MonitoringSpeciesTotalsEditedEvent> { t0Store.on(it) }
-        eventPublisher.register<T0PlotDataAssignedEvent> { observationStore.on(it) }
+        // Recalculation runs asynchronously via JobRunr in production. In scenario tests we
+        // invoke the recalc method directly so observation results reflect the changes inline.
+        eventPublisher.register<T0PlotDataAssignedEvent> {
+          observationStore.recalculateSurvivalRates(it.monitoringPlotId)
+        }
+        eventPublisher.register<T0StratumDataAssignedEvent> {
+          observationStore.recalculateSurvivalRates(it.stratumId)
+        }
       }
 
       return ObservationScenario(


### PR DESCRIPTION
The @EventListener handlers for T0PlotDataAssignedEvent and
T0StratumDataAssignedEvent previously ran recalculateSurvivalRates
synchronously inside the T0 assignment transaction, making the user
wait. They now enqueue a JobRunr job so the request returns immediately.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>