### PR TITLE
SW-8359 Include observation in activity payloads

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/accelerator/api/ActivitiesAdminController.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/api/ActivitiesAdminController.kt
@@ -17,6 +17,9 @@ import com.terraformation.backend.db.default_schema.FileId
 import com.terraformation.backend.db.default_schema.GlobalRole
 import com.terraformation.backend.db.default_schema.ProjectId
 import com.terraformation.backend.db.default_schema.UserId
+import com.terraformation.backend.db.tracking.ObservationId
+import com.terraformation.backend.db.tracking.ObservationMediaType
+import com.terraformation.backend.db.tracking.ObservationPlotPosition
 import com.terraformation.backend.funder.db.PublishedActivityStore
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.Parameter
@@ -106,6 +109,20 @@ class ActivitiesAdminController(
   }
 }
 
+data class AdminActivityObservationMediaFilePayload(
+    val monitoringPlotNumber: Long,
+    val position: ObservationPlotPosition?,
+    val type: ObservationMediaType,
+) {
+  constructor(
+      observation: ActivityMediaModel.Observation
+  ) : this(
+      monitoringPlotNumber = observation.monitoringPlotNumber,
+      position = observation.position,
+      type = observation.type,
+  )
+}
+
 data class AdminActivityMediaFilePayload(
     val caption: String?,
     val capturedDate: LocalDate,
@@ -117,6 +134,7 @@ data class AdminActivityMediaFilePayload(
     val isCoverPhoto: Boolean,
     val isHiddenOnMap: Boolean,
     val listPosition: Int,
+    val observation: AdminActivityObservationMediaFilePayload?,
     val type: ActivityMediaType,
 ) {
   constructor(
@@ -132,8 +150,15 @@ data class AdminActivityMediaFilePayload(
       isCoverPhoto = model.isCoverPhoto,
       isHiddenOnMap = model.isHiddenOnMap,
       listPosition = model.listPosition,
+      observation = model.observation?.let { AdminActivityObservationMediaFilePayload(it) },
       type = model.type,
   )
+}
+
+data class AdminActivityObservationPayload(
+    val observationId: ObservationId,
+) {
+  constructor(model: ExistingActivityModel.Observation) : this(model.observationId)
 }
 
 data class AdminActivityPayload(
@@ -146,6 +171,7 @@ data class AdminActivityPayload(
     val media: List<AdminActivityMediaFilePayload>,
     val modifiedBy: UserId,
     val modifiedTime: Instant,
+    val observation: AdminActivityObservationPayload?,
     val publishedBy: UserId?,
     val publishedTime: Instant?,
     val status: ActivityStatus,
@@ -165,6 +191,7 @@ data class AdminActivityPayload(
       media = model.media.map { AdminActivityMediaFilePayload(it) },
       modifiedBy = model.modifiedBy,
       modifiedTime = model.modifiedTime,
+      observation = model.observation?.let { AdminActivityObservationPayload(it) },
       publishedBy = model.publishedBy,
       publishedTime = model.publishedTime,
       status = model.activityStatus,

--- a/src/main/kotlin/com/terraformation/backend/accelerator/api/ActivitiesController.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/api/ActivitiesController.kt
@@ -23,6 +23,7 @@ import com.terraformation.backend.db.accelerator.ActivityStatus
 import com.terraformation.backend.db.accelerator.ActivityType
 import com.terraformation.backend.db.default_schema.FileId
 import com.terraformation.backend.db.default_schema.ProjectId
+import com.terraformation.backend.db.tracking.ObservationId
 import com.terraformation.backend.db.tracking.ObservationMediaType
 import com.terraformation.backend.db.tracking.ObservationPlotPosition
 import com.terraformation.backend.file.SUPPORTED_MEDIA_TYPES
@@ -213,7 +214,7 @@ class ActivitiesController(
   }
 }
 
-data class ObservationActivityMediaFilePayload(
+data class ActivityObservationMediaFilePayload(
     val monitoringPlotNumber: Long,
     val position: ObservationPlotPosition?,
     val type: ObservationMediaType,
@@ -240,7 +241,7 @@ data class ActivityMediaFilePayload(
         description =
             "If this file is from an observation, additional observation-specific data about it."
     )
-    val observation: ObservationActivityMediaFilePayload? = null,
+    val observation: ActivityObservationMediaFilePayload? = null,
     val type: ActivityMediaType,
 ) {
   constructor(
@@ -254,9 +255,15 @@ data class ActivityMediaFilePayload(
       isCoverPhoto = model.isCoverPhoto,
       isHiddenOnMap = model.isHiddenOnMap,
       listPosition = model.listPosition,
-      observation = model.observation?.let { ObservationActivityMediaFilePayload(it) },
+      observation = model.observation?.let { ActivityObservationMediaFilePayload(it) },
       type = model.type,
   )
+}
+
+data class ActivityObservationPayload(
+    val observationId: ObservationId,
+) {
+  constructor(model: ExistingActivityModel.Observation) : this(model.observationId)
 }
 
 data class ActivityPayload(
@@ -265,6 +272,7 @@ data class ActivityPayload(
     val id: ActivityId,
     val isHighlight: Boolean,
     val media: List<ActivityMediaFilePayload>,
+    val observation: ActivityObservationPayload? = null,
     val publishedTime: Instant?,
     val status: ActivityStatus,
     val type: ActivityType,
@@ -277,6 +285,7 @@ data class ActivityPayload(
       id = model.id,
       isHighlight = model.isHighlight,
       media = model.media.map { ActivityMediaFilePayload(it) },
+      observation = model.observation?.let { ActivityObservationPayload(it) },
       publishedTime = model.publishedTime,
       status = model.activityStatus,
       type = model.activityType,

--- a/src/main/kotlin/com/terraformation/backend/accelerator/db/ActivityStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/db/ActivityStore.kt
@@ -78,6 +78,7 @@ class ActivityStore(
         media = emptyList(),
         modifiedBy = userId,
         modifiedTime = now,
+        observation = null,
         projectId = model.projectId,
     )
   }
@@ -266,40 +267,34 @@ class ActivityStore(
       mediaDepth: ActivityMediaDepth,
   ): List<ExistingActivityModel> {
     return with(ACTIVITIES) {
-      if (mediaDepth != ActivityMediaDepth.None) {
-        val mediaCondition =
-            when (mediaDepth) {
-              ActivityMediaDepth.CoverPhotos -> ACTIVITY_MEDIA_FILES.IS_COVER_PHOTO.isTrue()
-              ActivityMediaDepth.All -> DSL.trueCondition()
-            }
-        val mediaField = mediaMultiset(mediaCondition)
-        dslContext
-            .select(
-                asterisk(),
-                PUBLISHED_ACTIVITIES.PUBLISHED_BY,
-                PUBLISHED_ACTIVITIES.PUBLISHED_TIME,
-                mediaField,
-            )
-            .from(ACTIVITIES)
-            .leftJoin(PUBLISHED_ACTIVITIES)
-            .on(ID.eq(PUBLISHED_ACTIVITIES.ACTIVITY_ID))
-            .where(condition)
-            .orderBy(ID)
-            .fetch { ExistingActivityModel.of(it, mediaField) }
-      } else {
-        dslContext
-            .select(
-                asterisk(),
-                PUBLISHED_ACTIVITIES.PUBLISHED_BY,
-                PUBLISHED_ACTIVITIES.PUBLISHED_TIME,
-            )
-            .from(ACTIVITIES)
-            .leftJoin(PUBLISHED_ACTIVITIES)
-            .on(ID.eq(PUBLISHED_ACTIVITIES.ACTIVITY_ID))
-            .where(condition)
-            .orderBy(ID)
-            .fetch { ExistingActivityModel.of(it, null) }
-      }
+      val mediaField =
+          if (mediaDepth != ActivityMediaDepth.None) {
+            val mediaCondition =
+                when (mediaDepth) {
+                  ActivityMediaDepth.CoverPhotos -> ACTIVITY_MEDIA_FILES.IS_COVER_PHOTO.isTrue()
+                  ActivityMediaDepth.All -> DSL.trueCondition()
+                }
+            mediaMultiset(mediaCondition)
+          } else {
+            null
+          }
+
+      dslContext
+          .select(
+              asterisk(),
+              ACTIVITY_OBSERVATIONS.OBSERVATION_ID,
+              PUBLISHED_ACTIVITIES.PUBLISHED_BY,
+              PUBLISHED_ACTIVITIES.PUBLISHED_TIME,
+              mediaField ?: DSL.one(),
+          )
+          .from(ACTIVITIES)
+          .leftJoin(ACTIVITY_OBSERVATIONS)
+          .on(ID.eq(ACTIVITY_OBSERVATIONS.ACTIVITY_ID))
+          .leftJoin(PUBLISHED_ACTIVITIES)
+          .on(ID.eq(PUBLISHED_ACTIVITIES.ACTIVITY_ID))
+          .where(condition)
+          .orderBy(ID)
+          .fetch { ExistingActivityModel.of(it, mediaField) }
     }
   }
 

--- a/src/main/kotlin/com/terraformation/backend/accelerator/model/ActivityModel.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/model/ActivityModel.kt
@@ -4,9 +4,11 @@ import com.terraformation.backend.db.accelerator.ActivityId
 import com.terraformation.backend.db.accelerator.ActivityStatus
 import com.terraformation.backend.db.accelerator.ActivityType
 import com.terraformation.backend.db.accelerator.tables.references.ACTIVITIES
+import com.terraformation.backend.db.accelerator.tables.references.ACTIVITY_OBSERVATIONS
 import com.terraformation.backend.db.default_schema.ProjectId
 import com.terraformation.backend.db.default_schema.UserId
 import com.terraformation.backend.db.funder.tables.references.PUBLISHED_ACTIVITIES
+import com.terraformation.backend.db.tracking.ObservationId
 import java.time.Instant
 import java.time.LocalDate
 import org.jooq.Field
@@ -24,12 +26,17 @@ data class ExistingActivityModel(
     val media: List<ActivityMediaModel> = emptyList(),
     val modifiedBy: UserId,
     val modifiedTime: Instant,
+    val observation: Observation? = null,
     val projectId: ProjectId,
     val publishedBy: UserId? = null,
     val publishedTime: Instant? = null,
     val verifiedBy: UserId? = null,
     val verifiedTime: Instant? = null,
 ) {
+  data class Observation(
+      val observationId: ObservationId,
+  )
+
   companion object {
     fun of(
         record: Record,
@@ -48,6 +55,7 @@ data class ExistingActivityModel(
             media = mediaField?.let { record[it] } ?: emptyList(),
             modifiedBy = record[MODIFIED_BY]!!,
             modifiedTime = record[MODIFIED_TIME]!!,
+            observation = record[ACTIVITY_OBSERVATIONS.OBSERVATION_ID]?.let { Observation(it) },
             projectId = record[PROJECT_ID]!!,
             publishedBy = record[PUBLISHED_ACTIVITIES.PUBLISHED_BY],
             publishedTime = record[PUBLISHED_ACTIVITIES.PUBLISHED_TIME],

--- a/src/main/kotlin/com/terraformation/backend/funder/api/FunderActivitiesController.kt
+++ b/src/main/kotlin/com/terraformation/backend/funder/api/FunderActivitiesController.kt
@@ -11,6 +11,8 @@ import com.terraformation.backend.db.accelerator.ActivityMediaType
 import com.terraformation.backend.db.accelerator.ActivityType
 import com.terraformation.backend.db.default_schema.FileId
 import com.terraformation.backend.db.default_schema.ProjectId
+import com.terraformation.backend.db.tracking.ObservationMediaType
+import com.terraformation.backend.db.tracking.ObservationPlotPosition
 import com.terraformation.backend.file.api.GetMuxStreamResponsePayload
 import com.terraformation.backend.funder.PublishedActivityService
 import com.terraformation.backend.funder.db.PublishedActivityStore
@@ -19,6 +21,7 @@ import com.terraformation.backend.funder.model.PublishedActivityModel
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.media.Schema
 import jakarta.ws.rs.QueryParam
+import java.time.Instant
 import java.time.LocalDate
 import org.locationtech.jts.geom.Point
 import org.springframework.core.io.InputStreamResource
@@ -87,6 +90,20 @@ class FunderActivitiesController(
   }
 }
 
+data class FunderObservationActivityMediaFilePayload(
+    val monitoringPlotNumber: Long,
+    val position: ObservationPlotPosition?,
+    val type: ObservationMediaType,
+) {
+  constructor(
+      observation: PublishedActivityMediaModel.Observation
+  ) : this(
+      monitoringPlotNumber = observation.monitoringPlotNumber,
+      position = observation.position,
+      type = observation.type,
+  )
+}
+
 data class FunderActivityMediaFilePayload(
     val caption: String?,
     val capturedDate: LocalDate,
@@ -96,6 +113,7 @@ data class FunderActivityMediaFilePayload(
     val isCoverPhoto: Boolean,
     val isHiddenOnMap: Boolean,
     val listPosition: Int,
+    val observation: FunderObservationActivityMediaFilePayload?,
     val type: ActivityMediaType,
 ) {
   constructor(
@@ -109,7 +127,24 @@ data class FunderActivityMediaFilePayload(
       isCoverPhoto = model.isCoverPhoto,
       isHiddenOnMap = model.isHiddenOnMap,
       listPosition = model.listPosition,
+      observation = model.observation?.let { FunderObservationActivityMediaFilePayload(it) },
       type = model.type,
+  )
+}
+
+data class FunderActivityObservationPayload(
+    val completedTime: Instant,
+    val livePlants: Int?,
+    val plantDensity: Int?,
+    val survivalRate: Int?,
+) {
+  constructor(
+      model: PublishedActivityModel.Observation
+  ) : this(
+      completedTime = model.completedTime,
+      livePlants = model.livePlants,
+      plantDensity = model.plantDensity,
+      survivalRate = model.survivalRate,
   )
 }
 
@@ -119,6 +154,7 @@ data class FunderActivityPayload(
     val id: ActivityId,
     val isHighlight: Boolean,
     val media: List<FunderActivityMediaFilePayload>,
+    val observation: FunderActivityObservationPayload?,
     val type: ActivityType,
 ) {
   constructor(
@@ -129,6 +165,7 @@ data class FunderActivityPayload(
       id = model.id,
       isHighlight = model.isHighlight,
       media = model.media.map { FunderActivityMediaFilePayload(it) },
+      observation = model.observation?.let { FunderActivityObservationPayload(it) },
       type = model.activityType,
   )
 }

--- a/src/main/kotlin/com/terraformation/backend/funder/db/PublishedActivityStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/funder/db/PublishedActivityStore.kt
@@ -19,6 +19,8 @@ import com.terraformation.backend.db.funder.tables.references.PUBLISHED_ACTIVITI
 import com.terraformation.backend.db.funder.tables.references.PUBLISHED_ACTIVITY_MEDIA_FILES
 import com.terraformation.backend.db.funder.tables.references.PUBLISHED_ACTIVITY_OBSERVATIONS
 import com.terraformation.backend.db.funder.tables.references.PUBLISHED_ACTIVITY_OBSERVATION_MEDIA_FILES
+import com.terraformation.backend.db.tracking.tables.references.MONITORING_PLOTS
+import com.terraformation.backend.db.tracking.tables.references.OBSERVATIONS
 import com.terraformation.backend.db.tracking.tables.references.OBSERVATION_MEDIA_FILES
 import com.terraformation.backend.db.tracking.tables.references.OBSERVATION_SITE_RESULTS
 import com.terraformation.backend.file.event.FileReferenceDeletedEvent
@@ -122,10 +124,21 @@ class PublishedActivityStore(
                         FILES.CAPTURED_LOCAL_TIME,
                         FILES.STORAGE_URL,
                         geolocationField,
+                        MONITORING_PLOTS.PLOT_NUMBER,
+                        PUBLISHED_ACTIVITY_OBSERVATION_MEDIA_FILES.POSITION_ID,
+                        PUBLISHED_ACTIVITY_OBSERVATION_MEDIA_FILES.TYPE_ID,
                     )
                     .from(PUBLISHED_ACTIVITY_MEDIA_FILES)
                     .join(FILES)
                     .on(PUBLISHED_ACTIVITY_MEDIA_FILES.FILE_ID.eq(FILES.ID))
+                    .leftJoin(PUBLISHED_ACTIVITY_OBSERVATION_MEDIA_FILES)
+                    .on(FILE_ID.eq(PUBLISHED_ACTIVITY_OBSERVATION_MEDIA_FILES.FILE_ID))
+                    .leftJoin(MONITORING_PLOTS)
+                    .on(
+                        PUBLISHED_ACTIVITY_OBSERVATION_MEDIA_FILES.MONITORING_PLOT_ID.eq(
+                            MONITORING_PLOTS.ID
+                        )
+                    )
                     .where(ACTIVITY_ID.eq(PUBLISHED_ACTIVITIES.ACTIVITY_ID))
                     .orderBy(LIST_POSITION)
             )
@@ -141,14 +154,32 @@ class PublishedActivityStore(
     return with(PUBLISHED_ACTIVITIES) {
       if (includeMedia) {
         dslContext
-            .select(asterisk(), mediaMultiset)
+            .select(
+                asterisk(),
+                PUBLISHED_ACTIVITY_OBSERVATIONS.asterisk(),
+                OBSERVATIONS.COMPLETED_TIME,
+                mediaMultiset,
+            )
             .from(PUBLISHED_ACTIVITIES)
+            .leftJoin(PUBLISHED_ACTIVITY_OBSERVATIONS)
+            .on(ACTIVITY_ID.eq(PUBLISHED_ACTIVITY_OBSERVATIONS.ACTIVITY_ID))
+            .leftJoin(OBSERVATIONS)
+            .on(PUBLISHED_ACTIVITY_OBSERVATIONS.OBSERVATION_ID.eq(OBSERVATIONS.ID))
             .where(condition)
             .orderBy(ACTIVITY_DATE, ACTIVITY_ID)
             .fetch { PublishedActivityModel.of(it, mediaMultiset) }
       } else {
         dslContext
-            .selectFrom(PUBLISHED_ACTIVITIES)
+            .select(
+                asterisk(),
+                PUBLISHED_ACTIVITY_OBSERVATIONS.asterisk(),
+                OBSERVATIONS.COMPLETED_TIME,
+            )
+            .from(PUBLISHED_ACTIVITIES)
+            .leftJoin(PUBLISHED_ACTIVITY_OBSERVATIONS)
+            .on(ACTIVITY_ID.eq(PUBLISHED_ACTIVITY_OBSERVATIONS.ACTIVITY_ID))
+            .leftJoin(OBSERVATIONS)
+            .on(PUBLISHED_ACTIVITY_OBSERVATIONS.OBSERVATION_ID.eq(OBSERVATIONS.ID))
             .where(condition)
             .orderBy(ACTIVITY_DATE, ACTIVITY_ID)
             .fetch { PublishedActivityModel.of(it, null) }

--- a/src/main/kotlin/com/terraformation/backend/funder/model/PublishedActivityMediaModel.kt
+++ b/src/main/kotlin/com/terraformation/backend/funder/model/PublishedActivityMediaModel.kt
@@ -5,6 +5,10 @@ import com.terraformation.backend.db.accelerator.ActivityMediaType
 import com.terraformation.backend.db.default_schema.FileId
 import com.terraformation.backend.db.default_schema.tables.references.FILES
 import com.terraformation.backend.db.funder.tables.references.PUBLISHED_ACTIVITY_MEDIA_FILES
+import com.terraformation.backend.db.funder.tables.references.PUBLISHED_ACTIVITY_OBSERVATION_MEDIA_FILES
+import com.terraformation.backend.db.tracking.ObservationMediaType
+import com.terraformation.backend.db.tracking.ObservationPlotPosition
+import com.terraformation.backend.db.tracking.tables.references.MONITORING_PLOTS
 import java.time.LocalDate
 import java.time.LocalDateTime
 import org.jooq.Field
@@ -22,10 +26,31 @@ data class PublishedActivityMediaModel(
     val isCoverPhoto: Boolean,
     val isHiddenOnMap: Boolean,
     val listPosition: Int,
+    val observation: Observation? = null,
     val type: ActivityMediaType,
 ) {
   val capturedDate: LocalDate
     get() = capturedLocalTime.toLocalDate()
+
+  data class Observation(
+      val monitoringPlotNumber: Long,
+      val position: ObservationPlotPosition?,
+      val type: ObservationMediaType,
+  ) {
+    companion object {
+      fun ofOrNull(record: Record): Observation? {
+        return record[MONITORING_PLOTS.PLOT_NUMBER]?.let { plotNumber ->
+          record[PUBLISHED_ACTIVITY_OBSERVATION_MEDIA_FILES.TYPE_ID]?.let { type ->
+            Observation(
+                monitoringPlotNumber = plotNumber,
+                position = record[PUBLISHED_ACTIVITY_OBSERVATION_MEDIA_FILES.POSITION_ID],
+                type = type,
+            )
+          }
+        }
+      }
+    }
+  }
 
   companion object {
     fun of(
@@ -43,6 +68,7 @@ data class PublishedActivityMediaModel(
             isCoverPhoto = record[IS_COVER_PHOTO]!!,
             isHiddenOnMap = record[IS_HIDDEN_ON_MAP]!!,
             listPosition = record[LIST_POSITION]!!,
+            observation = Observation.ofOrNull(record),
             type = record[ACTIVITY_MEDIA_TYPE_ID]!!,
         )
       }

--- a/src/main/kotlin/com/terraformation/backend/funder/model/PublishedActivityModel.kt
+++ b/src/main/kotlin/com/terraformation/backend/funder/model/PublishedActivityModel.kt
@@ -5,6 +5,9 @@ import com.terraformation.backend.db.accelerator.ActivityType
 import com.terraformation.backend.db.default_schema.ProjectId
 import com.terraformation.backend.db.default_schema.UserId
 import com.terraformation.backend.db.funder.tables.references.PUBLISHED_ACTIVITIES
+import com.terraformation.backend.db.funder.tables.references.PUBLISHED_ACTIVITY_OBSERVATIONS
+import com.terraformation.backend.db.tracking.ObservationId
+import com.terraformation.backend.db.tracking.tables.references.OBSERVATIONS
 import java.time.Instant
 import java.time.LocalDate
 import org.jooq.Field
@@ -17,10 +20,35 @@ data class PublishedActivityModel(
     val id: ActivityId,
     val isHighlight: Boolean,
     val media: List<PublishedActivityMediaModel> = emptyList(),
+    val observation: Observation? = null,
     val projectId: ProjectId,
     val publishedBy: UserId? = null,
     val publishedTime: Instant? = null,
 ) {
+  data class Observation(
+      val observationId: ObservationId,
+      val completedTime: Instant,
+      val livePlants: Int?,
+      val plantDensity: Int?,
+      val survivalRate: Int?,
+  ) {
+    companion object {
+      fun ofOrNull(record: Record): Observation? {
+        return with(PUBLISHED_ACTIVITY_OBSERVATIONS) {
+          record[OBSERVATION_ID]?.let { observationId ->
+            Observation(
+                observationId = observationId,
+                completedTime = record[OBSERVATIONS.COMPLETED_TIME]!!,
+                livePlants = record[LIVE_PLANTS],
+                plantDensity = record[PLANT_DENSITY],
+                survivalRate = record[SURVIVAL_RATE],
+            )
+          }
+        }
+      }
+    }
+  }
+
   companion object {
     fun of(
         record: Record,
@@ -34,6 +62,7 @@ data class PublishedActivityModel(
             id = record[ACTIVITY_ID]!!,
             isHighlight = record[IS_HIGHLIGHT]!!,
             media = mediaField?.let { record[it] } ?: emptyList(),
+            observation = Observation.ofOrNull(record),
             projectId = record[PROJECT_ID]!!,
             publishedBy = record[PUBLISHED_ACTIVITIES.PUBLISHED_BY],
             publishedTime = record[PUBLISHED_ACTIVITIES.PUBLISHED_TIME],

--- a/src/test/kotlin/com/terraformation/backend/accelerator/db/ActivityStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/db/ActivityStoreTest.kt
@@ -271,7 +271,7 @@ class ActivityStoreTest : DatabaseTest(), RunsAsDatabaseUser {
       insertStratum()
       insertSubstratum()
       insertMonitoringPlot(plotNumber = 321)
-      insertObservation(completedTime = Instant.EPOCH)
+      val observationId = insertObservation(completedTime = Instant.EPOCH)
       insertObservationPlot()
 
       val activityId =
@@ -280,6 +280,7 @@ class ActivityStoreTest : DatabaseTest(), RunsAsDatabaseUser {
               activityType = ActivityType.Monitoring,
               description = "Test monitoring activity",
           )
+      insertActivityObservation()
       val fileId1 =
           insertFile(
               capturedLocalTime = LocalDate.of(2024, 2, 19).atStartOfDay(),
@@ -370,6 +371,7 @@ class ActivityStoreTest : DatabaseTest(), RunsAsDatabaseUser {
                   ),
               modifiedBy = user.userId,
               modifiedTime = Instant.EPOCH,
+              observation = ExistingActivityModel.Observation(observationId),
               projectId = projectId,
           )
 

--- a/src/test/kotlin/com/terraformation/backend/funder/db/PublishedActivityStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/funder/db/PublishedActivityStoreTest.kt
@@ -91,16 +91,28 @@ class PublishedActivityStoreTest : DatabaseTest(), RunsAsDatabaseUser {
       val activity1FileId2 = insertFile(capturedLocalTime = LocalDate.EPOCH.atStartOfDay())
       insertActivityMediaFile()
       insertPublishedActivityMediaFile()
+
+      insertPlantingSite(x = 0, width = 10)
+      insertStratum()
+      insertSubstratum()
+      insertMonitoringPlot(plotNumber = 123)
+      val completedTime = Instant.ofEpochSecond(12345)
+      val observationId = insertObservation(completedTime = completedTime)
+      insertObservationPlot(completedBy = user.userId)
+
       val activityId2 =
           insertActivity(activityType = ActivityType.Monitoring, verifiedBy = user.userId)
+      insertActivityObservation()
       insertPublishedActivity(
           activityDate = LocalDate.of(2025, 1, 2),
           activityType = ActivityType.Monitoring,
           description = "Activity 2",
       )
+      insertPublishedActivityObservation()
       val activity2FileId = insertFile(capturedLocalTime = LocalDate.EPOCH.atStartOfDay())
       insertActivityMediaFile()
       insertPublishedActivityMediaFile()
+      insertPublishedActivityObservationMediaFile()
 
       // Activities from other projects shouldn't be included.
       insertProject()
@@ -165,8 +177,22 @@ class PublishedActivityStoreTest : DatabaseTest(), RunsAsDatabaseUser {
                               isCoverPhoto = false,
                               isHiddenOnMap = false,
                               listPosition = 1,
+                              observation =
+                                  PublishedActivityMediaModel.Observation(
+                                      monitoringPlotNumber = 123,
+                                      position = ObservationPlotPosition.SouthwestCorner,
+                                      type = ObservationMediaType.Plot,
+                                  ),
                               type = ActivityMediaType.Photo,
                           ),
+                      ),
+                  observation =
+                      PublishedActivityModel.Observation(
+                          livePlants = 100,
+                          completedTime = completedTime,
+                          observationId = observationId,
+                          plantDensity = 20,
+                          survivalRate = 90,
                       ),
                   projectId = projectId,
                   publishedBy = user.userId,


### PR DESCRIPTION
If an activity is associated with an observation, include its observation ID in
the admin and regular activity payloads. Clients can then fetch the observation
to get additional details.

Include observation-specific media file fields in the admin version of the
activity media files payload; they were only present in the non-admin version.