### PR TITLE
SW-8371 Add api endpoint to create a scheduled planting date for a planting season

### DIFF
--- a/jooq/src/main/kotlin/com/terraformation/backend/jooq/Config.kt
+++ b/jooq/src/main/kotlin/com/terraformation/backend/jooq/Config.kt
@@ -545,6 +545,10 @@ val ID_WRAPPERS =
                 IdWrapper("PlantingSiteNotificationId", listOf("planting_site_notifications\\.id")),
                 IdWrapper("RecordedPlantId", listOf("recorded_plants\\.id")),
                 IdWrapper("RecordedTreeId", listOf("recorded_trees\\.id")),
+                IdWrapper(
+                    "ScheduledPlantingDateId",
+                    listOf("scheduled_planting_dates\\.id", ".*\\.scheduled_planting_date_id"),
+                ),
                 IdWrapper("SimplePlantingSeasonId", listOf("simple_planting_seasons\\.id")),
                 IdWrapper(
                     "SubstratumHistoryId",

--- a/src/main/kotlin/com/terraformation/backend/plantingmanagement/Models.kt
+++ b/src/main/kotlin/com/terraformation/backend/plantingmanagement/Models.kt
@@ -41,4 +41,8 @@ data class PlantingSeasonScheduledDateModel(
     val date: LocalDate,
     val plantingSeasonId: PlantingSeasonId,
     val species: List<PlantingSeasonScheduledDateSpecies> = emptyList(),
-)
+) {
+  init {
+    require(species.all { it.quantity >= 0 }) { "All quantities must be >= 0" }
+  }
+}

--- a/src/main/kotlin/com/terraformation/backend/plantingmanagement/Models.kt
+++ b/src/main/kotlin/com/terraformation/backend/plantingmanagement/Models.kt
@@ -30,3 +30,15 @@ data class PlantingSeasonSpeciesTargetModel(
     val speciesId: SpeciesId,
     val substratumId: SubstratumId,
 )
+
+data class PlantingSeasonScheduledDateSpecies(
+    val quantity: Int,
+    val speciesId: SpeciesId,
+    val substratumId: SubstratumId,
+)
+
+data class PlantingSeasonScheduledDateModel(
+    val date: LocalDate,
+    val plantingSeasonId: PlantingSeasonId,
+    val species: List<PlantingSeasonScheduledDateSpecies> = emptyList(),
+)

--- a/src/main/kotlin/com/terraformation/backend/plantingmanagement/api/PlantingSeasonScheduledDatesController.kt
+++ b/src/main/kotlin/com/terraformation/backend/plantingmanagement/api/PlantingSeasonScheduledDatesController.kt
@@ -12,6 +12,7 @@ import com.terraformation.backend.plantingmanagement.PlantingSeasonScheduledDate
 import com.terraformation.backend.plantingmanagement.db.PlantingSeasonScheduledDatesStore
 import io.swagger.v3.oas.annotations.Operation
 import jakarta.validation.Valid
+import jakarta.validation.constraints.Min
 import java.time.LocalDate
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
@@ -42,7 +43,7 @@ class PlantingSeasonScheduledDatesController(
 }
 
 data class ScheduledPlantingDateSpeciesPayload(
-    val quantity: Int,
+    @field:Min(0) val quantity: Int,
     val speciesId: SpeciesId,
     val substratumId: SubstratumId,
 ) {

--- a/src/main/kotlin/com/terraformation/backend/plantingmanagement/api/PlantingSeasonScheduledDatesController.kt
+++ b/src/main/kotlin/com/terraformation/backend/plantingmanagement/api/PlantingSeasonScheduledDatesController.kt
@@ -57,7 +57,7 @@ data class ScheduledPlantingDateSpeciesPayload(
 
 data class ScheduledPlantingDateRequestPayload(
     val date: LocalDate,
-    val species: List<ScheduledPlantingDateSpeciesPayload> = emptyList(),
+    val species: List<ScheduledPlantingDateSpeciesPayload>,
 ) {
   fun toModel(plantingSeasonId: PlantingSeasonId): PlantingSeasonScheduledDateModel =
       PlantingSeasonScheduledDateModel(

--- a/src/main/kotlin/com/terraformation/backend/plantingmanagement/api/PlantingSeasonScheduledDatesController.kt
+++ b/src/main/kotlin/com/terraformation/backend/plantingmanagement/api/PlantingSeasonScheduledDatesController.kt
@@ -1,0 +1,67 @@
+package com.terraformation.backend.plantingmanagement.api
+
+import com.terraformation.backend.api.ApiResponse404
+import com.terraformation.backend.api.ApiResponseSimpleSuccess
+import com.terraformation.backend.api.SimpleSuccessResponsePayload
+import com.terraformation.backend.api.TrackingEndpoint
+import com.terraformation.backend.db.default_schema.SpeciesId
+import com.terraformation.backend.db.tracking.PlantingSeasonId
+import com.terraformation.backend.db.tracking.SubstratumId
+import com.terraformation.backend.plantingmanagement.PlantingSeasonScheduledDateModel
+import com.terraformation.backend.plantingmanagement.PlantingSeasonScheduledDateSpecies
+import com.terraformation.backend.plantingmanagement.db.PlantingSeasonScheduledDatesStore
+import io.swagger.v3.oas.annotations.Operation
+import jakarta.validation.Valid
+import java.time.LocalDate
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RequestMapping("/api/v1/planting-seasons/{plantingSeasonId}/scheduled-dates")
+@RestController
+@TrackingEndpoint
+class PlantingSeasonScheduledDatesController(
+    private val plantingSeasonScheduledDatesStore: PlantingSeasonScheduledDatesStore,
+) {
+  @ApiResponseSimpleSuccess
+  @ApiResponse404
+  @Operation(
+      summary = "Creates a new scheduled date for a planting season.",
+  )
+  @PostMapping
+  fun createScheduledPlantingDate(
+      @PathVariable plantingSeasonId: PlantingSeasonId,
+      @RequestBody @Valid payload: CreateScheduledPlantingDateRequestPayload,
+  ): SimpleSuccessResponsePayload {
+    plantingSeasonScheduledDatesStore.create(payload.toModel(plantingSeasonId))
+
+    return SimpleSuccessResponsePayload()
+  }
+}
+
+data class CreateScheduledPlantingDateSpeciesPayload(
+    val quantity: Int,
+    val speciesId: SpeciesId,
+    val substratumId: SubstratumId,
+) {
+  fun toModel(): PlantingSeasonScheduledDateSpecies =
+      PlantingSeasonScheduledDateSpecies(
+          quantity = quantity,
+          speciesId = speciesId,
+          substratumId = substratumId,
+      )
+}
+
+data class CreateScheduledPlantingDateRequestPayload(
+    val date: LocalDate,
+    val species: List<CreateScheduledPlantingDateSpeciesPayload> = emptyList(),
+) {
+  fun toModel(plantingSeasonId: PlantingSeasonId): PlantingSeasonScheduledDateModel =
+      PlantingSeasonScheduledDateModel(
+          plantingSeasonId = plantingSeasonId,
+          date = date,
+          species = species.map { it.toModel() },
+      )
+}

--- a/src/main/kotlin/com/terraformation/backend/plantingmanagement/api/PlantingSeasonScheduledDatesController.kt
+++ b/src/main/kotlin/com/terraformation/backend/plantingmanagement/api/PlantingSeasonScheduledDatesController.kt
@@ -41,7 +41,7 @@ class PlantingSeasonScheduledDatesController(
   }
 }
 
-data class CreateScheduledPlantingDateSpeciesPayload(
+data class ScheduledPlantingDateSpeciesPayload(
     val quantity: Int,
     val speciesId: SpeciesId,
     val substratumId: SubstratumId,
@@ -56,7 +56,7 @@ data class CreateScheduledPlantingDateSpeciesPayload(
 
 data class CreateScheduledPlantingDateRequestPayload(
     val date: LocalDate,
-    val species: List<CreateScheduledPlantingDateSpeciesPayload> = emptyList(),
+    val species: List<ScheduledPlantingDateSpeciesPayload> = emptyList(),
 ) {
   fun toModel(plantingSeasonId: PlantingSeasonId): PlantingSeasonScheduledDateModel =
       PlantingSeasonScheduledDateModel(

--- a/src/main/kotlin/com/terraformation/backend/plantingmanagement/api/PlantingSeasonScheduledDatesController.kt
+++ b/src/main/kotlin/com/terraformation/backend/plantingmanagement/api/PlantingSeasonScheduledDatesController.kt
@@ -33,7 +33,7 @@ class PlantingSeasonScheduledDatesController(
   @PostMapping
   fun createScheduledPlantingDate(
       @PathVariable plantingSeasonId: PlantingSeasonId,
-      @RequestBody @Valid payload: CreateScheduledPlantingDateRequestPayload,
+      @RequestBody @Valid payload: ScheduledPlantingDateRequestPayload,
   ): SimpleSuccessResponsePayload {
     plantingSeasonScheduledDatesStore.create(payload.toModel(plantingSeasonId))
 
@@ -54,7 +54,7 @@ data class ScheduledPlantingDateSpeciesPayload(
       )
 }
 
-data class CreateScheduledPlantingDateRequestPayload(
+data class ScheduledPlantingDateRequestPayload(
     val date: LocalDate,
     val species: List<ScheduledPlantingDateSpeciesPayload> = emptyList(),
 ) {

--- a/src/main/kotlin/com/terraformation/backend/plantingmanagement/db/Exceptions.kt
+++ b/src/main/kotlin/com/terraformation/backend/plantingmanagement/db/Exceptions.kt
@@ -4,6 +4,7 @@ import com.terraformation.backend.db.EntityNotFoundException
 import com.terraformation.backend.db.MismatchedStateException
 import com.terraformation.backend.db.tracking.PlantingSeasonId
 import com.terraformation.backend.db.tracking.PlantingSiteId
+import java.time.LocalDate
 
 class PlantingSeasonNotFoundException(val plantingSeasonId: PlantingSeasonId) :
     EntityNotFoundException("Planting season $plantingSeasonId not found")
@@ -11,4 +12,12 @@ class PlantingSeasonNotFoundException(val plantingSeasonId: PlantingSeasonId) :
 class PlantingSeasonExistsException(plantingSiteId: PlantingSiteId, name: String) :
     MismatchedStateException(
         "Planting Site $plantingSiteId already has a planting season with name $name"
+    )
+
+class PlantingSeasonScheduledDateExistsException(
+    plantingSeasonId: PlantingSeasonId,
+    date: LocalDate,
+) :
+    MismatchedStateException(
+        "Planting Season $plantingSeasonId already has a scheduled planting date for $date"
     )

--- a/src/main/kotlin/com/terraformation/backend/plantingmanagement/db/PlantingSeasonScheduledDatesStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/plantingmanagement/db/PlantingSeasonScheduledDatesStore.kt
@@ -22,45 +22,49 @@ class PlantingSeasonScheduledDatesStore(
     val userId = currentUser().userId
     val now = clock.instant()
 
-    val scheduledDateId =
-        with(SCHEDULED_PLANTING_DATES) {
-          dslContext
-              .insertInto(SCHEDULED_PLANTING_DATES)
-              .set(PLANTING_SEASON_ID, model.plantingSeasonId)
-              .set(DATE, model.date)
-              .set(CREATED_BY, userId)
-              .set(CREATED_TIME, now)
-              .set(MODIFIED_BY, userId)
-              .set(MODIFIED_TIME, now)
-              .onConflictDoNothing()
-              .returning(ID)
-              .fetchOne(ID)
-              ?: throw PlantingSeasonScheduledDateExistsException(
-                  model.plantingSeasonId,
-                  model.date,
-              )
+    val scheduledDateId = dslContext.transactionResult { _ ->
+      val scheduledDateId =
+          with(SCHEDULED_PLANTING_DATES) {
+            dslContext
+                .insertInto(SCHEDULED_PLANTING_DATES)
+                .set(PLANTING_SEASON_ID, model.plantingSeasonId)
+                .set(DATE, model.date)
+                .set(CREATED_BY, userId)
+                .set(CREATED_TIME, now)
+                .set(MODIFIED_BY, userId)
+                .set(MODIFIED_TIME, now)
+                .onConflictDoNothing()
+                .returning(ID)
+                .fetchOne(ID)
+                ?: throw PlantingSeasonScheduledDateExistsException(
+                    model.plantingSeasonId,
+                    model.date,
+                )
+          }
+
+      with(SCHEDULED_PLANTING_DATE_SPECIES) {
+        val insertQuery =
+            dslContext.insertInto(
+                SCHEDULED_PLANTING_DATE_SPECIES,
+                SCHEDULED_PLANTING_DATE_ID,
+                SPECIES_ID,
+                SUBSTRATUM_ID,
+                QUANTITY,
+            )
+
+        model.species.forEach { species ->
+          insertQuery.values(
+              scheduledDateId,
+              species.speciesId,
+              species.substratumId,
+              species.quantity,
+          )
         }
 
-    with(SCHEDULED_PLANTING_DATE_SPECIES) {
-      val insertQuery =
-          dslContext.insertInto(
-              SCHEDULED_PLANTING_DATE_SPECIES,
-              SCHEDULED_PLANTING_DATE_ID,
-              SPECIES_ID,
-              SUBSTRATUM_ID,
-              QUANTITY,
-          )
-
-      model.species.forEach { species ->
-        insertQuery.values(
-            scheduledDateId,
-            species.speciesId,
-            species.substratumId,
-            species.quantity,
-        )
+        insertQuery.onConflictDoNothing().execute()
       }
 
-      insertQuery.onConflictDoNothing().execute()
+      scheduledDateId
     }
 
     return scheduledDateId

--- a/src/main/kotlin/com/terraformation/backend/plantingmanagement/db/PlantingSeasonScheduledDatesStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/plantingmanagement/db/PlantingSeasonScheduledDatesStore.kt
@@ -61,7 +61,7 @@ class PlantingSeasonScheduledDatesStore(
           )
         }
 
-        insertQuery.onConflictDoNothing().execute()
+        insertQuery.execute()
       }
 
       newScheduledDateId

--- a/src/main/kotlin/com/terraformation/backend/plantingmanagement/db/PlantingSeasonScheduledDatesStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/plantingmanagement/db/PlantingSeasonScheduledDatesStore.kt
@@ -16,7 +16,6 @@ class PlantingSeasonScheduledDatesStore(
     private val dslContext: DSLContext,
 ) {
   fun create(model: PlantingSeasonScheduledDateModel): ScheduledPlantingDateId {
-    require(model.species.all { it.quantity >= 0 }) { "All quantities must be >= 0" }
     requirePermissions { updatePlantingSeason(model.plantingSeasonId) }
 
     val userId = currentUser().userId

--- a/src/main/kotlin/com/terraformation/backend/plantingmanagement/db/PlantingSeasonScheduledDatesStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/plantingmanagement/db/PlantingSeasonScheduledDatesStore.kt
@@ -1,0 +1,68 @@
+package com.terraformation.backend.plantingmanagement.db
+
+import com.terraformation.backend.auth.currentUser
+import com.terraformation.backend.customer.model.requirePermissions
+import com.terraformation.backend.db.tracking.ScheduledPlantingDateId
+import com.terraformation.backend.db.tracking.tables.references.SCHEDULED_PLANTING_DATES
+import com.terraformation.backend.db.tracking.tables.references.SCHEDULED_PLANTING_DATE_SPECIES
+import com.terraformation.backend.plantingmanagement.PlantingSeasonScheduledDateModel
+import jakarta.inject.Named
+import java.time.InstantSource
+import org.jooq.DSLContext
+
+@Named
+class PlantingSeasonScheduledDatesStore(
+    private val clock: InstantSource,
+    private val dslContext: DSLContext,
+) {
+  fun create(model: PlantingSeasonScheduledDateModel): ScheduledPlantingDateId {
+    require(model.species.all { it.quantity >= 0 }) { "All quantities must be >= 0" }
+    requirePermissions { updatePlantingSeason(model.plantingSeasonId) }
+
+    val userId = currentUser().userId
+    val now = clock.instant()
+
+    val scheduledDateId =
+        with(SCHEDULED_PLANTING_DATES) {
+          dslContext
+              .insertInto(SCHEDULED_PLANTING_DATES)
+              .set(PLANTING_SEASON_ID, model.plantingSeasonId)
+              .set(DATE, model.date)
+              .set(CREATED_BY, userId)
+              .set(CREATED_TIME, now)
+              .set(MODIFIED_BY, userId)
+              .set(MODIFIED_TIME, now)
+              .onConflictDoNothing()
+              .returning(ID)
+              .fetchOne(ID)
+              ?: throw PlantingSeasonScheduledDateExistsException(
+                  model.plantingSeasonId,
+                  model.date,
+              )
+        }
+
+    with(SCHEDULED_PLANTING_DATE_SPECIES) {
+      val insertQuery =
+          dslContext.insertInto(
+              SCHEDULED_PLANTING_DATE_SPECIES,
+              SCHEDULED_PLANTING_DATE_ID,
+              SPECIES_ID,
+              SUBSTRATUM_ID,
+              QUANTITY,
+          )
+
+      model.species.forEach { species ->
+        insertQuery.values(
+            scheduledDateId,
+            species.speciesId,
+            species.substratumId,
+            species.quantity,
+        )
+      }
+
+      insertQuery.onConflictDoNothing().execute()
+    }
+
+    return scheduledDateId
+  }
+}

--- a/src/main/kotlin/com/terraformation/backend/plantingmanagement/db/PlantingSeasonScheduledDatesStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/plantingmanagement/db/PlantingSeasonScheduledDatesStore.kt
@@ -23,7 +23,7 @@ class PlantingSeasonScheduledDatesStore(
     val now = clock.instant()
 
     val scheduledDateId = dslContext.transactionResult { _ ->
-      val scheduledDateId =
+      val newScheduledDateId =
           with(SCHEDULED_PLANTING_DATES) {
             dslContext
                 .insertInto(SCHEDULED_PLANTING_DATES)
@@ -54,7 +54,7 @@ class PlantingSeasonScheduledDatesStore(
 
         model.species.forEach { species ->
           insertQuery.values(
-              scheduledDateId,
+              newScheduledDateId,
               species.speciesId,
               species.substratumId,
               species.quantity,
@@ -64,7 +64,7 @@ class PlantingSeasonScheduledDatesStore(
         insertQuery.onConflictDoNothing().execute()
       }
 
-      scheduledDateId
+      newScheduledDateId
     }
 
     return scheduledDateId

--- a/src/test/kotlin/com/terraformation/backend/db/DatabaseBackedTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/db/DatabaseBackedTest.kt
@@ -467,6 +467,7 @@ import com.terraformation.backend.db.tracking.tables.daos.PlantingSitesDao
 import com.terraformation.backend.db.tracking.tables.daos.PlantingsDao
 import com.terraformation.backend.db.tracking.tables.daos.RecordedPlantsDao
 import com.terraformation.backend.db.tracking.tables.daos.RecordedTreesDao
+import com.terraformation.backend.db.tracking.tables.daos.ScheduledPlantingDatesDao
 import com.terraformation.backend.db.tracking.tables.daos.SimplePlantingSeasonsDao
 import com.terraformation.backend.db.tracking.tables.daos.SimplifiedPlantingSiteHistoriesDao
 import com.terraformation.backend.db.tracking.tables.daos.SimplifiedPlantingSitesDao
@@ -513,6 +514,7 @@ import com.terraformation.backend.db.tracking.tables.pojos.PlotT0DensitiesRow
 import com.terraformation.backend.db.tracking.tables.pojos.PlotT0ObservationsRow
 import com.terraformation.backend.db.tracking.tables.pojos.RecordedPlantsRow
 import com.terraformation.backend.db.tracking.tables.pojos.RecordedTreesRow
+import com.terraformation.backend.db.tracking.tables.pojos.ScheduledPlantingDatesRow
 import com.terraformation.backend.db.tracking.tables.pojos.SimplePlantingSeasonsRow
 import com.terraformation.backend.db.tracking.tables.pojos.SimplifiedPlantingSiteHistoriesRow
 import com.terraformation.backend.db.tracking.tables.pojos.SimplifiedPlantingSitesRow
@@ -800,6 +802,7 @@ abstract class DatabaseBackedTest {
   protected val reportProjectIndicatorTargetsDao: ReportProjectIndicatorTargetsDao by lazyDao()
   protected val reportProjectIndicatorsDao: ReportProjectIndicatorsDao by lazyDao()
   protected val reportsDao: ReportsDao by lazyDao()
+  protected val scheduledPlantingDatesDao: ScheduledPlantingDatesDao by lazyDao()
   protected val seedFundReportFilesDao: SeedFundReportFilesDao by lazyDao()
   protected val seedFundReportPhotosDao: SeedFundReportPhotosDao by lazyDao()
   protected val seedFundReportsDao: SeedFundReportsDao by lazyDao()
@@ -2332,6 +2335,28 @@ abstract class DatabaseBackedTest {
         )
 
     plantingSeasonSpeciesTargetsDao.insert(rowWithDefaults)
+  }
+
+  fun insertPlantingSeasonScheduledDate(
+      row: ScheduledPlantingDatesRow = ScheduledPlantingDatesRow(),
+      createdBy: UserId = row.createdBy ?: currentUser().userId,
+      createdTime: Instant = row.createdTime ?: Instant.EPOCH,
+      date: LocalDate = LocalDate.EPOCH,
+      modifiedBy: UserId = row.modifiedBy ?: createdBy,
+      modifiedTime: Instant = row.modifiedTime ?: createdTime,
+      plantingSeasonId: PlantingSeasonId = row.plantingSeasonId ?: inserted.plantingSeasonId,
+  ) {
+    val rowWithDefaults =
+        row.copy(
+            createdBy = createdBy,
+            createdTime = createdTime,
+            date = date,
+            modifiedBy = modifiedBy,
+            modifiedTime = modifiedTime,
+            plantingSeasonId = plantingSeasonId,
+        )
+
+    scheduledPlantingDatesDao.insert(rowWithDefaults)
   }
 
   var nextPlantingSiteNumber: Int = 1

--- a/src/test/kotlin/com/terraformation/backend/plantingmanagement/PlantingSeasonScheduledDateModelTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/plantingmanagement/PlantingSeasonScheduledDateModelTest.kt
@@ -1,0 +1,39 @@
+package com.terraformation.backend.plantingmanagement
+
+import com.terraformation.backend.db.default_schema.SpeciesId
+import com.terraformation.backend.db.tracking.PlantingSeasonId
+import com.terraformation.backend.db.tracking.SubstratumId
+import java.time.LocalDate
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+class PlantingSeasonScheduledDateModelTest {
+
+  @Test
+  fun `throws IllegalArgumentException when a quantity is less than 0`() {
+    val plantingSeasonId = PlantingSeasonId(1)
+    val speciesId1 = SpeciesId(2)
+    val speciesId2 = SpeciesId(2)
+    val substratumId = SubstratumId(3)
+
+    assertThrows<IllegalArgumentException> {
+      PlantingSeasonScheduledDateModel(
+          plantingSeasonId = plantingSeasonId,
+          date = LocalDate.EPOCH,
+          species =
+              listOf(
+                  PlantingSeasonScheduledDateSpecies(
+                      quantity = -1,
+                      speciesId = speciesId1,
+                      substratumId = substratumId,
+                  ),
+                  PlantingSeasonScheduledDateSpecies(
+                      quantity = 1,
+                      speciesId = speciesId2,
+                      substratumId = substratumId,
+                  ),
+              ),
+      )
+    }
+  }
+}

--- a/src/test/kotlin/com/terraformation/backend/plantingmanagement/db/PlantingSeasonScheduledDatesStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/plantingmanagement/db/PlantingSeasonScheduledDatesStoreTest.kt
@@ -148,23 +148,27 @@ internal class PlantingSeasonScheduledDatesStoreTest : DatabaseTest(), RunsAsDat
 
     @Test
     fun `throws DuplicateKeyException when same species-substratum combination is added twice`() {
-      assertThrows<DuplicateKeyException> { store.create(PlantingSeasonScheduledDateModel(
-          plantingSeasonId = plantingSeasonId,
-          date = LocalDate.EPOCH,
-          species =
-              listOf(
-                  PlantingSeasonScheduledDateSpecies(
-                      quantity = 5,
-                      speciesId = speciesId,
-                      substratumId = substratumId,
-                  ),
-                  PlantingSeasonScheduledDateSpecies(
-                      quantity = 10,
-                      speciesId = speciesId,
-                      substratumId = substratumId,
-                  ),
-              ),
-      )) }
+      assertThrows<DuplicateKeyException> {
+        store.create(
+            PlantingSeasonScheduledDateModel(
+                plantingSeasonId = plantingSeasonId,
+                date = LocalDate.EPOCH,
+                species =
+                    listOf(
+                        PlantingSeasonScheduledDateSpecies(
+                            quantity = 5,
+                            speciesId = speciesId,
+                            substratumId = substratumId,
+                        ),
+                        PlantingSeasonScheduledDateSpecies(
+                            quantity = 10,
+                            speciesId = speciesId,
+                            substratumId = substratumId,
+                        ),
+                    ),
+            )
+        )
+      }
     }
 
     @Test

--- a/src/test/kotlin/com/terraformation/backend/plantingmanagement/db/PlantingSeasonScheduledDatesStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/plantingmanagement/db/PlantingSeasonScheduledDatesStoreTest.kt
@@ -1,0 +1,204 @@
+package com.terraformation.backend.plantingmanagement.db
+
+import com.terraformation.backend.RunsAsDatabaseUser
+import com.terraformation.backend.TestClock
+import com.terraformation.backend.customer.model.TerrawareUser
+import com.terraformation.backend.db.DatabaseTest
+import com.terraformation.backend.db.default_schema.Role
+import com.terraformation.backend.db.default_schema.SpeciesId
+import com.terraformation.backend.db.tracking.PlantingSeasonId
+import com.terraformation.backend.db.tracking.SubstratumId
+import com.terraformation.backend.db.tracking.tables.records.ScheduledPlantingDateSpeciesRecord
+import com.terraformation.backend.db.tracking.tables.records.ScheduledPlantingDatesRecord
+import com.terraformation.backend.db.tracking.tables.references.SCHEDULED_PLANTING_DATE_SPECIES
+import com.terraformation.backend.plantingmanagement.PlantingSeasonScheduledDateModel
+import com.terraformation.backend.plantingmanagement.PlantingSeasonScheduledDateSpecies
+import java.time.LocalDate
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.springframework.security.access.AccessDeniedException
+
+internal class PlantingSeasonScheduledDatesStoreTest : DatabaseTest(), RunsAsDatabaseUser {
+  override lateinit var user: TerrawareUser
+  private val clock = TestClock()
+  private val store: PlantingSeasonScheduledDatesStore by lazy {
+    PlantingSeasonScheduledDatesStore(clock, dslContext)
+  }
+
+  private lateinit var plantingSeasonId: PlantingSeasonId
+  private lateinit var substratumId: SubstratumId
+  private lateinit var speciesId: SpeciesId
+
+  @BeforeEach
+  fun setUp() {
+    insertOrganization()
+    insertPlantingSite()
+    insertOrganizationUser(role = Role.Manager)
+    insertStratum()
+    plantingSeasonId = insertPlantingSeason()
+    substratumId = insertSubstratum()
+    speciesId = insertSpecies()
+  }
+
+  @Nested
+  inner class Create {
+    @Test
+    fun `inserts a new scheduled date with no species`() {
+      val model =
+          PlantingSeasonScheduledDateModel(
+              plantingSeasonId = plantingSeasonId,
+              date = LocalDate.EPOCH,
+          )
+
+      store.create(model)
+
+      assertTableEquals(
+          ScheduledPlantingDatesRecord(
+              plantingSeasonId = plantingSeasonId,
+              date = LocalDate.EPOCH,
+              createdBy = user.userId,
+              createdTime = clock.instant,
+              modifiedBy = user.userId,
+              modifiedTime = clock.instant,
+          )
+      )
+
+      assertTableEmpty(SCHEDULED_PLANTING_DATE_SPECIES)
+    }
+
+    @Test
+    fun `inserts a new scheduled date with species`() {
+      val substratumId2 = insertSubstratum()
+      val speciesId2 = insertSpecies()
+
+      val model =
+          PlantingSeasonScheduledDateModel(
+              plantingSeasonId = plantingSeasonId,
+              date = LocalDate.EPOCH.plusDays(1),
+              species =
+                  listOf(
+                      PlantingSeasonScheduledDateSpecies(
+                          quantity = 5,
+                          speciesId = speciesId,
+                          substratumId = substratumId,
+                      ),
+                      PlantingSeasonScheduledDateSpecies(
+                          quantity = 10,
+                          speciesId = speciesId2,
+                          substratumId = substratumId,
+                      ),
+                      PlantingSeasonScheduledDateSpecies(
+                          quantity = 15,
+                          speciesId = speciesId,
+                          substratumId = substratumId2,
+                      ),
+                      PlantingSeasonScheduledDateSpecies(
+                          quantity = 20,
+                          speciesId = speciesId2,
+                          substratumId = substratumId2,
+                      ),
+                  ),
+          )
+
+      val scheduledDateId = store.create(model)
+
+      assertTableEquals(
+          ScheduledPlantingDatesRecord(
+              plantingSeasonId = plantingSeasonId,
+              date = LocalDate.EPOCH.plusDays(1),
+              createdBy = user.userId,
+              createdTime = clock.instant,
+              modifiedBy = user.userId,
+              modifiedTime = clock.instant,
+          )
+      )
+
+      assertTableEquals(
+          listOf(
+              ScheduledPlantingDateSpeciesRecord(
+                  quantity = 5,
+                  scheduledPlantingDateId = scheduledDateId,
+                  speciesId = speciesId,
+                  substratumId = substratumId,
+              ),
+              ScheduledPlantingDateSpeciesRecord(
+                  quantity = 10,
+                  scheduledPlantingDateId = scheduledDateId,
+                  speciesId = speciesId2,
+                  substratumId = substratumId,
+              ),
+              ScheduledPlantingDateSpeciesRecord(
+                  quantity = 15,
+                  scheduledPlantingDateId = scheduledDateId,
+                  speciesId = speciesId,
+                  substratumId = substratumId2,
+              ),
+              ScheduledPlantingDateSpeciesRecord(
+                  quantity = 20,
+                  scheduledPlantingDateId = scheduledDateId,
+                  speciesId = speciesId2,
+                  substratumId = substratumId2,
+              ),
+          )
+      )
+    }
+
+    @Test
+    fun `throws AccessDeniedException when user lacks permission`() {
+      deleteOrganizationUser()
+      insertOrganizationUser(role = Role.Contributor)
+
+      assertThrows<AccessDeniedException> {
+        store.create(
+            PlantingSeasonScheduledDateModel(
+                plantingSeasonId = plantingSeasonId,
+                date = LocalDate.EPOCH,
+            )
+        )
+      }
+    }
+
+    @Test
+    fun `throws IllegalArgumentException when a quantity is less than 0`() {
+      val speciesId2 = insertSpecies()
+
+      assertThrows<IllegalArgumentException> {
+        store.create(
+            PlantingSeasonScheduledDateModel(
+                plantingSeasonId = plantingSeasonId,
+                date = LocalDate.EPOCH,
+                species =
+                    listOf(
+                        PlantingSeasonScheduledDateSpecies(
+                            quantity = -1,
+                            speciesId = speciesId,
+                            substratumId = substratumId,
+                        ),
+                        PlantingSeasonScheduledDateSpecies(
+                            quantity = 1,
+                            speciesId = speciesId2,
+                            substratumId = substratumId,
+                        ),
+                    ),
+            )
+        )
+      }
+    }
+
+    @Test
+    fun `throws PlantingSeasonScheduledDateExistsException when date already exists`() {
+      insertPlantingSeasonScheduledDate()
+
+      assertThrows<PlantingSeasonScheduledDateExistsException> {
+        store.create(
+            PlantingSeasonScheduledDateModel(
+                plantingSeasonId = plantingSeasonId,
+                date = LocalDate.EPOCH,
+            )
+        )
+      }
+    }
+  }
+}

--- a/src/test/kotlin/com/terraformation/backend/plantingmanagement/db/PlantingSeasonScheduledDatesStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/plantingmanagement/db/PlantingSeasonScheduledDatesStoreTest.kt
@@ -161,33 +161,6 @@ internal class PlantingSeasonScheduledDatesStoreTest : DatabaseTest(), RunsAsDat
     }
 
     @Test
-    fun `throws IllegalArgumentException when a quantity is less than 0`() {
-      val speciesId2 = insertSpecies()
-
-      assertThrows<IllegalArgumentException> {
-        store.create(
-            PlantingSeasonScheduledDateModel(
-                plantingSeasonId = plantingSeasonId,
-                date = LocalDate.EPOCH,
-                species =
-                    listOf(
-                        PlantingSeasonScheduledDateSpecies(
-                            quantity = -1,
-                            speciesId = speciesId,
-                            substratumId = substratumId,
-                        ),
-                        PlantingSeasonScheduledDateSpecies(
-                            quantity = 1,
-                            speciesId = speciesId2,
-                            substratumId = substratumId,
-                        ),
-                    ),
-            )
-        )
-      }
-    }
-
-    @Test
     fun `throws PlantingSeasonScheduledDateExistsException when date already exists`() {
       insertPlantingSeasonScheduledDate()
 

--- a/src/test/kotlin/com/terraformation/backend/plantingmanagement/db/PlantingSeasonScheduledDatesStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/plantingmanagement/db/PlantingSeasonScheduledDatesStoreTest.kt
@@ -18,6 +18,7 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
+import org.springframework.dao.DuplicateKeyException
 import org.springframework.security.access.AccessDeniedException
 
 internal class PlantingSeasonScheduledDatesStoreTest : DatabaseTest(), RunsAsDatabaseUser {
@@ -143,6 +144,27 @@ internal class PlantingSeasonScheduledDatesStoreTest : DatabaseTest(), RunsAsDat
               ),
           )
       )
+    }
+
+    @Test
+    fun `throws DuplicateKeyException when same species-substratum combination is added twice`() {
+      assertThrows<DuplicateKeyException> { store.create(PlantingSeasonScheduledDateModel(
+          plantingSeasonId = plantingSeasonId,
+          date = LocalDate.EPOCH,
+          species =
+              listOf(
+                  PlantingSeasonScheduledDateSpecies(
+                      quantity = 5,
+                      speciesId = speciesId,
+                      substratumId = substratumId,
+                  ),
+                  PlantingSeasonScheduledDateSpecies(
+                      quantity = 10,
+                      speciesId = speciesId,
+                      substratumId = substratumId,
+                  ),
+              ),
+      )) }
     }
 
     @Test


### PR DESCRIPTION
Handle creating a scheduled planting date for a planting season with a new endpoint. This also includes the list of the date's species/substratum/quantity combos.