### PR TITLE
SW-8399 Run survival rate recalculation asynchronously after species totals edits

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/tracking/db/ObservationStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/db/ObservationStore.kt
@@ -1370,7 +1370,8 @@ class ObservationStore(
             isPermanent,
             plantCountAdjustments,
         )
-        recalculateSurvivalRateResults(observationId, observation.plantingSiteId)
+        // Propagate the new totals from species to aggregate totals
+        updateObservationResults(observationId, observation.plantingSiteId)
 
         // Aggregation from substratum to stratum (and then to site) works by adding up the most
         // recent data for each substratum at the time of the observation in question.
@@ -1459,7 +1460,7 @@ class ObservationStore(
               isPermanent = isPermanent,
               plantCountsBySpecies = plantCountAdjustments,
           )
-          recalculateSurvivalRateResults(laterObservationId, observation.plantingSiteId)
+          updateObservationResults(laterObservationId, observation.plantingSiteId)
         }
 
         eventPublisher.publishEvent(
@@ -2152,6 +2153,14 @@ class ObservationStore(
     jobScheduler.enqueue<ObservationStore> {
       // Do the survival rate recalculation asynchronously to avoid delays on a T0 settings change.
       runRecalculateSurvivalRates(event.stratumId)
+    }
+  }
+
+  @EventListener
+  fun on(event: MonitoringSpeciesTotalsEditedEvent) {
+    jobScheduler.enqueue<ObservationStore> {
+      // Do the survival rate recalculation asynchronously to avoid delays on species total edit.
+      runRecalculateSurvivalRates(event.monitoringPlotId)
     }
   }
 

--- a/src/test/kotlin/com/terraformation/backend/tracking/scenario/ObservationScenario.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/scenario/ObservationScenario.kt
@@ -124,6 +124,9 @@ class ObservationScenario(
         eventPublisher.register<MonitoringSpeciesTotalsEditedEvent> { t0Store.on(it) }
         // Recalculation runs asynchronously via JobRunr in production. In scenario tests we
         // invoke the recalc method directly so observation results reflect the changes inline.
+        eventPublisher.register<MonitoringSpeciesTotalsEditedEvent> {
+          observationStore.recalculateSurvivalRates(it.monitoringPlotId)
+        }
         eventPublisher.register<T0PlotDataAssignedEvent> {
           observationStore.recalculateSurvivalRates(it.monitoringPlotId)
         }


### PR DESCRIPTION
updateMonitoringSpecies now publishes MonitoringSpeciesTotalsEditedEvent
without inline survival-rate recomputation. A new @EventListener in
ObservationStore enqueues runRecalculateSurvivalRates for the affected
plot via JobRunr. Totals propagation from OBSERVED_*_SPECIES_TOTALS into
OBSERVATION_*_RESULTS stays synchronous via updateObservationResults so
the async recompute reads fresh numerators; the same split is applied to
the later-observations loop.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>