### PR TITLE
Run unit tests in random order

### DIFF
--- a/src/test/resources/junit-platform.properties
+++ b/src/test/resources/junit-platform.properties
@@ -13,4 +13,3 @@ junit.jupiter.execution.parallel.config.dynamic.max-pool-size-factor = 1.0
 # They tend to be located in the same package and would run in parallel with the default order.
 # Random ordering can also expose unintentional dependencies between tests.
 junit.jupiter.testclass.order.default = org.junit.jupiter.api.ClassOrderer$Random
-junit.jupiter.testmethod.order.default = org.junit.jupiter.api.MethodOrderer$Random

--- a/src/test/resources/junit-platform.properties
+++ b/src/test/resources/junit-platform.properties
@@ -8,3 +8,9 @@ junit.jupiter.execution.parallel.mode.default = concurrent
 # method grows the pool if all the threads are currently busy, which they will be during a test run.
 junit.jupiter.execution.parallel.config.dynamic.saturate = true
 junit.jupiter.execution.parallel.config.dynamic.max-pool-size-factor = 1.0
+
+# Run tests in random order to reduce contention between tests that touch the same resources.
+# They tend to be located in the same package and would run in parallel with the default order.
+# Random ordering can also expose unintentional dependencies between tests.
+junit.jupiter.testclass.order.default = org.junit.jupiter.api.ClassOrderer$Random
+junit.jupiter.testmethod.order.default = org.junit.jupiter.api.MethodOrderer$Random


### PR DESCRIPTION
Tell JUnit to execute the test suite in random order. Random test order can expose
cases where tests are affected by each other's side effects, but also, it reduces
the typical amount of time we spend running parallel tests that touch the same
database tables, which can improve test suite execution times.