### PR TITLE
SW-8371 Add api endpoint to update a scheduled planting date for a planting season

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/plantingmanagement/api/PlantingSeasonScheduledDatesController.kt
+++ b/src/main/kotlin/com/terraformation/backend/plantingmanagement/api/PlantingSeasonScheduledDatesController.kt
@@ -6,6 +6,7 @@ import com.terraformation.backend.api.SimpleSuccessResponsePayload
 import com.terraformation.backend.api.TrackingEndpoint
 import com.terraformation.backend.db.default_schema.SpeciesId
 import com.terraformation.backend.db.tracking.PlantingSeasonId
+import com.terraformation.backend.db.tracking.ScheduledPlantingDateId
 import com.terraformation.backend.db.tracking.SubstratumId
 import com.terraformation.backend.plantingmanagement.PlantingSeasonScheduledDateModel
 import com.terraformation.backend.plantingmanagement.PlantingSeasonScheduledDateSpecies
@@ -16,6 +17,7 @@ import jakarta.validation.constraints.Min
 import java.time.LocalDate
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.PutMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
@@ -37,6 +39,22 @@ class PlantingSeasonScheduledDatesController(
       @RequestBody @Valid payload: ScheduledPlantingDateRequestPayload,
   ): SimpleSuccessResponsePayload {
     plantingSeasonScheduledDatesStore.create(payload.toModel(plantingSeasonId))
+
+    return SimpleSuccessResponsePayload()
+  }
+
+  @ApiResponseSimpleSuccess
+  @ApiResponse404
+  @Operation(
+      summary = "Updates a scheduled date for a planting season.",
+  )
+  @PutMapping("/{id}")
+  fun updateScheduledPlantingDate(
+      @PathVariable plantingSeasonId: PlantingSeasonId,
+      @PathVariable id: ScheduledPlantingDateId,
+      @RequestBody @Valid payload: ScheduledPlantingDateRequestPayload,
+  ): SimpleSuccessResponsePayload {
+    plantingSeasonScheduledDatesStore.update(id, payload.toModel(plantingSeasonId))
 
     return SimpleSuccessResponsePayload()
   }

--- a/src/main/kotlin/com/terraformation/backend/plantingmanagement/api/PlantingSeasonScheduledDatesController.kt
+++ b/src/main/kotlin/com/terraformation/backend/plantingmanagement/api/PlantingSeasonScheduledDatesController.kt
@@ -48,13 +48,16 @@ class PlantingSeasonScheduledDatesController(
   @Operation(
       summary = "Updates a scheduled date for a planting season.",
   )
-  @PutMapping("/{id}")
+  @PutMapping("/{scheduledPlantingDateId}")
   fun updateScheduledPlantingDate(
       @PathVariable plantingSeasonId: PlantingSeasonId,
-      @PathVariable id: ScheduledPlantingDateId,
+      @PathVariable scheduledPlantingDateId: ScheduledPlantingDateId,
       @RequestBody @Valid payload: ScheduledPlantingDateRequestPayload,
   ): SimpleSuccessResponsePayload {
-    plantingSeasonScheduledDatesStore.update(id, payload.toModel(plantingSeasonId))
+    plantingSeasonScheduledDatesStore.update(
+        scheduledPlantingDateId,
+        payload.toModel(plantingSeasonId),
+    )
 
     return SimpleSuccessResponsePayload()
   }

--- a/src/main/kotlin/com/terraformation/backend/plantingmanagement/db/Exceptions.kt
+++ b/src/main/kotlin/com/terraformation/backend/plantingmanagement/db/Exceptions.kt
@@ -4,6 +4,7 @@ import com.terraformation.backend.db.EntityNotFoundException
 import com.terraformation.backend.db.MismatchedStateException
 import com.terraformation.backend.db.tracking.PlantingSeasonId
 import com.terraformation.backend.db.tracking.PlantingSiteId
+import com.terraformation.backend.db.tracking.ScheduledPlantingDateId
 import java.time.LocalDate
 
 class PlantingSeasonNotFoundException(val plantingSeasonId: PlantingSeasonId) :
@@ -21,3 +22,7 @@ class PlantingSeasonScheduledDateExistsException(
     MismatchedStateException(
         "Planting Season $plantingSeasonId already has a scheduled planting date for $date"
     )
+
+class PlantingSeasonScheduledDateNotFoundException(
+    scheduledPlantingDateId: ScheduledPlantingDateId
+) : EntityNotFoundException("Scheduled planting date $scheduledPlantingDateId not found")

--- a/src/main/kotlin/com/terraformation/backend/plantingmanagement/db/PlantingSeasonScheduledDatesStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/plantingmanagement/db/PlantingSeasonScheduledDatesStore.kt
@@ -68,4 +68,56 @@ class PlantingSeasonScheduledDatesStore(
 
     return scheduledDateId
   }
+
+  fun update(
+      scheduledDateId: ScheduledPlantingDateId,
+      model: PlantingSeasonScheduledDateModel,
+  ) {
+    require(model.species.all { it.quantity >= 0 }) { "All quantities must be >= 0" }
+    requirePermissions { updatePlantingSeason(model.plantingSeasonId) }
+
+    dslContext.transaction { _ ->
+      val updatedCount =
+          with(SCHEDULED_PLANTING_DATES) {
+            dslContext
+                .update(SCHEDULED_PLANTING_DATES)
+                .set(DATE, model.date)
+                .set(MODIFIED_BY, currentUser().userId)
+                .set(MODIFIED_TIME, clock.instant())
+                .where(ID.eq(scheduledDateId))
+                .execute()
+          }
+
+      if (updatedCount == 0) {
+        throw PlantingSeasonScheduledDateNotFoundException(scheduledDateId)
+      }
+
+      with(SCHEDULED_PLANTING_DATE_SPECIES) {
+        dslContext
+            .deleteFrom(SCHEDULED_PLANTING_DATE_SPECIES)
+            .where(SCHEDULED_PLANTING_DATE_ID.eq(scheduledDateId))
+            .execute()
+
+        val insertQuery =
+            dslContext.insertInto(
+                SCHEDULED_PLANTING_DATE_SPECIES,
+                SCHEDULED_PLANTING_DATE_ID,
+                SPECIES_ID,
+                SUBSTRATUM_ID,
+                QUANTITY,
+            )
+
+        model.species.forEach { species ->
+          insertQuery.values(
+              scheduledDateId,
+              species.speciesId,
+              species.substratumId,
+              species.quantity,
+          )
+        }
+
+        insertQuery.onConflictDoNothing().execute()
+      }
+    }
+  }
 }

--- a/src/main/kotlin/com/terraformation/backend/plantingmanagement/db/PlantingSeasonScheduledDatesStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/plantingmanagement/db/PlantingSeasonScheduledDatesStore.kt
@@ -85,6 +85,7 @@ class PlantingSeasonScheduledDatesStore(
                 .set(MODIFIED_BY, currentUser().userId)
                 .set(MODIFIED_TIME, clock.instant())
                 .where(ID.eq(scheduledDateId))
+                .and(PLANTING_SEASON_ID.eq(model.plantingSeasonId))
                 .execute()
           }
 

--- a/src/main/kotlin/com/terraformation/backend/plantingmanagement/db/PlantingSeasonScheduledDatesStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/plantingmanagement/db/PlantingSeasonScheduledDatesStore.kt
@@ -117,7 +117,7 @@ class PlantingSeasonScheduledDatesStore(
           )
         }
 
-        insertQuery.onConflictDoNothing().execute()
+        insertQuery.execute()
       }
     }
   }

--- a/src/main/kotlin/com/terraformation/backend/plantingmanagement/db/PlantingSeasonScheduledDatesStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/plantingmanagement/db/PlantingSeasonScheduledDatesStore.kt
@@ -73,7 +73,6 @@ class PlantingSeasonScheduledDatesStore(
       scheduledDateId: ScheduledPlantingDateId,
       model: PlantingSeasonScheduledDateModel,
   ) {
-    require(model.species.all { it.quantity >= 0 }) { "All quantities must be >= 0" }
     requirePermissions { updatePlantingSeason(model.plantingSeasonId) }
 
     dslContext.transaction { _ ->

--- a/src/test/kotlin/com/terraformation/backend/db/DatabaseBackedTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/db/DatabaseBackedTest.kt
@@ -433,6 +433,7 @@ import com.terraformation.backend.db.tracking.RecordedPlantId
 import com.terraformation.backend.db.tracking.RecordedPlantStatus
 import com.terraformation.backend.db.tracking.RecordedSpeciesCertainty
 import com.terraformation.backend.db.tracking.RecordedTreeId
+import com.terraformation.backend.db.tracking.ScheduledPlantingDateId
 import com.terraformation.backend.db.tracking.SimplePlantingSeasonId
 import com.terraformation.backend.db.tracking.StratumHistoryId
 import com.terraformation.backend.db.tracking.StratumId
@@ -467,6 +468,7 @@ import com.terraformation.backend.db.tracking.tables.daos.PlantingSitesDao
 import com.terraformation.backend.db.tracking.tables.daos.PlantingsDao
 import com.terraformation.backend.db.tracking.tables.daos.RecordedPlantsDao
 import com.terraformation.backend.db.tracking.tables.daos.RecordedTreesDao
+import com.terraformation.backend.db.tracking.tables.daos.ScheduledPlantingDateSpeciesDao
 import com.terraformation.backend.db.tracking.tables.daos.ScheduledPlantingDatesDao
 import com.terraformation.backend.db.tracking.tables.daos.SimplePlantingSeasonsDao
 import com.terraformation.backend.db.tracking.tables.daos.SimplifiedPlantingSiteHistoriesDao
@@ -514,6 +516,7 @@ import com.terraformation.backend.db.tracking.tables.pojos.PlotT0DensitiesRow
 import com.terraformation.backend.db.tracking.tables.pojos.PlotT0ObservationsRow
 import com.terraformation.backend.db.tracking.tables.pojos.RecordedPlantsRow
 import com.terraformation.backend.db.tracking.tables.pojos.RecordedTreesRow
+import com.terraformation.backend.db.tracking.tables.pojos.ScheduledPlantingDateSpeciesRow
 import com.terraformation.backend.db.tracking.tables.pojos.ScheduledPlantingDatesRow
 import com.terraformation.backend.db.tracking.tables.pojos.SimplePlantingSeasonsRow
 import com.terraformation.backend.db.tracking.tables.pojos.SimplifiedPlantingSiteHistoriesRow
@@ -803,6 +806,7 @@ abstract class DatabaseBackedTest {
   protected val reportProjectIndicatorsDao: ReportProjectIndicatorsDao by lazyDao()
   protected val reportsDao: ReportsDao by lazyDao()
   protected val scheduledPlantingDatesDao: ScheduledPlantingDatesDao by lazyDao()
+  protected val scheduledPlantingDateSpeciesDao: ScheduledPlantingDateSpeciesDao by lazyDao()
   protected val seedFundReportFilesDao: SeedFundReportFilesDao by lazyDao()
   protected val seedFundReportPhotosDao: SeedFundReportPhotosDao by lazyDao()
   protected val seedFundReportsDao: SeedFundReportsDao by lazyDao()
@@ -2345,7 +2349,7 @@ abstract class DatabaseBackedTest {
       modifiedBy: UserId = row.modifiedBy ?: createdBy,
       modifiedTime: Instant = row.modifiedTime ?: createdTime,
       plantingSeasonId: PlantingSeasonId = row.plantingSeasonId ?: inserted.plantingSeasonId,
-  ) {
+  ): ScheduledPlantingDateId {
     val rowWithDefaults =
         row.copy(
             createdBy = createdBy,
@@ -2357,6 +2361,27 @@ abstract class DatabaseBackedTest {
         )
 
     scheduledPlantingDatesDao.insert(rowWithDefaults)
+
+    return rowWithDefaults.id!!.also { inserted.scheduledPlantingDateIds.add(it) }
+  }
+
+  fun insertScheduledPlantingDateSpecies(
+      row: ScheduledPlantingDateSpeciesRow = ScheduledPlantingDateSpeciesRow(),
+      scheduledPlantingDateId: ScheduledPlantingDateId =
+          row.scheduledPlantingDateId ?: inserted.scheduledPlantingDateId,
+      speciesId: SpeciesId = row.speciesId ?: inserted.speciesId,
+      substratumId: SubstratumId = row.substratumId ?: inserted.substratumId,
+      quantity: Int = row.quantity ?: 1,
+  ) {
+    val rowWithDefaults =
+        row.copy(
+            scheduledPlantingDateId = scheduledPlantingDateId,
+            speciesId = speciesId,
+            substratumId = substratumId,
+            quantity = quantity,
+        )
+
+    scheduledPlantingDateSpeciesDao.insert(rowWithDefaults)
   }
 
   var nextPlantingSiteNumber: Int = 1
@@ -5924,6 +5949,7 @@ abstract class DatabaseBackedTest {
     val projectReportConfigIds = mutableListOf<ProjectReportConfigId>()
     val recordedTreeIds = mutableListOf<RecordedTreeId>()
     val reportIds = mutableListOf<ReportId>()
+    val scheduledPlantingDateIds = mutableListOf<ScheduledPlantingDateId>()
     val seedbankWithdrawalIds = mutableListOf<SeedbankWithdrawalId>()
     val seedFundReportIds = mutableListOf<SeedFundReportId>()
     val simplePlantingSeasonIds = mutableListOf<SimplePlantingSeasonId>()
@@ -6064,6 +6090,9 @@ abstract class DatabaseBackedTest {
 
     val reportId
       get() = reportIds.last()
+
+    val scheduledPlantingDateId
+      get() = scheduledPlantingDateIds.last()
 
     val seedFundReportId
       get() = seedFundReportIds.last()

--- a/src/test/kotlin/com/terraformation/backend/plantingmanagement/db/PlantingSeasonScheduledDatesStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/plantingmanagement/db/PlantingSeasonScheduledDatesStoreTest.kt
@@ -360,5 +360,21 @@ internal class PlantingSeasonScheduledDatesStoreTest : DatabaseTest(), RunsAsDat
         )
       }
     }
+
+    @Test
+    fun `throws PlantingSeasonScheduledDateNotFoundException when date belongs to different planting season`() {
+      insertPlantingSeason()
+      val scheduledDate = insertPlantingSeasonScheduledDate()
+
+      assertThrows<PlantingSeasonScheduledDateNotFoundException> {
+        store.update(
+            scheduledDate,
+            PlantingSeasonScheduledDateModel(
+                plantingSeasonId = plantingSeasonId,
+                date = LocalDate.EPOCH,
+            ),
+        )
+      }
+    }
   }
 }

--- a/src/test/kotlin/com/terraformation/backend/plantingmanagement/db/PlantingSeasonScheduledDatesStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/plantingmanagement/db/PlantingSeasonScheduledDatesStoreTest.kt
@@ -7,12 +7,14 @@ import com.terraformation.backend.db.DatabaseTest
 import com.terraformation.backend.db.default_schema.Role
 import com.terraformation.backend.db.default_schema.SpeciesId
 import com.terraformation.backend.db.tracking.PlantingSeasonId
+import com.terraformation.backend.db.tracking.ScheduledPlantingDateId
 import com.terraformation.backend.db.tracking.SubstratumId
 import com.terraformation.backend.db.tracking.tables.records.ScheduledPlantingDateSpeciesRecord
 import com.terraformation.backend.db.tracking.tables.records.ScheduledPlantingDatesRecord
 import com.terraformation.backend.db.tracking.tables.references.SCHEDULED_PLANTING_DATE_SPECIES
 import com.terraformation.backend.plantingmanagement.PlantingSeasonScheduledDateModel
 import com.terraformation.backend.plantingmanagement.PlantingSeasonScheduledDateSpecies
+import java.time.Instant
 import java.time.LocalDate
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
@@ -196,6 +198,165 @@ internal class PlantingSeasonScheduledDatesStoreTest : DatabaseTest(), RunsAsDat
                 plantingSeasonId = plantingSeasonId,
                 date = LocalDate.EPOCH,
             )
+        )
+      }
+    }
+  }
+
+  @Nested
+  inner class Update {
+    @Test
+    fun `updates the scheduled date`() {
+      val scheduledDateId = insertPlantingSeasonScheduledDate()
+      val newDate = LocalDate.EPOCH.plusDays(1)
+
+      clock.instant = Instant.ofEpochSecond(100)
+      val model =
+          PlantingSeasonScheduledDateModel(
+              plantingSeasonId = plantingSeasonId,
+              date = newDate,
+          )
+
+      store.update(scheduledDateId, model)
+
+      assertTableEquals(
+          ScheduledPlantingDatesRecord(
+              plantingSeasonId = plantingSeasonId,
+              date = newDate,
+              createdBy = user.userId,
+              createdTime = Instant.EPOCH,
+              modifiedBy = user.userId,
+              modifiedTime = clock.instant,
+          )
+      )
+
+      assertTableEmpty(SCHEDULED_PLANTING_DATE_SPECIES)
+    }
+
+    @Test
+    fun `updates the species for the scheduled date`() {
+      val speciesId2 = insertSpecies()
+      val substratumId2 = insertSubstratum()
+      val scheduledDateId = insertPlantingSeasonScheduledDate()
+      insertScheduledPlantingDateSpecies(
+          quantity = 5,
+          speciesId = speciesId,
+          substratumId = substratumId,
+      )
+      insertScheduledPlantingDateSpecies(
+          quantity = 10,
+          speciesId = speciesId2,
+          substratumId = substratumId2,
+      )
+
+      clock.instant = Instant.ofEpochSecond(100)
+      val model =
+          PlantingSeasonScheduledDateModel(
+              plantingSeasonId = plantingSeasonId,
+              date = LocalDate.EPOCH.plusDays(1),
+              species =
+                  listOf(
+                      PlantingSeasonScheduledDateSpecies(
+                          quantity = 11,
+                          speciesId = speciesId2,
+                          substratumId = substratumId2,
+                      ),
+                      PlantingSeasonScheduledDateSpecies(
+                          quantity = 15,
+                          speciesId = speciesId2,
+                          substratumId = substratumId,
+                      ),
+                  ),
+          )
+
+      store.update(scheduledDateId, model)
+
+      assertTableEquals(
+          ScheduledPlantingDatesRecord(
+              plantingSeasonId = plantingSeasonId,
+              date = LocalDate.EPOCH.plusDays(1),
+              createdBy = user.userId,
+              createdTime = Instant.EPOCH,
+              modifiedBy = user.userId,
+              modifiedTime = clock.instant,
+          )
+      )
+
+      assertTableEquals(
+          listOf(
+              ScheduledPlantingDateSpeciesRecord(
+                  quantity = 11,
+                  scheduledPlantingDateId = scheduledDateId,
+                  speciesId = speciesId2,
+                  substratumId = substratumId2,
+              ),
+              ScheduledPlantingDateSpeciesRecord(
+                  quantity = 15,
+                  scheduledPlantingDateId = scheduledDateId,
+                  speciesId = speciesId2,
+                  substratumId = substratumId,
+              ),
+          )
+      )
+    }
+
+    @Test
+    fun `throws AccessDeniedException when user lacks permission`() {
+      val scheduledDateId = insertPlantingSeasonScheduledDate()
+      deleteOrganizationUser()
+      insertOrganizationUser(role = Role.Contributor)
+
+      assertThrows<AccessDeniedException> {
+        store.update(
+            scheduledDateId,
+            PlantingSeasonScheduledDateModel(
+                plantingSeasonId = plantingSeasonId,
+                date = LocalDate.EPOCH.plusDays(1),
+            ),
+        )
+      }
+    }
+
+    @Test
+    fun `throws IllegalArgumentException when a quantity is less than 0`() {
+      val speciesId2 = insertSpecies()
+      val scheduledDateId = insertPlantingSeasonScheduledDate()
+      insertScheduledPlantingDateSpecies(speciesId = speciesId)
+      insertScheduledPlantingDateSpecies(speciesId = speciesId2)
+
+      assertThrows<IllegalArgumentException> {
+        store.update(
+            scheduledDateId,
+            PlantingSeasonScheduledDateModel(
+                plantingSeasonId = plantingSeasonId,
+                date = LocalDate.EPOCH,
+                species =
+                    listOf(
+                        PlantingSeasonScheduledDateSpecies(
+                            quantity = -1,
+                            speciesId = speciesId,
+                            substratumId = substratumId,
+                        ),
+                        PlantingSeasonScheduledDateSpecies(
+                            quantity = 1,
+                            speciesId = speciesId2,
+                            substratumId = substratumId,
+                        ),
+                    ),
+            ),
+        )
+      }
+    }
+
+    @Test
+    fun `throws PlantingSeasonScheduledDateNotFoundException when date doesn't exist`() {
+      assertThrows<PlantingSeasonScheduledDateNotFoundException> {
+        store.update(
+            ScheduledPlantingDateId((99999L)),
+            PlantingSeasonScheduledDateModel(
+                plantingSeasonId = plantingSeasonId,
+                date = LocalDate.EPOCH,
+            ),
         )
       }
     }

--- a/src/test/kotlin/com/terraformation/backend/plantingmanagement/db/PlantingSeasonScheduledDatesStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/plantingmanagement/db/PlantingSeasonScheduledDatesStoreTest.kt
@@ -301,6 +301,34 @@ internal class PlantingSeasonScheduledDatesStoreTest : DatabaseTest(), RunsAsDat
     }
 
     @Test
+    fun `throws DuplicateKeyException when same species-substratum combination is added twice`() {
+      val scheduledDate = insertPlantingSeasonScheduledDate()
+
+      assertThrows<DuplicateKeyException> {
+        store.update(
+            scheduledDate,
+            PlantingSeasonScheduledDateModel(
+                plantingSeasonId = plantingSeasonId,
+                date = LocalDate.EPOCH,
+                species =
+                    listOf(
+                        PlantingSeasonScheduledDateSpecies(
+                            quantity = 5,
+                            speciesId = speciesId,
+                            substratumId = substratumId,
+                        ),
+                        PlantingSeasonScheduledDateSpecies(
+                            quantity = 10,
+                            speciesId = speciesId,
+                            substratumId = substratumId,
+                        ),
+                    ),
+            ),
+        )
+      }
+    }
+
+    @Test
     fun `throws AccessDeniedException when user lacks permission`() {
       val scheduledDateId = insertPlantingSeasonScheduledDate()
       deleteOrganizationUser()

--- a/src/test/kotlin/com/terraformation/backend/plantingmanagement/db/PlantingSeasonScheduledDatesStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/plantingmanagement/db/PlantingSeasonScheduledDatesStoreTest.kt
@@ -318,37 +318,6 @@ internal class PlantingSeasonScheduledDatesStoreTest : DatabaseTest(), RunsAsDat
     }
 
     @Test
-    fun `throws IllegalArgumentException when a quantity is less than 0`() {
-      val speciesId2 = insertSpecies()
-      val scheduledDateId = insertPlantingSeasonScheduledDate()
-      insertScheduledPlantingDateSpecies(speciesId = speciesId)
-      insertScheduledPlantingDateSpecies(speciesId = speciesId2)
-
-      assertThrows<IllegalArgumentException> {
-        store.update(
-            scheduledDateId,
-            PlantingSeasonScheduledDateModel(
-                plantingSeasonId = plantingSeasonId,
-                date = LocalDate.EPOCH,
-                species =
-                    listOf(
-                        PlantingSeasonScheduledDateSpecies(
-                            quantity = -1,
-                            speciesId = speciesId,
-                            substratumId = substratumId,
-                        ),
-                        PlantingSeasonScheduledDateSpecies(
-                            quantity = 1,
-                            speciesId = speciesId2,
-                            substratumId = substratumId,
-                        ),
-                    ),
-            ),
-        )
-      }
-    }
-
-    @Test
     fun `throws PlantingSeasonScheduledDateNotFoundException when date doesn't exist`() {
       assertThrows<PlantingSeasonScheduledDateNotFoundException> {
         store.update(


### PR DESCRIPTION
Handle updating a scheduled planting date for a planting season with a new endpoint. This includes the date itself as well as any of the date's species/substratum/quantity combos. 