### PR TITLE
SW-8371 Add api endpoint to fetch the list of scheduled planting dates for a planting season

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/plantingmanagement/Models.kt
+++ b/src/main/kotlin/com/terraformation/backend/plantingmanagement/Models.kt
@@ -4,6 +4,7 @@ import com.terraformation.backend.db.default_schema.SpeciesId
 import com.terraformation.backend.db.tracking.PlantingSeasonId
 import com.terraformation.backend.db.tracking.PlantingSeasonStatus
 import com.terraformation.backend.db.tracking.PlantingSiteId
+import com.terraformation.backend.db.tracking.ScheduledPlantingDateId
 import com.terraformation.backend.db.tracking.SubstratumId
 import java.time.LocalDate
 
@@ -46,3 +47,10 @@ data class PlantingSeasonScheduledDateModel(
     require(species.all { it.quantity >= 0 }) { "All quantities must be >= 0" }
   }
 }
+
+data class ExistingPlantingSeasonScheduledDateModel(
+    val date: LocalDate,
+    val plantingSeasonId: PlantingSeasonId,
+    val scheduledPlantingDateId: ScheduledPlantingDateId,
+    val species: List<PlantingSeasonScheduledDateSpecies> = emptyList(),
+)

--- a/src/main/kotlin/com/terraformation/backend/plantingmanagement/api/PlantingSeasonScheduledDatesController.kt
+++ b/src/main/kotlin/com/terraformation/backend/plantingmanagement/api/PlantingSeasonScheduledDatesController.kt
@@ -4,6 +4,7 @@ import com.terraformation.backend.api.ApiResponse200
 import com.terraformation.backend.api.ApiResponse404
 import com.terraformation.backend.api.ApiResponseSimpleSuccess
 import com.terraformation.backend.api.SimpleSuccessResponsePayload
+import com.terraformation.backend.api.SuccessResponsePayload
 import com.terraformation.backend.api.TrackingEndpoint
 import com.terraformation.backend.db.default_schema.SpeciesId
 import com.terraformation.backend.db.tracking.PlantingSeasonId
@@ -104,7 +105,8 @@ data class ScheduledPlantingDateRequestPayload(
       )
 }
 
-data class ListScheduledDatesResponsePayload(val scheduledDates: List<ScheduledDatePayload>)
+data class ListScheduledDatesResponsePayload(val scheduledDates: List<ScheduledDatePayload>) :
+    SuccessResponsePayload
 
 data class ScheduledDatePayload(
     val date: LocalDate,

--- a/src/main/kotlin/com/terraformation/backend/plantingmanagement/api/PlantingSeasonScheduledDatesController.kt
+++ b/src/main/kotlin/com/terraformation/backend/plantingmanagement/api/PlantingSeasonScheduledDatesController.kt
@@ -1,5 +1,6 @@
 package com.terraformation.backend.plantingmanagement.api
 
+import com.terraformation.backend.api.ApiResponse200
 import com.terraformation.backend.api.ApiResponse404
 import com.terraformation.backend.api.ApiResponseSimpleSuccess
 import com.terraformation.backend.api.SimpleSuccessResponsePayload
@@ -8,6 +9,7 @@ import com.terraformation.backend.db.default_schema.SpeciesId
 import com.terraformation.backend.db.tracking.PlantingSeasonId
 import com.terraformation.backend.db.tracking.ScheduledPlantingDateId
 import com.terraformation.backend.db.tracking.SubstratumId
+import com.terraformation.backend.plantingmanagement.ExistingPlantingSeasonScheduledDateModel
 import com.terraformation.backend.plantingmanagement.PlantingSeasonScheduledDateModel
 import com.terraformation.backend.plantingmanagement.PlantingSeasonScheduledDateSpecies
 import com.terraformation.backend.plantingmanagement.db.PlantingSeasonScheduledDatesStore
@@ -15,6 +17,7 @@ import io.swagger.v3.oas.annotations.Operation
 import jakarta.validation.Valid
 import jakarta.validation.constraints.Min
 import java.time.LocalDate
+import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.PutMapping
@@ -28,6 +31,19 @@ import org.springframework.web.bind.annotation.RestController
 class PlantingSeasonScheduledDatesController(
     private val plantingSeasonScheduledDatesStore: PlantingSeasonScheduledDatesStore,
 ) {
+  @ApiResponse200
+  @Operation(summary = "Gets all scheduled dates for a planting season.")
+  @GetMapping
+  fun getScheduledPlantingDates(
+      @PathVariable plantingSeasonId: PlantingSeasonId,
+  ): ListScheduledDatesResponsePayload {
+    val models = plantingSeasonScheduledDatesStore.fetchList(plantingSeasonId)
+
+    return ListScheduledDatesResponsePayload(
+        scheduledDates = models.map { ScheduledDatePayload(it) }
+    )
+  }
+
   @ApiResponseSimpleSuccess
   @ApiResponse404
   @Operation(
@@ -86,4 +102,27 @@ data class ScheduledPlantingDateRequestPayload(
           date = date,
           species = species.map { it.toModel() },
       )
+}
+
+data class ListScheduledDatesResponsePayload(val scheduledDates: List<ScheduledDatePayload>)
+
+data class ScheduledDatePayload(
+    val date: LocalDate,
+    val scheduledPlantingDateId: ScheduledPlantingDateId,
+    val species: List<ScheduledPlantingDateSpeciesPayload>,
+) {
+  constructor(
+      model: ExistingPlantingSeasonScheduledDateModel
+  ) : this(
+      date = model.date,
+      scheduledPlantingDateId = model.scheduledPlantingDateId,
+      species =
+          model.species.map {
+            ScheduledPlantingDateSpeciesPayload(
+                quantity = it.quantity,
+                speciesId = it.speciesId,
+                substratumId = it.substratumId,
+            )
+          },
+  )
 }

--- a/src/main/kotlin/com/terraformation/backend/plantingmanagement/db/PlantingSeasonScheduledDatesStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/plantingmanagement/db/PlantingSeasonScheduledDatesStore.kt
@@ -143,6 +143,7 @@ class PlantingSeasonScheduledDatesStore(
                   DSL.select(SPECIES_ID, SUBSTRATUM_ID, QUANTITY)
                       .from(SCHEDULED_PLANTING_DATE_SPECIES)
                       .where(SCHEDULED_PLANTING_DATE_ID.eq(SCHEDULED_PLANTING_DATES.ID))
+                      .orderBy(SPECIES_ID, SUBSTRATUM_ID)
               )
               .convertFrom { result ->
                 result.map { record ->
@@ -160,6 +161,7 @@ class PlantingSeasonScheduledDatesStore(
           .select(SCHEDULED_PLANTING_DATES.asterisk(), speciesMultiset)
           .from(SCHEDULED_PLANTING_DATES)
           .where(condition)
+          .orderBy(DATE.desc())
           .fetch { record ->
             ExistingPlantingSeasonScheduledDateModel(
                 date = record[DATE]!!,

--- a/src/main/kotlin/com/terraformation/backend/plantingmanagement/db/PlantingSeasonScheduledDatesStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/plantingmanagement/db/PlantingSeasonScheduledDatesStore.kt
@@ -2,19 +2,32 @@ package com.terraformation.backend.plantingmanagement.db
 
 import com.terraformation.backend.auth.currentUser
 import com.terraformation.backend.customer.model.requirePermissions
+import com.terraformation.backend.db.tracking.PlantingSeasonId
 import com.terraformation.backend.db.tracking.ScheduledPlantingDateId
 import com.terraformation.backend.db.tracking.tables.references.SCHEDULED_PLANTING_DATES
 import com.terraformation.backend.db.tracking.tables.references.SCHEDULED_PLANTING_DATE_SPECIES
+import com.terraformation.backend.plantingmanagement.ExistingPlantingSeasonScheduledDateModel
 import com.terraformation.backend.plantingmanagement.PlantingSeasonScheduledDateModel
+import com.terraformation.backend.plantingmanagement.PlantingSeasonScheduledDateSpecies
 import jakarta.inject.Named
 import java.time.InstantSource
+import org.jooq.Condition
 import org.jooq.DSLContext
+import org.jooq.impl.DSL
 
 @Named
 class PlantingSeasonScheduledDatesStore(
     private val clock: InstantSource,
     private val dslContext: DSLContext,
 ) {
+  fun fetchList(
+      plantingSeasonId: PlantingSeasonId
+  ): List<ExistingPlantingSeasonScheduledDateModel> {
+    requirePermissions { readPlantingSeason(plantingSeasonId) }
+
+    return fetchByCondition(SCHEDULED_PLANTING_DATES.PLANTING_SEASON_ID.eq(plantingSeasonId))
+  }
+
   fun create(model: PlantingSeasonScheduledDateModel): ScheduledPlantingDateId {
     requirePermissions { updatePlantingSeason(model.plantingSeasonId) }
 
@@ -118,6 +131,43 @@ class PlantingSeasonScheduledDatesStore(
 
         insertQuery.execute()
       }
+    }
+  }
+
+  private fun fetchByCondition(
+      condition: Condition
+  ): List<ExistingPlantingSeasonScheduledDateModel> {
+    val speciesMultiset =
+        with(SCHEDULED_PLANTING_DATE_SPECIES) {
+          DSL.multiset(
+                  DSL.select(SPECIES_ID, SUBSTRATUM_ID, QUANTITY)
+                      .from(SCHEDULED_PLANTING_DATE_SPECIES)
+                      .where(SCHEDULED_PLANTING_DATE_ID.eq(SCHEDULED_PLANTING_DATES.ID))
+              )
+              .convertFrom { result ->
+                result.map { record ->
+                  PlantingSeasonScheduledDateSpecies(
+                      speciesId = record[SPECIES_ID]!!,
+                      substratumId = record[SUBSTRATUM_ID]!!,
+                      quantity = record[QUANTITY]!!,
+                  )
+                }
+              }
+        }
+
+    return with(SCHEDULED_PLANTING_DATES) {
+      dslContext
+          .select(SCHEDULED_PLANTING_DATES.asterisk(), speciesMultiset)
+          .from(SCHEDULED_PLANTING_DATES)
+          .where(condition)
+          .fetch { record ->
+            ExistingPlantingSeasonScheduledDateModel(
+                date = record[DATE]!!,
+                plantingSeasonId = record[PLANTING_SEASON_ID]!!,
+                scheduledPlantingDateId = record[ID]!!,
+                species = record[speciesMultiset],
+            )
+          }
     }
   }
 }

--- a/src/test/kotlin/com/terraformation/backend/plantingmanagement/db/PlantingSeasonScheduledDatesStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/plantingmanagement/db/PlantingSeasonScheduledDatesStoreTest.kt
@@ -91,19 +91,6 @@ internal class PlantingSeasonScheduledDatesStoreTest : DatabaseTest(), RunsAsDat
       assertEquals(
           listOf(
               ExistingPlantingSeasonScheduledDateModel(
-                  date = date1,
-                  plantingSeasonId = plantingSeasonId,
-                  scheduledPlantingDateId = scheduledDate1,
-                  species =
-                      listOf(
-                          PlantingSeasonScheduledDateSpecies(
-                              quantity = 10,
-                              speciesId = speciesId,
-                              substratumId = substratumId,
-                          )
-                      ),
-              ),
-              ExistingPlantingSeasonScheduledDateModel(
                   date = date2,
                   plantingSeasonId = plantingSeasonId,
                   scheduledPlantingDateId = scheduledDate2,
@@ -112,6 +99,19 @@ internal class PlantingSeasonScheduledDatesStoreTest : DatabaseTest(), RunsAsDat
                           PlantingSeasonScheduledDateSpecies(
                               quantity = 20,
                               speciesId = speciesId2,
+                              substratumId = substratumId,
+                          )
+                      ),
+              ),
+              ExistingPlantingSeasonScheduledDateModel(
+                  date = date1,
+                  plantingSeasonId = plantingSeasonId,
+                  scheduledPlantingDateId = scheduledDate1,
+                  species =
+                      listOf(
+                          PlantingSeasonScheduledDateSpecies(
+                              quantity = 10,
+                              speciesId = speciesId,
                               substratumId = substratumId,
                           )
                       ),

--- a/src/test/kotlin/com/terraformation/backend/plantingmanagement/db/PlantingSeasonScheduledDatesStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/plantingmanagement/db/PlantingSeasonScheduledDatesStoreTest.kt
@@ -12,10 +12,12 @@ import com.terraformation.backend.db.tracking.SubstratumId
 import com.terraformation.backend.db.tracking.tables.records.ScheduledPlantingDateSpeciesRecord
 import com.terraformation.backend.db.tracking.tables.records.ScheduledPlantingDatesRecord
 import com.terraformation.backend.db.tracking.tables.references.SCHEDULED_PLANTING_DATE_SPECIES
+import com.terraformation.backend.plantingmanagement.ExistingPlantingSeasonScheduledDateModel
 import com.terraformation.backend.plantingmanagement.PlantingSeasonScheduledDateModel
 import com.terraformation.backend.plantingmanagement.PlantingSeasonScheduledDateSpecies
 import java.time.Instant
 import java.time.LocalDate
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
@@ -43,6 +45,91 @@ internal class PlantingSeasonScheduledDatesStoreTest : DatabaseTest(), RunsAsDat
     plantingSeasonId = insertPlantingSeason()
     substratumId = insertSubstratum()
     speciesId = insertSpecies()
+  }
+
+  @Nested
+  inner class FetchList {
+    @Test
+    fun `returns empty list when no dates exist`() {
+      val result = store.fetchList(plantingSeasonId)
+
+      assertEquals(
+          emptyList<ExistingPlantingSeasonScheduledDateModel>(),
+          result,
+          "No dates to fetch",
+      )
+    }
+
+    @Test
+    fun `returns dates for the specified season`() {
+      val date1 = LocalDate.EPOCH
+      val date2 = LocalDate.EPOCH.plusDays(1)
+      val speciesId2 = insertSpecies()
+      val scheduledDate1 = insertPlantingSeasonScheduledDate(date = date1)
+      val scheduledDate2 = insertPlantingSeasonScheduledDate(date = date2)
+      insertScheduledPlantingDateSpecies(
+          scheduledPlantingDateId = scheduledDate1,
+          speciesId = speciesId,
+          quantity = 10,
+      )
+      insertScheduledPlantingDateSpecies(
+          scheduledPlantingDateId = scheduledDate2,
+          speciesId = speciesId2,
+          quantity = 20,
+      )
+
+      insertPlantingSeason()
+      val otherSeasonScheduledDate = insertPlantingSeasonScheduledDate(date = date1)
+      insertScheduledPlantingDateSpecies(
+          scheduledPlantingDateId = otherSeasonScheduledDate,
+          speciesId = speciesId,
+          quantity = 30,
+      )
+
+      val result = store.fetchList(plantingSeasonId)
+
+      assertEquals(
+          listOf(
+              ExistingPlantingSeasonScheduledDateModel(
+                  date = date1,
+                  plantingSeasonId = plantingSeasonId,
+                  scheduledPlantingDateId = scheduledDate1,
+                  species =
+                      listOf(
+                          PlantingSeasonScheduledDateSpecies(
+                              quantity = 10,
+                              speciesId = speciesId,
+                              substratumId = substratumId,
+                          )
+                      ),
+              ),
+              ExistingPlantingSeasonScheduledDateModel(
+                  date = date2,
+                  plantingSeasonId = plantingSeasonId,
+                  scheduledPlantingDateId = scheduledDate2,
+                  species =
+                      listOf(
+                          PlantingSeasonScheduledDateSpecies(
+                              quantity = 20,
+                              speciesId = speciesId2,
+                              substratumId = substratumId,
+                          )
+                      ),
+              ),
+          ),
+          result,
+          "Dates for the correct season",
+      )
+    }
+
+    @Test
+    fun `throws PlantingSeasonNotFoundException when user lacks permission`() {
+      insertPlantingSeasonScheduledDate()
+      insertScheduledPlantingDateSpecies()
+
+      deleteOrganizationUser()
+      assertThrows<PlantingSeasonNotFoundException> { store.fetchList(plantingSeasonId) }
+    }
   }
 
   @Nested


### PR DESCRIPTION
Handle fetching the list of scheduled planting dates for a planting season with a new endpoint. This also includes the date's species/substratum/quantity combos for each date.