### PR TITLE
SW-8371 Add api endpoint to fetch a single scheduled planting date for a planting season

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/plantingmanagement/api/PlantingSeasonScheduledDatesController.kt
+++ b/src/main/kotlin/com/terraformation/backend/plantingmanagement/api/PlantingSeasonScheduledDatesController.kt
@@ -46,7 +46,7 @@ class PlantingSeasonScheduledDatesController(
   }
 
   @ApiResponse200
-  @Operation(summary = "Gets all scheduled dates for a planting season.")
+  @Operation(summary = "Gets a single scheduled date for a planting season.")
   @GetMapping("/{scheduledPlantingDateId}")
   fun getSingleScheduledPlantingDate(
       @PathVariable plantingSeasonId: PlantingSeasonId,

--- a/src/main/kotlin/com/terraformation/backend/plantingmanagement/api/PlantingSeasonScheduledDatesController.kt
+++ b/src/main/kotlin/com/terraformation/backend/plantingmanagement/api/PlantingSeasonScheduledDatesController.kt
@@ -45,6 +45,18 @@ class PlantingSeasonScheduledDatesController(
     )
   }
 
+  @ApiResponse200
+  @Operation(summary = "Gets all scheduled dates for a planting season.")
+  @GetMapping("/{scheduledPlantingDateId}")
+  fun getSingleScheduledPlantingDate(
+      @PathVariable plantingSeasonId: PlantingSeasonId,
+      @PathVariable scheduledPlantingDateId: ScheduledPlantingDateId,
+  ): ScheduledDatePayload {
+    val model = plantingSeasonScheduledDatesStore.fetch(plantingSeasonId, scheduledPlantingDateId)
+
+    return ScheduledDatePayload(model)
+  }
+
   @ApiResponseSimpleSuccess
   @ApiResponse404
   @Operation(

--- a/src/main/kotlin/com/terraformation/backend/plantingmanagement/api/PlantingSeasonScheduledDatesController.kt
+++ b/src/main/kotlin/com/terraformation/backend/plantingmanagement/api/PlantingSeasonScheduledDatesController.kt
@@ -51,10 +51,10 @@ class PlantingSeasonScheduledDatesController(
   fun getSingleScheduledPlantingDate(
       @PathVariable plantingSeasonId: PlantingSeasonId,
       @PathVariable scheduledPlantingDateId: ScheduledPlantingDateId,
-  ): ScheduledDatePayload {
+  ): GetScheduledDateResponsePayload {
     val model = plantingSeasonScheduledDatesStore.fetch(plantingSeasonId, scheduledPlantingDateId)
 
-    return ScheduledDatePayload(model)
+    return GetScheduledDateResponsePayload(scheduledDate = ScheduledDatePayload(model))
   }
 
   @ApiResponseSimpleSuccess
@@ -118,6 +118,9 @@ data class ScheduledPlantingDateRequestPayload(
 }
 
 data class ListScheduledDatesResponsePayload(val scheduledDates: List<ScheduledDatePayload>) :
+    SuccessResponsePayload
+
+data class GetScheduledDateResponsePayload(val scheduledDate: ScheduledDatePayload) :
     SuccessResponsePayload
 
 data class ScheduledDatePayload(

--- a/src/main/kotlin/com/terraformation/backend/plantingmanagement/db/PlantingSeasonScheduledDatesStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/plantingmanagement/db/PlantingSeasonScheduledDatesStore.kt
@@ -28,6 +28,20 @@ class PlantingSeasonScheduledDatesStore(
     return fetchByCondition(SCHEDULED_PLANTING_DATES.PLANTING_SEASON_ID.eq(plantingSeasonId))
   }
 
+  fun fetch(
+      plantingSeasonId: PlantingSeasonId,
+      scheduledPlantingDateId: ScheduledPlantingDateId,
+  ): ExistingPlantingSeasonScheduledDateModel {
+    requirePermissions { readPlantingSeason(plantingSeasonId) }
+
+    return fetchByCondition(
+            SCHEDULED_PLANTING_DATES.ID.eq(scheduledPlantingDateId)
+                .and(SCHEDULED_PLANTING_DATES.PLANTING_SEASON_ID.eq(plantingSeasonId))
+        )
+        .firstOrNull()
+        ?: throw PlantingSeasonScheduledDateNotFoundException(scheduledPlantingDateId)
+  }
+
   fun create(model: PlantingSeasonScheduledDateModel): ScheduledPlantingDateId {
     requirePermissions { updatePlantingSeason(model.plantingSeasonId) }
 

--- a/src/test/kotlin/com/terraformation/backend/plantingmanagement/db/PlantingSeasonScheduledDatesStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/plantingmanagement/db/PlantingSeasonScheduledDatesStoreTest.kt
@@ -133,6 +133,83 @@ internal class PlantingSeasonScheduledDatesStoreTest : DatabaseTest(), RunsAsDat
   }
 
   @Nested
+  inner class Fetch {
+    @Test
+    fun `returns the specified scheduled date`() {
+      val date1 = LocalDate.EPOCH
+      val speciesId2 = insertSpecies()
+      val scheduledDate = insertPlantingSeasonScheduledDate(date = date1)
+      insertScheduledPlantingDateSpecies(
+          scheduledPlantingDateId = scheduledDate,
+          speciesId = speciesId,
+          quantity = 10,
+      )
+      insertScheduledPlantingDateSpecies(
+          scheduledPlantingDateId = scheduledDate,
+          speciesId = speciesId2,
+          quantity = 20,
+      )
+
+      val otherScheduledDate = insertPlantingSeasonScheduledDate(date = date1.plusDays(1))
+      insertScheduledPlantingDateSpecies(
+          scheduledPlantingDateId = otherScheduledDate,
+          speciesId = speciesId,
+          quantity = 30,
+      )
+
+      val result = store.fetch(plantingSeasonId, scheduledDate)
+
+      assertEquals(
+          ExistingPlantingSeasonScheduledDateModel(
+              date = date1,
+              plantingSeasonId = plantingSeasonId,
+              scheduledPlantingDateId = scheduledDate,
+              species =
+                  listOf(
+                      PlantingSeasonScheduledDateSpecies(
+                          quantity = 10,
+                          speciesId = speciesId,
+                          substratumId = substratumId,
+                      ),
+                      PlantingSeasonScheduledDateSpecies(
+                          quantity = 20,
+                          speciesId = speciesId2,
+                          substratumId = substratumId,
+                      ),
+                  ),
+          ),
+          result,
+          "returns correct scheduled date",
+      )
+    }
+
+    @Test
+    fun `throws PlantingSeasonScheduledDateNotFoundException when no date does exist`() {
+      assertThrows<PlantingSeasonScheduledDateNotFoundException> {
+        store.fetch(plantingSeasonId, ScheduledPlantingDateId(99999L))
+      }
+    }
+
+    @Test
+    fun `throws PlantingSeasonScheduledDateNotFoundException when date does not belong to season`() {
+      insertPlantingSeason()
+      val scheduledDateId = insertPlantingSeasonScheduledDate()
+      assertThrows<PlantingSeasonScheduledDateNotFoundException> {
+        store.fetch(plantingSeasonId, scheduledDateId)
+      }
+    }
+
+    @Test
+    fun `throws PlantingSeasonNotFoundException when user lacks permission`() {
+      val scheduledDate = insertPlantingSeasonScheduledDate()
+      insertScheduledPlantingDateSpecies()
+
+      deleteOrganizationUser()
+      assertThrows<PlantingSeasonNotFoundException> { store.fetch(plantingSeasonId, scheduledDate) }
+    }
+  }
+
+  @Nested
   inner class Create {
     @Test
     fun `inserts a new scheduled date with no species`() {

--- a/src/test/kotlin/com/terraformation/backend/plantingmanagement/db/PlantingSeasonScheduledDatesStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/plantingmanagement/db/PlantingSeasonScheduledDatesStoreTest.kt
@@ -184,7 +184,7 @@ internal class PlantingSeasonScheduledDatesStoreTest : DatabaseTest(), RunsAsDat
     }
 
     @Test
-    fun `throws PlantingSeasonScheduledDateNotFoundException when no date does exist`() {
+    fun `throws PlantingSeasonScheduledDateNotFoundException when no date exists`() {
       assertThrows<PlantingSeasonScheduledDateNotFoundException> {
         store.fetch(plantingSeasonId, ScheduledPlantingDateId(99999L))
       }


### PR DESCRIPTION
Handle fetching a single scheduled planting date for a planting season with a new endpoint. This also includes the date's species/substratum/quantity combos.