### PR TITLE
SW-8371 Add api endpoint to delete a scheduled planting date for a planting season

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/plantingmanagement/api/PlantingSeasonScheduledDatesController.kt
+++ b/src/main/kotlin/com/terraformation/backend/plantingmanagement/api/PlantingSeasonScheduledDatesController.kt
@@ -18,6 +18,7 @@ import io.swagger.v3.oas.annotations.Operation
 import jakarta.validation.Valid
 import jakarta.validation.constraints.Min
 import java.time.LocalDate
+import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
@@ -87,6 +88,18 @@ class PlantingSeasonScheduledDatesController(
         scheduledPlantingDateId,
         payload.toModel(plantingSeasonId),
     )
+
+    return SimpleSuccessResponsePayload()
+  }
+
+  @ApiResponseSimpleSuccess
+  @ApiResponse200
+  @DeleteMapping("/{scheduledPlantingDateId}")
+  fun deleteScheduledPlantingDate(
+      @PathVariable plantingSeasonId: PlantingSeasonId,
+      @PathVariable scheduledPlantingDateId: ScheduledPlantingDateId,
+  ): SimpleSuccessResponsePayload {
+    plantingSeasonScheduledDatesStore.delete(plantingSeasonId, scheduledPlantingDateId)
 
     return SimpleSuccessResponsePayload()
   }

--- a/src/main/kotlin/com/terraformation/backend/plantingmanagement/api/PlantingSeasonScheduledDatesController.kt
+++ b/src/main/kotlin/com/terraformation/backend/plantingmanagement/api/PlantingSeasonScheduledDatesController.kt
@@ -94,6 +94,9 @@ class PlantingSeasonScheduledDatesController(
 
   @ApiResponseSimpleSuccess
   @ApiResponse200
+  @Operation(
+      summary = "Deletes a scheduled date for a planting season.",
+  )
   @DeleteMapping("/{scheduledPlantingDateId}")
   fun deleteScheduledPlantingDate(
       @PathVariable plantingSeasonId: PlantingSeasonId,

--- a/src/main/kotlin/com/terraformation/backend/plantingmanagement/db/PlantingSeasonScheduledDatesStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/plantingmanagement/db/PlantingSeasonScheduledDatesStore.kt
@@ -148,6 +148,26 @@ class PlantingSeasonScheduledDatesStore(
     }
   }
 
+  fun delete(
+      plantingSeasonId: PlantingSeasonId,
+      scheduledDateId: ScheduledPlantingDateId,
+  ) {
+    requirePermissions { updatePlantingSeason(plantingSeasonId) }
+
+    with(SCHEDULED_PLANTING_DATES) {
+      val rowsDeleted =
+          dslContext
+              .deleteFrom(SCHEDULED_PLANTING_DATES)
+              .where(ID.eq(scheduledDateId))
+              .and(PLANTING_SEASON_ID.eq(plantingSeasonId))
+              .execute()
+
+      if (rowsDeleted == 0) {
+        throw PlantingSeasonScheduledDateNotFoundException(scheduledDateId)
+      }
+    }
+  }
+
   private fun fetchByCondition(
       condition: Condition
   ): List<ExistingPlantingSeasonScheduledDateModel> {

--- a/src/test/kotlin/com/terraformation/backend/plantingmanagement/db/PlantingSeasonScheduledDatesStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/plantingmanagement/db/PlantingSeasonScheduledDatesStoreTest.kt
@@ -11,6 +11,7 @@ import com.terraformation.backend.db.tracking.ScheduledPlantingDateId
 import com.terraformation.backend.db.tracking.SubstratumId
 import com.terraformation.backend.db.tracking.tables.records.ScheduledPlantingDateSpeciesRecord
 import com.terraformation.backend.db.tracking.tables.records.ScheduledPlantingDatesRecord
+import com.terraformation.backend.db.tracking.tables.references.SCHEDULED_PLANTING_DATES
 import com.terraformation.backend.db.tracking.tables.references.SCHEDULED_PLANTING_DATE_SPECIES
 import com.terraformation.backend.plantingmanagement.ExistingPlantingSeasonScheduledDateModel
 import com.terraformation.backend.plantingmanagement.PlantingSeasonScheduledDateModel
@@ -536,6 +537,46 @@ internal class PlantingSeasonScheduledDatesStoreTest : DatabaseTest(), RunsAsDat
             ),
         )
       }
+    }
+  }
+
+  @Nested
+  inner class Delete {
+    @Test
+    fun `deletes the scheduled date`() {
+      val scheduledDateId = insertPlantingSeasonScheduledDate()
+      insertScheduledPlantingDateSpecies()
+
+      store.delete(plantingSeasonId, scheduledDateId)
+
+      assertTableEmpty(SCHEDULED_PLANTING_DATES)
+      assertTableEmpty(SCHEDULED_PLANTING_DATE_SPECIES)
+    }
+
+    @Test
+    fun `throws PlantingSeasonScheduledDateNotFoundException when date doesn't exist`() {
+      assertThrows<PlantingSeasonScheduledDateNotFoundException> {
+        store.delete(plantingSeasonId, ScheduledPlantingDateId(99999L))
+      }
+    }
+
+    @Test
+    fun `throws PlantingSeasonScheduledDateNotFoundException when date belongs to different season`() {
+      insertPlantingSeason()
+      val scheduledDateId = insertPlantingSeasonScheduledDate()
+
+      assertThrows<PlantingSeasonScheduledDateNotFoundException> {
+        store.delete(plantingSeasonId, scheduledDateId)
+      }
+    }
+
+    @Test
+    fun `throws AccessDeniedException when user lacks permission`() {
+      val scheduledDateId = insertPlantingSeasonScheduledDate()
+      insertScheduledPlantingDateSpecies()
+      deleteOrganizationUser()
+      insertOrganizationUser(role = Role.Contributor)
+      assertThrows<AccessDeniedException> { store.delete(plantingSeasonId, scheduledDateId) }
     }
   }
 }


### PR DESCRIPTION
Handle deleting a scheduled planting date for a planting season with a new endpoint. This also includes deleting the date's species/substratum/quantity combos.