### PR TITLE
SW-8372 Rename PlantingSeasonPayload to SimplePlantingSeasonPayload to avoid conflicts in FE

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/tracking/api/PlantingSitesController.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/api/PlantingSitesController.kt
@@ -400,7 +400,7 @@ data class StratumResponsePayload(
   )
 }
 
-data class PlantingSeasonPayload(
+data class SimplePlantingSeasonPayload(
     val endDate: LocalDate,
     val id: SimplePlantingSeasonId,
     val startDate: LocalDate,
@@ -429,7 +429,7 @@ data class PlantingSitePayload(
     val latestObservationId: ObservationId?,
     val name: String,
     val organizationId: OrganizationId,
-    val plantingSeasons: List<PlantingSeasonPayload>,
+    val plantingSeasons: List<SimplePlantingSeasonPayload>,
     @Schema(description = "Use strata instead", deprecated = true)
     val plantingZones: List<PlantingZonePayload>?,
     val projectId: ProjectId? = null,
@@ -452,7 +452,7 @@ data class PlantingSitePayload(
       latestObservationId = model.latestObservationId,
       name = model.name,
       organizationId = model.organizationId,
-      plantingSeasons = model.plantingSeasons.map { PlantingSeasonPayload(it) },
+      plantingSeasons = model.plantingSeasons.map { SimplePlantingSeasonPayload(it) },
       plantingZones = if (includeZones) model.strata.map { PlantingZonePayload(it) } else null,
       projectId = model.projectId,
       strata = model.strata.map { StratumResponsePayload(it) },


### PR DESCRIPTION
`PlantingSeasonPayload` is an overloaded class type, causing the schema generation in the FE to only have one version of it. Rename the old payload type to `SimplePlantingSeasonPayload`. 

A later PR will have a unit test that prevents this from happening again.