### PR TITLE
Verify that response payload classes have status

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/search/api/SearchPayloads.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/api/SearchPayloads.kt
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonInclude
 import com.fasterxml.jackson.annotation.JsonSubTypes
 import com.fasterxml.jackson.annotation.JsonTypeInfo
 import com.fasterxml.jackson.annotation.JsonTypeName
+import com.terraformation.backend.api.SuccessResponsePayload
 import com.terraformation.backend.search.AndNode
 import com.terraformation.backend.search.FieldNode
 import com.terraformation.backend.search.NoConditionNode
@@ -174,7 +175,8 @@ data class FieldNodePayload(
 }
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
-data class SearchResponsePayload(val results: List<Map<String, Any>>, val cursor: String?) {
+data class SearchResponsePayload(val results: List<Map<String, Any>>, val cursor: String?) :
+    SuccessResponsePayload {
   constructor(searchResults: SearchResults) : this(searchResults.results, searchResults.cursor)
 }
 
@@ -198,6 +200,7 @@ data class FieldValuesPayload(
     val partial: Boolean,
 )
 
-data class SearchValuesResponsePayload(val results: Map<String, FieldValuesPayload>)
+data class SearchValuesResponsePayload(val results: Map<String, FieldValuesPayload>) :
+    SuccessResponsePayload
 
-data class SearchCountResponsePayload(val count: Long)
+data class SearchCountResponsePayload(val count: Long) : SuccessResponsePayload

--- a/src/main/kotlin/com/terraformation/backend/species/api/SpeciesLookupController.kt
+++ b/src/main/kotlin/com/terraformation/backend/species/api/SpeciesLookupController.kt
@@ -139,7 +139,7 @@ data class SpeciesLookupDetailsResponsePayload(
                 "alternative."
     )
     val suggestedScientificName: String?,
-) {
+) : SuccessResponsePayload {
   constructor(
       model: GbifTaxonModel,
       problem: SpeciesProblemsRow?,

--- a/src/test/kotlin/com/terraformation/backend/api/OpenApiAnnotationTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/api/OpenApiAnnotationTest.kt
@@ -5,6 +5,9 @@ import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.responses.ApiResponse
 import io.swagger.v3.oas.annotations.tags.Tag
 import java.lang.reflect.Method
+import java.lang.reflect.ParameterizedType
+import java.lang.reflect.Type
+import java.lang.reflect.WildcardType
 import java.util.stream.Stream
 import kotlin.streams.asStream
 import org.junit.jupiter.api.Assertions.assertNotNull
@@ -18,8 +21,11 @@ import org.springframework.boot.env.YamlPropertySourceLoader
 import org.springframework.context.annotation.ClassPathScanningCandidateComponentProvider
 import org.springframework.core.annotation.MergedAnnotations
 import org.springframework.core.env.StandardEnvironment
+import org.springframework.core.io.ByteArrayResource
 import org.springframework.core.io.ClassPathResource
+import org.springframework.core.io.InputStreamResource
 import org.springframework.core.type.filter.AnnotationTypeFilter
+import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PatchMapping
@@ -64,6 +70,17 @@ class OpenApiAnnotationTest {
     val operation = MergedAnnotations.from(method).get(Operation::class.java)
     assertTrue(operation.isPresent, "No Operation annotation on $name")
     assertNotNull(operation.getString("summary"), "Operation annotation on $name missing summary")
+  }
+
+  @MethodSource("findAllEndpointMethods")
+  @ParameterizedTest(name = "{0}")
+  fun `all endpoint response payloads implement ResponsePayload`(name: String, method: Method) {
+    val payloadClass = responsePayloadClass(method.genericReturnType) ?: return
+
+    assertTrue(
+        ResponsePayload::class.java.isAssignableFrom(payloadClass),
+        "Response payload ${payloadClass.name} does not implement ResponsePayload",
+    )
   }
 
   @MethodSource("findAllControllerPackages")
@@ -111,6 +128,48 @@ class OpenApiAnnotationTest {
             PutMapping::class,
             RequestMapping::class,
         )
+
+    /**
+     * Return types that endpoints use for raw (non-JSON) responses such as binary downloads or
+     * plain-text webhook acknowledgments. Endpoints with these return types are exempt from the
+     * requirement to implement [ResponsePayload].
+     */
+    private val rawResponseTypes: Set<Class<*>> =
+        setOf(
+            ByteArray::class.java,
+            ByteArrayResource::class.java,
+            InputStreamResource::class.java,
+            String::class.java,
+        )
+
+    /**
+     * Returns the class of the response payload for an endpoint method, or null if the endpoint
+     * returns raw data that doesn't need to implement a response payload interface.
+     */
+    private fun responsePayloadClass(returnType: Type): Class<*>? {
+      val rawClass =
+          when (returnType) {
+            is Class<*> -> returnType
+            is ParameterizedType -> {
+              val rawType = returnType.rawType as? Class<*> ?: return null
+              if (ResponseEntity::class.java.isAssignableFrom(rawType)) {
+                val typeArg = returnType.actualTypeArguments.firstOrNull() ?: return null
+                if (typeArg is WildcardType) {
+                  return null
+                }
+                return responsePayloadClass(typeArg)
+              }
+              rawType
+            }
+            else -> return null
+          }
+
+      if (rawClass.isPrimitive || rawClass in rawResponseTypes) {
+        return null
+      }
+
+      return rawClass
+    }
 
     private fun controllerClasses(): Sequence<Class<*>> {
       val scanner = ClassPathScanningCandidateComponentProvider(false)


### PR DESCRIPTION
In theory, all our response payload classes should implement the `ResponsePayload`
interface (or one of its sub-interfaces) so that our API consistently includes a
"status" property in the responses.

Add the interface to the payload classes that were missing it, and add a unit test
to catch if we forget to include it in future payloads.