### PR TITLE
SW-7126 Return null planting density when no data

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/tracking/api/MonitoringResultsPayloads.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/api/MonitoringResultsPayloads.kt
@@ -150,7 +150,7 @@ data class ObservationMonitoringPlotResultsPayload(
     @Schema(description = "IDs of any older monitoring plots this one overlaps with.")
     val overlapsWithPlotIds: Set<MonitoringPlotId>,
     @Schema(description = "Number of live plants per hectare.") //
-    val plantingDensity: Int,
+    val plantingDensity: Int?,
     val plants: List<RecordedPlantPayload>?,
     @Schema(description = "Length of each edge of the monitoring plot in meters.")
     val sizeMeters: Int,
@@ -241,7 +241,7 @@ data class ObservationSubstratumResultsPayload(
             "Estimated planting density for the substratum based on the observed planting densities " +
                 "of monitoring plots."
     )
-    val plantingDensity: Int,
+    val plantingDensity: Int?,
     val plantingDensityStdDev: Int?,
     @Schema(
         description =
@@ -304,7 +304,7 @@ data class ObservationStratumResultsPayload(
             "Estimated planting density for the stratum based on the observed planting densities " +
                 "of monitoring plots."
     )
-    val plantingDensity: Int,
+    val plantingDensity: Int?,
     val plantingDensityStdDev: Int?,
     @Schema(
         description = "ID of the stratum. Absent if the stratum was deleted after the observation."
@@ -379,7 +379,7 @@ data class ObservationResultsPayload(
             "Estimated planting density for the site, based on the observed planting densities " +
                 "of monitoring plots."
     )
-    val plantingDensity: Int,
+    val plantingDensity: Int?,
     val plantingDensityStdDev: Int?,
     val plantingSiteHistoryId: PlantingSiteHistoryId?,
     val plantingSiteId: PlantingSiteId,
@@ -441,7 +441,7 @@ data class StratumObservationSummaryPayload(
             "Estimated planting density for the stratum based on the observed planting densities " +
                 "of monitoring plots."
     )
-    val plantingDensity: Int,
+    val plantingDensity: Int?,
     val plantingDensityStdDev: Int?,
     @Schema(
         description =
@@ -510,7 +510,7 @@ data class PlantingSiteObservationSummaryPayload(
             "Estimated planting density for the site, based on the observed planting densities " +
                 "of monitoring plots."
     )
-    val plantingDensity: Int,
+    val plantingDensity: Int?,
     val plantingDensityStdDev: Int?,
     val plantingSiteId: PlantingSiteId,
     @Schema(

--- a/src/main/kotlin/com/terraformation/backend/tracking/db/ObservationResultsStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/db/ObservationResultsStore.kt
@@ -452,17 +452,17 @@ class ObservationResultsStore(private val dslContext: DSLContext) {
             val completedPlotsPlantingDensities =
                 monitoringPlots
                     .filter { it.status == ObservationPlotStatus.Completed }
-                    .map { it.plantingDensity }
+                    .mapNotNull { it.plantingDensity }
             val plantingDensity =
                 if (completedPlotsPlantingDensities.isNotEmpty()) {
                   completedPlotsPlantingDensities.average()
                 } else {
-                  0.0
+                  null
                 }
             val plantingDensityStdDev = completedPlotsPlantingDensities.calculateStandardDeviation()
 
             val estimatedPlants =
-                if (plantingCompleted) {
+                if (plantingCompleted && plantingDensity != null) {
                   areaHa.toDouble() * plantingDensity
                 } else {
                   null
@@ -475,7 +475,7 @@ class ObservationResultsStore(private val dslContext: DSLContext) {
                 monitoringPlots = monitoringPlots,
                 name = record[SUBSTRATUM_HISTORIES.NAME.asNonNullable()],
                 plantingCompleted = plantingCompleted,
-                plantingDensity = plantingDensity.roundToInt(),
+                plantingDensity = plantingDensity?.roundToInt(),
                 plantingDensityStdDev = plantingDensityStdDev,
                 species = species,
                 substratumId = record[SUBSTRATUM_HISTORIES.SUBSTRATUM_ID.asNonNullable()],
@@ -602,17 +602,17 @@ class ObservationResultsStore(private val dslContext: DSLContext) {
             val completedPlotsPlantingDensities =
                 monitoringPlots
                     .filter { it.status == ObservationPlotStatus.Completed }
-                    .map { it.plantingDensity }
+                    .mapNotNull { it.plantingDensity }
             val plantingDensity =
                 if (completedPlotsPlantingDensities.isNotEmpty()) {
                   completedPlotsPlantingDensities.average()
                 } else {
-                  0.0
+                  null
                 }
             val plantingDensityStdDev = completedPlotsPlantingDensities.calculateStandardDeviation()
 
             val estimatedPlants =
-                if (plantingCompleted) {
+                if (plantingCompleted && plantingDensity != null) {
                   areaHa.toDouble() * plantingDensity
                 } else {
                   null
@@ -624,7 +624,7 @@ class ObservationResultsStore(private val dslContext: DSLContext) {
                 estimatedPlants = estimatedPlants?.roundToInt(),
                 name = record[STRATUM_HISTORIES.NAME.asNonNullable()],
                 plantingCompleted = plantingCompleted,
-                plantingDensity = plantingDensity.roundToInt(),
+                plantingDensity = plantingDensity?.roundToInt(),
                 plantingDensityStdDev = plantingDensityStdDev,
                 species = identifiedSpecies,
                 stratumId = record[STRATUM_HISTORIES.STRATUM_ID.asNonNullable()],
@@ -700,12 +700,12 @@ class ObservationResultsStore(private val dslContext: DSLContext) {
               val completedPlotsPlantingDensities =
                   monitoringPlots
                       .filter { it.status == ObservationPlotStatus.Completed }
-                      .map { it.plantingDensity }
+                      .mapNotNull { it.plantingDensity }
               val plantingDensity =
                   if (completedPlotsPlantingDensities.isNotEmpty()) {
                     completedPlotsPlantingDensities.average()
                   } else {
-                    0.0
+                    null
                   }
               val plantingDensityStdDev =
                   completedPlotsPlantingDensities.calculateStandardDeviation()
@@ -750,7 +750,7 @@ class ObservationResultsStore(private val dslContext: DSLContext) {
                   observationId = record[OBSERVATIONS.ID.asNonNullable()],
                   observationType = record[OBSERVATIONS.OBSERVATION_TYPE_ID.asNonNullable()],
                   plantingCompleted = plantingCompleted,
-                  plantingDensity = plantingDensity.roundToInt(),
+                  plantingDensity = plantingDensity?.roundToInt(),
                   plantingDensityStdDev = plantingDensityStdDev,
                   plantingSiteHistoryId = record[PLANTING_SITE_HISTORIES.ID],
                   plantingSiteId = record[OBSERVATIONS.PLANTING_SITE_ID.asNonNullable()],

--- a/src/main/kotlin/com/terraformation/backend/tracking/db/ObservationResultsStoreV2.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/db/ObservationResultsStoreV2.kt
@@ -174,7 +174,7 @@ class ObservationResultsStoreV2(private val dslContext: DSLContext) {
             }
 
             val survivalRate = record[OBSERVATION_PLOT_RESULTS.SURVIVAL_RATE]
-            val plantingDensity = record[OBSERVATION_PLOT_RESULTS.PLANT_DENSITY] ?: 0
+            val plantingDensity = record[OBSERVATION_PLOT_RESULTS.PLANT_DENSITY]
 
             val status = record[OBSERVATION_PLOTS.STATUS_ID]!!
 
@@ -298,12 +298,12 @@ class ObservationResultsStoreV2(private val dslContext: DSLContext) {
 
             val survivalRate = record[OBSERVATION_SUBSTRATUM_RESULTS.SURVIVAL_RATE]
             val survivalRateStdDev = record[OBSERVATION_SUBSTRATUM_RESULTS.SURVIVAL_RATE_STD_DEV]
-            val plantingDensity = record[OBSERVATION_SUBSTRATUM_RESULTS.PLANT_DENSITY] ?: 0
+            val plantingDensity = record[OBSERVATION_SUBSTRATUM_RESULTS.PLANT_DENSITY]
             val plantingDensityStdDev = record[OBSERVATION_SUBSTRATUM_RESULTS.PLANT_DENSITY_STD_DEV]
 
             val plantingCompleted = record[SUBSTRATA.PLANTING_COMPLETED_TIME] != null
             val estimatedPlants =
-                if (plantingCompleted) {
+                if (plantingCompleted && plantingDensity != null) {
                   (areaHa.toDouble() * plantingDensity).roundToInt()
                 } else {
                   null
@@ -421,12 +421,12 @@ class ObservationResultsStoreV2(private val dslContext: DSLContext) {
 
             val survivalRate = record[OBSERVATION_STRATUM_RESULTS.SURVIVAL_RATE]
             val survivalRateStdDev = record[OBSERVATION_STRATUM_RESULTS.SURVIVAL_RATE_STD_DEV]
-            val plantingDensity = record[OBSERVATION_STRATUM_RESULTS.PLANT_DENSITY] ?: 0
+            val plantingDensity = record[OBSERVATION_STRATUM_RESULTS.PLANT_DENSITY]
             val plantingDensityStdDev = record[OBSERVATION_STRATUM_RESULTS.PLANT_DENSITY_STD_DEV]
 
             val plantingCompleted = record[stratumPlantingCompletedField]
             val estimatedPlants =
-                if (plantingCompleted) {
+                if (plantingCompleted && plantingDensity != null) {
                   (areaHa.toDouble() * plantingDensity).roundToInt()
                 } else {
                   null
@@ -528,7 +528,7 @@ class ObservationResultsStoreV2(private val dslContext: DSLContext) {
 
               val survivalRate = record[OBSERVATION_SITE_RESULTS.SURVIVAL_RATE]
               val survivalRateStdDev = record[OBSERVATION_SITE_RESULTS.SURVIVAL_RATE_STD_DEV]
-              val plantingDensity = record[OBSERVATION_SITE_RESULTS.PLANT_DENSITY] ?: 0
+              val plantingDensity = record[OBSERVATION_SITE_RESULTS.PLANT_DENSITY]
               val plantingDensityStdDev = record[OBSERVATION_SITE_RESULTS.PLANT_DENSITY_STD_DEV]
 
               ObservationResultsModel(

--- a/src/main/kotlin/com/terraformation/backend/tracking/model/ObservationResultsModel.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/model/ObservationResultsModel.kt
@@ -90,7 +90,7 @@ interface BaseMonitoringResult {
    * Estimated planting density for the region based on the observed planting densities of
    * monitoring plots.
    */
-  val plantingDensity: Int
+  val plantingDensity: Int?
 
   /** List of species result used for this rollup */
   val species: List<ObservationSpeciesResultsModel>
@@ -140,7 +140,7 @@ data class ObservationMonitoringPlotResultsModel(
      * because the intent is to track how many of the plants that were introduced to the site are
      * still alive.
      */
-    override val plantingDensity: Int,
+    override val plantingDensity: Int?,
     val plants: List<RecordedPlantModel>?,
     val sizeMeters: Int,
     override val species: List<ObservationSpeciesResultsModel>,
@@ -195,7 +195,7 @@ data class ObservationSubstratumResultsModel(
     val monitoringPlots: List<ObservationMonitoringPlotResultsModel>,
     val name: String,
     override val plantingCompleted: Boolean,
-    override val plantingDensity: Int,
+    override val plantingDensity: Int?,
     override val plantingDensityStdDev: Int?,
     override val species: List<ObservationSpeciesResultsModel>,
     val substratumId: SubstratumId?,
@@ -212,7 +212,7 @@ data class ObservationStratumResultsModel(
     override val estimatedPlants: Int?,
     val name: String,
     override val plantingCompleted: Boolean,
-    override val plantingDensity: Int,
+    override val plantingDensity: Int?,
     override val plantingDensityStdDev: Int?,
     override val species: List<ObservationSpeciesResultsModel>,
     val stratumId: StratumId?,
@@ -233,7 +233,7 @@ data class ObservationResultsModel(
     val observationId: ObservationId,
     val observationType: ObservationType,
     override val plantingCompleted: Boolean,
-    override val plantingDensity: Int,
+    override val plantingDensity: Int?,
     override val plantingDensityStdDev: Int?,
     val plantingSiteHistoryId: PlantingSiteHistoryId?,
     val plantingSiteId: PlantingSiteId,
@@ -256,7 +256,7 @@ data class ObservationStratumRollupResultsModel(
     /** Time when the latest observation in this rollup was completed. */
     val latestCompletedTime: Instant,
     override val plantingCompleted: Boolean,
-    override val plantingDensity: Int,
+    override val plantingDensity: Int?,
     override val plantingDensityStdDev: Int?,
     override val species: List<ObservationSpeciesResultsModel>,
     val stratumId: StratumId,
@@ -297,17 +297,19 @@ data class ObservationStratumRollupResultsModel(
         it.certainty != RecordedSpeciesCertainty.Unknown && (it.totalLive + it.totalExisting) > 0
       }
 
-      val completedPlotsPlantingDensities = completedMonitoringPlots.map { it.plantingDensity }
+      val completedPlotsPlantingDensities = completedMonitoringPlots.mapNotNull {
+        it.plantingDensity
+      }
       val plantingDensity =
           if (completedPlotsPlantingDensities.isNotEmpty()) {
             completedPlotsPlantingDensities.average().roundToInt()
           } else {
-            0
+            null
           }
       val plantingDensityStdDev = completedPlotsPlantingDensities.calculateStandardDeviation()
 
       val estimatedPlants =
-          if (plantingCompleted) {
+          if (plantingCompleted && plantingDensity != null) {
             areaHa.toDouble() * plantingDensity
           } else {
             null
@@ -363,7 +365,7 @@ data class ObservationRollupResultsModel(
     /** Time when the latest observation in this rollup was completed. */
     val latestCompletedTime: Instant,
     override val plantingCompleted: Boolean,
-    override val plantingDensity: Int,
+    override val plantingDensity: Int?,
     override val plantingDensityStdDev: Int?,
     val plantingSiteId: PlantingSiteId,
     /** List of species result used for this rollup */
@@ -405,12 +407,12 @@ data class ObservationRollupResultsModel(
       val completedPlotsPlantingDensities =
           monitoringPlots
               .filter { it.status == ObservationPlotStatus.Completed }
-              .map { it.plantingDensity }
+              .mapNotNull { it.plantingDensity }
       val plantingDensity =
           if (completedPlotsPlantingDensities.isNotEmpty()) {
             completedPlotsPlantingDensities.average().roundToInt()
           } else {
-            0
+            null
           }
       val plantingDensityStdDev = completedPlotsPlantingDensities.calculateStandardDeviation()
 

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/ObservationScenarioV2Test.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/ObservationScenarioV2Test.kt
@@ -676,7 +676,7 @@ class ObservationScenarioV2Test : ObservationScenarioTest() {
           completePlotResults.status,
           "Completed Plot Status",
       )
-      assertEquals(0, incompletePlotResults.plantingDensity, "Incomplete Plot Planting Density")
+      assertNull(incompletePlotResults.plantingDensity, "Incomplete Plot Planting Density")
       assertEquals(
           ObservationPlotStatus.NotObserved,
           incompletePlotResults.status,


### PR DESCRIPTION
Previously, when there was no observation data for a plot/substratum/stratum,
we returned a planting density of 0, making the result indistinguishable from
cases where the number of observed plants was so small that the observed density
was actually 0.

Instead, return null planting densities if we don't have any observation data.