### PR TITLE
SW-7126 Return null totals when no data

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/tracking/api/MonitoringResultsPayloads.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/api/MonitoringResultsPayloads.kt
@@ -39,7 +39,7 @@ data class ObservationSpeciesResultsPayload(
     @Schema(
         description =
             "Number of live plants observed in permanent plots in this observation, not " +
-                "including existing plants. 0 if ths is a plot-level result for a temporary " +
+                "including existing plants. 0 if this is a plot-level result for a temporary " +
                 "monitoring plot."
     )
     val permanentLive: Int,
@@ -167,14 +167,14 @@ data class ObservationMonitoringPlotResultsPayload(
             "Total number of plants recorded. Includes all plants, regardless of live/dead " +
                 "status or species."
     )
-    val totalPlants: Int,
+    val totalPlants: Int?,
     @Schema(
         description =
             "Total number of species observed, not counting dead plants. Includes plants with " +
                 "Known and Other certainties. In the case of Other, each distinct user-supplied " +
                 "species name is counted as a separate species for purposes of this total."
     )
-    val totalSpecies: Int,
+    val totalSpecies: Int?,
     @Schema(description = "Information about plants of unknown species, if any were observed.")
     val unknownSpecies: ObservationSpeciesResultsPayload?,
 ) {
@@ -256,14 +256,14 @@ data class ObservationSubstratumResultsPayload(
             "Total number of plants recorded. Includes all plants, regardless of live/dead " +
                 "status or species."
     )
-    val totalPlants: Int,
+    val totalPlants: Int?,
     @Schema(
         description =
             "Total number of species observed, not counting dead plants. Includes plants with " +
                 "Known and Other certainties. In the case of Other, each distinct user-supplied " +
                 "species name is counted as a separate species for purposes of this total."
     )
-    val totalSpecies: Int,
+    val totalSpecies: Int?,
 ) {
   constructor(
       model: ObservationSubstratumResultsModel
@@ -324,14 +324,14 @@ data class ObservationStratumResultsPayload(
             "Total number of plants recorded. Includes all plants, regardless of live/dead " +
                 "status or species."
     )
-    val totalPlants: Int,
+    val totalPlants: Int?,
     @Schema(
         description =
             "Total number of species observed, not counting dead plants. Includes plants with " +
                 "Known and Other certainties. In the case of Other, each distinct user-supplied " +
                 "species name is counted as a separate species for purposes of this total."
     )
-    val totalSpecies: Int,
+    val totalSpecies: Int?,
 ) {
   constructor(
       model: ObservationStratumResultsModel
@@ -389,8 +389,8 @@ data class ObservationResultsPayload(
     val strata: List<ObservationStratumResultsPayload>,
     val survivalRate: Int?,
     val survivalRateStdDev: Int?,
-    val totalPlants: Int,
-    val totalSpecies: Int,
+    val totalPlants: Int?,
+    val totalSpecies: Int?,
     val type: ObservationType,
 ) {
   constructor(
@@ -460,16 +460,17 @@ data class StratumObservationSummaryPayload(
     val survivalRateStdDev: Int?,
     @Schema(
         description =
-            "Total number of plants recorded from the latest observations of each substratum. Includes all plants, regardless of live/dead status or species."
+            "Total number of plants recorded from the latest observations of each substratum. " +
+                "Includes all plants, regardless of live/dead status or species."
     )
-    val totalPlants: Int,
+    val totalPlants: Int?,
     @Schema(
         description =
             "Total number of species observed, not counting dead plants. Includes plants with " +
                 "Known and Other certainties. In the case of Other, each distinct user-supplied " +
                 "species name is counted as a separate species for purposes of this total."
     )
-    val totalSpecies: Int,
+    val totalSpecies: Int?,
 ) {
   constructor(
       model: ObservationStratumRollupResultsModel
@@ -528,16 +529,18 @@ data class PlantingSiteObservationSummaryPayload(
     val survivalRateStdDev: Int?,
     @Schema(
         description =
-            "Total number of plants recorded from the latest observations of each substratum within each stratum. Includes all plants, regardless of live/dead status or species."
+            "Total number of plants recorded from the latest observations of each substratum " +
+                "within each stratum. Includes all plants, regardless of live/dead status or " +
+                "species."
     )
-    val totalPlants: Int,
+    val totalPlants: Int?,
     @Schema(
         description =
             "Total number of species observed, not counting dead plants. Includes plants with " +
                 "Known and Other certainties. In the case of Other, each distinct user-supplied " +
                 "species name is counted as a separate species for purposes of this total."
     )
-    val totalSpecies: Int,
+    val totalSpecies: Int?,
 ) {
   constructor(
       model: ObservationRollupResultsModel

--- a/src/main/kotlin/com/terraformation/backend/tracking/db/ObservationMultisets.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/db/ObservationMultisets.kt
@@ -6,6 +6,7 @@ import com.terraformation.backend.db.default_schema.SpeciesIdConverter
 import com.terraformation.backend.db.default_schema.tables.references.FILES
 import com.terraformation.backend.db.forMultiset
 import com.terraformation.backend.db.tracking.MonitoringPlotId
+import com.terraformation.backend.db.tracking.ObservationPlotStatus
 import com.terraformation.backend.db.tracking.PlantingSiteIdConverter
 import com.terraformation.backend.db.tracking.RecordedSpeciesCertainty
 import com.terraformation.backend.db.tracking.StratumIdConverter
@@ -293,19 +294,19 @@ internal val monitoringPlotSpeciesMultiset =
                           OBSERVATION_PLOTS.IS_PERMANENT.eq(true)
                               .and(PLOT_T0_DENSITIES.MONITORING_PLOT_ID.eq(MONITORING_PLOTS.ID))
                       )
-              )
-              .or(
-                  MONITORING_PLOT_ID.isNull
-                      .and(OBSERVATION_PLOTS.IS_PERMANENT.eq(false))
-                      .and(
-                          STRATUM_T0_TEMP_DENSITIES.STRATUM_ID.eq(
-                              OBSERVATION_PLOTS.monitoringPlotHistories.substratumHistories
-                                  .stratumHistories
-                                  .STRATUM_ID
-                          )
+                      .or(
+                          MONITORING_PLOT_ID.isNull
+                              .and(OBSERVATION_PLOTS.IS_PERMANENT.eq(false))
+                              .and(
+                                  STRATUM_T0_TEMP_DENSITIES.STRATUM_ID.eq(
+                                      OBSERVATION_PLOTS.monitoringPlotHistories.substratumHistories
+                                          .stratumHistories
+                                          .STRATUM_ID
+                                  )
+                              )
                       )
-                  //                        )
               )
+              .and(OBSERVATION_PLOTS.STATUS_ID.eq(ObservationPlotStatus.Completed))
               .and(OBSERVATION_ID.eq(OBSERVATIONS.ID).or(OBSERVATION_ID.isNull))
               .orderBy(SPECIES_ID, SPECIES_NAME)
       )

--- a/src/main/kotlin/com/terraformation/backend/tracking/db/ObservationResultsStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/db/ObservationResultsStore.kt
@@ -302,8 +302,9 @@ class ObservationResultsStore(private val dslContext: DSLContext) {
                 record[
                     MONITORING_PLOTS.plantingSites.SURVIVAL_RATE_INCLUDES_TEMP_PLOTS
                         .asNonNullable()]
-            val totalLive = species.sumOf { it.totalLive }
-            val totalPlants = species.sumOf { it.totalLive + it.totalExisting + it.totalDead }
+            val totalLive = species.ifEmpty { null }?.sumOf { it.totalLive }
+            val totalPlants =
+                species.ifEmpty { null }?.sumOf { it.totalLive + it.totalExisting + it.totalDead }
             val totalLiveSpeciesExceptUnknown = species.count {
               it.certainty != RecordedSpeciesCertainty.Unknown &&
                   (it.totalLive + it.totalExisting) > 0
@@ -313,7 +314,11 @@ class ObservationResultsStore(private val dslContext: DSLContext) {
 
             val areaSquareMeters = sizeMeters * sizeMeters
             val plantingDensity =
-                (totalLive * SQUARE_METERS_PER_HECTARE / areaSquareMeters).roundToInt()
+                if (totalLive != null) {
+                  (totalLive * SQUARE_METERS_PER_HECTARE / areaSquareMeters).roundToInt()
+                } else {
+                  null
+                }
 
             val status = record[OBSERVATION_PLOTS.STATUS_ID]!!
 
@@ -407,7 +412,7 @@ class ObservationResultsStore(private val dslContext: DSLContext) {
                         .asNonNullable()]
 
             val species = record[substratumSpeciesMultisetField]
-            val totalPlants = species.sumOf { it.totalLive + it.totalDead }
+            val totalPlants = species.ifEmpty { null }?.sumOf { it.totalLive + it.totalDead }
             val totalLiveSpeciesExceptUnknown = species.count {
               it.certainty != RecordedSpeciesCertainty.Unknown &&
                   (it.totalLive + it.totalExisting) > 0
@@ -551,7 +556,7 @@ class ObservationResultsStore(private val dslContext: DSLContext) {
             val identifiedSpecies = species.filter {
               it.certainty != RecordedSpeciesCertainty.Unknown
             }
-            val totalPlants = species.sumOf { it.totalLive + it.totalDead }
+            val totalPlants = species.ifEmpty { null }?.sumOf { it.totalLive + it.totalDead }
             val totalLiveSpeciesExceptUnknown = identifiedSpecies.count {
               (it.totalLive + it.totalExisting) > 0
             }
@@ -717,8 +722,8 @@ class ObservationResultsStore(private val dslContext: DSLContext) {
                     null
                   }
 
-              val totalSpecies = liveSpecies.size
-              val totalPlants = species.sumOf { it.totalLive + it.totalDead }
+              val totalSpecies = if (species.isNotEmpty()) liveSpecies.size else null
+              val totalPlants = species.ifEmpty { null }?.sumOf { it.totalLive + it.totalDead }
 
               val survivalRate =
                   if (strata.isNotEmpty() && strata.all { it.survivalRate != null }) {

--- a/src/main/kotlin/com/terraformation/backend/tracking/db/ObservationResultsStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/db/ObservationResultsStore.kt
@@ -305,10 +305,13 @@ class ObservationResultsStore(private val dslContext: DSLContext) {
             val totalLive = species.ifEmpty { null }?.sumOf { it.totalLive }
             val totalPlants =
                 species.ifEmpty { null }?.sumOf { it.totalLive + it.totalExisting + it.totalDead }
-            val totalLiveSpeciesExceptUnknown = species.count {
-              it.certainty != RecordedSpeciesCertainty.Unknown &&
-                  (it.totalLive + it.totalExisting) > 0
-            }
+            val totalLiveSpeciesExceptUnknown =
+                species
+                    .ifEmpty { null }
+                    ?.count {
+                      it.certainty != RecordedSpeciesCertainty.Unknown &&
+                          (it.totalLive + it.totalExisting) > 0
+                    }
 
             val survivalRate = species.calculateSurvivalRate(survivalRateIncludesTempPlots)
 

--- a/src/main/kotlin/com/terraformation/backend/tracking/db/ObservationResultsStoreV2.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/db/ObservationResultsStoreV2.kt
@@ -167,11 +167,15 @@ class ObservationResultsStoreV2(private val dslContext: DSLContext) {
             val isPermanent = record[OBSERVATION_PLOTS.IS_PERMANENT.asNonNullable()]
             val sizeMeters = record[MONITORING_PLOTS.SIZE_METERS]!!
             val species = record[monitoringPlotSpeciesMultiset]
-            val totalPlants = species.sumOf { it.totalLive + it.totalExisting + it.totalDead }
-            val totalLiveSpeciesExceptUnknown = species.count {
-              it.certainty != RecordedSpeciesCertainty.Unknown &&
-                  (it.totalLive + it.totalExisting) > 0
-            }
+            val totalPlants =
+                species.ifEmpty { null }?.sumOf { it.totalLive + it.totalExisting + it.totalDead }
+            val totalLiveSpeciesExceptUnknown =
+                species
+                    .ifEmpty { null }
+                    ?.count {
+                      it.certainty != RecordedSpeciesCertainty.Unknown &&
+                          (it.totalLive + it.totalExisting) > 0
+                    }
 
             val survivalRate = record[OBSERVATION_PLOT_RESULTS.SURVIVAL_RATE]
             val plantingDensity = record[OBSERVATION_PLOT_RESULTS.PLANT_DENSITY]
@@ -281,11 +285,14 @@ class ObservationResultsStoreV2(private val dslContext: DSLContext) {
                         .asNonNullable()]
 
             val species = record[substratumSpeciesMultisetField]
-            val totalPlants = species.sumOf { it.totalLive + it.totalDead }
-            val totalLiveSpeciesExceptUnknown = species.count {
-              it.certainty != RecordedSpeciesCertainty.Unknown &&
-                  (it.totalLive + it.totalExisting) > 0
-            }
+            val totalPlants = species.ifEmpty { null }?.sumOf { it.totalLive + it.totalDead }
+            val totalLiveSpeciesExceptUnknown =
+                species
+                    .ifEmpty { null }
+                    ?.count {
+                      it.certainty != RecordedSpeciesCertainty.Unknown &&
+                          (it.totalLive + it.totalExisting) > 0
+                    }
 
             val isCompleted =
                 monitoringPlots.isNotEmpty() && monitoringPlots.all { it.completedTime != null }
@@ -400,10 +407,13 @@ class ObservationResultsStoreV2(private val dslContext: DSLContext) {
             val identifiedSpecies = species.filter {
               it.certainty != RecordedSpeciesCertainty.Unknown
             }
-            val totalPlants = species.sumOf { it.totalLive + it.totalDead }
-            val totalLiveSpeciesExceptUnknown = identifiedSpecies.count {
-              (it.totalLive + it.totalExisting) > 0
-            }
+            val totalPlants = species.ifEmpty { null }?.sumOf { it.totalLive + it.totalDead }
+            val totalLiveSpeciesExceptUnknown =
+                if (species.isNotEmpty()) {
+                  identifiedSpecies.count { (it.totalLive + it.totalExisting) > 0 }
+                } else {
+                  null
+                }
 
             val isCompleted =
                 substrata.isNotEmpty() &&
@@ -523,8 +533,8 @@ class ObservationResultsStoreV2(private val dslContext: DSLContext) {
                     null
                   }
 
-              val totalSpecies = liveSpecies.size
-              val totalPlants = species.sumOf { it.totalLive + it.totalDead }
+              val totalSpecies = if (species.isNotEmpty()) liveSpecies.size else null
+              val totalPlants = species.ifEmpty { null }?.sumOf { it.totalLive + it.totalDead }
 
               val survivalRate = record[OBSERVATION_SITE_RESULTS.SURVIVAL_RATE]
               val survivalRateStdDev = record[OBSERVATION_SITE_RESULTS.SURVIVAL_RATE_STD_DEV]

--- a/src/main/kotlin/com/terraformation/backend/tracking/model/ObservationResultsModel.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/model/ObservationResultsModel.kt
@@ -107,13 +107,13 @@ interface BaseMonitoringResult {
    * Total number of plants recorded. Includes all plants, regardless of live/dead status or
    * species.
    */
-  val totalPlants: Int
+  val totalPlants: Int?
   /**
    * Total number of species observed, not counting dead plants. Includes plants with Known and
    * Other certainties. In the case of Other, each distinct user-supplied species name is counted as
    * a separate species for purposes of this total.
    */
-  val totalSpecies: Int
+  val totalSpecies: Int?
 }
 
 data class ObservationMonitoringPlotResultsModel(
@@ -155,13 +155,13 @@ data class ObservationMonitoringPlotResultsModel(
      * Total number of plants recorded. Includes all plants, regardless of live/dead status or
      * species.
      */
-    override val totalPlants: Int,
+    override val totalPlants: Int?,
     /**
      * Total number of species observed, not counting dead plants. Includes plants with Known and
      * Other certainties. In the case of Other, each distinct user-supplied species name is counted
      * as a separate species for purposes of this total.
      */
-    override val totalSpecies: Int,
+    override val totalSpecies: Int?,
 ) : BaseMonitoringResult
 
 /**
@@ -202,8 +202,8 @@ data class ObservationSubstratumResultsModel(
     override val survivalRate: Int?,
     override val survivalRateStdDev: Int?,
     val survivalRateIncludesTempPlots: Boolean,
-    override val totalPlants: Int,
-    override val totalSpecies: Int,
+    override val totalPlants: Int?,
+    override val totalSpecies: Int?,
 ) : BaseAggregatedMonitoringResult
 
 data class ObservationStratumResultsModel(
@@ -219,8 +219,8 @@ data class ObservationStratumResultsModel(
     val substrata: List<ObservationSubstratumResultsModel>,
     override val survivalRate: Int?,
     override val survivalRateStdDev: Int?,
-    override val totalPlants: Int,
-    override val totalSpecies: Int,
+    override val totalPlants: Int?,
+    override val totalSpecies: Int?,
 ) : BaseAggregatedMonitoringResult
 
 data class ObservationResultsModel(
@@ -244,8 +244,8 @@ data class ObservationResultsModel(
     override val survivalRate: Int?,
     val survivalRateIncludesTempPlots: Boolean,
     override val survivalRateStdDev: Int?,
-    override val totalPlants: Int,
-    override val totalSpecies: Int,
+    override val totalPlants: Int?,
+    override val totalSpecies: Int?,
 ) : BaseAggregatedMonitoringResult
 
 data class ObservationStratumRollupResultsModel(
@@ -265,8 +265,8 @@ data class ObservationStratumRollupResultsModel(
     override val survivalRate: Int?,
     override val survivalRateStdDev: Int?,
     val survivalRateIncludesTempPlots: Boolean,
-    override val totalPlants: Int,
-    override val totalSpecies: Int,
+    override val totalPlants: Int?,
+    override val totalSpecies: Int?,
 ) : BaseAggregatedMonitoringResult {
   companion object {
     fun of(
@@ -351,7 +351,7 @@ data class ObservationStratumRollupResultsModel(
           survivalRate = survivalRate,
           survivalRateStdDev = survivalRateStdDev,
           survivalRateIncludesTempPlots = survivalRateIncludesTempPlots,
-          totalPlants = species.sumOf { it.totalLive + it.totalDead },
+          totalPlants = species.ifEmpty { null }?.sumOf { it.totalLive + it.totalDead },
           totalSpecies = totalLiveSpeciesExceptUnknown,
       )
     }
@@ -374,8 +374,8 @@ data class ObservationRollupResultsModel(
     val strata: List<ObservationStratumRollupResultsModel>,
     override val survivalRate: Int?,
     override val survivalRateStdDev: Int?,
-    override val totalPlants: Int,
-    override val totalSpecies: Int,
+    override val totalPlants: Int?,
+    override val totalSpecies: Int?,
 ) : BaseAggregatedMonitoringResult {
   companion object {
     fun of(
@@ -451,7 +451,7 @@ data class ObservationRollupResultsModel(
           strata = nonNullStratumResults,
           survivalRate = survivalRate,
           survivalRateStdDev = survivalRateStdDev,
-          totalPlants = species.sumOf { it.totalLive + it.totalDead },
+          totalPlants = species.ifEmpty { null }?.sumOf { it.totalLive + it.totalDead },
           totalSpecies = totalLiveSpeciesExceptUnknown,
       )
     }
@@ -531,7 +531,7 @@ fun List<ObservationSpeciesResultsModel>.unionSpecies(
             t0Density = t0Density,
             totalDead = groupedSpecies.sumOf { it.totalDead },
             totalExisting = groupedSpecies.sumOf { it.totalExisting },
-            totalLive = groupedSpecies.sumOf { it.totalLive },
+            totalLive = totalLive,
             totalPlants = groupedSpecies.sumOf { it.totalPlants },
         )
       }

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/ObservationResultsStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/ObservationResultsStoreTest.kt
@@ -912,7 +912,8 @@ class ObservationResultsStoreTest : ObservationScenarioTest() {
 
       // Plot with no plant because it is not observed
       val incompletePlotId = insertMonitoringPlot()
-      insertObservationPlot(claimedBy = user.userId)
+      insertObservationPlot(claimedBy = user.userId, isPermanent = true)
+      insertPlotT0Density()
 
       observationStore.completePlot(
           inserted.observationId,
@@ -964,7 +965,11 @@ class ObservationResultsStoreTest : ObservationScenarioTest() {
           completePlotResults.status,
           "Completed Plot Status",
       )
+
+      assertNull(incompletePlotResults.totalPlants, "Incomplete Plot Total Plants")
+      assertNull(incompletePlotResults.totalSpecies, "Incomplete Plot Total Species")
       assertNull(incompletePlotResults.plantingDensity, "Incomplete Plot Planting Density")
+      assertEquals(emptyList<Any>(), incompletePlotResults.species, "Incomplete Plot Species")
       assertEquals(
           ObservationPlotStatus.NotObserved,
           incompletePlotResults.status,

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/ObservationResultsStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/ObservationResultsStoreTest.kt
@@ -964,7 +964,7 @@ class ObservationResultsStoreTest : ObservationScenarioTest() {
           completePlotResults.status,
           "Completed Plot Status",
       )
-      assertEquals(0, incompletePlotResults.plantingDensity, "Incomplete Plot Planting Density")
+      assertNull(incompletePlotResults.plantingDensity, "Incomplete Plot Planting Density")
       assertEquals(
           ObservationPlotStatus.NotObserved,
           incompletePlotResults.status,

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/ObservationScenarioV2Test.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/ObservationScenarioV2Test.kt
@@ -677,6 +677,8 @@ class ObservationScenarioV2Test : ObservationScenarioTest() {
           "Completed Plot Status",
       )
       assertNull(incompletePlotResults.plantingDensity, "Incomplete Plot Planting Density")
+      assertNull(incompletePlotResults.totalPlants, "Incomplete Plot Total Plants")
+      assertNull(incompletePlotResults.totalSpecies, "Incomplete Plot Total Species")
       assertEquals(
           ObservationPlotStatus.NotObserved,
           incompletePlotResults.status,

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/observationStore/ObservationStoreSurvivalRateCalculationTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/observationStore/ObservationStoreSurvivalRateCalculationTest.kt
@@ -131,7 +131,6 @@ class ObservationStoreSurvivalRateCalculationTest : ObservationScenarioTest() {
         SurvivalRates(
             mapOf(
                 plotId to mapOf(speciesId to BigDecimal.ZERO),
-                plotId2 to mapOf(speciesId to BigDecimal.ZERO),
             ),
             mapOf(substratumId to mapOf(speciesId to BigDecimal.ZERO)),
             mapOf(stratumId to mapOf(speciesId to BigDecimal.ZERO)),
@@ -328,7 +327,7 @@ class ObservationStoreSurvivalRateCalculationTest : ObservationScenarioTest() {
 
     assertSurvivalRates(
         SurvivalRates(
-            plot1SurvivalRates + mapOf(plot2 to mapOf(speciesId1 to 0, speciesId2 to 0, null to 0)),
+            plot1SurvivalRates,
             mapOf(substratumId to survivalRates1),
             mapOf(stratumId to survivalRates1),
             mapOf(plantingSiteId to survivalRates1),


### PR DESCRIPTION
When there is no observation data for a plot/substratum/stratum, we report a
total plant count and total species count of 0, which is misleading since it
looks like an observation happened but no plants were present.

Instead, return null totals if we don't have any recorded plants.