### PR TITLE
SW-8371 Allow fetching list of all planting seasons in org

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/plantingmanagement/api/PlantingSeasonsController.kt
+++ b/src/main/kotlin/com/terraformation/backend/plantingmanagement/api/PlantingSeasonsController.kt
@@ -98,10 +98,11 @@ class PlantingSeasonsController(
     val seasons =
         if (plantingSiteId != null) plantingSeasonStore.fetchList(plantingSiteId)
         else if (organizationId != null) plantingSeasonStore.fetchList(organizationId)
-        else
-            throw IllegalArgumentException(
-                "Either plantingSiteId or organizationId must be specified"
-            )
+        else {
+          throw IllegalArgumentException(
+              "Either plantingSiteId or organizationId must be specified"
+          )
+        }
 
     return ListPlantingSeasonsResponsePayload(seasons.map { PlantingSeasonPayload(it) })
   }

--- a/src/main/kotlin/com/terraformation/backend/plantingmanagement/api/PlantingSeasonsController.kt
+++ b/src/main/kotlin/com/terraformation/backend/plantingmanagement/api/PlantingSeasonsController.kt
@@ -6,6 +6,7 @@ import com.terraformation.backend.api.ApiResponseSimpleSuccess
 import com.terraformation.backend.api.SimpleSuccessResponsePayload
 import com.terraformation.backend.api.SuccessResponsePayload
 import com.terraformation.backend.api.TrackingEndpoint
+import com.terraformation.backend.db.default_schema.OrganizationId
 import com.terraformation.backend.db.tracking.PlantingSeasonId
 import com.terraformation.backend.db.tracking.PlantingSeasonStatus
 import com.terraformation.backend.db.tracking.PlantingSiteId
@@ -44,8 +45,8 @@ class PlantingSeasonsController(
       @RequestBody payload: CreatePlantingSeasonRequestPayload
   ): CreatePlantingSeasonResponsePayload {
     payload.validate()
-
     val plantingSeasonId = plantingSeasonService.create(payload.toModel())
+
     return CreatePlantingSeasonResponsePayload(plantingSeasonId)
   }
 
@@ -57,6 +58,7 @@ class PlantingSeasonsController(
       @PathVariable id: PlantingSeasonId,
   ): GetPlantingSeasonResponsePayload {
     val model = plantingSeasonStore.fetchById(id)
+
     return GetPlantingSeasonResponsePayload(model)
   }
 
@@ -70,6 +72,7 @@ class PlantingSeasonsController(
   ): SimpleSuccessResponsePayload {
     payload.validate()
     plantingSeasonStore.update(id, payload.name, payload.startDate, payload.endDate)
+
     return SimpleSuccessResponsePayload()
   }
 
@@ -81,6 +84,7 @@ class PlantingSeasonsController(
       @PathVariable id: PlantingSeasonId,
   ): SimpleSuccessResponsePayload {
     plantingSeasonStore.delete(id)
+
     return SimpleSuccessResponsePayload()
   }
 
@@ -88,9 +92,17 @@ class PlantingSeasonsController(
   @Operation(summary = "Lists the planting seasons for a planting site.")
   @GetMapping
   fun listPlantingSeasons(
-      @RequestParam plantingSiteId: PlantingSiteId,
+      @RequestParam plantingSiteId: PlantingSiteId?,
+      @RequestParam organizationId: OrganizationId?,
   ): ListPlantingSeasonsResponsePayload {
-    val seasons = plantingSeasonStore.fetchList(plantingSiteId)
+    val seasons =
+        if (plantingSiteId != null) plantingSeasonStore.fetchList(plantingSiteId)
+        else if (organizationId != null) plantingSeasonStore.fetchList(organizationId)
+        else
+            throw IllegalArgumentException(
+                "Either plantingSiteId or organizationId must be specified"
+            )
+
     return ListPlantingSeasonsResponsePayload(seasons.map { PlantingSeasonPayload(it) })
   }
 }

--- a/src/main/kotlin/com/terraformation/backend/plantingmanagement/db/PlantingSeasonStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/plantingmanagement/db/PlantingSeasonStore.kt
@@ -3,11 +3,13 @@ package com.terraformation.backend.plantingmanagement.db
 import com.terraformation.backend.auth.currentUser
 import com.terraformation.backend.customer.db.ParentStore
 import com.terraformation.backend.customer.model.requirePermissions
+import com.terraformation.backend.db.default_schema.OrganizationId
 import com.terraformation.backend.db.tracking.PlantingSeasonId
 import com.terraformation.backend.db.tracking.PlantingSeasonStatus
 import com.terraformation.backend.db.tracking.PlantingSiteId
 import com.terraformation.backend.db.tracking.tables.references.PLANTING_SEASONS
 import com.terraformation.backend.db.tracking.tables.references.PLANTING_SEASON_SPECIES_TARGETS
+import com.terraformation.backend.db.tracking.tables.references.PLANTING_SITES
 import com.terraformation.backend.plantingmanagement.ExistingPlantingSeasonModel
 import com.terraformation.backend.plantingmanagement.NewPlantingSeasonModel
 import com.terraformation.backend.plantingmanagement.PlantingSeasonSpeciesTargetModel
@@ -61,6 +63,18 @@ class PlantingSeasonStore(
     requirePermissions { readPlantingSite(plantingSiteId) }
 
     return fetchByCondition(PLANTING_SEASONS.PLANTING_SITE_ID.eq(plantingSiteId))
+  }
+
+  fun fetchList(organizationId: OrganizationId): List<ExistingPlantingSeasonModel> {
+    requirePermissions { readOrganization(organizationId) }
+
+    return fetchByCondition(
+        PLANTING_SEASONS.PLANTING_SITE_ID.`in`(
+            DSL.select(PLANTING_SITES.ID)
+                .from(PLANTING_SITES)
+                .where(PLANTING_SITES.ORGANIZATION_ID.eq(organizationId))
+        )
+    )
   }
 
   fun update(

--- a/src/test/kotlin/com/terraformation/backend/plantingmanagement/db/PlantingSeasonStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/plantingmanagement/db/PlantingSeasonStoreTest.kt
@@ -5,6 +5,8 @@ import com.terraformation.backend.TestClock
 import com.terraformation.backend.customer.db.ParentStore
 import com.terraformation.backend.customer.model.TerrawareUser
 import com.terraformation.backend.db.DatabaseTest
+import com.terraformation.backend.db.OrganizationNotFoundException
+import com.terraformation.backend.db.default_schema.OrganizationId
 import com.terraformation.backend.db.default_schema.Role
 import com.terraformation.backend.db.tracking.PlantingSeasonId
 import com.terraformation.backend.db.tracking.PlantingSeasonStatus
@@ -32,11 +34,12 @@ internal class PlantingSeasonStoreTest : DatabaseTest(), RunsAsDatabaseUser {
     PlantingSeasonStore(clock, dslContext, ParentStore(dslContext))
   }
 
+  private lateinit var organizationId: OrganizationId
   private lateinit var plantingSiteId: PlantingSiteId
 
   @BeforeEach
   fun setUp() {
-    insertOrganization()
+    organizationId = insertOrganization()
     insertPlantingSite()
     insertOrganizationUser(role = Role.Manager)
     plantingSiteId = inserted.plantingSiteId
@@ -218,8 +221,66 @@ internal class PlantingSeasonStoreTest : DatabaseTest(), RunsAsDatabaseUser {
     }
 
     @Test
+    fun `returns all seasons for organization`() {
+      val id1 =
+          insertPlantingSeason(
+              name = "Spring 2025",
+              startDate = LocalDate.of(2025, 1, 1),
+              endDate = LocalDate.of(2025, 3, 31),
+              status = PlantingSeasonStatus.Upcoming,
+          )
+      val id2 =
+          insertPlantingSeason(
+              name = "Fall 2025",
+              startDate = LocalDate.of(2025, 9, 1),
+              endDate = LocalDate.of(2025, 11, 30),
+              status = PlantingSeasonStatus.Upcoming,
+          )
+      insertOrganization()
+      insertOrganizationUser(role = Role.Manager)
+      insertPlantingSite()
+      insertPlantingSeason(
+          name = "Other Org Season",
+          startDate = LocalDate.of(2025, 1, 1),
+          endDate = LocalDate.of(2025, 3, 31),
+          status = PlantingSeasonStatus.Upcoming,
+      )
+
+      val result = store.fetchList(organizationId)
+
+      assertEquals(
+          listOf(
+              ExistingPlantingSeasonModel(
+                  endDate = LocalDate.of(2025, 3, 31),
+                  id = id1,
+                  name = "Spring 2025",
+                  plantingSiteId = plantingSiteId,
+                  startDate = LocalDate.of(2025, 1, 1),
+                  status = PlantingSeasonStatus.Upcoming,
+              ),
+              ExistingPlantingSeasonModel(
+                  endDate = LocalDate.of(2025, 11, 30),
+                  id = id2,
+                  name = "Fall 2025",
+                  plantingSiteId = plantingSiteId,
+                  startDate = LocalDate.of(2025, 9, 1),
+                  status = PlantingSeasonStatus.Upcoming,
+              ),
+          ),
+          result,
+      )
+    }
+
+    @Test
     fun `returns empty list when no seasons exist for site`() {
       val result = store.fetchList(plantingSiteId)
+
+      assertEquals(emptyList<ExistingPlantingSeasonModel>(), result)
+    }
+
+    @Test
+    fun `returns empty list when no seasons exist for org`() {
+      val result = store.fetchList(organizationId)
 
       assertEquals(emptyList<ExistingPlantingSeasonModel>(), result)
     }
@@ -316,6 +377,13 @@ internal class PlantingSeasonStoreTest : DatabaseTest(), RunsAsDatabaseUser {
       deleteOrganizationUser()
 
       assertThrows<PlantingSiteNotFoundException> { store.fetchList(plantingSiteId) }
+    }
+
+    @Test
+    fun `throws OrganizationNotFoundException when user is not a member of the organization`() {
+      deleteOrganizationUser()
+
+      assertThrows<OrganizationNotFoundException> { store.fetchList(organizationId) }
     }
   }
 


### PR DESCRIPTION
The designs show the planting seasons list page with a planting site selected and another with all planting sites selected. Make `plantingSiteId` optional and allow for `organizationId` as well (optional, requiring one or the other).