### PR TITLE
SW-8347 Use different history text for accession check-in

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/i18n/Messages.kt
+++ b/src/main/kotlin/com/terraformation/backend/i18n/Messages.kt
@@ -564,6 +564,9 @@ class Messages {
               ),
       )
 
+  fun historyAccessionCheckedIn(newState: AccessionState) =
+      getMessage("historyAccessionCheckedIn", newState.getDisplayName(currentLocale()))
+
   fun historyAccessionCreated() = getMessage("historyAccessionCreated")
 
   fun historyAccessionQuantityUpdated(newQuantity: SeedQuantityModel) =

--- a/src/main/kotlin/com/terraformation/backend/seedbank/db/AccessionStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/seedbank/db/AccessionStore.kt
@@ -579,7 +579,11 @@ class AccessionStore(
             AccessionHistoryModel(
                 createdTime = updatedTime,
                 date = date,
-                description = messages.historyAccessionStateChanged(newState),
+                description =
+                    when (oldState) {
+                      AccessionState.AwaitingCheckIn -> messages.historyAccessionCheckedIn(newState)
+                      else -> messages.historyAccessionStateChanged(newState)
+                    },
                 fullName = fullName,
                 type = AccessionHistoryType.StateChanged,
                 userId = userId,

--- a/src/main/resources/i18n/Messages_en.properties
+++ b/src/main/resources/i18n/Messages_en.properties
@@ -138,6 +138,7 @@ eventSubject.RecordedTree.field.shrubDiameterCm=crown diameter
 eventSubject.RecordedTree.full={0} {1}
 eventSubject.RecordedTree.short={0}
 formerUser=Former User
+historyAccessionCheckedIn=checked in the accession and updated the status to {0}
 historyAccessionCreated=created accession
 historyAccessionQuantityUpdated=updated the quantity to {0}
 historyAccessionQuantityWithdrawn=withdrew {0}

--- a/src/main/resources/i18n/Messages_es.properties
+++ b/src/main/resources/i18n/Messages_es.properties
@@ -237,6 +237,8 @@ eventSubject.RecordedTree.full={0} {1}
 eventSubject.RecordedTree.short={0}
 # 897498fc
 formerUser=Usuario anterior
+# 9754c8ad
+historyAccessionCheckedIn=ingresó la colección y actualizó el estado a {0}
 # 11138bfd
 historyAccessionCreated=accesión creada
 # 8fe87f5b

--- a/src/main/resources/i18n/Messages_fr.properties
+++ b/src/main/resources/i18n/Messages_fr.properties
@@ -237,6 +237,8 @@ eventSubject.RecordedTree.full={0} {1}
 eventSubject.RecordedTree.short={0}
 # 897498fc
 formerUser=Ancien utilisateur
+# 9754c8ad
+historyAccessionCheckedIn=a enregistré la collection et mis à jour le statut en {0}
 # 11138bfd
 historyAccessionCreated=a créé une accession
 # 8fe87f5b

--- a/src/test/kotlin/com/terraformation/backend/seedbank/db/accessionStore/AccessionStoreHistoryTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/db/accessionStore/AccessionStoreHistoryTest.kt
@@ -263,7 +263,8 @@ internal class AccessionStoreHistoryTest : AccessionStoreTest() {
             AccessionHistoryModel(
                 createdTime = checkInTime,
                 date = LocalDate.ofInstant(checkInTime, ZoneOffset.UTC),
-                description = "updated the status to Awaiting Processing",
+                description =
+                    "checked in the accession and updated the status to Awaiting Processing",
                 fullName = null,
                 type = AccessionHistoryType.StateChanged,
                 userId = checkInUserId,


### PR DESCRIPTION
We want the accession history table to be more explicit about when accessions were
checked in. Use a different description for accessions that are transitioning from
"Awaiting Check-In" status.