### PR TITLE
SW-8369 Do not change status when updating a closed planting season

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/plantingmanagement/db/PlantingSeasonStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/plantingmanagement/db/PlantingSeasonStore.kt
@@ -98,7 +98,14 @@ class PlantingSeasonStore(
               .set(NAME, name)
               .set(START_DATE, startDate)
               .set(END_DATE, endDate)
-              .set(STATUS_ID, status)
+              .set(
+                  STATUS_ID,
+                  DSL.`when`(
+                          STATUS_ID.eq(PlantingSeasonStatus.Closed),
+                          PlantingSeasonStatus.Closed,
+                      )
+                      .else_(status),
+              )
               .set(MODIFIED_BY, currentUser().userId)
               .set(MODIFIED_TIME, now)
               .where(ID.eq(plantingSeasonId))

--- a/src/test/kotlin/com/terraformation/backend/plantingmanagement/db/PlantingSeasonStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/plantingmanagement/db/PlantingSeasonStoreTest.kt
@@ -560,6 +560,37 @@ internal class PlantingSeasonStoreTest : DatabaseTest(), RunsAsDatabaseUser {
     }
 
     @Test
+    fun `does not change status when season is closed`() {
+      val id =
+          insertPlantingSeason(
+              name = "Season",
+              startDate = LocalDate.of(2025, 1, 1),
+              endDate = LocalDate.of(2025, 3, 31),
+              status = PlantingSeasonStatus.Closed,
+          )
+      val newStart = LocalDate.of(2024, 1, 1)
+      val newEnd = LocalDate.of(2024, 3, 31)
+      clock.instant = newEnd.plusDays(1).atStartOfDay().toInstant(ZoneOffset.UTC)
+
+      store.update(id, "Season", newStart, newEnd)
+
+      assertTableEquals(
+          PlantingSeasonsRecord(
+              id = id,
+              name = "Season",
+              plantingSiteId = plantingSiteId,
+              startDate = newStart,
+              endDate = newEnd,
+              statusId = PlantingSeasonStatus.Closed,
+              createdBy = user.userId,
+              createdTime = Instant.EPOCH,
+              modifiedBy = user.userId,
+              modifiedTime = clock.instant,
+          )
+      )
+    }
+
+    @Test
     fun `throws PlantingSeasonNotFoundException when season does not exist`() {
       val nonExistentId = PlantingSeasonId(999999L)
 


### PR DESCRIPTION
There's no way to change a planting season back to active once it's been closed. Fix the `update` logic to not reset the status for closed planting seasons.