### PR TITLE
SW-7311 Increase default number of monitoring plots

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/tracking/model/StratumModel.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/model/StratumModel.kt
@@ -417,12 +417,12 @@ data class StratumModel<
     // required in each observation. The "Student's t" value is a constant based on a 90%
     // confidence level and should rarely need to change, but the other two will be adjusted by
     // admins based on the conditions at the planting site. These defaults mean that strata
-    // will have 11 permanent plots and 14 temporary plots.
-    val DEFAULT_ERROR_MARGIN = BigDecimal(100)
+    // will have 18 permanent plots and 6 temporary plots.
+    val DEFAULT_ERROR_MARGIN = BigDecimal(10)
     val DEFAULT_STUDENTS_T = BigDecimal("1.645")
-    val DEFAULT_VARIANCE = BigDecimal(40000)
-    const val DEFAULT_NUM_PERMANENT_PLOTS = 8
-    const val DEFAULT_NUM_TEMPORARY_PLOTS = 3
+    val DEFAULT_VARIANCE = BigDecimal(850)
+    const val DEFAULT_NUM_PERMANENT_PLOTS = 18
+    const val DEFAULT_NUM_TEMPORARY_PLOTS = 6
 
     /** Target planting density to use if not included in stratum properties. */
     val DEFAULT_TARGET_PLANTING_DENSITY = BigDecimal(1500)

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/plantingSiteStore/PlantingSiteStoreApplyEditTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/plantingSiteStore/PlantingSiteStoreApplyEditTest.kt
@@ -361,7 +361,7 @@ internal class PlantingSiteStoreApplyEditTest : BasePlantingSiteStoreTest() {
       // PlantingSiteEditCalculatorV2Test.
       val initial =
           newSite(x = 0, width = 1000) {
-            stratum(name = "A", x = 0, width = 500) {
+            stratum(name = "A", x = 0, width = 500, numPermanent = 8, numTemporary = 3) {
               substratum {
                 permanent(plotNumber = 1, x = 300, y = 0)
                 permanent(plotNumber = 2, x = 300, y = 30)
@@ -369,7 +369,7 @@ internal class PlantingSiteStoreApplyEditTest : BasePlantingSiteStoreTest() {
                 permanent(plotNumber = 7, x = 300, y = 90)
               }
             }
-            stratum(name = "B", x = 500, width = 500) {
+            stratum(name = "B", x = 500, width = 500, numPermanent = 8, numTemporary = 3) {
               substratum {
                 permanent(plotNumber = 16, x = 600, y = 0)
                 permanent(plotNumber = 18, x = 600, y = 30)

--- a/src/test/kotlin/com/terraformation/backend/tracking/edit/PlantingSiteEditCalculatorTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/edit/PlantingSiteEditCalculatorTest.kt
@@ -131,9 +131,11 @@ class PlantingSiteEditCalculatorTest {
     val newTargetPlantingDensity = BigDecimal(1100)
     val newVariance = BigDecimal(40001)
 
-    val existing = existingSite { stratum { substratum { repeat(8) { permanent() } } } }
+    val existing = existingSite {
+      stratum(numPermanent = 8, numTemporary = 3) { substratum { repeat(8) { permanent() } } }
+    }
     val desired = newSite {
-      stratum {
+      stratum(numPermanent = 8, numTemporary = 3) {
         errorMargin = newErrorMargin
         studentsT = newStudentsT
         targetPlantingDensity = newTargetPlantingDensity


### PR DESCRIPTION
Change the default statistical settings to bump the default number of
permanent plots from 8 to 18 and the number of temporary plots from
3 to 6.