### PR TITLE
Fix FieldValuesPayload to correctly use nullable strings in the list

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/search/api/SearchPayloads.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/api/SearchPayloads.kt
@@ -182,6 +182,7 @@ data class SearchResponsePayload(val results: List<Map<String, Any>>, val cursor
 
 data class FieldValuesPayload(
     @ArraySchema(
+        schema = Schema(nullable = true),
         arraySchema =
             Schema(
                 description =
@@ -189,7 +190,7 @@ data class FieldValuesPayload(
                         "accessions have them. For fields that allow the user to enter arbitrary " +
                         "values, this is equivalent to querying the list of values without any " +
                         "filter criteria, that is, it's a list of all the user-entered values."
-            )
+            ),
     )
     val values: List<String?>,
     @Schema(


### PR DESCRIPTION
The `FieldValuesPaylod` was removed from the seedbank api because it was a duplicate of the search api version. This caused the FE schema definition of the `values` property to change from `(string|null)[]` to `string[]` causing issues. Add back the `Schema(nullable = true)` to the `ArraySchema` to fix this.