### PR TITLE
SW-8377 Update season transitioning logic to new table

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/notification/NotificationService.kt
+++ b/src/main/kotlin/com/terraformation/backend/notification/NotificationService.kt
@@ -697,7 +697,7 @@ class NotificationService(
   @EventListener
   fun on(event: PlantingSeasonStartedEvent) {
     log.info(
-        "Creating notifications for start of planting season ${event.simplePlantingSeasonId} at site ${event.plantingSiteId}"
+        "Creating notifications for start of planting season ${event.plantingSeasonId} at site ${event.plantingSiteId}"
     )
     val plantingSite = plantingSiteStore.fetchSiteById(event.plantingSiteId, PlantingSiteDepth.Site)
 

--- a/src/main/kotlin/com/terraformation/backend/tracking/db/PlantingSiteStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/db/PlantingSiteStore.kt
@@ -2936,8 +2936,8 @@ class PlantingSiteStore(
           "({0} AT TIME ZONE COALESCE({1}, {2}, 'UTC'))::date",
           LocalDate::class.java,
           DSL.`val`(instant),
-          PLANTING_SEASONS.plantingSites.TIME_ZONE,
-          PLANTING_SEASONS.plantingSites.organizations.TIME_ZONE,
+          PLANTING_SITES.TIME_ZONE,
+          PLANTING_SITES.organizations.TIME_ZONE,
       )
 
   private fun markPlantingSeasonActive(
@@ -2969,6 +2969,8 @@ class PlantingSiteStore(
             PLANTING_SEASONS.ID.asNonNullable(),
         )
         .from(PLANTING_SEASONS)
+        .join(PLANTING_SITES)
+        .on(PLANTING_SEASONS.PLANTING_SITE_ID.eq(PLANTING_SITES.ID))
         .where(PLANTING_SEASONS.START_DATE.le(localDateInSiteTimezone()))
         .and(PLANTING_SEASONS.END_DATE.gt(localDateInSiteTimezone()))
         .and(PLANTING_SEASONS.STATUS_ID.eq(PlantingSeasonStatus.Upcoming))
@@ -3012,6 +3014,8 @@ class PlantingSiteStore(
             PLANTING_SEASONS.ID.asNonNullable(),
         )
         .from(PLANTING_SEASONS)
+        .join(PLANTING_SITES)
+        .on(PLANTING_SEASONS.PLANTING_SITE_ID.eq(PLANTING_SITES.ID))
         .where(PLANTING_SEASONS.END_DATE.lt(localDateInSiteTimezone()))
         .and(PLANTING_SEASONS.STATUS_ID.eq(PlantingSeasonStatus.Active))
         .fetch()

--- a/src/main/kotlin/com/terraformation/backend/tracking/db/PlantingSiteStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/db/PlantingSiteStore.kt
@@ -2931,12 +2931,13 @@ class PlantingSiteStore(
     }
   }
 
-  private fun localDateInSiteTimezone() =
+  private fun localDateInSiteTimezone(instant: Instant = clock.instant()) =
       DSL.field(
-          "({0} AT TIME ZONE COALESCE({1}, 'UTC'))::date",
+          "({0} AT TIME ZONE COALESCE({1}, {2}, 'UTC'))::date",
           LocalDate::class.java,
-          DSL.`val`(clock.instant()),
-          PLANTING_SITES.TIME_ZONE,
+          DSL.`val`(instant),
+          PLANTING_SEASONS.plantingSites.TIME_ZONE,
+          PLANTING_SEASONS.plantingSites.organizations.TIME_ZONE,
       )
 
   private fun markPlantingSeasonActive(
@@ -2968,8 +2969,6 @@ class PlantingSiteStore(
             PLANTING_SEASONS.ID.asNonNullable(),
         )
         .from(PLANTING_SEASONS)
-        .join(PLANTING_SITES)
-        .on(PLANTING_SEASONS.PLANTING_SITE_ID.eq(PLANTING_SITES.ID))
         .where(PLANTING_SEASONS.START_DATE.le(localDateInSiteTimezone()))
         .and(PLANTING_SEASONS.END_DATE.gt(localDateInSiteTimezone()))
         .and(PLANTING_SEASONS.STATUS_ID.eq(PlantingSeasonStatus.Upcoming))
@@ -3013,8 +3012,6 @@ class PlantingSiteStore(
             PLANTING_SEASONS.ID.asNonNullable(),
         )
         .from(PLANTING_SEASONS)
-        .join(PLANTING_SITES)
-        .on(PLANTING_SEASONS.PLANTING_SITE_ID.eq(PLANTING_SITES.ID))
         .where(PLANTING_SEASONS.END_DATE.lt(localDateInSiteTimezone()))
         .and(PLANTING_SEASONS.STATUS_ID.eq(PlantingSeasonStatus.Active))
         .fetch()

--- a/src/main/kotlin/com/terraformation/backend/tracking/db/PlantingSiteStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/db/PlantingSiteStore.kt
@@ -22,6 +22,8 @@ import com.terraformation.backend.db.tracking.MonitoringPlotId
 import com.terraformation.backend.db.tracking.MonitoringPlotIdConverter
 import com.terraformation.backend.db.tracking.ObservationPlotStatus
 import com.terraformation.backend.db.tracking.ObservationType
+import com.terraformation.backend.db.tracking.PlantingSeasonId
+import com.terraformation.backend.db.tracking.PlantingSeasonStatus
 import com.terraformation.backend.db.tracking.PlantingSiteHistoryId
 import com.terraformation.backend.db.tracking.PlantingSiteId
 import com.terraformation.backend.db.tracking.SimplePlantingSeasonId
@@ -48,6 +50,7 @@ import com.terraformation.backend.db.tracking.tables.references.MONITORING_PLOT_
 import com.terraformation.backend.db.tracking.tables.references.OBSERVATIONS
 import com.terraformation.backend.db.tracking.tables.references.OBSERVATION_PLOTS
 import com.terraformation.backend.db.tracking.tables.references.PLANTINGS
+import com.terraformation.backend.db.tracking.tables.references.PLANTING_SEASONS
 import com.terraformation.backend.db.tracking.tables.references.PLANTING_SITES
 import com.terraformation.backend.db.tracking.tables.references.PLANTING_SITE_HISTORIES
 import com.terraformation.backend.db.tracking.tables.references.PLANTING_SITE_NOTIFICATIONS
@@ -72,7 +75,7 @@ import com.terraformation.backend.tracking.edit.MonitoringPlotEdit
 import com.terraformation.backend.tracking.edit.PlantingSiteEdit
 import com.terraformation.backend.tracking.edit.StratumEdit
 import com.terraformation.backend.tracking.edit.SubstratumEdit
-import com.terraformation.backend.tracking.event.PlantingSeasonEndedEvent
+import com.terraformation.backend.tracking.event.PlantingSeasonPastEndDateEvent
 import com.terraformation.backend.tracking.event.PlantingSeasonRescheduledEvent
 import com.terraformation.backend.tracking.event.PlantingSeasonScheduledEvent
 import com.terraformation.backend.tracking.event.PlantingSeasonStartedEvent
@@ -1613,8 +1616,8 @@ class PlantingSiteStore(
   }
 
   fun transitionPlantingSeasons() {
-    endPlantingSeasons()
-    startPlantingSeasons()
+    markPlantingSeasonsPastEndDate()
+    markPlantingSeasonsActive()
   }
 
   fun markNotificationComplete(
@@ -2928,85 +2931,95 @@ class PlantingSiteStore(
     }
   }
 
-  private fun startPlantingSeason(
+  private fun localDateInSiteTimezone() =
+      DSL.field(
+          "({0} AT TIME ZONE COALESCE({1}, 'UTC'))::date",
+          LocalDate::class.java,
+          DSL.`val`(clock.instant()),
+          PLANTING_SITES.TIME_ZONE,
+      )
+
+  private fun markPlantingSeasonActive(
       plantingSiteId: PlantingSiteId,
-      simplePlantingSeasonId: SimplePlantingSeasonId,
+      plantingSeasonId: PlantingSeasonId,
   ) {
     dslContext.transaction { _ ->
       val rowsUpdated =
           dslContext
-              .update(SIMPLE_PLANTING_SEASONS)
-              .set(SIMPLE_PLANTING_SEASONS.IS_ACTIVE, true)
-              .where(SIMPLE_PLANTING_SEASONS.ID.eq(simplePlantingSeasonId))
-              .and(SIMPLE_PLANTING_SEASONS.PLANTING_SITE_ID.eq(plantingSiteId))
-              .and(SIMPLE_PLANTING_SEASONS.IS_ACTIVE.isFalse)
+              .update(PLANTING_SEASONS)
+              .set(PLANTING_SEASONS.STATUS_ID, PlantingSeasonStatus.Active)
+              .where(PLANTING_SEASONS.ID.eq(plantingSeasonId))
+              .and(PLANTING_SEASONS.PLANTING_SITE_ID.eq(plantingSiteId))
+              .and(PLANTING_SEASONS.STATUS_ID.eq(PlantingSeasonStatus.Upcoming))
               .execute()
 
       if (rowsUpdated > 0) {
-        log.info("Planting season $simplePlantingSeasonId at site $plantingSiteId has started")
+        log.info("Planting season $plantingSeasonId at site $plantingSiteId has started")
 
-        eventPublisher.publishEvent(
-            PlantingSeasonStartedEvent(plantingSiteId, simplePlantingSeasonId)
-        )
+        eventPublisher.publishEvent(PlantingSeasonStartedEvent(plantingSiteId, plantingSeasonId))
       }
     }
   }
 
-  private fun startPlantingSeasons() {
-    val now = clock.instant()
-
+  private fun markPlantingSeasonsActive() {
     dslContext
         .select(
-            SIMPLE_PLANTING_SEASONS.PLANTING_SITE_ID.asNonNullable(),
-            SIMPLE_PLANTING_SEASONS.ID.asNonNullable(),
+            PLANTING_SEASONS.PLANTING_SITE_ID.asNonNullable(),
+            PLANTING_SEASONS.ID.asNonNullable(),
         )
-        .from(SIMPLE_PLANTING_SEASONS)
-        .where(SIMPLE_PLANTING_SEASONS.START_TIME.le(now))
-        .and(SIMPLE_PLANTING_SEASONS.END_TIME.gt(now))
-        .and(SIMPLE_PLANTING_SEASONS.IS_ACTIVE.isFalse)
+        .from(PLANTING_SEASONS)
+        .join(PLANTING_SITES)
+        .on(PLANTING_SEASONS.PLANTING_SITE_ID.eq(PLANTING_SITES.ID))
+        .where(PLANTING_SEASONS.START_DATE.le(localDateInSiteTimezone()))
+        .and(PLANTING_SEASONS.END_DATE.gt(localDateInSiteTimezone()))
+        .and(PLANTING_SEASONS.STATUS_ID.eq(PlantingSeasonStatus.Upcoming))
         .fetch()
         .forEach { (plantingSiteId, plantingSeasonId) ->
-          startPlantingSeason(plantingSiteId, plantingSeasonId)
+          markPlantingSeasonActive(plantingSiteId, plantingSeasonId)
         }
   }
 
-  private fun endPlantingSeason(
+  private fun markPlantingSeasonPastEndDate(
       plantingSiteId: PlantingSiteId,
-      simplePlantingSeasonId: SimplePlantingSeasonId,
+      plantingSeasonId: PlantingSeasonId,
   ) {
     dslContext.transaction { _ ->
       val rowsUpdated =
           dslContext
-              .update(SIMPLE_PLANTING_SEASONS)
-              .set(SIMPLE_PLANTING_SEASONS.IS_ACTIVE, false)
-              .where(SIMPLE_PLANTING_SEASONS.ID.eq(simplePlantingSeasonId))
-              .and(SIMPLE_PLANTING_SEASONS.PLANTING_SITE_ID.eq(plantingSiteId))
-              .and(SIMPLE_PLANTING_SEASONS.IS_ACTIVE.isTrue)
+              .update(PLANTING_SEASONS)
+              .set(PLANTING_SEASONS.STATUS_ID, PlantingSeasonStatus.PastEndDate)
+              .where(PLANTING_SEASONS.ID.eq(plantingSeasonId))
+              .and(PLANTING_SEASONS.PLANTING_SITE_ID.eq(plantingSiteId))
+              .and(PLANTING_SEASONS.STATUS_ID.eq(PlantingSeasonStatus.Active))
               .execute()
 
       if (rowsUpdated > 0) {
-        log.info("Planting season $simplePlantingSeasonId at site $plantingSiteId has ended")
+        log.info(
+            "Planting season $plantingSeasonId at site $plantingSiteId is now past the end date"
+        )
 
         deleteRecurringPlantingSeasonNotifications(plantingSiteId)
         eventPublisher.publishEvent(
-            PlantingSeasonEndedEvent(plantingSiteId, simplePlantingSeasonId)
+            PlantingSeasonPastEndDateEvent(plantingSiteId, plantingSeasonId)
         )
       }
     }
   }
 
-  private fun endPlantingSeasons() {
+  private fun markPlantingSeasonsPastEndDate() {
     dslContext
         .select(
-            SIMPLE_PLANTING_SEASONS.PLANTING_SITE_ID.asNonNullable(),
-            SIMPLE_PLANTING_SEASONS.ID.asNonNullable(),
+            PLANTING_SEASONS.PLANTING_SITE_ID.asNonNullable(),
+            PLANTING_SEASONS.ID.asNonNullable(),
         )
-        .from(SIMPLE_PLANTING_SEASONS)
-        .where(SIMPLE_PLANTING_SEASONS.END_TIME.le(clock.instant()))
-        .and(SIMPLE_PLANTING_SEASONS.IS_ACTIVE.isTrue)
+        .from(PLANTING_SEASONS)
+        .join(PLANTING_SITES)
+        .on(PLANTING_SEASONS.PLANTING_SITE_ID.eq(PLANTING_SITES.ID))
+        .where(PLANTING_SEASONS.END_DATE.lt(localDateInSiteTimezone()))
+        .and(PLANTING_SEASONS.STATUS_ID.eq(PlantingSeasonStatus.Active))
         .fetch()
         .forEach { (plantingSiteId, plantingSeasonId) ->
-          endPlantingSeason(plantingSiteId, plantingSeasonId)
+          markPlantingSeasonPastEndDate(plantingSiteId, plantingSeasonId)
         }
   }
 

--- a/src/main/kotlin/com/terraformation/backend/tracking/event/Events.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/event/Events.kt
@@ -14,6 +14,7 @@ import com.terraformation.backend.db.tracking.ObservationId
 import com.terraformation.backend.db.tracking.ObservationMediaType
 import com.terraformation.backend.db.tracking.ObservationPlotPosition
 import com.terraformation.backend.db.tracking.ObservationState
+import com.terraformation.backend.db.tracking.PlantingSeasonId
 import com.terraformation.backend.db.tracking.PlantingSiteHistoryId
 import com.terraformation.backend.db.tracking.PlantingSiteId
 import com.terraformation.backend.db.tracking.RecordedPlantStatus
@@ -128,12 +129,12 @@ data class PlantingSeasonScheduledEvent(
 
 data class PlantingSeasonStartedEvent(
     val plantingSiteId: PlantingSiteId,
-    val simplePlantingSeasonId: SimplePlantingSeasonId,
+    val plantingSeasonId: PlantingSeasonId,
 )
 
-data class PlantingSeasonEndedEvent(
+data class PlantingSeasonPastEndDateEvent(
     val plantingSiteId: PlantingSiteId,
-    val simplePlantingSeasonId: SimplePlantingSeasonId,
+    val plantingSeasonId: PlantingSeasonId,
 )
 
 interface PlantingSeasonSchedulingNotificationEvent {

--- a/src/test/kotlin/com/terraformation/backend/notification/NotificationServiceAppTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/notification/NotificationServiceAppTest.kt
@@ -853,10 +853,13 @@ internal class NotificationServiceAppTest : DatabaseTest(), RunsAsUser {
     val plantingSiteName = "My Site"
 
     insertPlantingSite(name = plantingSiteName)
-    insertSimplePlantingSeason()
+    insertPlantingSeason()
 
     testEventNotification(
-        PlantingSeasonStartedEvent(inserted.plantingSiteId, inserted.simplePlantingSeasonId),
+        PlantingSeasonStartedEvent(
+            inserted.plantingSiteId,
+            inserted.plantingSeasonId,
+        ),
         type = NotificationType.PlantingSeasonStarted,
         title = "It's planting season!",
         body =

--- a/src/test/kotlin/com/terraformation/backend/notification/NotificationServiceEmailTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/notification/NotificationServiceEmailTest.kt
@@ -88,6 +88,7 @@ import com.terraformation.backend.db.tracking.MonitoringPlotId
 import com.terraformation.backend.db.tracking.ObservationId
 import com.terraformation.backend.db.tracking.ObservationState
 import com.terraformation.backend.db.tracking.ObservationType
+import com.terraformation.backend.db.tracking.PlantingSeasonId
 import com.terraformation.backend.db.tracking.PlantingSiteHistoryId
 import com.terraformation.backend.db.tracking.PlantingSiteId
 import com.terraformation.backend.db.tracking.RecordedPlantStatus
@@ -181,7 +182,6 @@ import java.time.Month
 import java.time.ZoneId
 import java.time.ZonedDateTime
 import java.util.Locale
-import org.jooq.Configuration as JooqConfiguration
 import org.jooq.DSLContext
 import org.jooq.TransactionalRunnable
 import org.jooq.impl.DSL
@@ -191,6 +191,7 @@ import org.junit.jupiter.api.Assertions.fail
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.mail.javamail.JavaMailSenderImpl
+import org.jooq.Configuration as JooqConfiguration
 
 internal class NotificationServiceEmailTest {
   private val acceleratorUser: IndividualUser = mockk()
@@ -1164,7 +1165,7 @@ internal class NotificationServiceEmailTest {
 
   @Test
   fun plantingSeasonStarted() {
-    val event = PlantingSeasonStartedEvent(plantingSite.id, SimplePlantingSeasonId(1))
+    val event = PlantingSeasonStartedEvent(plantingSite.id, PlantingSeasonId(1))
 
     service.on(event)
 

--- a/src/test/kotlin/com/terraformation/backend/notification/NotificationServiceEmailTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/notification/NotificationServiceEmailTest.kt
@@ -182,6 +182,7 @@ import java.time.Month
 import java.time.ZoneId
 import java.time.ZonedDateTime
 import java.util.Locale
+import org.jooq.Configuration as JooqConfiguration
 import org.jooq.DSLContext
 import org.jooq.TransactionalRunnable
 import org.jooq.impl.DSL
@@ -191,7 +192,6 @@ import org.junit.jupiter.api.Assertions.fail
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.mail.javamail.JavaMailSenderImpl
-import org.jooq.Configuration as JooqConfiguration
 
 internal class NotificationServiceEmailTest {
   private val acceleratorUser: IndividualUser = mockk()

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/plantingSiteStore/PlantingSiteStoreTransitionSeasonsTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/plantingSiteStore/PlantingSiteStoreTransitionSeasonsTest.kt
@@ -1,90 +1,69 @@
 package com.terraformation.backend.tracking.db.plantingSiteStore
 
-import com.terraformation.backend.tracking.event.PlantingSeasonEndedEvent
+import com.terraformation.backend.db.tracking.PlantingSeasonStatus
+import com.terraformation.backend.tracking.event.PlantingSeasonPastEndDateEvent
 import com.terraformation.backend.tracking.event.PlantingSeasonStartedEvent
-import com.terraformation.backend.tracking.model.PlantingSiteModel
-import com.terraformation.backend.tracking.model.UpdatedPlantingSeasonModel
 import com.terraformation.backend.util.toInstant
 import java.time.LocalDate
-import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 
 internal class PlantingSiteStoreTransitionSeasonsTest : BasePlantingSiteStoreTest() {
+
   @Nested
-  inner class TransitionSimpleSimplePlantingSeasons {
+  inner class TransitionPlantingSeasons {
     @Test
-    fun `marks planting season as active when its start time arrives`() {
-      val startDate = LocalDate.EPOCH.plusDays(1)
+    fun `uses site timezone for determining when season becomes active`() {
+      val startDate = LocalDate.EPOCH.plusDays(10)
       val endDate = startDate.plusDays(60)
-      val model =
-          store.createPlantingSite(
-              PlantingSiteModel.create(
-                  name = "name",
-                  organizationId = organizationId,
-                  timeZone = timeZone,
-              ),
-              plantingSeasons =
-                  listOf(UpdatedPlantingSeasonModel(startDate = startDate, endDate = endDate)),
+
+      val plantingSiteId = insertPlantingSite(timeZone = timeZone)
+      val plantingSeasonId =
+          insertPlantingSeason(
+              startDate = startDate,
+              endDate = endDate,
+              status = PlantingSeasonStatus.Upcoming,
+              plantingSiteId = plantingSiteId,
           )
 
-      assertSeasonActive(false, "Should start as inactive")
+      // Pacific/Honolulu is UTC-10, so midnight there = 10:00 UTC.
+      // At 09:59:59 UTC on start_date, it is still the previous day in Honolulu.
+      clock.instant = startDate.toInstant(timeZone).minusSeconds(1)
 
       store.transitionPlantingSeasons()
 
-      assertSeasonActive(false, "Should stay inactive until start time arrives")
+      assertEquals(
+          PlantingSeasonStatus.Upcoming,
+          plantingSeasonsDao.fetchById(plantingSeasonId).first().statusId,
+          "Season should be Upcoming before midnight in site timezone",
+      )
       eventPublisher.assertEventNotPublished<PlantingSeasonStartedEvent>()
 
       clock.instant = startDate.toInstant(timeZone)
 
       store.transitionPlantingSeasons()
 
-      assertSeasonActive(true, "Should transition to active")
+      assertEquals(
+          PlantingSeasonStatus.Active,
+          plantingSeasonsDao.fetchById(plantingSeasonId).first().statusId,
+          "Season should be Active at midnight in site timezone",
+      )
       eventPublisher.assertEventPublished(
-          PlantingSeasonStartedEvent(model.id, model.plantingSeasons.first().id)
+          PlantingSeasonStartedEvent(plantingSiteId, plantingSeasonId)
       )
-
-      clock.instant = endDate.minusDays(1).toInstant(timeZone)
-      eventPublisher.clear()
-
-      store.transitionPlantingSeasons()
-      eventPublisher.assertNoEventsPublished(
-          "Should not publish any events if planting season already in correct state"
-      )
-    }
-
-    @Test
-    fun `marks planting season as inactive when its end time arrives`() {
-      val startDate = LocalDate.EPOCH.plusDays(1)
-      val endDate = startDate.plusDays(60)
-
-      clock.instant = startDate.toInstant(timeZone)
-
-      val model =
-          store.createPlantingSite(
-              PlantingSiteModel.create(
-                  name = "name",
-                  organizationId = organizationId,
-                  timeZone = timeZone,
-              ),
-              plantingSeasons =
-                  listOf(UpdatedPlantingSeasonModel(startDate = startDate, endDate = endDate)),
-          )
-
-      assertSeasonActive(true, "Should start as active")
-
-      store.transitionPlantingSeasons()
-
-      assertSeasonActive(true, "Should remain active until end time arrives")
-      eventPublisher.assertEventNotPublished<PlantingSeasonEndedEvent>()
 
       clock.instant = endDate.plusDays(1).toInstant(timeZone)
 
       store.transitionPlantingSeasons()
 
-      assertSeasonActive(false, "Should have been marked as inactive")
+      assertEquals(
+          PlantingSeasonStatus.PastEndDate,
+          plantingSeasonsDao.fetchById(plantingSeasonId).first().statusId,
+          "Season should be PastEndDate after end date in site timezone",
+      )
       eventPublisher.assertEventPublished(
-          PlantingSeasonEndedEvent(model.id, model.plantingSeasons.first().id)
+          PlantingSeasonPastEndDateEvent(plantingSiteId, plantingSeasonId)
       )
 
       clock.instant = endDate.plusDays(2).toInstant(timeZone)
@@ -93,14 +72,6 @@ internal class PlantingSiteStoreTransitionSeasonsTest : BasePlantingSiteStoreTes
       store.transitionPlantingSeasons()
       eventPublisher.assertNoEventsPublished(
           "Should not publish any events if planting season already in correct state"
-      )
-    }
-
-    private fun assertSeasonActive(isActive: Boolean, message: String) {
-      assertEquals(
-          listOf(isActive),
-          simplePlantingSeasonsDao.findAll().map { it.isActive },
-          message,
       )
     }
   }

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/plantingSiteStore/PlantingSiteStoreTransitionSeasonsTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/plantingSiteStore/PlantingSiteStoreTransitionSeasonsTest.kt
@@ -1,5 +1,6 @@
 package com.terraformation.backend.tracking.db.plantingSiteStore
 
+import com.terraformation.backend.db.default_schema.tables.references.ORGANIZATIONS
 import com.terraformation.backend.db.tracking.PlantingSeasonStatus
 import com.terraformation.backend.tracking.event.PlantingSeasonPastEndDateEvent
 import com.terraformation.backend.tracking.event.PlantingSeasonStartedEvent
@@ -61,6 +62,70 @@ internal class PlantingSiteStoreTransitionSeasonsTest : BasePlantingSiteStoreTes
           PlantingSeasonStatus.PastEndDate,
           plantingSeasonsDao.fetchById(plantingSeasonId).first().statusId,
           "Season should be PastEndDate after end date in site timezone",
+      )
+      eventPublisher.assertEventPublished(
+          PlantingSeasonPastEndDateEvent(plantingSiteId, plantingSeasonId)
+      )
+
+      clock.instant = endDate.plusDays(2).toInstant(timeZone)
+      eventPublisher.clear()
+
+      store.transitionPlantingSeasons()
+      eventPublisher.assertNoEventsPublished(
+          "Should not publish any events if planting season already in correct state"
+      )
+    }
+
+    @Test
+    fun `uses org timezone when no site timezone for determining when season becomes active`() {
+      val startDate = LocalDate.EPOCH.plusDays(10)
+      val endDate = startDate.plusDays(60)
+
+      dslContext.deleteFrom(ORGANIZATIONS).where(ORGANIZATIONS.ID.eq(organizationId))
+      insertOrganization(timeZone = timeZone)
+      val plantingSiteId = insertPlantingSite()
+      val plantingSeasonId =
+          insertPlantingSeason(
+              startDate = startDate,
+              endDate = endDate,
+              status = PlantingSeasonStatus.Upcoming,
+              plantingSiteId = plantingSiteId,
+          )
+
+      // Pacific/Honolulu is UTC-10, so midnight there = 10:00 UTC.
+      // At 09:59:59 UTC on start_date, it is still the previous day in Honolulu.
+      clock.instant = startDate.toInstant(timeZone).minusSeconds(1)
+
+      store.transitionPlantingSeasons()
+
+      assertEquals(
+          PlantingSeasonStatus.Upcoming,
+          plantingSeasonsDao.fetchById(plantingSeasonId).first().statusId,
+          "Season should be Upcoming before midnight in org timezone",
+      )
+      eventPublisher.assertEventNotPublished<PlantingSeasonStartedEvent>()
+
+      clock.instant = startDate.toInstant(timeZone)
+
+      store.transitionPlantingSeasons()
+
+      assertEquals(
+          PlantingSeasonStatus.Active,
+          plantingSeasonsDao.fetchById(plantingSeasonId).first().statusId,
+          "Season should be Active at midnight in org timezone",
+      )
+      eventPublisher.assertEventPublished(
+          PlantingSeasonStartedEvent(plantingSiteId, plantingSeasonId)
+      )
+
+      clock.instant = endDate.plusDays(1).toInstant(timeZone)
+
+      store.transitionPlantingSeasons()
+
+      assertEquals(
+          PlantingSeasonStatus.PastEndDate,
+          plantingSeasonsDao.fetchById(plantingSeasonId).first().statusId,
+          "Season should be PastEndDate after end date in org timezone",
       )
       eventPublisher.assertEventPublished(
           PlantingSeasonPastEndDateEvent(plantingSiteId, plantingSeasonId)


### PR DESCRIPTION
PlantingSeasonScheduler transitions the `isActive` flag on simple planting seasons. Change this to transition the `status_id` on named planting seasons insead. Add a test for org timezone fallback for the end_date. 