### PR TITLE
SW-8372 Change PlantingSeasonScheduledEvent to named planting seasons only

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/plantingmanagement/db/PlantingSeasonStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/plantingmanagement/db/PlantingSeasonStore.kt
@@ -13,17 +13,20 @@ import com.terraformation.backend.db.tracking.tables.references.PLANTING_SITES
 import com.terraformation.backend.plantingmanagement.ExistingPlantingSeasonModel
 import com.terraformation.backend.plantingmanagement.NewPlantingSeasonModel
 import com.terraformation.backend.plantingmanagement.PlantingSeasonSpeciesTargetModel
+import com.terraformation.backend.tracking.event.PlantingSeasonScheduledEvent
 import jakarta.inject.Named
 import java.time.InstantSource
 import java.time.LocalDate
 import org.jooq.Condition
 import org.jooq.DSLContext
 import org.jooq.impl.DSL
+import org.springframework.context.ApplicationEventPublisher
 
 @Named
 class PlantingSeasonStore(
     private val clock: InstantSource,
     private val dslContext: DSLContext,
+    private val eventPublisher: ApplicationEventPublisher,
     private val parentStore: ParentStore,
 ) {
   fun create(newModel: NewPlantingSeasonModel): PlantingSeasonId {
@@ -34,21 +37,33 @@ class PlantingSeasonStore(
     val status = calculateStatus(newModel.startDate, newModel.endDate, newModel.plantingSiteId)
 
     return with(PLANTING_SEASONS) {
-      dslContext
-          .insertInto(PLANTING_SEASONS)
-          .set(NAME, newModel.name)
-          .set(PLANTING_SITE_ID, newModel.plantingSiteId)
-          .set(START_DATE, newModel.startDate)
-          .set(END_DATE, newModel.endDate)
-          .set(STATUS_ID, status)
-          .set(CREATED_BY, userId)
-          .set(CREATED_TIME, now)
-          .set(MODIFIED_BY, userId)
-          .set(MODIFIED_TIME, now)
-          .onConflictDoNothing()
-          .returning(ID)
-          .fetchOne(ID)
-          ?: throw PlantingSeasonExistsException(newModel.plantingSiteId, newModel.name)
+      val newSeasonId =
+          dslContext
+              .insertInto(PLANTING_SEASONS)
+              .set(NAME, newModel.name)
+              .set(PLANTING_SITE_ID, newModel.plantingSiteId)
+              .set(START_DATE, newModel.startDate)
+              .set(END_DATE, newModel.endDate)
+              .set(STATUS_ID, status)
+              .set(CREATED_BY, userId)
+              .set(CREATED_TIME, now)
+              .set(MODIFIED_BY, userId)
+              .set(MODIFIED_TIME, now)
+              .onConflictDoNothing()
+              .returning(ID)
+              .fetchOne(ID)
+              ?: throw PlantingSeasonExistsException(newModel.plantingSiteId, newModel.name)
+
+      eventPublisher.publishEvent(
+          PlantingSeasonScheduledEvent(
+              plantingSeasonId = newSeasonId,
+              plantingSiteId = newModel.plantingSiteId,
+              startDate = newModel.startDate,
+              endDate = newModel.endDate,
+          )
+      )
+
+      newSeasonId
     }
   }
 

--- a/src/main/kotlin/com/terraformation/backend/tracking/db/PlantingSiteStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/db/PlantingSiteStore.kt
@@ -77,7 +77,6 @@ import com.terraformation.backend.tracking.edit.StratumEdit
 import com.terraformation.backend.tracking.edit.SubstratumEdit
 import com.terraformation.backend.tracking.event.PlantingSeasonPastEndDateEvent
 import com.terraformation.backend.tracking.event.PlantingSeasonRescheduledEvent
-import com.terraformation.backend.tracking.event.PlantingSeasonScheduledEvent
 import com.terraformation.backend.tracking.event.PlantingSeasonStartedEvent
 import com.terraformation.backend.tracking.event.PlantingSiteDeletionStartedEvent
 import com.terraformation.backend.tracking.event.PlantingSiteHistoryCreatedEvent
@@ -1229,17 +1228,6 @@ class PlantingSiteStore(
 
     if (seasonsToInsert.isNotEmpty()) {
       simplePlantingSeasonsDao.insert(seasonsToInsert)
-
-      seasonsToInsert.forEach { season ->
-        eventPublisher.publishEvent(
-            PlantingSeasonScheduledEvent(
-                plantingSiteId,
-                season.id!!,
-                season.startDate!!,
-                season.endDate!!,
-            )
-        )
-      }
     }
   }
 

--- a/src/main/kotlin/com/terraformation/backend/tracking/event/Events.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/event/Events.kt
@@ -121,8 +121,8 @@ data class PlantingSeasonRescheduledEvent(
 )
 
 data class PlantingSeasonScheduledEvent(
+    val plantingSeasonId: PlantingSeasonId,
     val plantingSiteId: PlantingSiteId,
-    val simplePlantingSeasonId: SimplePlantingSeasonId,
     val startDate: LocalDate,
     val endDate: LocalDate,
 )

--- a/src/test/kotlin/com/terraformation/backend/notification/NotificationServiceEmailTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/notification/NotificationServiceEmailTest.kt
@@ -1087,10 +1087,10 @@ internal class NotificationServiceEmailTest {
 
     val event =
         PlantingSeasonScheduledEvent(
-            plantingSite.id,
-            SimplePlantingSeasonId(1),
-            LocalDate.of(2023, 1, 1),
-            LocalDate.of(2023, 3, 3),
+            plantingSeasonId = PlantingSeasonId(1),
+            plantingSiteId = plantingSite.id,
+            startDate = LocalDate.of(2023, 1, 1),
+            endDate = LocalDate.of(2023, 3, 3),
         )
 
     service.on(event)
@@ -1108,10 +1108,10 @@ internal class NotificationServiceEmailTest {
   fun `plantingSeasonScheduled without Terraformation contact`() {
     val event =
         PlantingSeasonScheduledEvent(
-            plantingSite.id,
-            SimplePlantingSeasonId(1),
-            LocalDate.of(2023, 1, 1),
-            LocalDate.of(2023, 3, 3),
+            plantingSeasonId = PlantingSeasonId(1),
+            plantingSiteId = plantingSite.id,
+            startDate = LocalDate.of(2023, 1, 1),
+            endDate = LocalDate.of(2023, 3, 3),
         )
 
     service.on(event)

--- a/src/test/kotlin/com/terraformation/backend/plantingmanagement/PlantingSeasonServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/plantingmanagement/PlantingSeasonServiceTest.kt
@@ -2,6 +2,7 @@ package com.terraformation.backend.plantingmanagement
 
 import com.terraformation.backend.RunsAsDatabaseUser
 import com.terraformation.backend.TestClock
+import com.terraformation.backend.TestEventPublisher
 import com.terraformation.backend.customer.db.ParentStore
 import com.terraformation.backend.customer.model.TerrawareUser
 import com.terraformation.backend.db.DatabaseTest
@@ -24,11 +25,12 @@ internal class PlantingSeasonServiceTest : DatabaseTest(), RunsAsDatabaseUser {
   override lateinit var user: TerrawareUser
 
   private val clock = TestClock()
+  private val eventPublisher = TestEventPublisher()
   private val plantingSeasonSpeciesTargetsStore: PlantingSeasonSpeciesTargetsStore by lazy {
     PlantingSeasonSpeciesTargetsStore(clock, dslContext)
   }
   private val plantingSeasonStore: PlantingSeasonStore by lazy {
-    PlantingSeasonStore(clock, dslContext, ParentStore(dslContext))
+    PlantingSeasonStore(clock, dslContext, eventPublisher, ParentStore(dslContext))
   }
   private val service: PlantingSeasonService by lazy {
     PlantingSeasonService(dslContext, plantingSeasonStore, plantingSeasonSpeciesTargetsStore)

--- a/src/test/kotlin/com/terraformation/backend/plantingmanagement/db/PlantingSeasonStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/plantingmanagement/db/PlantingSeasonStoreTest.kt
@@ -2,6 +2,7 @@ package com.terraformation.backend.plantingmanagement.db
 
 import com.terraformation.backend.RunsAsDatabaseUser
 import com.terraformation.backend.TestClock
+import com.terraformation.backend.TestEventPublisher
 import com.terraformation.backend.customer.db.ParentStore
 import com.terraformation.backend.customer.model.TerrawareUser
 import com.terraformation.backend.db.DatabaseTest
@@ -16,6 +17,7 @@ import com.terraformation.backend.plantingmanagement.ExistingPlantingSeasonModel
 import com.terraformation.backend.plantingmanagement.NewPlantingSeasonModel
 import com.terraformation.backend.plantingmanagement.PlantingSeasonSpeciesTargetModel
 import com.terraformation.backend.tracking.db.PlantingSiteNotFoundException
+import com.terraformation.backend.tracking.event.PlantingSeasonScheduledEvent
 import java.time.Instant
 import java.time.LocalDate
 import java.time.ZoneOffset
@@ -30,8 +32,9 @@ internal class PlantingSeasonStoreTest : DatabaseTest(), RunsAsDatabaseUser {
   override lateinit var user: TerrawareUser
 
   private val clock = TestClock()
+  private val eventPublisher = TestEventPublisher()
   private val store: PlantingSeasonStore by lazy {
-    PlantingSeasonStore(clock, dslContext, ParentStore(dslContext))
+    PlantingSeasonStore(clock, dslContext, eventPublisher, ParentStore(dslContext))
   }
 
   private lateinit var organizationId: OrganizationId
@@ -138,6 +141,31 @@ internal class PlantingSeasonStoreTest : DatabaseTest(), RunsAsDatabaseUser {
               createdTime = clock.instant,
               modifiedBy = user.userId,
               modifiedTime = clock.instant,
+          )
+      )
+    }
+
+    @Test
+    fun `publishes event when planting season is created`() {
+      val startDate = LocalDate.of(2025, 1, 1)
+      val endDate = LocalDate.of(2025, 3, 31)
+
+      val plantingSeasonId =
+          store.create(
+              NewPlantingSeasonModel(
+                  endDate = endDate,
+                  name = "Spring 2025",
+                  plantingSiteId = plantingSiteId,
+                  startDate = startDate,
+              )
+          )
+
+      eventPublisher.assertEventPublished(
+          PlantingSeasonScheduledEvent(
+              plantingSeasonId = plantingSeasonId,
+              plantingSiteId = plantingSiteId,
+              startDate = startDate,
+              endDate = endDate,
           )
       )
     }

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/plantingSiteStore/PlantingSiteStoreUpdateSeasonsTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/plantingSiteStore/PlantingSiteStoreUpdateSeasonsTest.kt
@@ -2,7 +2,6 @@ package com.terraformation.backend.tracking.db.plantingSiteStore
 
 import com.terraformation.backend.db.tracking.tables.pojos.SimplePlantingSeasonsRow
 import com.terraformation.backend.tracking.event.PlantingSeasonRescheduledEvent
-import com.terraformation.backend.tracking.event.PlantingSeasonScheduledEvent
 import com.terraformation.backend.tracking.model.CannotCreatePastPlantingSeasonException
 import com.terraformation.backend.tracking.model.CannotUpdatePastPlantingSeasonException
 import com.terraformation.backend.tracking.model.PlantingSeasonTooFarInFutureException
@@ -384,28 +383,6 @@ internal class PlantingSiteStoreUpdateSeasonsTest : BasePlantingSiteStoreTest() 
           )
 
       assertEquals(expected, simplePlantingSeasonsDao.findAll().sortedBy { it.startDate })
-    }
-
-    @Test
-    fun `publishes event when planting season is added`() {
-      val plantingSiteId = insertPlantingSite()
-      val startDate = LocalDate.of(2023, 1, 2)
-      val endDate = LocalDate.of(2023, 2, 15)
-
-      store.updatePlantingSite(
-          plantingSiteId,
-          listOf(
-              UpdatedPlantingSeasonModel(startDate = startDate, endDate = endDate),
-          ),
-      ) {
-        it
-      }
-
-      val plantingSeasonId = simplePlantingSeasonsDao.findAll().first().id!!
-
-      eventPublisher.assertEventPublished(
-          PlantingSeasonScheduledEvent(plantingSiteId, plantingSeasonId, startDate, endDate)
-      )
     }
 
     @Test


### PR DESCRIPTION
The `PlantingSiteStore` published `PlantingSeasonScheduledEvent`s when simple planting seasons were created. Remove this and instead publish the event when named planting seasons are created.