### PR TITLE
SW-7126 Only include t0 species if plots completed

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/tracking/db/ObservationResultsStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/db/ObservationResultsStore.kt
@@ -421,12 +421,21 @@ class ObservationResultsStore(private val dslContext: DSLContext) {
                         .SURVIVAL_RATE_INCLUDES_TEMP_PLOTS
                         .asNonNullable()]
 
-            val species = record[substratumSpeciesMultisetField]
+            val anyCompleted = monitoringPlots.any { it.completedTime != null }
+            val species =
+                if (anyCompleted) {
+                  record[substratumSpeciesMultisetField]
+                } else {
+                  emptyList()
+                }
             val totalPlants = species.ifEmpty { null }?.sumOf { it.totalLive + it.totalDead }
-            val totalLiveSpeciesExceptUnknown = species.count {
-              it.certainty != RecordedSpeciesCertainty.Unknown &&
-                  (it.totalLive + it.totalExisting) > 0
-            }
+            val totalLiveSpeciesExceptUnknown =
+                species
+                    .ifEmpty { null }
+                    ?.count {
+                      it.certainty != RecordedSpeciesCertainty.Unknown &&
+                          (it.totalLive + it.totalExisting) > 0
+                    }
 
             val isCompleted =
                 monitoringPlots.isNotEmpty() && monitoringPlots.all { it.completedTime != null }
@@ -555,7 +564,6 @@ class ObservationResultsStore(private val dslContext: DSLContext) {
         .convertFrom { results ->
           results.map { record: Record ->
             val areaHa = record[STRATUM_HISTORIES.AREA_HA]!!
-            val species = record[stratumSpeciesMultisetField]
             val substrata = record[substrataField]
             val survivalRateIncludesTempPlots =
                 record[
@@ -563,13 +571,21 @@ class ObservationResultsStore(private val dslContext: DSLContext) {
                         .SURVIVAL_RATE_INCLUDES_TEMP_PLOTS
                         .asNonNullable()]
 
+            val anyCompleted = substrata.any { substratum ->
+              substratum.monitoringPlots.any { it.completedTime != null }
+            }
+            val species =
+                if (anyCompleted) {
+                  record[stratumSpeciesMultisetField]
+                } else {
+                  emptyList()
+                }
             val identifiedSpecies = species.filter {
               it.certainty != RecordedSpeciesCertainty.Unknown
             }
             val totalPlants = species.ifEmpty { null }?.sumOf { it.totalLive + it.totalDead }
-            val totalLiveSpeciesExceptUnknown = identifiedSpecies.count {
-              (it.totalLive + it.totalExisting) > 0
-            }
+            val totalLiveSpeciesExceptUnknown =
+                identifiedSpecies.ifEmpty { null }?.count { (it.totalLive + it.totalExisting) > 0 }
 
             val isCompleted =
                 substrata.isNotEmpty() &&
@@ -701,7 +717,16 @@ class ObservationResultsStore(private val dslContext: DSLContext) {
               val areaHa = record[PLANTING_SITE_HISTORIES.AREA_HA]
 
               val strata = record[strataField]
-              val species = record[plantingSiteSpeciesMultisetField]
+              val monitoringPlots = strata.flatMap { it.substrata }.flatMap { it.monitoringPlots }
+              val completedPlots = monitoringPlots.filter {
+                it.status == ObservationPlotStatus.Completed
+              }
+              val species =
+                  if (completedPlots.isNotEmpty()) {
+                    record[plantingSiteSpeciesMultisetField]
+                  } else {
+                    emptyList()
+                  }
               val survivalRateIncludesTempPlots =
                   record[
                       OBSERVATIONS.plantingSites.SURVIVAL_RATE_INCLUDES_TEMP_PLOTS.asNonNullable()]
@@ -711,11 +736,7 @@ class ObservationResultsStore(private val dslContext: DSLContext) {
 
               val plantingCompleted = strata.isNotEmpty() && strata.all { it.plantingCompleted }
 
-              val monitoringPlots = strata.flatMap { it.substrata }.flatMap { it.monitoringPlots }
-              val completedPlotsPlantingDensities =
-                  monitoringPlots
-                      .filter { it.status == ObservationPlotStatus.Completed }
-                      .mapNotNull { it.plantingDensity }
+              val completedPlotsPlantingDensities = completedPlots.mapNotNull { it.plantingDensity }
               val plantingDensity =
                   if (completedPlotsPlantingDensities.isNotEmpty()) {
                     completedPlotsPlantingDensities.average()

--- a/src/main/kotlin/com/terraformation/backend/tracking/db/ObservationResultsStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/db/ObservationResultsStore.kt
@@ -585,7 +585,11 @@ class ObservationResultsStore(private val dslContext: DSLContext) {
             }
             val totalPlants = species.ifEmpty { null }?.sumOf { it.totalLive + it.totalDead }
             val totalLiveSpeciesExceptUnknown =
-                identifiedSpecies.ifEmpty { null }?.count { (it.totalLive + it.totalExisting) > 0 }
+                if (species.isNotEmpty()) {
+                  identifiedSpecies.count { (it.totalLive + it.totalExisting) > 0 }
+                } else {
+                  null
+                }
 
             val isCompleted =
                 substrata.isNotEmpty() &&

--- a/src/main/kotlin/com/terraformation/backend/tracking/db/ObservationResultsStoreV2.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/db/ObservationResultsStoreV2.kt
@@ -284,7 +284,13 @@ class ObservationResultsStoreV2(private val dslContext: DSLContext) {
                         .SURVIVAL_RATE_INCLUDES_TEMP_PLOTS
                         .asNonNullable()]
 
-            val species = record[substratumSpeciesMultisetField]
+            val anyCompleted = monitoringPlots.any { it.completedTime != null }
+            val species =
+                if (anyCompleted) {
+                  record[substratumSpeciesMultisetField]
+                } else {
+                  emptyList()
+                }
             val totalPlants = species.ifEmpty { null }?.sumOf { it.totalLive + it.totalDead }
             val totalLiveSpeciesExceptUnknown =
                 species
@@ -401,8 +407,16 @@ class ObservationResultsStoreV2(private val dslContext: DSLContext) {
         .convertFrom { results ->
           results.map { record: Record ->
             val areaHa = record[STRATUM_HISTORIES.AREA_HA]!!
-            val species = record[stratumSpeciesMultisetField]
             val substrata = record[substrataField]
+            val anyCompleted = substrata.any { substratum ->
+              substratum.monitoringPlots.any { it.completedTime != null }
+            }
+            val species =
+                if (anyCompleted) {
+                  record[stratumSpeciesMultisetField]
+                } else {
+                  emptyList()
+                }
 
             val identifiedSpecies = species.filter {
               it.certainty != RecordedSpeciesCertainty.Unknown
@@ -516,7 +530,17 @@ class ObservationResultsStoreV2(private val dslContext: DSLContext) {
               val areaHa = record[PLANTING_SITE_HISTORIES.AREA_HA]
 
               val strata = record[strataField]
-              val species = record[plantingSiteSpeciesMultisetField]
+              val anyCompleted = strata.any { stratum ->
+                stratum.substrata.any { substratum ->
+                  substratum.monitoringPlots.any { it.completedTime != null }
+                }
+              }
+              val species =
+                  if (anyCompleted) {
+                    record[plantingSiteSpeciesMultisetField]
+                  } else {
+                    emptyList()
+                  }
               val survivalRateIncludesTempPlots =
                   record[
                       OBSERVATIONS.plantingSites.SURVIVAL_RATE_INCLUDES_TEMP_PLOTS.asNonNullable()]

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/ObservationResultsStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/ObservationResultsStoreTest.kt
@@ -978,6 +978,54 @@ class ObservationResultsStoreTest : ObservationScenarioTest() {
     }
 
     @Test
+    fun `plant counts and survival rate are null if there are no completed plots`() {
+      insertSpecies()
+      val observationId = insertObservation()
+
+      // Stratum and substratum with a plot that wasn't observed
+      val incompleteStratumId = insertStratum()
+      insertSubstratum()
+      val incompletePlotId = insertMonitoringPlot()
+      insertObservationPlot(claimedBy = user.userId, isPermanent = true)
+      insertPlotT0Density()
+
+      val results = resultsStore.fetchOneById(observationId)
+      val incompleteStratumResults = results.strata.single { it.stratumId == incompleteStratumId }
+      val incompleteSubstratumResults = incompleteStratumResults.substrata[0]
+      val incompletePlotResults =
+          incompleteSubstratumResults.monitoringPlots.first {
+            it.monitoringPlotId == incompletePlotId
+          }
+
+      assertNull(results.totalPlants, "Site Total Plants")
+      assertNull(results.totalSpecies, "Site Total Species")
+      assertNull(results.plantingDensity, "Site Planting Density")
+      assertNull(results.plantingDensityStdDev, "Site Planting Density Standard Deviation")
+
+      assertNull(incompleteStratumResults.totalPlants, "Incomplete Stratum Total Plants")
+      assertNull(incompleteStratumResults.totalSpecies, "Incomplete Stratum Total Species")
+      assertNull(incompleteStratumResults.plantingDensity, "Incomplete Stratum Planting Density")
+      assertNull(incompleteStratumResults.survivalRate, "Incomplete Stratum Survival Rate")
+      assertEquals(emptyList<Any>(), incompleteStratumResults.species, "Incomplete Stratum Species")
+      assertNull(incompleteSubstratumResults.totalPlants, "Incomplete Substratum Total Plants")
+      assertNull(incompleteSubstratumResults.totalSpecies, "Incomplete Substratum Total Species")
+      assertNull(
+          incompleteSubstratumResults.plantingDensity,
+          "Incomplete Substratum Planting Density",
+      )
+      assertNull(incompleteSubstratumResults.survivalRate, "Incomplete Substratum Survival Rate")
+      assertEquals(
+          emptyList<Any>(),
+          incompleteSubstratumResults.species,
+          "Incomplete Substratum Species",
+      )
+      assertNull(incompletePlotResults.totalPlants, "Incomplete Plot Total Plants")
+      assertNull(incompletePlotResults.totalSpecies, "Incomplete Plot Total Species")
+      assertNull(incompletePlotResults.plantingDensity, "Incomplete Plot Planting Density")
+      assertEquals(emptyList<Any>(), incompletePlotResults.species, "Incomplete Plot Species")
+    }
+
+    @Test
     fun `planting site summary only considers substrata with completed plots`() {
       val speciesId1 = insertSpecies()
       val speciesId2 = insertSpecies()

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/ObservationScenarioV2Test.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/ObservationScenarioV2Test.kt
@@ -685,6 +685,46 @@ class ObservationScenarioV2Test : ObservationScenarioTest() {
           "Incomplete Plot Status",
       )
     }
+
+    @Test
+    fun `plant counts and survival rate are null if there are no completed plots`() {
+      insertSpecies()
+      val observationId = insertObservation()
+      val incompleteStratumId = insertStratum()
+      insertSubstratum()
+      val incompletePlotId = insertMonitoringPlot()
+      insertObservationPlot(claimedBy = user.userId, isPermanent = true)
+      insertPlotT0Density()
+
+      val results = resultsStoreV2.fetchOneById(observationId)
+      val incompleteStratumResults = results.strata.single { it.stratumId == incompleteStratumId }
+      val incompleteSubstratumResults = incompleteStratumResults.substrata[0]
+      val incompletePlotResults =
+          incompleteSubstratumResults.monitoringPlots.first {
+            it.monitoringPlotId == incompletePlotId
+          }
+
+      assertNull(results.totalPlants, "Site Total Plants")
+      assertNull(results.totalSpecies, "Site Total Species")
+      assertNull(results.plantingDensity, "Site Planting Density")
+      assertNull(results.survivalRate, "Site Survival Rate")
+
+      assertNull(incompleteStratumResults.totalPlants, "Incomplete Stratum Total Plants")
+      assertNull(incompleteStratumResults.totalSpecies, "Incomplete Stratum Total Species")
+      assertNull(incompleteStratumResults.plantingDensity, "Incomplete Stratum Planting Density")
+      assertNull(incompleteStratumResults.survivalRate, "Incomplete Stratum Survival Rate")
+      assertNull(incompleteSubstratumResults.totalPlants, "Incomplete Substratum Total Plants")
+      assertNull(incompleteSubstratumResults.totalSpecies, "Incomplete Substratum Total Species")
+      assertNull(
+          incompleteSubstratumResults.plantingDensity,
+          "Incomplete Substratum Planting Density",
+      )
+      assertNull(incompleteSubstratumResults.survivalRate, "Incomplete Substratum Survival Rate")
+      assertNull(incompletePlotResults.totalPlants, "Incomplete Plot Total Plants")
+      assertNull(incompletePlotResults.totalSpecies, "Incomplete Plot Total Species")
+      assertNull(incompletePlotResults.plantingDensity, "Incomplete Plot Planting Density")
+      assertEquals(emptyList<Any>(), incompletePlotResults.species, "Incomplete Plot Species")
+    }
   }
 
   @Nested


### PR DESCRIPTION
If there are t0 densities recorded for a given species in a monitoring plot, and
the species isn't observed in a later observation, we show a survival rate of 0
as intended. However, it doesn't make sense to show 0 values for areas where no
plots at all have been completed yet.

Update the results code to ignore the t0 species list if there are no completed
plots.