### PR TITLE
SW-8372 Change PlantingSeasonRescheduledEvent to named planting seasons only

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/plantingmanagement/db/PlantingSeasonStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/plantingmanagement/db/PlantingSeasonStore.kt
@@ -13,6 +13,7 @@ import com.terraformation.backend.db.tracking.tables.references.PLANTING_SITES
 import com.terraformation.backend.plantingmanagement.ExistingPlantingSeasonModel
 import com.terraformation.backend.plantingmanagement.NewPlantingSeasonModel
 import com.terraformation.backend.plantingmanagement.PlantingSeasonSpeciesTargetModel
+import com.terraformation.backend.tracking.event.PlantingSeasonRescheduledEvent
 import com.terraformation.backend.tracking.event.PlantingSeasonScheduledEvent
 import jakarta.inject.Named
 import java.time.InstantSource
@@ -100,11 +101,12 @@ class PlantingSeasonStore(
   ) {
     requirePermissions { updatePlantingSeason(plantingSeasonId) }
 
-    val now = clock.instant()
-    val plantingSiteId =
-        parentStore.getPlantingSiteId(plantingSeasonId)
+    val existingSeason =
+        fetchByCondition(PLANTING_SEASONS.ID.eq(plantingSeasonId)).firstOrNull()
             ?: throw PlantingSeasonNotFoundException(plantingSeasonId)
-    val status = calculateStatus(startDate, endDate, plantingSiteId)
+
+    val now = clock.instant()
+    val status = calculateStatus(startDate, endDate, existingSeason.plantingSiteId)
 
     val rowsUpdated =
         with(PLANTING_SEASONS) {
@@ -129,6 +131,19 @@ class PlantingSeasonStore(
 
     if (rowsUpdated == 0) {
       throw PlantingSeasonNotFoundException(plantingSeasonId)
+    }
+
+    if (existingSeason.startDate != startDate || existingSeason.endDate != endDate) {
+      eventPublisher.publishEvent(
+          PlantingSeasonRescheduledEvent(
+              plantingSeasonId = existingSeason.id,
+              plantingSiteId = existingSeason.plantingSiteId,
+              oldStartDate = existingSeason.startDate,
+              oldEndDate = existingSeason.endDate,
+              newStartDate = startDate,
+              newEndDate = endDate,
+          )
+      )
     }
   }
 

--- a/src/main/kotlin/com/terraformation/backend/tracking/db/PlantingSiteStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/db/PlantingSiteStore.kt
@@ -76,7 +76,6 @@ import com.terraformation.backend.tracking.edit.PlantingSiteEdit
 import com.terraformation.backend.tracking.edit.StratumEdit
 import com.terraformation.backend.tracking.edit.SubstratumEdit
 import com.terraformation.backend.tracking.event.PlantingSeasonPastEndDateEvent
-import com.terraformation.backend.tracking.event.PlantingSeasonRescheduledEvent
 import com.terraformation.backend.tracking.event.PlantingSeasonStartedEvent
 import com.terraformation.backend.tracking.event.PlantingSiteDeletionStartedEvent
 import com.terraformation.backend.tracking.event.PlantingSiteHistoryCreatedEvent
@@ -1213,17 +1212,6 @@ class PlantingSiteStore(
             .where(ID.eq(desiredSeason.id))
             .execute()
       }
-
-      eventPublisher.publishEvent(
-          PlantingSeasonRescheduledEvent(
-              plantingSiteId,
-              existingSeason.id,
-              existingSeason.startDate,
-              existingSeason.endDate,
-              desiredSeason.startDate,
-              desiredSeason.endDate,
-          )
-      )
     }
 
     if (seasonsToInsert.isNotEmpty()) {

--- a/src/main/kotlin/com/terraformation/backend/tracking/event/Events.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/event/Events.kt
@@ -20,7 +20,6 @@ import com.terraformation.backend.db.tracking.PlantingSiteId
 import com.terraformation.backend.db.tracking.RecordedPlantStatus
 import com.terraformation.backend.db.tracking.RecordedSpeciesCertainty
 import com.terraformation.backend.db.tracking.RecordedTreeId
-import com.terraformation.backend.db.tracking.SimplePlantingSeasonId
 import com.terraformation.backend.db.tracking.StratumId
 import com.terraformation.backend.db.tracking.TreeGrowthForm
 import com.terraformation.backend.eventlog.EntityCreatedPersistentEvent
@@ -112,8 +111,8 @@ data class ObservationStateUpdatedEvent(
 data class PlantingSiteDeletionStartedEvent(val plantingSiteId: PlantingSiteId)
 
 data class PlantingSeasonRescheduledEvent(
+    val plantingSeasonId: PlantingSeasonId,
     val plantingSiteId: PlantingSiteId,
-    val simplePlantingSeasonId: SimplePlantingSeasonId,
     val oldStartDate: LocalDate,
     val oldEndDate: LocalDate,
     val newStartDate: LocalDate,

--- a/src/test/kotlin/com/terraformation/backend/notification/NotificationServiceEmailTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/notification/NotificationServiceEmailTest.kt
@@ -93,7 +93,6 @@ import com.terraformation.backend.db.tracking.PlantingSiteHistoryId
 import com.terraformation.backend.db.tracking.PlantingSiteId
 import com.terraformation.backend.db.tracking.RecordedPlantStatus
 import com.terraformation.backend.db.tracking.RecordedSpeciesCertainty
-import com.terraformation.backend.db.tracking.SimplePlantingSeasonId
 import com.terraformation.backend.db.tracking.StratumId
 import com.terraformation.backend.db.tracking.SubstratumId
 import com.terraformation.backend.device.db.DeviceStore
@@ -1126,12 +1125,12 @@ internal class NotificationServiceEmailTest {
 
     val event =
         PlantingSeasonRescheduledEvent(
-            plantingSite.id,
-            SimplePlantingSeasonId(1),
-            LocalDate.of(2023, 1, 1),
-            LocalDate.of(2023, 3, 3),
-            LocalDate.of(2023, 1, 2),
-            LocalDate.of(2023, 3, 4),
+            plantingSeasonId = PlantingSeasonId(1),
+            plantingSiteId = plantingSite.id,
+            oldStartDate = LocalDate.of(2023, 1, 1),
+            oldEndDate = LocalDate.of(2023, 3, 3),
+            newStartDate = LocalDate.of(2023, 1, 2),
+            newEndDate = LocalDate.of(2023, 3, 4),
         )
 
     service.on(event)
@@ -1150,12 +1149,12 @@ internal class NotificationServiceEmailTest {
   fun `plantingSeasonRescheduled without Terraformation contact`() {
     val event =
         PlantingSeasonRescheduledEvent(
-            plantingSite.id,
-            SimplePlantingSeasonId(1),
-            LocalDate.of(2023, 1, 1),
-            LocalDate.of(2023, 3, 3),
-            LocalDate.of(2023, 1, 2),
-            LocalDate.of(2023, 3, 4),
+            plantingSeasonId = PlantingSeasonId(1),
+            plantingSiteId = plantingSite.id,
+            oldStartDate = LocalDate.of(2023, 1, 1),
+            oldEndDate = LocalDate.of(2023, 3, 3),
+            newStartDate = LocalDate.of(2023, 1, 2),
+            newEndDate = LocalDate.of(2023, 3, 4),
         )
 
     service.on(event)

--- a/src/test/kotlin/com/terraformation/backend/plantingmanagement/db/PlantingSeasonStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/plantingmanagement/db/PlantingSeasonStoreTest.kt
@@ -17,6 +17,7 @@ import com.terraformation.backend.plantingmanagement.ExistingPlantingSeasonModel
 import com.terraformation.backend.plantingmanagement.NewPlantingSeasonModel
 import com.terraformation.backend.plantingmanagement.PlantingSeasonSpeciesTargetModel
 import com.terraformation.backend.tracking.db.PlantingSiteNotFoundException
+import com.terraformation.backend.tracking.event.PlantingSeasonRescheduledEvent
 import com.terraformation.backend.tracking.event.PlantingSeasonScheduledEvent
 import java.time.Instant
 import java.time.LocalDate
@@ -527,26 +528,28 @@ internal class PlantingSeasonStoreTest : DatabaseTest(), RunsAsDatabaseUser {
 
     @Test
     fun `sets status to Active when today falls within the new date range`() {
-      val id =
+      val oldStartDate = LocalDate.of(2025, 1, 1)
+      val oldEndDate = LocalDate.of(2025, 1, 31)
+      val plantingSeasonId =
           insertPlantingSeason(
               name = "Season",
-              startDate = LocalDate.of(2025, 1, 1),
-              endDate = LocalDate.of(2025, 1, 31),
+              startDate = oldStartDate,
+              endDate = oldEndDate,
               status = PlantingSeasonStatus.Upcoming,
           )
-      val newStart = LocalDate.of(2025, 1, 1)
-      val newEnd = LocalDate.of(2025, 3, 31)
-      clock.instant = newStart.atStartOfDay().toInstant(ZoneOffset.UTC)
+      val newStartDate = LocalDate.of(2025, 1, 1)
+      val newEndDate = LocalDate.of(2025, 3, 31)
+      clock.instant = newStartDate.atStartOfDay().toInstant(ZoneOffset.UTC)
 
-      store.update(id, "Season", newStart, newEnd)
+      store.update(plantingSeasonId, "Season", newStartDate, newEndDate)
 
       assertTableEquals(
           PlantingSeasonsRecord(
-              id = id,
+              id = plantingSeasonId,
               name = "Season",
               plantingSiteId = plantingSiteId,
-              startDate = newStart,
-              endDate = newEnd,
+              startDate = newStartDate,
+              endDate = newEndDate,
               statusId = PlantingSeasonStatus.Active,
               createdBy = user.userId,
               createdTime = Instant.EPOCH,
@@ -554,30 +557,43 @@ internal class PlantingSeasonStoreTest : DatabaseTest(), RunsAsDatabaseUser {
               modifiedTime = clock.instant,
           )
       )
+
+      eventPublisher.assertEventPublished(
+          PlantingSeasonRescheduledEvent(
+              plantingSeasonId = plantingSeasonId,
+              plantingSiteId = plantingSiteId,
+              oldStartDate = oldStartDate,
+              oldEndDate = oldEndDate,
+              newStartDate = newStartDate,
+              newEndDate = newEndDate,
+          )
+      )
     }
 
     @Test
     fun `sets status to PastEndDate when new end date is in the past`() {
-      val id =
+      val oldStartDate = LocalDate.of(2025, 1, 1)
+      val oldEndDate = LocalDate.of(2025, 3, 31)
+      val plantingSeasonId =
           insertPlantingSeason(
               name = "Season",
-              startDate = LocalDate.of(2025, 1, 1),
-              endDate = LocalDate.of(2025, 3, 31),
+              startDate = oldStartDate,
+              endDate = oldEndDate,
               status = PlantingSeasonStatus.Upcoming,
           )
-      val newStart = LocalDate.of(2024, 1, 1)
-      val newEnd = LocalDate.of(2024, 3, 31)
-      clock.instant = newEnd.plusDays(1).atStartOfDay().toInstant(ZoneOffset.UTC)
+      val newStartDate = LocalDate.of(2024, 1, 1)
+      val newEndDate = LocalDate.of(2024, 3, 31)
+      clock.instant = newEndDate.plusDays(1).atStartOfDay().toInstant(ZoneOffset.UTC)
 
-      store.update(id, "Season", newStart, newEnd)
+      store.update(plantingSeasonId, "Season", newStartDate, newEndDate)
 
       assertTableEquals(
           PlantingSeasonsRecord(
-              id = id,
+              id = plantingSeasonId,
               name = "Season",
               plantingSiteId = plantingSiteId,
-              startDate = newStart,
-              endDate = newEnd,
+              startDate = newStartDate,
+              endDate = newEndDate,
               statusId = PlantingSeasonStatus.PastEndDate,
               createdBy = user.userId,
               createdTime = Instant.EPOCH,
@@ -585,30 +601,43 @@ internal class PlantingSeasonStoreTest : DatabaseTest(), RunsAsDatabaseUser {
               modifiedTime = clock.instant,
           )
       )
+
+      eventPublisher.assertEventPublished(
+          PlantingSeasonRescheduledEvent(
+              plantingSeasonId = plantingSeasonId,
+              plantingSiteId = plantingSiteId,
+              oldStartDate = oldStartDate,
+              oldEndDate = oldEndDate,
+              newStartDate = newStartDate,
+              newEndDate = newEndDate,
+          )
+      )
     }
 
     @Test
     fun `does not change status when season is closed`() {
-      val id =
+      val oldStartDate = LocalDate.of(2025, 1, 1)
+      val oldEndDate = LocalDate.of(2025, 3, 31)
+      val plantingSeasonId =
           insertPlantingSeason(
               name = "Season",
-              startDate = LocalDate.of(2025, 1, 1),
-              endDate = LocalDate.of(2025, 3, 31),
+              startDate = oldStartDate,
+              endDate = oldEndDate,
               status = PlantingSeasonStatus.Closed,
           )
-      val newStart = LocalDate.of(2024, 1, 1)
-      val newEnd = LocalDate.of(2024, 3, 31)
-      clock.instant = newEnd.plusDays(1).atStartOfDay().toInstant(ZoneOffset.UTC)
+      val newStartDate = LocalDate.of(2024, 1, 1)
+      val newEndDate = LocalDate.of(2024, 3, 31)
+      clock.instant = newEndDate.plusDays(1).atStartOfDay().toInstant(ZoneOffset.UTC)
 
-      store.update(id, "Season", newStart, newEnd)
+      store.update(plantingSeasonId, "Season", newStartDate, newEndDate)
 
       assertTableEquals(
           PlantingSeasonsRecord(
-              id = id,
+              id = plantingSeasonId,
               name = "Season",
               plantingSiteId = plantingSiteId,
-              startDate = newStart,
-              endDate = newEnd,
+              startDate = newStartDate,
+              endDate = newEndDate,
               statusId = PlantingSeasonStatus.Closed,
               createdBy = user.userId,
               createdTime = Instant.EPOCH,
@@ -616,6 +645,49 @@ internal class PlantingSeasonStoreTest : DatabaseTest(), RunsAsDatabaseUser {
               modifiedTime = clock.instant,
           )
       )
+
+      eventPublisher.assertEventPublished(
+          PlantingSeasonRescheduledEvent(
+              plantingSeasonId = plantingSeasonId,
+              plantingSiteId = plantingSiteId,
+              oldStartDate = oldStartDate,
+              oldEndDate = oldEndDate,
+              newStartDate = newStartDate,
+              newEndDate = newEndDate,
+          )
+      )
+    }
+
+    @Test
+    fun `does not publish PlantingSeasonRescheduledEvent when dates do not change`() {
+      val startDate = LocalDate.of(2025, 1, 1)
+      val endDate = LocalDate.of(2025, 3, 31)
+      val plantingSeasonId =
+          insertPlantingSeason(
+              name = "Season",
+              startDate = startDate,
+              endDate = endDate,
+              status = PlantingSeasonStatus.Closed,
+          )
+
+      store.update(plantingSeasonId, "New Season", startDate, endDate)
+
+      assertTableEquals(
+          PlantingSeasonsRecord(
+              id = plantingSeasonId,
+              name = "New Season",
+              plantingSiteId = plantingSiteId,
+              startDate = startDate,
+              endDate = endDate,
+              statusId = PlantingSeasonStatus.Closed,
+              createdBy = user.userId,
+              createdTime = Instant.EPOCH,
+              modifiedBy = user.userId,
+              modifiedTime = Instant.EPOCH,
+          )
+      )
+
+      eventPublisher.assertNoEventsPublished()
     }
 
     @Test

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/plantingSiteStore/PlantingSiteStoreUpdateSeasonsTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/plantingSiteStore/PlantingSiteStoreUpdateSeasonsTest.kt
@@ -1,7 +1,6 @@
 package com.terraformation.backend.tracking.db.plantingSiteStore
 
 import com.terraformation.backend.db.tracking.tables.pojos.SimplePlantingSeasonsRow
-import com.terraformation.backend.tracking.event.PlantingSeasonRescheduledEvent
 import com.terraformation.backend.tracking.model.CannotCreatePastPlantingSeasonException
 import com.terraformation.backend.tracking.model.CannotUpdatePastPlantingSeasonException
 import com.terraformation.backend.tracking.model.PlantingSeasonTooFarInFutureException
@@ -383,42 +382,6 @@ internal class PlantingSiteStoreUpdateSeasonsTest : BasePlantingSiteStoreTest() 
           )
 
       assertEquals(expected, simplePlantingSeasonsDao.findAll().sortedBy { it.startDate })
-    }
-
-    @Test
-    fun `publishes event when planting season is modified`() {
-      val plantingSiteId = insertPlantingSite()
-      val oldStartDate = LocalDate.of(2023, 1, 1)
-      val oldEndDate = LocalDate.of(2023, 1, 31)
-      val newStartDate = LocalDate.of(2023, 1, 2)
-      val newEndDate = LocalDate.of(2023, 2, 15)
-
-      val plantingSeasonId =
-          insertSimplePlantingSeason(startDate = oldStartDate, endDate = oldEndDate)
-
-      store.updatePlantingSite(
-          plantingSiteId,
-          listOf(
-              UpdatedPlantingSeasonModel(
-                  startDate = newStartDate,
-                  endDate = newEndDate,
-                  id = plantingSeasonId,
-              ),
-          ),
-      ) {
-        it
-      }
-
-      eventPublisher.assertEventPublished(
-          PlantingSeasonRescheduledEvent(
-              plantingSiteId,
-              plantingSeasonId,
-              oldStartDate,
-              oldEndDate,
-              newStartDate,
-              newEndDate,
-          )
-      )
     }
 
     private inline fun <reified T : Exception> assertPlantingSeasonUpdateThrows(


### PR DESCRIPTION
The `PlantingSiteStore` published `PlantingSeasonRescheduledEvent`s when simple planting seasons had their start or end dates changed. Remove this and instead publish the event when named planting seasons update their start or end dates.