### PR TITLE
SW-8369 Don't allow closed planting seasons to be edited in any way

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/plantingmanagement/db/Exceptions.kt
+++ b/src/main/kotlin/com/terraformation/backend/plantingmanagement/db/Exceptions.kt
@@ -26,3 +26,6 @@ class PlantingSeasonScheduledDateExistsException(
 class PlantingSeasonScheduledDateNotFoundException(
     scheduledPlantingDateId: ScheduledPlantingDateId
 ) : EntityNotFoundException("Scheduled planting date $scheduledPlantingDateId not found")
+
+class PlantingSeasonClosedException(val plantingSeasonId: PlantingSeasonId) :
+    MismatchedStateException("Planting season $plantingSeasonId alraedy closed")

--- a/src/main/kotlin/com/terraformation/backend/plantingmanagement/db/Exceptions.kt
+++ b/src/main/kotlin/com/terraformation/backend/plantingmanagement/db/Exceptions.kt
@@ -28,4 +28,4 @@ class PlantingSeasonScheduledDateNotFoundException(
 ) : EntityNotFoundException("Scheduled planting date $scheduledPlantingDateId not found")
 
 class PlantingSeasonClosedException(val plantingSeasonId: PlantingSeasonId) :
-    MismatchedStateException("Planting season $plantingSeasonId alraedy closed")
+    MismatchedStateException("Planting season $plantingSeasonId already closed")

--- a/src/main/kotlin/com/terraformation/backend/plantingmanagement/db/PlantingSeasonScheduledDatesStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/plantingmanagement/db/PlantingSeasonScheduledDatesStore.kt
@@ -3,7 +3,9 @@ package com.terraformation.backend.plantingmanagement.db
 import com.terraformation.backend.auth.currentUser
 import com.terraformation.backend.customer.model.requirePermissions
 import com.terraformation.backend.db.tracking.PlantingSeasonId
+import com.terraformation.backend.db.tracking.PlantingSeasonStatus
 import com.terraformation.backend.db.tracking.ScheduledPlantingDateId
+import com.terraformation.backend.db.tracking.tables.references.PLANTING_SEASONS
 import com.terraformation.backend.db.tracking.tables.references.SCHEDULED_PLANTING_DATES
 import com.terraformation.backend.db.tracking.tables.references.SCHEDULED_PLANTING_DATE_SPECIES
 import com.terraformation.backend.plantingmanagement.ExistingPlantingSeasonScheduledDateModel
@@ -44,6 +46,8 @@ class PlantingSeasonScheduledDatesStore(
 
   fun create(model: PlantingSeasonScheduledDateModel): ScheduledPlantingDateId {
     requirePermissions { updatePlantingSeason(model.plantingSeasonId) }
+
+    validateSeasonNotClosed(model.plantingSeasonId)
 
     val userId = currentUser().userId
     val now = clock.instant()
@@ -102,6 +106,8 @@ class PlantingSeasonScheduledDatesStore(
   ) {
     requirePermissions { updatePlantingSeason(model.plantingSeasonId) }
 
+    validateSeasonNotClosed(model.plantingSeasonId)
+
     dslContext.transaction { _ ->
       val updatedCount =
           with(SCHEDULED_PLANTING_DATES) {
@@ -154,6 +160,8 @@ class PlantingSeasonScheduledDatesStore(
   ) {
     requirePermissions { updatePlantingSeason(plantingSeasonId) }
 
+    validateSeasonNotClosed(plantingSeasonId)
+
     with(SCHEDULED_PLANTING_DATES) {
       val rowsDeleted =
           dslContext
@@ -204,6 +212,21 @@ class PlantingSeasonScheduledDatesStore(
                 species = record[speciesMultiset],
             )
           }
+    }
+  }
+
+  private fun validateSeasonNotClosed(plantingSeasonId: PlantingSeasonId) {
+    with(PLANTING_SEASONS) {
+      val status =
+          dslContext
+              .select(STATUS_ID)
+              .from(PLANTING_SEASONS)
+              .where(ID.eq(plantingSeasonId))
+              .fetchOne(STATUS_ID) ?: throw PlantingSeasonNotFoundException(plantingSeasonId)
+
+      if (status == PlantingSeasonStatus.Closed) {
+        throw PlantingSeasonClosedException(plantingSeasonId)
+      }
     }
   }
 }

--- a/src/main/kotlin/com/terraformation/backend/plantingmanagement/db/PlantingSeasonSpeciesTargetsStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/plantingmanagement/db/PlantingSeasonSpeciesTargetsStore.kt
@@ -4,7 +4,9 @@ import com.terraformation.backend.auth.currentUser
 import com.terraformation.backend.customer.model.requirePermissions
 import com.terraformation.backend.db.default_schema.SpeciesId
 import com.terraformation.backend.db.tracking.PlantingSeasonId
+import com.terraformation.backend.db.tracking.PlantingSeasonStatus
 import com.terraformation.backend.db.tracking.SubstratumId
+import com.terraformation.backend.db.tracking.tables.references.PLANTING_SEASONS
 import com.terraformation.backend.db.tracking.tables.references.PLANTING_SEASON_SPECIES_TARGETS
 import com.terraformation.backend.plantingmanagement.PlantingSeasonSpeciesTargetModel
 import jakarta.inject.Named
@@ -32,6 +34,8 @@ class PlantingSeasonSpeciesTargetsStore(
   ) {
     require(quantity >= 0) { "Quantity must be >= 0" }
     requirePermissions { updatePlantingSeason(plantingSeasonId) }
+
+    validateSeasonNotClosed(plantingSeasonId)
 
     val userId = currentUser().userId
     val now = clock.instant()
@@ -106,6 +110,8 @@ class PlantingSeasonSpeciesTargetsStore(
   ) {
     requirePermissions { updatePlantingSeason(plantingSeasonId) }
 
+    validateSeasonNotClosed(plantingSeasonId)
+
     with(PLANTING_SEASON_SPECIES_TARGETS) {
       dslContext
           .deleteFrom(PLANTING_SEASON_SPECIES_TARGETS)
@@ -124,6 +130,21 @@ class PlantingSeasonSpeciesTargetsStore(
             speciesId = record[SPECIES_ID]!!,
             quantity = record[QUANTITY]!!,
         )
+      }
+    }
+  }
+
+  private fun validateSeasonNotClosed(plantingSeasonId: PlantingSeasonId) {
+    with(PLANTING_SEASONS) {
+      val status =
+          dslContext
+              .select(STATUS_ID)
+              .from(PLANTING_SEASONS)
+              .where(ID.eq(plantingSeasonId))
+              .fetchOne(STATUS_ID) ?: throw PlantingSeasonNotFoundException(plantingSeasonId)
+
+      if (status == PlantingSeasonStatus.Closed) {
+        throw PlantingSeasonClosedException(plantingSeasonId)
       }
     }
   }

--- a/src/main/kotlin/com/terraformation/backend/plantingmanagement/db/PlantingSeasonStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/plantingmanagement/db/PlantingSeasonStore.kt
@@ -105,6 +105,10 @@ class PlantingSeasonStore(
         fetchByCondition(PLANTING_SEASONS.ID.eq(plantingSeasonId)).firstOrNull()
             ?: throw PlantingSeasonNotFoundException(plantingSeasonId)
 
+    if (existingSeason.status == PlantingSeasonStatus.Closed) {
+      throw PlantingSeasonClosedException(plantingSeasonId)
+    }
+
     val now = clock.instant()
     val status = calculateStatus(startDate, endDate, existingSeason.plantingSiteId)
 

--- a/src/main/kotlin/com/terraformation/backend/plantingmanagement/db/PlantingSeasonStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/plantingmanagement/db/PlantingSeasonStore.kt
@@ -110,7 +110,10 @@ class PlantingSeasonStore(
     }
 
     val now = clock.instant()
-    val status = calculateStatus(startDate, endDate, existingSeason.plantingSiteId)
+    val status =
+        if (existingSeason.startDate == startDate && existingSeason.endDate == endDate)
+            existingSeason.status
+        else calculateStatus(startDate, endDate, existingSeason.plantingSiteId)
 
     val rowsUpdated =
         with(PLANTING_SEASONS) {

--- a/src/test/kotlin/com/terraformation/backend/plantingmanagement/db/PlantingSeasonScheduledDatesStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/plantingmanagement/db/PlantingSeasonScheduledDatesStoreTest.kt
@@ -7,6 +7,7 @@ import com.terraformation.backend.db.DatabaseTest
 import com.terraformation.backend.db.default_schema.Role
 import com.terraformation.backend.db.default_schema.SpeciesId
 import com.terraformation.backend.db.tracking.PlantingSeasonId
+import com.terraformation.backend.db.tracking.PlantingSeasonStatus
 import com.terraformation.backend.db.tracking.ScheduledPlantingDateId
 import com.terraformation.backend.db.tracking.SubstratumId
 import com.terraformation.backend.db.tracking.tables.records.ScheduledPlantingDateSpeciesRecord
@@ -339,6 +340,20 @@ internal class PlantingSeasonScheduledDatesStoreTest : DatabaseTest(), RunsAsDat
     }
 
     @Test
+    fun `throws PlantingSeasonClosedException if season is closed`() {
+      val plantingSeasonId = insertPlantingSeason(status = PlantingSeasonStatus.Closed)
+
+      assertThrows<PlantingSeasonClosedException> {
+        store.create(
+            PlantingSeasonScheduledDateModel(
+                plantingSeasonId = plantingSeasonId,
+                date = LocalDate.EPOCH,
+            ),
+        )
+      }
+    }
+
+    @Test
     fun `throws AccessDeniedException when user lacks permission`() {
       deleteOrganizationUser()
       insertOrganizationUser(role = Role.Contributor)
@@ -494,6 +509,35 @@ internal class PlantingSeasonScheduledDatesStoreTest : DatabaseTest(), RunsAsDat
     }
 
     @Test
+    fun `throws PlantingSeasonClosedException if season is closed`() {
+      val plantingSeasonId = insertPlantingSeason(status = PlantingSeasonStatus.Closed)
+      val scheduledDateId = insertPlantingSeasonScheduledDate()
+
+      assertThrows<PlantingSeasonClosedException> {
+        store.update(
+            scheduledDateId,
+            PlantingSeasonScheduledDateModel(
+                plantingSeasonId = plantingSeasonId,
+                date = LocalDate.EPOCH,
+                species =
+                    listOf(
+                        PlantingSeasonScheduledDateSpecies(
+                            quantity = 5,
+                            speciesId = speciesId,
+                            substratumId = substratumId,
+                        ),
+                        PlantingSeasonScheduledDateSpecies(
+                            quantity = 10,
+                            speciesId = speciesId,
+                            substratumId = substratumId,
+                        ),
+                    ),
+            ),
+        )
+      }
+    }
+
+    @Test
     fun `throws AccessDeniedException when user lacks permission`() {
       val scheduledDateId = insertPlantingSeasonScheduledDate()
       deleteOrganizationUser()
@@ -551,6 +595,16 @@ internal class PlantingSeasonScheduledDatesStoreTest : DatabaseTest(), RunsAsDat
 
       assertTableEmpty(SCHEDULED_PLANTING_DATES)
       assertTableEmpty(SCHEDULED_PLANTING_DATE_SPECIES)
+    }
+
+    @Test
+    fun `throws PlantingSeasonClosedException if season is closed`() {
+      val plantingSeasonId = insertPlantingSeason(status = PlantingSeasonStatus.Closed)
+      val scheduledDateId = insertPlantingSeasonScheduledDate()
+
+      assertThrows<PlantingSeasonClosedException> {
+        store.delete(plantingSeasonId, scheduledDateId)
+      }
     }
 
     @Test

--- a/src/test/kotlin/com/terraformation/backend/plantingmanagement/db/PlantingSeasonSpeciesTargetsStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/plantingmanagement/db/PlantingSeasonSpeciesTargetsStoreTest.kt
@@ -7,6 +7,7 @@ import com.terraformation.backend.db.DatabaseTest
 import com.terraformation.backend.db.default_schema.Role
 import com.terraformation.backend.db.default_schema.SpeciesId
 import com.terraformation.backend.db.tracking.PlantingSeasonId
+import com.terraformation.backend.db.tracking.PlantingSeasonStatus
 import com.terraformation.backend.db.tracking.SubstratumId
 import com.terraformation.backend.db.tracking.tables.records.PlantingSeasonSpeciesTargetsRecord
 import com.terraformation.backend.plantingmanagement.PlantingSeasonSpeciesTargetModel
@@ -152,6 +153,15 @@ internal class PlantingSeasonSpeciesTargetsStoreTest : DatabaseTest(), RunsAsDat
     }
 
     @Test
+    fun `throws PlantingSeasonClosedException if season is closed`() {
+      val plantingSeasonId = insertPlantingSeason(status = PlantingSeasonStatus.Closed)
+
+      assertThrows<PlantingSeasonClosedException> {
+        store.upsert(plantingSeasonId, substratumId, speciesId, quantity = 5)
+      }
+    }
+
+    @Test
     fun `throws AccessDeniedException when user lacks permission`() {
       deleteOrganizationUser()
       insertOrganizationUser(role = Role.Contributor)
@@ -262,6 +272,16 @@ internal class PlantingSeasonSpeciesTargetsStoreTest : DatabaseTest(), RunsAsDat
     @Test
     fun `does nothing when the species target row does not exist`() {
       store.delete(plantingSeasonId, substratumId, speciesId)
+    }
+
+    @Test
+    fun `throws PlantingSeasonClosedException if season is closed`() {
+      val plantingSeasonId = insertPlantingSeason(status = PlantingSeasonStatus.Closed)
+      insertPlantingSeasonSpeciesTarget(quantity = 5)
+
+      assertThrows<PlantingSeasonClosedException> {
+        store.delete(plantingSeasonId, substratumId, speciesId)
+      }
     }
 
     @Test

--- a/src/test/kotlin/com/terraformation/backend/plantingmanagement/db/PlantingSeasonStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/plantingmanagement/db/PlantingSeasonStoreTest.kt
@@ -615,47 +615,12 @@ internal class PlantingSeasonStoreTest : DatabaseTest(), RunsAsDatabaseUser {
     }
 
     @Test
-    fun `does not change status when season is closed`() {
-      val oldStartDate = LocalDate.of(2025, 1, 1)
-      val oldEndDate = LocalDate.of(2025, 3, 31)
-      val plantingSeasonId =
-          insertPlantingSeason(
-              name = "Season",
-              startDate = oldStartDate,
-              endDate = oldEndDate,
-              status = PlantingSeasonStatus.Closed,
-          )
-      val newStartDate = LocalDate.of(2024, 1, 1)
-      val newEndDate = LocalDate.of(2024, 3, 31)
-      clock.instant = newEndDate.plusDays(1).atStartOfDay().toInstant(ZoneOffset.UTC)
+    fun `throws PlantingSeasonClosedException if season is closed`() {
+      val plantingSeasonId = insertPlantingSeason(status = PlantingSeasonStatus.Closed)
 
-      store.update(plantingSeasonId, "Season", newStartDate, newEndDate)
-
-      assertTableEquals(
-          PlantingSeasonsRecord(
-              id = plantingSeasonId,
-              name = "Season",
-              plantingSiteId = plantingSiteId,
-              startDate = newStartDate,
-              endDate = newEndDate,
-              statusId = PlantingSeasonStatus.Closed,
-              createdBy = user.userId,
-              createdTime = Instant.EPOCH,
-              modifiedBy = user.userId,
-              modifiedTime = clock.instant,
-          )
-      )
-
-      eventPublisher.assertEventPublished(
-          PlantingSeasonRescheduledEvent(
-              plantingSeasonId = plantingSeasonId,
-              plantingSiteId = plantingSiteId,
-              oldStartDate = oldStartDate,
-              oldEndDate = oldEndDate,
-              newStartDate = newStartDate,
-              newEndDate = newEndDate,
-          )
-      )
+      assertThrows<PlantingSeasonClosedException> {
+        store.update(plantingSeasonId, "Not possible", LocalDate.EPOCH, LocalDate.EPOCH.plusDays(1))
+      }
     }
 
     @Test
@@ -667,7 +632,7 @@ internal class PlantingSeasonStoreTest : DatabaseTest(), RunsAsDatabaseUser {
               name = "Season",
               startDate = startDate,
               endDate = endDate,
-              status = PlantingSeasonStatus.Closed,
+              status = PlantingSeasonStatus.Active,
           )
 
       store.update(plantingSeasonId, "New Season", startDate, endDate)
@@ -679,7 +644,7 @@ internal class PlantingSeasonStoreTest : DatabaseTest(), RunsAsDatabaseUser {
               plantingSiteId = plantingSiteId,
               startDate = startDate,
               endDate = endDate,
-              statusId = PlantingSeasonStatus.Closed,
+              statusId = PlantingSeasonStatus.Active,
               createdBy = user.userId,
               createdTime = Instant.EPOCH,
               modifiedBy = user.userId,


### PR DESCRIPTION
Throw an exception for any edits on a planting season if the season's status is closed. This includes name, date range, species targets, and schedule dates.

Also fix a bug where changing the name of a season without modifying the dates still changed the status (the status changes by the `PlantingSeasonsScheduler`).