### PR TITLE
SW-8418 Add planting season allocated species to search api

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/search/table/PlantingSeasonAllocatedSpeciesTable.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/table/PlantingSeasonAllocatedSpeciesTable.kt
@@ -1,0 +1,45 @@
+package com.terraformation.backend.search.table
+
+import com.terraformation.backend.db.default_schema.tables.references.SPECIES
+import com.terraformation.backend.db.tracking.tables.references.PLANTING_SEASONS
+import com.terraformation.backend.db.tracking.tables.references.PLANTING_SEASON_ALLOCATED_SPECIES
+import com.terraformation.backend.search.SearchTable
+import com.terraformation.backend.search.SublistField
+import com.terraformation.backend.search.field.SearchField
+import org.jooq.Record
+import org.jooq.SelectJoinStep
+import org.jooq.TableField
+
+class PlantingSeasonAllocatedSpeciesTable(private val tables: SearchTables) : SearchTable() {
+  override val primaryKey: TableField<out Record, out Any?>
+    get() = PLANTING_SEASON_ALLOCATED_SPECIES.PLANTING_SEASON_ALLOCATED_SPECIES_ID
+
+  override val sublists: List<SublistField> by lazy {
+    with(tables) {
+      listOf(
+          plantingSeasons.asSingleValueSublist(
+              "plantingSeason",
+              PLANTING_SEASON_ALLOCATED_SPECIES.PLANTING_SEASON_ID.eq(PLANTING_SEASONS.ID),
+          ),
+          species.asSingleValueSublist(
+              "species",
+              PLANTING_SEASON_ALLOCATED_SPECIES.SPECIES_ID.eq(SPECIES.ID),
+          ),
+      )
+    }
+  }
+
+  override val fields: List<SearchField> =
+      listOf(
+          integerField("quantity", PLANTING_SEASON_ALLOCATED_SPECIES.QUANTITY),
+      )
+
+  override val inheritsVisibilityFrom: SearchTable
+    get() = tables.plantingSeasons
+
+  override fun <T : Record> joinForVisibility(query: SelectJoinStep<T>): SelectJoinStep<T> {
+    return query
+        .join(PLANTING_SEASONS)
+        .on(PLANTING_SEASON_ALLOCATED_SPECIES.PLANTING_SEASON_ID.eq(PLANTING_SEASONS.ID))
+  }
+}

--- a/src/main/kotlin/com/terraformation/backend/search/table/PlantingSeasonsTable.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/table/PlantingSeasonsTable.kt
@@ -2,6 +2,7 @@ package com.terraformation.backend.search.table
 
 import com.terraformation.backend.db.tracking.PlantingSeasonId
 import com.terraformation.backend.db.tracking.tables.references.PLANTING_SEASONS
+import com.terraformation.backend.db.tracking.tables.references.PLANTING_SEASON_ALLOCATED_SPECIES
 import com.terraformation.backend.db.tracking.tables.references.PLANTING_SEASON_SPECIES_TARGETS
 import com.terraformation.backend.db.tracking.tables.references.PLANTING_SITE_SUMMARIES
 import com.terraformation.backend.db.tracking.tables.references.SCHEDULED_PLANTING_DATES
@@ -19,6 +20,10 @@ class PlantingSeasonsTable(private val tables: SearchTables) : SearchTable() {
   override val sublists: List<SublistField> by lazy {
     with(tables) {
       listOf(
+          plantingSeasonAllocatedSpeciesTable.asMultiValueSublist(
+              "allocatedSpecies",
+              PLANTING_SEASONS.ID.eq(PLANTING_SEASON_ALLOCATED_SPECIES.PLANTING_SEASON_ID),
+          ),
           plantingSites.asSingleValueSublist(
               "plantingSite",
               PLANTING_SEASONS.PLANTING_SITE_ID.eq(PLANTING_SITE_SUMMARIES.ID),

--- a/src/main/kotlin/com/terraformation/backend/search/table/SearchTables.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/table/SearchTables.kt
@@ -69,6 +69,7 @@ class SearchTables(clock: Clock) {
   val participantProjectSpecies = ParticipantProjectSpeciesTable(this)
   val plantings = PlantingsTable(this)
   val plantingSeasons = PlantingSeasonsTable(this)
+  val plantingSeasonAllocatedSpeciesTable = PlantingSeasonAllocatedSpeciesTable(this)
   val plantingSeasonScheduledDates = PlantingSeasonScheduledDatesTable(this)
   val plantingSeasonSpeciesTargets = PlantingSeasonSpeciesTargetsTable(this)
   val plantingSiteHistories = PlantingSiteHistoriesTable(this)

--- a/src/main/resources/i18n/Messages_en.properties
+++ b/src/main/resources/i18n/Messages_en.properties
@@ -856,6 +856,7 @@ search.plantingSeasons.id=Planting season ID
 search.plantingSeasons.status=Planting season status
 search.plantingSeasons.name=Planting season name
 search.plantingSeasons.startDate=Planting season start date
+search.plantingSeasonAllocatedSpecies.quantity=Planting season allocated species quantity
 search.plantingSeasonSpeciesTargets.quantity=Planting season species target quantity
 search.plantingSeasonScheduledDates.date=Planting season scheduled planting date
 search.plantingSiteHistories.boundary=Planting site history boundary

--- a/src/main/resources/i18n/Messages_es.properties
+++ b/src/main/resources/i18n/Messages_es.properties
@@ -1525,6 +1525,8 @@ search.plantings.notes=Notas (plantación)
 search.plantings.numPlants=Número de plantas
 # 2308003f
 search.plantings.type=Tipo de plantación
+# 9da98c2e
+search.plantingSeasonAllocatedSpecies.quantity=Cantidad de especies asignadas a la temporada de plantación
 # 3f174563
 search.plantingSeasons.endDate=Fecha final de la época de siembra
 # ce2bcedb

--- a/src/main/resources/i18n/Messages_fr.properties
+++ b/src/main/resources/i18n/Messages_fr.properties
@@ -1525,6 +1525,8 @@ search.plantings.notes=Notes (plantation)
 search.plantings.numPlants=Nombre de plantes
 # 2308003f
 search.plantings.type=Type de plantation
+# 9da98c2e
+search.plantingSeasonAllocatedSpecies.quantity=Quantité d''espèces attribuées à la saison de plantation
 # 3f174563
 search.plantingSeasons.endDate=Date de fin de la saison de plantation
 # ce2bcedb

--- a/src/test/kotlin/com/terraformation/backend/db/DatabaseBackedTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/db/DatabaseBackedTest.kt
@@ -458,6 +458,7 @@ import com.terraformation.backend.db.tracking.tables.daos.ObservationStratumResu
 import com.terraformation.backend.db.tracking.tables.daos.ObservationSubstratumResultsDao
 import com.terraformation.backend.db.tracking.tables.daos.ObservationsDao
 import com.terraformation.backend.db.tracking.tables.daos.ObservedPlotCoordinatesDao
+import com.terraformation.backend.db.tracking.tables.daos.PlantingSeasonAllocatedSpeciesDao
 import com.terraformation.backend.db.tracking.tables.daos.PlantingSeasonSpeciesTargetsDao
 import com.terraformation.backend.db.tracking.tables.daos.PlantingSeasonsDao
 import com.terraformation.backend.db.tracking.tables.daos.PlantingSiteHistoriesDao
@@ -503,6 +504,7 @@ import com.terraformation.backend.db.tracking.tables.pojos.ObservedPlotCoordinat
 import com.terraformation.backend.db.tracking.tables.pojos.ObservedSiteSpeciesTotalsRow
 import com.terraformation.backend.db.tracking.tables.pojos.ObservedStratumSpeciesTotalsRow
 import com.terraformation.backend.db.tracking.tables.pojos.ObservedSubstratumSpeciesTotalsRow
+import com.terraformation.backend.db.tracking.tables.pojos.PlantingSeasonAllocatedSpeciesRow
 import com.terraformation.backend.db.tracking.tables.pojos.PlantingSeasonSpeciesTargetsRow
 import com.terraformation.backend.db.tracking.tables.pojos.PlantingSeasonsRow
 import com.terraformation.backend.db.tracking.tables.pojos.PlantingSiteHistoriesRow
@@ -739,6 +741,7 @@ abstract class DatabaseBackedTest {
   protected val participantProjectSpeciesDao: ParticipantProjectSpeciesDao by lazyDao()
   protected val plantingsDao: PlantingsDao by lazyDao()
   protected val plantingSeasonsDao: PlantingSeasonsDao by lazyDao()
+  protected val plantingSeasonAllocatedSpeciesDao: PlantingSeasonAllocatedSpeciesDao by lazyDao()
   protected val plantingSeasonSpeciesTargetsDao: PlantingSeasonSpeciesTargetsDao by lazyDao()
   protected val plantingSiteHistoriesDao: PlantingSiteHistoriesDao by lazyDao()
   protected val plantingSiteNotificationsDao: PlantingSiteNotificationsDao by lazyDao()
@@ -2307,6 +2310,30 @@ abstract class DatabaseBackedTest {
     plantingSeasonsDao.insert(rowWithDefaults)
 
     return rowWithDefaults.id!!.also { inserted.plantingSeasonIds.add(it) }
+  }
+
+  fun insertPlantingSeasonAllocatedSpecies(
+      row: PlantingSeasonAllocatedSpeciesRow = PlantingSeasonAllocatedSpeciesRow(),
+      createdBy: UserId = row.createdBy ?: currentUser().userId,
+      createdTime: Instant = row.createdTime ?: Instant.EPOCH,
+      modifiedBy: UserId = row.modifiedBy ?: createdBy,
+      modifiedTime: Instant = row.modifiedTime ?: createdTime,
+      plantingSeasonId: PlantingSeasonId = row.plantingSeasonId ?: inserted.plantingSeasonId,
+      quantity: Int = row.quantity ?: 1,
+      speciesId: SpeciesId = row.speciesId ?: inserted.speciesId,
+  ) {
+    val rowWithDefaults =
+        row.copy(
+            createdBy = createdBy,
+            createdTime = createdTime,
+            modifiedBy = modifiedBy,
+            modifiedTime = modifiedTime,
+            plantingSeasonId = plantingSeasonId,
+            quantity = quantity,
+            speciesId = speciesId,
+        )
+
+    plantingSeasonAllocatedSpeciesDao.insert(rowWithDefaults)
   }
 
   fun insertPlantingSeasonSpeciesTarget(

--- a/src/test/kotlin/com/terraformation/backend/tracking/TrackingSearchTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/TrackingSearchTest.kt
@@ -127,6 +127,8 @@ class TrackingSearchTest : DatabaseTest(), RunsAsUser {
         substratumId = substratumId3,
         quantity = 14,
     )
+    insertPlantingSeasonAllocatedSpecies(speciesId = speciesId1, quantity = 15)
+    insertPlantingSeasonAllocatedSpecies(speciesId = speciesId2, quantity = 16)
 
     val plantingSeasonId2 =
         insertPlantingSeason(
@@ -136,6 +138,7 @@ class TrackingSearchTest : DatabaseTest(), RunsAsUser {
             status = PlantingSeasonStatus.Upcoming,
         )
     insertPlantingSeasonSpeciesTarget(quantity = 12)
+    insertPlantingSeasonAllocatedSpecies(speciesId = speciesId1, quantity = 17)
 
     insertFacility(type = FacilityType.Nursery)
 
@@ -609,6 +612,17 @@ class TrackingSearchTest : DatabaseTest(), RunsAsUser {
                                 "endDate" to "1970-02-15",
                                 "id" to "$plantingSeasonId1",
                                 "name" to "Season 1",
+                                "allocatedSpecies" to
+                                    listOf(
+                                        mapOf(
+                                            "quantity" to "15",
+                                            "species" to mapOf("scientificName" to "Species 1"),
+                                        ),
+                                        mapOf(
+                                            "quantity" to "16",
+                                            "species" to mapOf("scientificName" to "Species 2"),
+                                        ),
+                                    ),
                                 "scheduledDates" to
                                     listOf(
                                         mapOf(
@@ -657,6 +671,13 @@ class TrackingSearchTest : DatabaseTest(), RunsAsUser {
                                 "endDate" to "1970-06-05",
                                 "id" to "$plantingSeasonId2",
                                 "name" to "Season 2",
+                                "allocatedSpecies" to
+                                    listOf(
+                                        mapOf(
+                                            "quantity" to "17",
+                                            "species" to mapOf("scientificName" to "Species 1"),
+                                        ),
+                                    ),
                                 "speciesTargets" to
                                     listOf(
                                         mapOf(
@@ -1001,6 +1022,8 @@ class TrackingSearchTest : DatabaseTest(), RunsAsUser {
                 "plantingSeasons.name",
                 "plantingSeasons.startDate",
                 "plantingSeasons.status",
+                "plantingSeasons.allocatedSpecies.quantity",
+                "plantingSeasons.allocatedSpecies.species.scientificName",
                 "plantingSeasons.speciesTargets.quantity",
                 "plantingSeasons.speciesTargets.species.scientificName",
                 "plantingSeasons.speciesTargets.substratum.name",


### PR DESCRIPTION
There doesn't really seem to be a need for a Read method for allocated species in a planting season. Instead add it to the search api since other items will be retrieved at the same time to meet the FE requirements (e.g. available in nursery by species, target sum per season and total, etc)