### PR TITLE
SW-8418 Remove allocated species when there are no other targets in the planting season

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/plantingmanagement/db/PlantingSeasonAllocatedSpeciesStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/plantingmanagement/db/PlantingSeasonAllocatedSpeciesStore.kt
@@ -7,9 +7,12 @@ import com.terraformation.backend.db.tracking.PlantingSeasonId
 import com.terraformation.backend.db.tracking.PlantingSeasonStatus
 import com.terraformation.backend.db.tracking.tables.references.PLANTING_SEASONS
 import com.terraformation.backend.db.tracking.tables.references.PLANTING_SEASON_ALLOCATED_SPECIES
+import com.terraformation.backend.db.tracking.tables.references.PLANTING_SEASON_SPECIES_TARGETS
+import com.terraformation.backend.plantingmanagement.event.PlantingSeasonSpeciesTargetDeletedEvent
 import jakarta.inject.Named
 import java.time.InstantSource
 import org.jooq.DSLContext
+import org.springframework.context.event.EventListener
 
 @Named
 class PlantingSeasonAllocatedSpeciesStore(
@@ -40,6 +43,30 @@ class PlantingSeasonAllocatedSpeciesStore(
           .set(QUANTITY, quantity)
           .set(MODIFIED_BY, userId)
           .set(MODIFIED_TIME, now)
+          .execute()
+    }
+  }
+
+  @EventListener
+  fun on(event: PlantingSeasonSpeciesTargetDeletedEvent) {
+    val remainingSpeciesTargets =
+        dslContext
+            .selectCount()
+            .from(PLANTING_SEASON_SPECIES_TARGETS)
+            .where(PLANTING_SEASON_SPECIES_TARGETS.PLANTING_SEASON_ID.eq(event.plantingSeasonId))
+            .and(PLANTING_SEASON_SPECIES_TARGETS.SPECIES_ID.eq(event.speciesId))
+            .fetchOne(0, Int::class.java) ?: 0
+
+    if (remainingSpeciesTargets == 0) {
+      delete(event.plantingSeasonId, event.speciesId)
+    }
+  }
+
+  private fun delete(plantingSeasonId: PlantingSeasonId, speciesId: SpeciesId) {
+    with(PLANTING_SEASON_ALLOCATED_SPECIES) {
+      dslContext
+          .deleteFrom(PLANTING_SEASON_ALLOCATED_SPECIES)
+          .where(PLANTING_SEASON_ID.eq(plantingSeasonId).and(SPECIES_ID.eq(speciesId)))
           .execute()
     }
   }

--- a/src/main/kotlin/com/terraformation/backend/plantingmanagement/db/PlantingSeasonAllocatedSpeciesStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/plantingmanagement/db/PlantingSeasonAllocatedSpeciesStore.kt
@@ -66,7 +66,8 @@ class PlantingSeasonAllocatedSpeciesStore(
     with(PLANTING_SEASON_ALLOCATED_SPECIES) {
       dslContext
           .deleteFrom(PLANTING_SEASON_ALLOCATED_SPECIES)
-          .where(PLANTING_SEASON_ID.eq(plantingSeasonId).and(SPECIES_ID.eq(speciesId)))
+          .where(PLANTING_SEASON_ID.eq(plantingSeasonId))
+          .and(SPECIES_ID.eq(speciesId))
           .execute()
     }
   }

--- a/src/main/kotlin/com/terraformation/backend/plantingmanagement/db/PlantingSeasonSpeciesTargetsStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/plantingmanagement/db/PlantingSeasonSpeciesTargetsStore.kt
@@ -1,7 +1,6 @@
 package com.terraformation.backend.plantingmanagement.db
 
 import com.terraformation.backend.auth.currentUser
-import com.terraformation.backend.customer.db.ParentStore
 import com.terraformation.backend.customer.model.requirePermissions
 import com.terraformation.backend.db.default_schema.SpeciesId
 import com.terraformation.backend.db.tracking.PlantingSeasonId
@@ -10,8 +9,7 @@ import com.terraformation.backend.db.tracking.SubstratumId
 import com.terraformation.backend.db.tracking.tables.references.PLANTING_SEASONS
 import com.terraformation.backend.db.tracking.tables.references.PLANTING_SEASON_SPECIES_TARGETS
 import com.terraformation.backend.plantingmanagement.PlantingSeasonSpeciesTargetModel
-import com.terraformation.backend.plantingmanagement.event.PlantingSeasonSpeciesTargetDeletedEventV1
-import com.terraformation.backend.tracking.db.PlantingSiteNotFoundException
+import com.terraformation.backend.plantingmanagement.event.PlantingSeasonSpeciesTargetDeletedEvent
 import jakarta.inject.Named
 import java.time.InstantSource
 import org.jooq.Condition
@@ -24,7 +22,6 @@ class PlantingSeasonSpeciesTargetsStore(
     private val clock: InstantSource,
     private val dslContext: DSLContext,
     private val eventPublisher: ApplicationEventPublisher,
-    private val parentStore: ParentStore,
 ) {
   fun fetchList(plantingSeasonId: PlantingSeasonId): List<PlantingSeasonSpeciesTargetModel> {
     requirePermissions { readPlantingSeason(plantingSeasonId) }
@@ -118,14 +115,6 @@ class PlantingSeasonSpeciesTargetsStore(
 
     validateSeasonNotClosed(plantingSeasonId)
 
-    val plantingSiteId =
-        parentStore.getPlantingSiteId(plantingSeasonId)
-            ?: throw PlantingSeasonNotFoundException(plantingSeasonId)
-
-    val organizationId =
-        parentStore.getOrganizationId(plantingSiteId)
-            ?: throw PlantingSiteNotFoundException(plantingSiteId)
-
     with(PLANTING_SEASON_SPECIES_TARGETS) {
       dslContext
           .deleteFrom(PLANTING_SEASON_SPECIES_TARGETS)
@@ -135,10 +124,8 @@ class PlantingSeasonSpeciesTargetsStore(
           .execute()
 
       eventPublisher.publishEvent(
-          PlantingSeasonSpeciesTargetDeletedEventV1(
-              organizationId = organizationId,
+          PlantingSeasonSpeciesTargetDeletedEvent(
               plantingSeasonId = plantingSeasonId,
-              plantingSiteId = plantingSiteId,
               speciesId = speciesId,
               substratumId = substratumId,
           )

--- a/src/main/kotlin/com/terraformation/backend/plantingmanagement/db/PlantingSeasonSpeciesTargetsStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/plantingmanagement/db/PlantingSeasonSpeciesTargetsStore.kt
@@ -1,6 +1,7 @@
 package com.terraformation.backend.plantingmanagement.db
 
 import com.terraformation.backend.auth.currentUser
+import com.terraformation.backend.customer.db.ParentStore
 import com.terraformation.backend.customer.model.requirePermissions
 import com.terraformation.backend.db.default_schema.SpeciesId
 import com.terraformation.backend.db.tracking.PlantingSeasonId
@@ -9,16 +10,21 @@ import com.terraformation.backend.db.tracking.SubstratumId
 import com.terraformation.backend.db.tracking.tables.references.PLANTING_SEASONS
 import com.terraformation.backend.db.tracking.tables.references.PLANTING_SEASON_SPECIES_TARGETS
 import com.terraformation.backend.plantingmanagement.PlantingSeasonSpeciesTargetModel
+import com.terraformation.backend.plantingmanagement.event.PlantingSeasonSpeciesTargetDeletedEventV1
+import com.terraformation.backend.tracking.db.PlantingSiteNotFoundException
 import jakarta.inject.Named
 import java.time.InstantSource
 import org.jooq.Condition
 import org.jooq.DSLContext
 import org.jooq.impl.DSL
+import org.springframework.context.ApplicationEventPublisher
 
 @Named
 class PlantingSeasonSpeciesTargetsStore(
     private val clock: InstantSource,
     private val dslContext: DSLContext,
+    private val eventPublisher: ApplicationEventPublisher,
+    private val parentStore: ParentStore,
 ) {
   fun fetchList(plantingSeasonId: PlantingSeasonId): List<PlantingSeasonSpeciesTargetModel> {
     requirePermissions { readPlantingSeason(plantingSeasonId) }
@@ -112,6 +118,14 @@ class PlantingSeasonSpeciesTargetsStore(
 
     validateSeasonNotClosed(plantingSeasonId)
 
+    val plantingSiteId =
+        parentStore.getPlantingSiteId(plantingSeasonId)
+            ?: throw PlantingSeasonNotFoundException(plantingSeasonId)
+
+    val organizationId =
+        parentStore.getOrganizationId(plantingSiteId)
+            ?: throw PlantingSiteNotFoundException(plantingSiteId)
+
     with(PLANTING_SEASON_SPECIES_TARGETS) {
       dslContext
           .deleteFrom(PLANTING_SEASON_SPECIES_TARGETS)
@@ -119,6 +133,16 @@ class PlantingSeasonSpeciesTargetsStore(
           .and(SUBSTRATUM_ID.eq(substratumId))
           .and(SPECIES_ID.eq(speciesId))
           .execute()
+
+      eventPublisher.publishEvent(
+          PlantingSeasonSpeciesTargetDeletedEventV1(
+              organizationId = organizationId,
+              plantingSeasonId = plantingSeasonId,
+              plantingSiteId = plantingSiteId,
+              speciesId = speciesId,
+              substratumId = substratumId,
+          )
+      )
     }
   }
 

--- a/src/main/kotlin/com/terraformation/backend/plantingmanagement/event/Events.kt
+++ b/src/main/kotlin/com/terraformation/backend/plantingmanagement/event/Events.kt
@@ -82,12 +82,8 @@ typealias PlantingSeasonUpdatedEvent = PlantingSeasonUpdatedEventV1
 
 typealias PlantingSeasonUpdatedEventValues = PlantingSeasonUpdatedEventV1.Values
 
-data class PlantingSeasonSpeciesTargetDeletedEventV1(
-    override val organizationId: OrganizationId,
-    override val plantingSeasonId: PlantingSeasonId,
-    override val plantingSiteId: PlantingSiteId,
+data class PlantingSeasonSpeciesTargetDeletedEvent(
+    val plantingSeasonId: PlantingSeasonId,
     val speciesId: SpeciesId,
     val substratumId: SubstratumId,
-) : EntityDeletedPersistentEvent, PlantingSeasonPersistentEvent
-
-typealias PlantingSeasonSpeciesTargetDeletedEvent = PlantingSeasonSpeciesTargetDeletedEventV1
+)

--- a/src/main/kotlin/com/terraformation/backend/plantingmanagement/event/Events.kt
+++ b/src/main/kotlin/com/terraformation/backend/plantingmanagement/event/Events.kt
@@ -1,9 +1,11 @@
 package com.terraformation.backend.plantingmanagement.event
 
 import com.terraformation.backend.db.default_schema.OrganizationId
+import com.terraformation.backend.db.default_schema.SpeciesId
 import com.terraformation.backend.db.tracking.PlantingSeasonId
 import com.terraformation.backend.db.tracking.PlantingSeasonStatus
 import com.terraformation.backend.db.tracking.PlantingSiteId
+import com.terraformation.backend.db.tracking.SubstratumId
 import com.terraformation.backend.eventlog.EntityCreatedPersistentEvent
 import com.terraformation.backend.eventlog.EntityDeletedPersistentEvent
 import com.terraformation.backend.eventlog.FieldsUpdatedPersistentEvent
@@ -79,3 +81,13 @@ data class PlantingSeasonUpdatedEventV1(
 typealias PlantingSeasonUpdatedEvent = PlantingSeasonUpdatedEventV1
 
 typealias PlantingSeasonUpdatedEventValues = PlantingSeasonUpdatedEventV1.Values
+
+data class PlantingSeasonSpeciesTargetDeletedEventV1(
+    override val organizationId: OrganizationId,
+    override val plantingSeasonId: PlantingSeasonId,
+    override val plantingSiteId: PlantingSiteId,
+    val speciesId: SpeciesId,
+    val substratumId: SubstratumId,
+) : EntityDeletedPersistentEvent, PlantingSeasonPersistentEvent
+
+typealias PlantingSeasonSpeciesTargetDeletedEvent = PlantingSeasonSpeciesTargetDeletedEventV1

--- a/src/test/kotlin/com/terraformation/backend/plantingmanagement/PlantingSeasonServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/plantingmanagement/PlantingSeasonServiceTest.kt
@@ -26,11 +26,12 @@ internal class PlantingSeasonServiceTest : DatabaseTest(), RunsAsDatabaseUser {
 
   private val clock = TestClock()
   private val eventPublisher = TestEventPublisher()
+  private val parentStore = ParentStore(dslContext)
   private val plantingSeasonSpeciesTargetsStore: PlantingSeasonSpeciesTargetsStore by lazy {
-    PlantingSeasonSpeciesTargetsStore(clock, dslContext)
+    PlantingSeasonSpeciesTargetsStore(clock, dslContext, eventPublisher, parentStore)
   }
   private val plantingSeasonStore: PlantingSeasonStore by lazy {
-    PlantingSeasonStore(clock, dslContext, eventPublisher, ParentStore(dslContext))
+    PlantingSeasonStore(clock, dslContext, eventPublisher, parentStore)
   }
   private val service: PlantingSeasonService by lazy {
     PlantingSeasonService(dslContext, plantingSeasonStore, plantingSeasonSpeciesTargetsStore)

--- a/src/test/kotlin/com/terraformation/backend/plantingmanagement/PlantingSeasonServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/plantingmanagement/PlantingSeasonServiceTest.kt
@@ -26,9 +26,7 @@ internal class PlantingSeasonServiceTest : DatabaseTest(), RunsAsDatabaseUser {
 
   private val clock = TestClock()
   private val eventPublisher = TestEventPublisher()
-  private val parentStore: ParentStore by lazy {
-    ParentStore(dslContext)
-  }
+  private val parentStore: ParentStore by lazy { ParentStore(dslContext) }
   private val plantingSeasonSpeciesTargetsStore: PlantingSeasonSpeciesTargetsStore by lazy {
     PlantingSeasonSpeciesTargetsStore(clock, dslContext, eventPublisher)
   }

--- a/src/test/kotlin/com/terraformation/backend/plantingmanagement/PlantingSeasonServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/plantingmanagement/PlantingSeasonServiceTest.kt
@@ -26,9 +26,11 @@ internal class PlantingSeasonServiceTest : DatabaseTest(), RunsAsDatabaseUser {
 
   private val clock = TestClock()
   private val eventPublisher = TestEventPublisher()
-  private val parentStore = ParentStore(dslContext)
+  private val parentStore: ParentStore by lazy {
+    ParentStore(dslContext)
+  }
   private val plantingSeasonSpeciesTargetsStore: PlantingSeasonSpeciesTargetsStore by lazy {
-    PlantingSeasonSpeciesTargetsStore(clock, dslContext, eventPublisher, parentStore)
+    PlantingSeasonSpeciesTargetsStore(clock, dslContext, eventPublisher)
   }
   private val plantingSeasonStore: PlantingSeasonStore by lazy {
     PlantingSeasonStore(clock, dslContext, eventPublisher, parentStore)

--- a/src/test/kotlin/com/terraformation/backend/plantingmanagement/db/PlantingSeasonAllocatedSpeciesStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/plantingmanagement/db/PlantingSeasonAllocatedSpeciesStoreTest.kt
@@ -9,6 +9,8 @@ import com.terraformation.backend.db.default_schema.SpeciesId
 import com.terraformation.backend.db.tracking.PlantingSeasonId
 import com.terraformation.backend.db.tracking.PlantingSeasonStatus
 import com.terraformation.backend.db.tracking.tables.records.PlantingSeasonAllocatedSpeciesRecord
+import com.terraformation.backend.db.tracking.tables.references.PLANTING_SEASON_ALLOCATED_SPECIES
+import com.terraformation.backend.plantingmanagement.event.PlantingSeasonSpeciesTargetDeletedEvent
 import java.time.Instant
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
@@ -91,6 +93,58 @@ internal class PlantingSeasonAllocatedSpeciesStoreTest : DatabaseTest(), RunsAsD
       assertThrows<AccessDeniedException> {
         store.upsert(plantingSeasonId, speciesId, quantity = 5)
       }
+    }
+  }
+
+  @Nested
+  inner class SpeciesTargetDeletedEvent {
+    @Test
+    fun `doesn't delete allocated species when target exists`() {
+      insertStratum()
+      val substratumId1 = insertSubstratum()
+      insertPlantingSeasonSpeciesTarget(substratumId = substratumId1, quantity = 5)
+      insertPlantingSeasonAllocatedSpecies(speciesId = speciesId, quantity = 15)
+
+      store.on(
+          PlantingSeasonSpeciesTargetDeletedEvent(
+              organizationId = inserted.organizationId,
+              plantingSiteId = inserted.plantingSiteId,
+              plantingSeasonId = plantingSeasonId,
+              speciesId = speciesId,
+              substratumId = substratumId1,
+          )
+      )
+
+      assertTableEquals(
+          PlantingSeasonAllocatedSpeciesRecord(
+              plantingSeasonId = plantingSeasonId,
+              speciesId = speciesId,
+              quantity = 15,
+              createdBy = user.userId,
+              createdTime = Instant.EPOCH,
+              modifiedBy = user.userId,
+              modifiedTime = clock.instant,
+          ),
+      )
+    }
+
+    @Test
+    fun `deletes allocated species when no more targets exist`() {
+      insertStratum()
+      val substratumId1 = insertSubstratum()
+      insertPlantingSeasonAllocatedSpecies(speciesId = speciesId, quantity = 15)
+
+      store.on(
+          PlantingSeasonSpeciesTargetDeletedEvent(
+              organizationId = inserted.organizationId,
+              plantingSiteId = inserted.plantingSiteId,
+              plantingSeasonId = plantingSeasonId,
+              speciesId = speciesId,
+              substratumId = substratumId1,
+          )
+      )
+
+      assertTableEmpty(PLANTING_SEASON_ALLOCATED_SPECIES)
     }
   }
 }

--- a/src/test/kotlin/com/terraformation/backend/plantingmanagement/db/PlantingSeasonAllocatedSpeciesStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/plantingmanagement/db/PlantingSeasonAllocatedSpeciesStoreTest.kt
@@ -107,8 +107,6 @@ internal class PlantingSeasonAllocatedSpeciesStoreTest : DatabaseTest(), RunsAsD
 
       store.on(
           PlantingSeasonSpeciesTargetDeletedEvent(
-              organizationId = inserted.organizationId,
-              plantingSiteId = inserted.plantingSiteId,
               plantingSeasonId = plantingSeasonId,
               speciesId = speciesId,
               substratumId = substratumId1,
@@ -136,8 +134,6 @@ internal class PlantingSeasonAllocatedSpeciesStoreTest : DatabaseTest(), RunsAsD
 
       store.on(
           PlantingSeasonSpeciesTargetDeletedEvent(
-              organizationId = inserted.organizationId,
-              plantingSiteId = inserted.plantingSiteId,
               plantingSeasonId = plantingSeasonId,
               speciesId = speciesId,
               substratumId = substratumId1,

--- a/src/test/kotlin/com/terraformation/backend/plantingmanagement/db/PlantingSeasonSpeciesTargetsStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/plantingmanagement/db/PlantingSeasonSpeciesTargetsStoreTest.kt
@@ -2,6 +2,8 @@ package com.terraformation.backend.plantingmanagement.db
 
 import com.terraformation.backend.RunsAsDatabaseUser
 import com.terraformation.backend.TestClock
+import com.terraformation.backend.TestEventPublisher
+import com.terraformation.backend.customer.db.ParentStore
 import com.terraformation.backend.customer.model.TerrawareUser
 import com.terraformation.backend.db.DatabaseTest
 import com.terraformation.backend.db.default_schema.Role
@@ -11,6 +13,7 @@ import com.terraformation.backend.db.tracking.PlantingSeasonStatus
 import com.terraformation.backend.db.tracking.SubstratumId
 import com.terraformation.backend.db.tracking.tables.records.PlantingSeasonSpeciesTargetsRecord
 import com.terraformation.backend.plantingmanagement.PlantingSeasonSpeciesTargetModel
+import com.terraformation.backend.plantingmanagement.event.PlantingSeasonSpeciesTargetDeletedEvent
 import java.time.Instant
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
@@ -23,8 +26,9 @@ internal class PlantingSeasonSpeciesTargetsStoreTest : DatabaseTest(), RunsAsDat
   override lateinit var user: TerrawareUser
 
   private val clock = TestClock()
+  private val eventPublisher = TestEventPublisher()
   private val store: PlantingSeasonSpeciesTargetsStore by lazy {
-    PlantingSeasonSpeciesTargetsStore(clock, dslContext)
+    PlantingSeasonSpeciesTargetsStore(clock, dslContext, eventPublisher, ParentStore(dslContext))
   }
 
   private lateinit var plantingSeasonId: PlantingSeasonId
@@ -265,6 +269,16 @@ internal class PlantingSeasonSpeciesTargetsStoreTest : DatabaseTest(), RunsAsDat
               createdTime = Instant.EPOCH,
               modifiedBy = user.userId,
               modifiedTime = clock.instant,
+          )
+      )
+
+      eventPublisher.assertEventPublished(
+          PlantingSeasonSpeciesTargetDeletedEvent(
+              organizationId = inserted.organizationId,
+              plantingSeasonId = plantingSeasonId,
+              plantingSiteId = inserted.plantingSiteId,
+              speciesId = speciesId,
+              substratumId = substratumId,
           )
       )
     }

--- a/src/test/kotlin/com/terraformation/backend/plantingmanagement/db/PlantingSeasonSpeciesTargetsStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/plantingmanagement/db/PlantingSeasonSpeciesTargetsStoreTest.kt
@@ -3,7 +3,6 @@ package com.terraformation.backend.plantingmanagement.db
 import com.terraformation.backend.RunsAsDatabaseUser
 import com.terraformation.backend.TestClock
 import com.terraformation.backend.TestEventPublisher
-import com.terraformation.backend.customer.db.ParentStore
 import com.terraformation.backend.customer.model.TerrawareUser
 import com.terraformation.backend.db.DatabaseTest
 import com.terraformation.backend.db.default_schema.Role
@@ -28,7 +27,7 @@ internal class PlantingSeasonSpeciesTargetsStoreTest : DatabaseTest(), RunsAsDat
   private val clock = TestClock()
   private val eventPublisher = TestEventPublisher()
   private val store: PlantingSeasonSpeciesTargetsStore by lazy {
-    PlantingSeasonSpeciesTargetsStore(clock, dslContext, eventPublisher, ParentStore(dslContext))
+    PlantingSeasonSpeciesTargetsStore(clock, dslContext, eventPublisher)
   }
 
   private lateinit var plantingSeasonId: PlantingSeasonId
@@ -274,9 +273,7 @@ internal class PlantingSeasonSpeciesTargetsStoreTest : DatabaseTest(), RunsAsDat
 
       eventPublisher.assertEventPublished(
           PlantingSeasonSpeciesTargetDeletedEvent(
-              organizationId = inserted.organizationId,
               plantingSeasonId = plantingSeasonId,
-              plantingSiteId = inserted.plantingSiteId,
               speciesId = speciesId,
               substratumId = substratumId,
           )


### PR DESCRIPTION
When the last target x substratum combo is removed for a species from a planting season, the allocated quantity is no longer useful. Remove it from the DB at this time.

Create the `PlantingSeasonSpeciesTargetDeletedEvent`(s) to use for this, which will also be used later on by the changelog.