### PR TITLE
Support activity media files without captured times

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/accelerator/api/ActivitiesAdminController.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/api/ActivitiesAdminController.kt
@@ -125,7 +125,7 @@ data class AdminActivityObservationMediaFilePayload(
 
 data class AdminActivityMediaFilePayload(
     val caption: String?,
-    val capturedDate: LocalDate,
+    val capturedDate: LocalDate?,
     val createdBy: UserId,
     val createdTime: Instant,
     val fileId: FileId,

--- a/src/main/kotlin/com/terraformation/backend/accelerator/api/ActivitiesController.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/api/ActivitiesController.kt
@@ -230,7 +230,7 @@ data class ActivityObservationMediaFilePayload(
 
 data class ActivityMediaFilePayload(
     val caption: String?,
-    val capturedDate: LocalDate,
+    val capturedDate: LocalDate?,
     val fileId: FileId,
     val fileName: String,
     val geolocation: Point?,

--- a/src/main/kotlin/com/terraformation/backend/accelerator/model/ActivityMediaModel.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/model/ActivityMediaModel.kt
@@ -22,7 +22,7 @@ import org.locationtech.jts.geom.Point
 data class ActivityMediaModel(
     val activityId: ActivityId,
     val caption: String?,
-    val capturedLocalTime: LocalDateTime,
+    val capturedLocalTime: LocalDateTime?,
     val createdBy: UserId,
     val createdTime: Instant,
     val fileId: FileId,
@@ -34,8 +34,8 @@ data class ActivityMediaModel(
     val observation: Observation? = null,
     val type: ActivityMediaType,
 ) {
-  val capturedDate: LocalDate
-    get() = capturedLocalTime.toLocalDate()
+  val capturedDate: LocalDate?
+    get() = capturedLocalTime?.toLocalDate()
 
   data class Observation(
       val monitoringPlotNumber: Long,
@@ -52,7 +52,7 @@ data class ActivityMediaModel(
       return ActivityMediaModel(
           activityId = record[ACTIVITY_MEDIA_FILES.ACTIVITY_ID]!!,
           caption = record[ACTIVITY_MEDIA_FILES.CAPTION],
-          capturedLocalTime = record[FILES.CAPTURED_LOCAL_TIME]!!,
+          capturedLocalTime = record[FILES.CAPTURED_LOCAL_TIME],
           createdBy = record[FILES.CREATED_BY]!!,
           createdTime = record[FILES.CREATED_TIME]!!,
           fileId = record[ACTIVITY_MEDIA_FILES.FILE_ID]!!,

--- a/src/main/kotlin/com/terraformation/backend/funder/api/FunderActivitiesController.kt
+++ b/src/main/kotlin/com/terraformation/backend/funder/api/FunderActivitiesController.kt
@@ -106,7 +106,7 @@ data class FunderObservationActivityMediaFilePayload(
 
 data class FunderActivityMediaFilePayload(
     val caption: String?,
-    val capturedDate: LocalDate,
+    val capturedDate: LocalDate?,
     val fileId: FileId,
     val fileName: String,
     val geolocation: Point?,

--- a/src/main/kotlin/com/terraformation/backend/funder/model/PublishedActivityMediaModel.kt
+++ b/src/main/kotlin/com/terraformation/backend/funder/model/PublishedActivityMediaModel.kt
@@ -19,7 +19,7 @@ import org.locationtech.jts.geom.Point
 data class PublishedActivityMediaModel(
     val activityId: ActivityId,
     val caption: String?,
-    val capturedLocalTime: LocalDateTime,
+    val capturedLocalTime: LocalDateTime?,
     val fileId: FileId,
     val fileName: String,
     val geolocation: Point?,
@@ -29,8 +29,8 @@ data class PublishedActivityMediaModel(
     val observation: Observation? = null,
     val type: ActivityMediaType,
 ) {
-  val capturedDate: LocalDate
-    get() = capturedLocalTime.toLocalDate()
+  val capturedDate: LocalDate?
+    get() = capturedLocalTime?.toLocalDate()
 
   data class Observation(
       val monitoringPlotNumber: Long,
@@ -61,7 +61,7 @@ data class PublishedActivityMediaModel(
         PublishedActivityMediaModel(
             activityId = record[ACTIVITY_ID]!!,
             caption = record[CAPTION],
-            capturedLocalTime = record[FILES.CAPTURED_LOCAL_TIME]!!,
+            capturedLocalTime = record[FILES.CAPTURED_LOCAL_TIME],
             fileId = record[FILE_ID]!!,
             fileName = record[FILES.STORAGE_URL]!!.toString().substringAfterLast('/'),
             geolocation = record[geolocationField] as? Point,

--- a/src/test/kotlin/com/terraformation/backend/accelerator/db/ActivityMediaStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/db/ActivityMediaStoreTest.kt
@@ -94,6 +94,33 @@ class ActivityMediaStoreTest : DatabaseTest(), RunsAsDatabaseUser {
           files.map { it.observation },
       )
     }
+
+    @Test
+    fun `returns files without captured times`() {
+      insertFile()
+      insertActivityMediaFile()
+
+      val files = store.fetchByActivityId(activityId)
+      assertEquals(
+          listOf(
+              ActivityMediaModel(
+                  activityId = activityId,
+                  caption = null,
+                  capturedLocalTime = null,
+                  createdBy = user.userId,
+                  createdTime = Instant.EPOCH,
+                  fileId = inserted.fileId,
+                  fileName = "1",
+                  geolocation = null,
+                  isCoverPhoto = false,
+                  isHiddenOnMap = false,
+                  listPosition = 1,
+                  type = ActivityMediaType.Photo,
+              )
+          ),
+          files,
+      )
+    }
   }
 
   @Nested

--- a/src/test/kotlin/com/terraformation/backend/funder/db/PublishedActivityStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/funder/db/PublishedActivityStoreTest.kt
@@ -109,7 +109,7 @@ class PublishedActivityStoreTest : DatabaseTest(), RunsAsDatabaseUser {
           description = "Activity 2",
       )
       insertPublishedActivityObservation()
-      val activity2FileId = insertFile(capturedLocalTime = LocalDate.EPOCH.atStartOfDay())
+      val activity2FileId = insertFile()
       insertActivityMediaFile()
       insertPublishedActivityMediaFile()
       insertPublishedActivityObservationMediaFile()
@@ -170,7 +170,7 @@ class PublishedActivityStoreTest : DatabaseTest(), RunsAsDatabaseUser {
                           PublishedActivityMediaModel(
                               activityId = activityId2,
                               caption = null,
-                              capturedLocalTime = LocalDate.EPOCH.atStartOfDay(),
+                              capturedLocalTime = null,
                               fileId = activity2FileId,
                               fileName = "2",
                               geolocation = null,


### PR DESCRIPTION
Currently we require activity media files to include captured times, which we
extract from EXIF metadata at upload time. But you can have valid images or videos
that lack that EXIF field; rather than bombing out with NPE, we should just return
a null captured date in the API responses.