### PR TITLE
SW-8432 Associate nursery withdrawals with a planting season if specified, fetch season id

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/nursery/api/WithdrawalsController.kt
+++ b/src/main/kotlin/com/terraformation/backend/nursery/api/WithdrawalsController.kt
@@ -294,7 +294,7 @@ data class CreateNurseryWithdrawalRequestPayload(
     @Schema(
         description =
             "If purpose is \"Out Plant\", the ID of the planting season to which the seedlings " +
-                "were intentioned."
+                "were intended. For \"Undo\" withdrawals, this is inherited from the original withdrawal."
     )
     val plantingSeasonId: PlantingSeasonId? = null,
     @Schema(

--- a/src/main/kotlin/com/terraformation/backend/nursery/api/WithdrawalsController.kt
+++ b/src/main/kotlin/com/terraformation/backend/nursery/api/WithdrawalsController.kt
@@ -25,6 +25,7 @@ import com.terraformation.backend.db.default_schema.FileId
 import com.terraformation.backend.db.nursery.BatchId
 import com.terraformation.backend.db.nursery.WithdrawalId
 import com.terraformation.backend.db.nursery.WithdrawalPurpose
+import com.terraformation.backend.db.tracking.PlantingSeasonId
 import com.terraformation.backend.db.tracking.PlantingSiteId
 import com.terraformation.backend.db.tracking.SubstratumId
 import com.terraformation.backend.file.SUPPORTED_PHOTO_TYPES
@@ -233,6 +234,7 @@ data class NurseryWithdrawalPayload(
     val facilityId: FacilityId,
     val id: WithdrawalId,
     val notes: String?,
+    val plantingSeasonId: PlantingSeasonId?,
     val purpose: WithdrawalPurpose,
     val withdrawnDate: LocalDate,
     @Schema(description = "If purpose is \"Undo\", the ID of the withdrawal this one undoes.")
@@ -248,6 +250,7 @@ data class NurseryWithdrawalPayload(
       model.facilityId,
       model.id,
       model.notes,
+      model.plantingSeasonId,
       model.purpose,
       model.withdrawnDate,
       model.undoesWithdrawalId,
@@ -290,6 +293,12 @@ data class CreateNurseryWithdrawalRequestPayload(
     val notes: String? = null,
     @Schema(
         description =
+            "If purpose is \"Out Plant\", the ID of the planting season to which the seedlings " +
+                "were intentioned."
+    )
+    val plantingSeasonId: PlantingSeasonId? = null,
+    @Schema(
+        description =
             "If purpose is \"Out Plant\", the ID of the planting site to which the seedlings " +
                 "were delivered."
     )
@@ -319,6 +328,7 @@ data class CreateNurseryWithdrawalRequestPayload(
           facilityId = facilityId,
           id = null,
           notes = notes,
+          plantingSeasonId = plantingSeasonId,
           purpose = purpose.purpose,
           withdrawnDate = withdrawnDate,
       )

--- a/src/main/kotlin/com/terraformation/backend/nursery/db/BatchStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/nursery/db/BatchStore.kt
@@ -691,11 +691,8 @@ class BatchStore(
     }
     if (
         withdrawal.plantingSeasonId != null &&
-            !listOf(
-                    WithdrawalPurpose.OutPlant,
-                    WithdrawalPurpose.Undo,
-                )
-                .contains(withdrawal.purpose)
+            withdrawal.purpose != WithdrawalPurpose.OutPlant &&
+            withdrawal.purpose != WithdrawalPurpose.Undo
     ) {
       throw IllegalArgumentException(
           "Planting season may only be specified for out-plant or undo withdrawals"

--- a/src/main/kotlin/com/terraformation/backend/nursery/db/BatchStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/nursery/db/BatchStore.kt
@@ -689,6 +689,18 @@ class BatchStore(
     } else if (withdrawal.destinationFacilityId != null) {
       throw IllegalArgumentException("Only nursery transfers may include destination facility ID")
     }
+    if (
+        withdrawal.plantingSeasonId != null &&
+            !listOf(
+                    WithdrawalPurpose.OutPlant,
+                    WithdrawalPurpose.Undo,
+                )
+                .contains(withdrawal.purpose)
+    ) {
+      throw IllegalArgumentException(
+          "Planting season may only be specified for out-plant or undo withdrawals"
+      )
+    }
 
     return dslContext.transactionResult { _ ->
       val withdrawalsRow =
@@ -700,6 +712,7 @@ class BatchStore(
               modifiedBy = currentUser().userId,
               modifiedTime = clock.instant(),
               notes = withdrawal.notes,
+              plantingSeasonId = withdrawal.plantingSeasonId,
               purposeId = withdrawal.purpose,
               withdrawnDate = withdrawal.withdrawnDate,
               undoesWithdrawalId = withdrawal.undoesWithdrawalId,
@@ -835,6 +848,7 @@ class BatchStore(
             batchWithdrawals = batchWithdrawals,
             facilityId = withdrawalToUndo.facilityId,
             id = null,
+            plantingSeasonId = withdrawalToUndo.plantingSeasonId,
             purpose = WithdrawalPurpose.Undo,
             withdrawnDate = todayAtNursery,
             undoesWithdrawalId = withdrawalId,

--- a/src/main/kotlin/com/terraformation/backend/nursery/model/WithdrawalModel.kt
+++ b/src/main/kotlin/com/terraformation/backend/nursery/model/WithdrawalModel.kt
@@ -7,6 +7,7 @@ import com.terraformation.backend.db.nursery.WithdrawalPurpose
 import com.terraformation.backend.db.nursery.tables.pojos.BatchWithdrawalsRow
 import com.terraformation.backend.db.nursery.tables.pojos.WithdrawalsRow
 import com.terraformation.backend.db.tracking.DeliveryId
+import com.terraformation.backend.db.tracking.PlantingSeasonId
 import java.time.LocalDate
 
 /**
@@ -44,6 +45,7 @@ data class WithdrawalModel<ID : WithdrawalId?>(
     val facilityId: FacilityId,
     val id: ID,
     val notes: String? = null,
+    val plantingSeasonId: PlantingSeasonId? = null,
     val purpose: WithdrawalPurpose,
     val withdrawnDate: LocalDate,
     val undoesWithdrawalId: WithdrawalId? = null,
@@ -89,6 +91,7 @@ fun WithdrawalsRow.toModel(
         facilityId = facilityId!!,
         id = id!!,
         notes = notes,
+        plantingSeasonId = plantingSeasonId,
         purpose = purposeId!!,
         withdrawnDate = withdrawnDate!!,
         undoesWithdrawalId = undoesWithdrawalId,

--- a/src/test/kotlin/com/terraformation/backend/nursery/db/batchStore/BatchStoreFetchTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/nursery/db/batchStore/BatchStoreFetchTest.kt
@@ -4,7 +4,9 @@ import com.terraformation.backend.db.default_schema.SeedTreatment
 import com.terraformation.backend.db.nursery.BatchSubstrate
 import com.terraformation.backend.db.nursery.WithdrawalPurpose
 import com.terraformation.backend.db.nursery.tables.pojos.BatchesRow
+import com.terraformation.backend.nursery.model.BatchWithdrawalModel
 import com.terraformation.backend.nursery.model.ExistingBatchModel
+import com.terraformation.backend.nursery.model.ExistingWithdrawalModel
 import io.mockk.every
 import java.time.Instant
 import java.time.LocalDate
@@ -97,20 +99,74 @@ internal class BatchStoreFetchTest : BatchStoreTest() {
   }
 
   @Test
-  fun `fetchWithdrawalById populates undo fields`() {
+  fun `fetchWithdrawalById populates all fields for withdrawal and undo withdrawal`() {
+    insertPlantingSite()
+    val plantingSeasonId = insertPlantingSeason()
+
     every { user.canReadWithdrawal(any()) } returns true
 
     insertBatch()
-    val withdrawalId = insertNurseryWithdrawal(purpose = WithdrawalPurpose.Other)
+    val withdrawalId =
+        insertNurseryWithdrawal(
+            purpose = WithdrawalPurpose.OutPlant,
+            plantingSeasonId = plantingSeasonId,
+        )
     insertBatchWithdrawal(readyQuantityWithdrawn = 1)
     val undoWithdrawalId =
-        insertNurseryWithdrawal(purpose = WithdrawalPurpose.Undo, undoesWithdrawalId = withdrawalId)
+        insertNurseryWithdrawal(
+            purpose = WithdrawalPurpose.Undo,
+            undoesWithdrawalId = withdrawalId,
+            plantingSeasonId = plantingSeasonId,
+        )
     insertBatchWithdrawal(readyQuantityWithdrawn = -1)
 
     val withdrawal = store.fetchWithdrawalById(withdrawalId)
-    assertEquals(undoWithdrawalId, withdrawal.undoneByWithdrawalId, "Undone by")
+    assertEquals(
+        ExistingWithdrawalModel(
+            batchWithdrawals =
+                listOf(
+                    BatchWithdrawalModel(
+                        batchId = inserted.batchId,
+                        germinatingQuantityWithdrawn = 0,
+                        activeGrowthQuantityWithdrawn = 0,
+                        hardeningOffQuantityWithdrawn = 0,
+                        readyQuantityWithdrawn = 1,
+                    )
+                ),
+            facilityId = facilityId,
+            id = withdrawalId,
+            plantingSeasonId = plantingSeasonId,
+            purpose = WithdrawalPurpose.OutPlant,
+            withdrawnDate = LocalDate.EPOCH,
+            undoneByWithdrawalId = undoWithdrawalId,
+        ),
+        withdrawal,
+        "Initial Withdrawal",
+    )
 
     val undoWithdrawal = store.fetchWithdrawalById(undoWithdrawalId)
     assertEquals(withdrawalId, undoWithdrawal.undoesWithdrawalId, "Undoes")
+    assertEquals(
+        ExistingWithdrawalModel(
+            batchWithdrawals =
+                listOf(
+                    BatchWithdrawalModel(
+                        batchId = inserted.batchId,
+                        germinatingQuantityWithdrawn = 0,
+                        activeGrowthQuantityWithdrawn = 0,
+                        hardeningOffQuantityWithdrawn = 0,
+                        readyQuantityWithdrawn = -1,
+                    )
+                ),
+            facilityId = facilityId,
+            id = undoWithdrawalId,
+            plantingSeasonId = plantingSeasonId,
+            purpose = WithdrawalPurpose.Undo,
+            withdrawnDate = LocalDate.EPOCH,
+            undoesWithdrawalId = withdrawalId,
+        ),
+        undoWithdrawal,
+        "Undo Withdrawal",
+    )
   }
 }

--- a/src/test/kotlin/com/terraformation/backend/nursery/db/batchStore/BatchStoreUndoWithdrawalTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/nursery/db/batchStore/BatchStoreUndoWithdrawalTest.kt
@@ -7,6 +7,7 @@ import com.terraformation.backend.db.nursery.BatchQuantityHistoryType
 import com.terraformation.backend.db.nursery.WithdrawalId
 import com.terraformation.backend.db.nursery.WithdrawalPurpose
 import com.terraformation.backend.db.nursery.tables.pojos.BatchQuantityHistoryRow
+import com.terraformation.backend.db.tracking.PlantingSeasonId
 import com.terraformation.backend.nursery.db.UndoOfNurseryTransferNotAllowedException
 import com.terraformation.backend.nursery.db.UndoOfUndoNotAllowedException
 import com.terraformation.backend.nursery.db.WithdrawalAlreadyUndoneException
@@ -26,6 +27,7 @@ import org.springframework.security.access.AccessDeniedException
 internal class BatchStoreUndoWithdrawalTest : BatchStoreTest() {
   private lateinit var batch1Id: BatchId
   private lateinit var batch2Id: BatchId
+  private lateinit var plantingSeasonId: PlantingSeasonId
 
   @BeforeEach
   fun insertInitialBatches() {
@@ -51,6 +53,9 @@ internal class BatchStoreUndoWithdrawalTest : BatchStoreTest() {
             totalLost = 0,
             totalLossCandidates = 50 + 60 + 70,
         )
+
+    insertPlantingSite()
+    plantingSeasonId = insertPlantingSeason()
 
     every { user.canReadWithdrawal(any()) } returns true
   }
@@ -81,7 +86,8 @@ internal class BatchStoreUndoWithdrawalTest : BatchStoreTest() {
                         activeGrowthQuantityWithdrawn = 5,
                         readyQuantityWithdrawn = 6,
                     ),
-                )
+                ),
+            plantingSeasonId = plantingSeasonId,
         )
 
     clock.instant = clock.instant.plus(2, ChronoUnit.DAYS)
@@ -125,6 +131,7 @@ internal class BatchStoreUndoWithdrawalTest : BatchStoreTest() {
                 ),
             facilityId = facilityId,
             id = undoWithdrawal.id,
+            plantingSeasonId = plantingSeasonId,
             purpose = WithdrawalPurpose.Undo,
             withdrawnDate = LocalDate.ofInstant(clock.instant, ZoneOffset.UTC),
             undoesWithdrawalId = withdrawalId,
@@ -224,7 +231,8 @@ internal class BatchStoreUndoWithdrawalTest : BatchStoreTest() {
               )
           ),
       destinationFacilityId: FacilityId? = null,
-      purpose: WithdrawalPurpose = WithdrawalPurpose.Other,
+      plantingSeasonId: PlantingSeasonId? = null,
+      purpose: WithdrawalPurpose = WithdrawalPurpose.OutPlant,
       withdrawnDate: LocalDate = LocalDate.EPOCH,
   ): WithdrawalId {
     return store
@@ -234,6 +242,7 @@ internal class BatchStoreUndoWithdrawalTest : BatchStoreTest() {
                 destinationFacilityId = destinationFacilityId,
                 facilityId = facilityId,
                 id = null,
+                plantingSeasonId = plantingSeasonId,
                 purpose = purpose,
                 withdrawnDate = withdrawnDate,
             )

--- a/src/test/kotlin/com/terraformation/backend/nursery/db/batchStore/BatchStoreWithdrawTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/nursery/db/batchStore/BatchStoreWithdrawTest.kt
@@ -10,7 +10,9 @@ import com.terraformation.backend.db.nursery.tables.pojos.BatchQuantityHistoryRo
 import com.terraformation.backend.db.nursery.tables.pojos.BatchWithdrawalsRow
 import com.terraformation.backend.db.nursery.tables.pojos.BatchesRow
 import com.terraformation.backend.db.nursery.tables.pojos.WithdrawalsRow
+import com.terraformation.backend.db.nursery.tables.records.WithdrawalsRecord
 import com.terraformation.backend.db.nursery.tables.references.BATCH_QUANTITY_HISTORY
+import com.terraformation.backend.db.tracking.PlantingSeasonId
 import com.terraformation.backend.nursery.db.BatchInventoryInsufficientException
 import com.terraformation.backend.nursery.db.CrossOrganizationNurseryTransferNotAllowedException
 import com.terraformation.backend.nursery.model.BatchWithdrawalModel
@@ -27,6 +29,7 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertAll
 import org.junit.jupiter.api.assertThrows
+import org.springframework.dao.DataIntegrityViolationException
 import org.springframework.security.access.AccessDeniedException
 
 internal class BatchStoreWithdrawTest : BatchStoreTest() {
@@ -1272,6 +1275,98 @@ internal class BatchStoreWithdrawTest : BatchStoreTest() {
               id = null,
               purpose = WithdrawalPurpose.NurseryTransfer,
               withdrawnDate = LocalDate.EPOCH,
+          )
+      )
+    }
+  }
+
+  @Test
+  fun `stores plantingSeasonId in withdrawal`() {
+    insertPlantingSite()
+    val plantingSeasonId = insertPlantingSeason()
+
+    store.withdraw(
+        NewWithdrawalModel(
+            facilityId = facilityId,
+            id = null,
+            purpose = WithdrawalPurpose.OutPlant,
+            withdrawnDate = LocalDate.EPOCH,
+            plantingSeasonId = plantingSeasonId,
+            batchWithdrawals =
+                listOf(
+                    BatchWithdrawalModel(
+                        batchId = species1Batch1Id,
+                        germinatingQuantityWithdrawn = 1,
+                        activeGrowthQuantityWithdrawn = 0,
+                        readyQuantityWithdrawn = 0,
+                        hardeningOffQuantityWithdrawn = 0,
+                    )
+                ),
+        )
+    )
+
+    assertTableEquals(
+        WithdrawalsRecord(
+            facilityId = facilityId,
+            purposeId = WithdrawalPurpose.OutPlant,
+            withdrawnDate = LocalDate.EPOCH,
+            plantingSeasonId = plantingSeasonId,
+            createdBy = user.userId,
+            createdTime = clock.instant(),
+            modifiedBy = user.userId,
+            modifiedTime = clock.instant(),
+        )
+    )
+  }
+
+  @Test
+  fun `throws exception if planting season id is specified but not found`() {
+    assertThrows<DataIntegrityViolationException> {
+      store.withdraw(
+          NewWithdrawalModel(
+              batchWithdrawals =
+                  listOf(
+                      BatchWithdrawalModel(
+                          batchId = species1Batch1Id,
+                          germinatingQuantityWithdrawn = 1,
+                          activeGrowthQuantityWithdrawn = 0,
+                          readyQuantityWithdrawn = 0,
+                          hardeningOffQuantityWithdrawn = 0,
+                      )
+                  ),
+              facilityId = facilityId,
+              id = null,
+              purpose = WithdrawalPurpose.OutPlant,
+              withdrawnDate = LocalDate.EPOCH,
+              plantingSeasonId = PlantingSeasonId(99999L),
+          )
+      )
+    }
+  }
+
+  @Test
+  fun `throws exception if planting season id and purpose is not OutPlant`() {
+    insertPlantingSite()
+    val plantingSeasonId = insertPlantingSeason()
+
+    assertThrows<IllegalArgumentException> {
+      store.withdraw(
+          NewWithdrawalModel(
+              batchWithdrawals =
+                  listOf(
+                      BatchWithdrawalModel(
+                          batchId = species1Batch1Id,
+                          germinatingQuantityWithdrawn = 1,
+                          activeGrowthQuantityWithdrawn = 0,
+                          readyQuantityWithdrawn = 0,
+                          hardeningOffQuantityWithdrawn = 0,
+                      )
+                  ),
+              facilityId = facilityId,
+              id = null,
+              purpose = WithdrawalPurpose.Other,
+              withdrawnDate = LocalDate.EPOCH,
+              plantingSeasonId = plantingSeasonId,
           )
       )
     }


### PR DESCRIPTION
Associate a withdrawal to a planting season if specified in the request. Associate an undo withdrawal to a planting season if the original withdrawal was associated. 

Include the planting season id in responses when fetching withdrawals.