### PR TITLE
SW-8427 Publish events for scheduled date writes

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/plantingmanagement/db/PlantingSeasonScheduledDatesStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/plantingmanagement/db/PlantingSeasonScheduledDatesStore.kt
@@ -1,6 +1,7 @@
 package com.terraformation.backend.plantingmanagement.db
 
 import com.terraformation.backend.auth.currentUser
+import com.terraformation.backend.customer.db.ParentStore
 import com.terraformation.backend.customer.model.requirePermissions
 import com.terraformation.backend.db.tracking.PlantingSeasonId
 import com.terraformation.backend.db.tracking.PlantingSeasonStatus
@@ -11,16 +12,24 @@ import com.terraformation.backend.db.tracking.tables.references.SCHEDULED_PLANTI
 import com.terraformation.backend.plantingmanagement.ExistingPlantingSeasonScheduledDateModel
 import com.terraformation.backend.plantingmanagement.PlantingSeasonScheduledDateModel
 import com.terraformation.backend.plantingmanagement.PlantingSeasonScheduledDateSpecies
+import com.terraformation.backend.plantingmanagement.event.PlantingSeasonScheduledDateCreatedEvent
+import com.terraformation.backend.plantingmanagement.event.PlantingSeasonScheduledDateDeletedEvent
+import com.terraformation.backend.plantingmanagement.event.PlantingSeasonScheduledDateUpdatedEvent
+import com.terraformation.backend.plantingmanagement.event.PlantingSeasonScheduledDateUpdatedEventValues
+import com.terraformation.backend.util.nullIfEquals
 import jakarta.inject.Named
 import java.time.InstantSource
 import org.jooq.Condition
 import org.jooq.DSLContext
 import org.jooq.impl.DSL
+import org.springframework.context.ApplicationEventPublisher
 
 @Named
 class PlantingSeasonScheduledDatesStore(
     private val clock: InstantSource,
     private val dslContext: DSLContext,
+    private val eventPublisher: ApplicationEventPublisher,
+    private val parentStore: ParentStore,
 ) {
   fun fetchList(
       plantingSeasonId: PlantingSeasonId
@@ -49,6 +58,12 @@ class PlantingSeasonScheduledDatesStore(
 
     validateSeasonNotClosed(model.plantingSeasonId)
 
+    val plantingSiteId =
+        parentStore.getPlantingSiteId(model.plantingSeasonId)
+            ?: throw PlantingSeasonNotFoundException(model.plantingSeasonId)
+    val organizationId =
+        parentStore.getOrganizationId(plantingSiteId)
+            ?: throw PlantingSeasonNotFoundException(model.plantingSeasonId)
     val userId = currentUser().userId
     val now = clock.instant()
 
@@ -94,6 +109,16 @@ class PlantingSeasonScheduledDatesStore(
         insertQuery.execute()
       }
 
+      eventPublisher.publishEvent(
+          PlantingSeasonScheduledDateCreatedEvent(
+              date = model.date,
+              organizationId = organizationId,
+              plantingSeasonId = model.plantingSeasonId,
+              plantingSiteId = plantingSiteId,
+              scheduledPlantingDateId = newScheduledDateId,
+          )
+      )
+
       newScheduledDateId
     }
 
@@ -107,6 +132,14 @@ class PlantingSeasonScheduledDatesStore(
     requirePermissions { updatePlantingSeason(model.plantingSeasonId) }
 
     validateSeasonNotClosed(model.plantingSeasonId)
+
+    val oldModel = fetch(model.plantingSeasonId, scheduledDateId)
+    val plantingSiteId =
+        parentStore.getPlantingSiteId(model.plantingSeasonId)
+            ?: throw PlantingSeasonNotFoundException(model.plantingSeasonId)
+    val organizationId =
+        parentStore.getOrganizationId(plantingSiteId)
+            ?: throw PlantingSeasonNotFoundException(model.plantingSeasonId)
 
     dslContext.transaction { _ ->
       val updatedCount =
@@ -151,6 +184,25 @@ class PlantingSeasonScheduledDatesStore(
 
         insertQuery.execute()
       }
+
+      if (oldModel.date != model.date) {
+        eventPublisher.publishEvent(
+            PlantingSeasonScheduledDateUpdatedEvent(
+                changedFrom =
+                    PlantingSeasonScheduledDateUpdatedEventValues(
+                        date = oldModel.date.nullIfEquals(model.date),
+                    ),
+                changedTo =
+                    PlantingSeasonScheduledDateUpdatedEventValues(
+                        date = model.date.nullIfEquals(oldModel.date),
+                    ),
+                organizationId = organizationId,
+                plantingSeasonId = model.plantingSeasonId,
+                plantingSiteId = plantingSiteId,
+                scheduledPlantingDateId = scheduledDateId,
+            )
+        )
+      }
     }
   }
 
@@ -161,6 +213,13 @@ class PlantingSeasonScheduledDatesStore(
     requirePermissions { updatePlantingSeason(plantingSeasonId) }
 
     validateSeasonNotClosed(plantingSeasonId)
+
+    val plantingSiteId =
+        parentStore.getPlantingSiteId(plantingSeasonId)
+            ?: throw PlantingSeasonNotFoundException(plantingSeasonId)
+    val organizationId =
+        parentStore.getOrganizationId(plantingSiteId)
+            ?: throw PlantingSeasonNotFoundException(plantingSeasonId)
 
     with(SCHEDULED_PLANTING_DATES) {
       val rowsDeleted =
@@ -174,6 +233,15 @@ class PlantingSeasonScheduledDatesStore(
         throw PlantingSeasonScheduledDateNotFoundException(scheduledDateId)
       }
     }
+
+    eventPublisher.publishEvent(
+        PlantingSeasonScheduledDateDeletedEvent(
+            organizationId = organizationId,
+            plantingSeasonId = plantingSeasonId,
+            plantingSiteId = plantingSiteId,
+            scheduledPlantingDateId = scheduledDateId,
+        )
+    )
   }
 
   private fun fetchByCondition(

--- a/src/main/resources/db/migration/0450/V493__PlantingSeasonScheduledDateCreatedEvent.sql
+++ b/src/main/resources/db/migration/0450/V493__PlantingSeasonScheduledDateCreatedEvent.sql
@@ -1,0 +1,19 @@
+CALL event_log_create_id_index('scheduledPlantingDateId');
+
+INSERT INTO event_log (created_by, created_time, event_class, payload)
+SELECT
+    spd.created_by,
+    spd.created_time,
+    'com.terraformation.backend.plantingmanagement.event.PlantingSeasonScheduledDateCreatedEventV1',
+    json_object(
+        '_historical' VALUE true,
+        'date' VALUE spd.date,
+        'organizationId' VALUE sites.organization_id,
+        'plantingSeasonId' VALUE seasons.id,
+        'plantingSiteId' VALUE sites.id,
+        'scheduledPlantingDateId' VALUE spd.id
+        ABSENT ON NULL
+    )::JSONB
+FROM tracking.scheduled_planting_dates spd
+JOIN tracking.planting_seasons seasons ON spd.planting_season_id = seasons.id
+JOIN tracking.planting_sites sites ON seasons.planting_site_id = sites.id;

--- a/src/test/kotlin/com/terraformation/backend/plantingmanagement/db/PlantingSeasonScheduledDatesStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/plantingmanagement/db/PlantingSeasonScheduledDatesStoreTest.kt
@@ -2,12 +2,16 @@ package com.terraformation.backend.plantingmanagement.db
 
 import com.terraformation.backend.RunsAsDatabaseUser
 import com.terraformation.backend.TestClock
+import com.terraformation.backend.TestEventPublisher
+import com.terraformation.backend.customer.db.ParentStore
 import com.terraformation.backend.customer.model.TerrawareUser
 import com.terraformation.backend.db.DatabaseTest
+import com.terraformation.backend.db.default_schema.OrganizationId
 import com.terraformation.backend.db.default_schema.Role
 import com.terraformation.backend.db.default_schema.SpeciesId
 import com.terraformation.backend.db.tracking.PlantingSeasonId
 import com.terraformation.backend.db.tracking.PlantingSeasonStatus
+import com.terraformation.backend.db.tracking.PlantingSiteId
 import com.terraformation.backend.db.tracking.ScheduledPlantingDateId
 import com.terraformation.backend.db.tracking.SubstratumId
 import com.terraformation.backend.db.tracking.tables.records.ScheduledPlantingDateSpeciesRecord
@@ -17,6 +21,10 @@ import com.terraformation.backend.db.tracking.tables.references.SCHEDULED_PLANTI
 import com.terraformation.backend.plantingmanagement.ExistingPlantingSeasonScheduledDateModel
 import com.terraformation.backend.plantingmanagement.PlantingSeasonScheduledDateModel
 import com.terraformation.backend.plantingmanagement.PlantingSeasonScheduledDateSpecies
+import com.terraformation.backend.plantingmanagement.event.PlantingSeasonScheduledDateCreatedEvent
+import com.terraformation.backend.plantingmanagement.event.PlantingSeasonScheduledDateDeletedEvent
+import com.terraformation.backend.plantingmanagement.event.PlantingSeasonScheduledDateUpdatedEvent
+import com.terraformation.backend.plantingmanagement.event.PlantingSeasonScheduledDateUpdatedEventValues
 import java.time.Instant
 import java.time.LocalDate
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -30,18 +38,21 @@ import org.springframework.security.access.AccessDeniedException
 internal class PlantingSeasonScheduledDatesStoreTest : DatabaseTest(), RunsAsDatabaseUser {
   override lateinit var user: TerrawareUser
   private val clock = TestClock()
+  private val eventPublisher = TestEventPublisher()
   private val store: PlantingSeasonScheduledDatesStore by lazy {
-    PlantingSeasonScheduledDatesStore(clock, dslContext)
+    PlantingSeasonScheduledDatesStore(clock, dslContext, eventPublisher, ParentStore(dslContext))
   }
 
+  private lateinit var organizationId: OrganizationId
   private lateinit var plantingSeasonId: PlantingSeasonId
+  private lateinit var plantingSiteId: PlantingSiteId
   private lateinit var substratumId: SubstratumId
   private lateinit var speciesId: SpeciesId
 
   @BeforeEach
   fun setUp() {
-    insertOrganization()
-    insertPlantingSite()
+    organizationId = insertOrganization()
+    plantingSiteId = insertPlantingSite()
     insertOrganizationUser(role = Role.Manager)
     insertStratum()
     plantingSeasonId = insertPlantingSeason()
@@ -221,7 +232,7 @@ internal class PlantingSeasonScheduledDatesStoreTest : DatabaseTest(), RunsAsDat
               date = LocalDate.EPOCH,
           )
 
-      store.create(model)
+      val scheduledPlantingDateId = store.create(model)
 
       assertTableEquals(
           ScheduledPlantingDatesRecord(
@@ -235,6 +246,16 @@ internal class PlantingSeasonScheduledDatesStoreTest : DatabaseTest(), RunsAsDat
       )
 
       assertTableEmpty(SCHEDULED_PLANTING_DATE_SPECIES)
+
+      eventPublisher.assertEventPublished(
+          PlantingSeasonScheduledDateCreatedEvent(
+              date = LocalDate.EPOCH,
+              organizationId = organizationId,
+              plantingSeasonId = plantingSeasonId,
+              plantingSiteId = plantingSiteId,
+              scheduledPlantingDateId = scheduledPlantingDateId,
+          )
+      )
     }
 
     @Test
@@ -411,6 +432,17 @@ internal class PlantingSeasonScheduledDatesStoreTest : DatabaseTest(), RunsAsDat
       )
 
       assertTableEmpty(SCHEDULED_PLANTING_DATE_SPECIES)
+
+      eventPublisher.assertEventPublished(
+          PlantingSeasonScheduledDateUpdatedEvent(
+              changedFrom = PlantingSeasonScheduledDateUpdatedEventValues(date = LocalDate.EPOCH),
+              changedTo = PlantingSeasonScheduledDateUpdatedEventValues(date = newDate),
+              organizationId = organizationId,
+              plantingSeasonId = plantingSeasonId,
+              plantingSiteId = plantingSiteId,
+              scheduledPlantingDateId = scheduledDateId,
+          )
+      )
     }
 
     @Test
@@ -595,6 +627,15 @@ internal class PlantingSeasonScheduledDatesStoreTest : DatabaseTest(), RunsAsDat
 
       assertTableEmpty(SCHEDULED_PLANTING_DATES)
       assertTableEmpty(SCHEDULED_PLANTING_DATE_SPECIES)
+
+      eventPublisher.assertEventPublished(
+          PlantingSeasonScheduledDateDeletedEvent(
+              organizationId = organizationId,
+              plantingSeasonId = plantingSeasonId,
+              plantingSiteId = plantingSiteId,
+              scheduledPlantingDateId = scheduledDateId,
+          )
+      )
     }
 
     @Test


### PR DESCRIPTION
When a planting season scheduled planting date is created, updated, or deleted,
publish the appropriate persistent event. Backfill the creation events for
existing scheduled planting dates.