### PR TITLE
SW-8427 Publish events for scheduled date species

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/plantingmanagement/Models.kt
+++ b/src/main/kotlin/com/terraformation/backend/plantingmanagement/Models.kt
@@ -45,6 +45,9 @@ data class PlantingSeasonScheduledDateModel(
 ) {
   init {
     require(species.all { it.quantity >= 0 }) { "All quantities must be >= 0" }
+    require(species.size == species.distinctBy { it.substratumId to it.speciesId }.size) {
+      "Species listed multiple times for substratum"
+    }
   }
 }
 

--- a/src/main/kotlin/com/terraformation/backend/plantingmanagement/db/PlantingSeasonScheduledDatesStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/plantingmanagement/db/PlantingSeasonScheduledDatesStore.kt
@@ -3,19 +3,30 @@ package com.terraformation.backend.plantingmanagement.db
 import com.terraformation.backend.auth.currentUser
 import com.terraformation.backend.customer.db.ParentStore
 import com.terraformation.backend.customer.model.requirePermissions
+import com.terraformation.backend.db.asNonNullable
 import com.terraformation.backend.db.tracking.PlantingSeasonId
 import com.terraformation.backend.db.tracking.PlantingSeasonStatus
 import com.terraformation.backend.db.tracking.ScheduledPlantingDateId
+import com.terraformation.backend.db.tracking.SubstratumHistoryId
+import com.terraformation.backend.db.tracking.SubstratumId
 import com.terraformation.backend.db.tracking.tables.references.PLANTING_SEASONS
 import com.terraformation.backend.db.tracking.tables.references.SCHEDULED_PLANTING_DATES
 import com.terraformation.backend.db.tracking.tables.references.SCHEDULED_PLANTING_DATE_SPECIES
+import com.terraformation.backend.db.tracking.tables.references.STRATA
+import com.terraformation.backend.db.tracking.tables.references.SUBSTRATA
+import com.terraformation.backend.db.tracking.tables.references.SUBSTRATUM_HISTORIES
 import com.terraformation.backend.plantingmanagement.ExistingPlantingSeasonScheduledDateModel
 import com.terraformation.backend.plantingmanagement.PlantingSeasonScheduledDateModel
 import com.terraformation.backend.plantingmanagement.PlantingSeasonScheduledDateSpecies
 import com.terraformation.backend.plantingmanagement.event.PlantingSeasonScheduledDateCreatedEvent
 import com.terraformation.backend.plantingmanagement.event.PlantingSeasonScheduledDateDeletedEvent
+import com.terraformation.backend.plantingmanagement.event.PlantingSeasonScheduledDateSpeciesCreatedEvent
+import com.terraformation.backend.plantingmanagement.event.PlantingSeasonScheduledDateSpeciesDeletedEvent
+import com.terraformation.backend.plantingmanagement.event.PlantingSeasonScheduledDateSpeciesUpdatedEvent
+import com.terraformation.backend.plantingmanagement.event.PlantingSeasonScheduledDateSpeciesUpdatedEventValues
 import com.terraformation.backend.plantingmanagement.event.PlantingSeasonScheduledDateUpdatedEvent
 import com.terraformation.backend.plantingmanagement.event.PlantingSeasonScheduledDateUpdatedEventValues
+import com.terraformation.backend.tracking.db.SubstratumNotFoundException
 import com.terraformation.backend.util.nullIfEquals
 import jakarta.inject.Named
 import java.time.InstantSource
@@ -109,6 +120,8 @@ class PlantingSeasonScheduledDatesStore(
         insertQuery.execute()
       }
 
+      val substratumInfo = fetchSubstratumInfo(model.species.map { it.substratumId }.toSet())
+
       eventPublisher.publishEvent(
           PlantingSeasonScheduledDateCreatedEvent(
               date = model.date,
@@ -118,6 +131,26 @@ class PlantingSeasonScheduledDatesStore(
               scheduledPlantingDateId = newScheduledDateId,
           )
       )
+
+      model.species.forEach { species ->
+        val info =
+            substratumInfo[species.substratumId]
+                ?: throw IllegalStateException("Substratum ${species.substratumId} not found")
+        eventPublisher.publishEvent(
+            PlantingSeasonScheduledDateSpeciesCreatedEvent(
+                organizationId = organizationId,
+                plantingSeasonId = model.plantingSeasonId,
+                plantingSiteId = plantingSiteId,
+                quantity = species.quantity,
+                scheduledPlantingDateId = newScheduledDateId,
+                speciesId = species.speciesId,
+                stratumName = info.stratumName,
+                substratumHistoryId = info.substratumHistoryId,
+                substratumId = species.substratumId,
+                substratumName = info.substratumName,
+            )
+        )
+      }
 
       newScheduledDateId
     }
@@ -133,15 +166,19 @@ class PlantingSeasonScheduledDatesStore(
 
     validateSeasonNotClosed(model.plantingSeasonId)
 
-    val oldModel = fetch(model.plantingSeasonId, scheduledDateId)
-    val plantingSiteId =
-        parentStore.getPlantingSiteId(model.plantingSeasonId)
-            ?: throw PlantingSeasonNotFoundException(model.plantingSeasonId)
-    val organizationId =
-        parentStore.getOrganizationId(plantingSiteId)
-            ?: throw PlantingSeasonNotFoundException(model.plantingSeasonId)
+    if (model.species.size != model.species.distinctBy { it.substratumId to it.speciesId }.size) {
+      throw IllegalArgumentException("Species listed multiple times for substratum")
+    }
 
-    dslContext.transaction { _ ->
+    withLockedDate(scheduledDateId) {
+      val oldModel = fetch(model.plantingSeasonId, scheduledDateId)
+      val plantingSiteId =
+          parentStore.getPlantingSiteId(model.plantingSeasonId)
+              ?: throw PlantingSeasonNotFoundException(model.plantingSeasonId)
+      val organizationId =
+          parentStore.getOrganizationId(plantingSiteId)
+              ?: throw PlantingSeasonNotFoundException(model.plantingSeasonId)
+
       val updatedCount =
           with(SCHEDULED_PLANTING_DATES) {
             dslContext
@@ -156,33 +193,6 @@ class PlantingSeasonScheduledDatesStore(
 
       if (updatedCount == 0) {
         throw PlantingSeasonScheduledDateNotFoundException(scheduledDateId)
-      }
-
-      with(SCHEDULED_PLANTING_DATE_SPECIES) {
-        dslContext
-            .deleteFrom(SCHEDULED_PLANTING_DATE_SPECIES)
-            .where(SCHEDULED_PLANTING_DATE_ID.eq(scheduledDateId))
-            .execute()
-
-        val insertQuery =
-            dslContext.insertInto(
-                SCHEDULED_PLANTING_DATE_SPECIES,
-                SCHEDULED_PLANTING_DATE_ID,
-                SPECIES_ID,
-                SUBSTRATUM_ID,
-                QUANTITY,
-            )
-
-        model.species.forEach { species ->
-          insertQuery.values(
-              scheduledDateId,
-              species.speciesId,
-              species.substratumId,
-              species.quantity,
-          )
-        }
-
-        insertQuery.execute()
       }
 
       if (oldModel.date != model.date) {
@@ -202,6 +212,110 @@ class PlantingSeasonScheduledDatesStore(
                 scheduledPlantingDateId = scheduledDateId,
             )
         )
+      }
+
+      with(SCHEDULED_PLANTING_DATE_SPECIES) {
+        // We want to diff the old and new species lists using (substratum, species) keys so we can
+        // tell which species have been added, removed, or updated in which substrata.
+        val oldByIds = oldModel.species.associateBy { it.substratumId to it.speciesId }
+        val newByIds = model.species.associateBy { it.substratumId to it.speciesId }
+
+        val removedKeys = oldByIds.keys - newByIds.keys
+        val addedKeys = newByIds.keys - oldByIds.keys
+        val commonKeys = oldByIds.keys intersect newByIds.keys
+        val touchedSubstrata = (removedKeys + addedKeys + commonKeys).map { it.first }.toSet()
+        val substrataInfo = fetchSubstratumInfo(touchedSubstrata)
+
+        removedKeys.forEach { (substratumId, speciesId) ->
+          val substratumInfo = substrataInfo.getValue(substratumId)
+
+          dslContext
+              .deleteFrom(SCHEDULED_PLANTING_DATE_SPECIES)
+              .where(SCHEDULED_PLANTING_DATE_ID.eq(scheduledDateId))
+              .and(SUBSTRATUM_ID.eq(substratumId))
+              .and(SPECIES_ID.eq(speciesId))
+              .execute()
+
+          eventPublisher.publishEvent(
+              PlantingSeasonScheduledDateSpeciesDeletedEvent(
+                  organizationId = organizationId,
+                  plantingSeasonId = model.plantingSeasonId,
+                  plantingSiteId = plantingSiteId,
+                  scheduledPlantingDateId = scheduledDateId,
+                  speciesId = speciesId,
+                  stratumName = substratumInfo.stratumName,
+                  substratumHistoryId = substratumInfo.substratumHistoryId,
+                  substratumId = substratumId,
+                  substratumName = substratumInfo.substratumName,
+              )
+          )
+        }
+
+        addedKeys.forEach { key ->
+          val species = newByIds.getValue(key)
+          val substratumInfo = substrataInfo.getValue(species.substratumId)
+
+          dslContext
+              .insertInto(SCHEDULED_PLANTING_DATE_SPECIES)
+              .set(SCHEDULED_PLANTING_DATE_ID, scheduledDateId)
+              .set(SUBSTRATUM_ID, species.substratumId)
+              .set(SPECIES_ID, species.speciesId)
+              .set(QUANTITY, species.quantity)
+              .execute()
+
+          eventPublisher.publishEvent(
+              PlantingSeasonScheduledDateSpeciesCreatedEvent(
+                  organizationId = organizationId,
+                  plantingSeasonId = model.plantingSeasonId,
+                  plantingSiteId = plantingSiteId,
+                  quantity = species.quantity,
+                  scheduledPlantingDateId = scheduledDateId,
+                  speciesId = species.speciesId,
+                  stratumName = substratumInfo.stratumName,
+                  substratumHistoryId = substratumInfo.substratumHistoryId,
+                  substratumId = species.substratumId,
+                  substratumName = substratumInfo.substratumName,
+              )
+          )
+        }
+
+        commonKeys.forEach { key ->
+          val oldSpecies = oldByIds.getValue(key)
+          val newSpecies = newByIds.getValue(key)
+          val substratumInfo = substrataInfo.getValue(newSpecies.substratumId)
+
+          if (oldSpecies.quantity != newSpecies.quantity) {
+            dslContext
+                .update(SCHEDULED_PLANTING_DATE_SPECIES)
+                .set(QUANTITY, newSpecies.quantity)
+                .where(SCHEDULED_PLANTING_DATE_ID.eq(scheduledDateId))
+                .and(SUBSTRATUM_ID.eq(newSpecies.substratumId))
+                .and(SPECIES_ID.eq(newSpecies.speciesId))
+                .execute()
+
+            eventPublisher.publishEvent(
+                PlantingSeasonScheduledDateSpeciesUpdatedEvent(
+                    changedFrom =
+                        PlantingSeasonScheduledDateSpeciesUpdatedEventValues(
+                            quantity = oldSpecies.quantity,
+                        ),
+                    changedTo =
+                        PlantingSeasonScheduledDateSpeciesUpdatedEventValues(
+                            quantity = newSpecies.quantity,
+                        ),
+                    organizationId = organizationId,
+                    plantingSeasonId = model.plantingSeasonId,
+                    plantingSiteId = plantingSiteId,
+                    scheduledPlantingDateId = scheduledDateId,
+                    speciesId = newSpecies.speciesId,
+                    stratumName = substratumInfo.stratumName,
+                    substratumHistoryId = substratumInfo.substratumHistoryId,
+                    substratumId = newSpecies.substratumId,
+                    substratumName = substratumInfo.substratumName,
+                )
+            )
+          }
+        }
       }
     }
   }
@@ -295,6 +409,63 @@ class PlantingSeasonScheduledDatesStore(
       if (status == PlantingSeasonStatus.Closed) {
         throw PlantingSeasonClosedException(plantingSeasonId)
       }
+    }
+  }
+
+  private data class SubstratumInfo(
+      val stratumName: String,
+      val substratumName: String,
+      val substratumHistoryId: SubstratumHistoryId,
+  )
+
+  private fun fetchSubstratumInfo(
+      substratumIds: Collection<SubstratumId>
+  ): Map<SubstratumId, SubstratumInfo> {
+    if (substratumIds.isEmpty()) return emptyMap()
+
+    val latestHistoryIdField =
+        DSL.field(
+            DSL.select(DSL.max(SUBSTRATUM_HISTORIES.ID))
+                .from(SUBSTRATUM_HISTORIES)
+                .where(SUBSTRATUM_HISTORIES.SUBSTRATUM_ID.eq(SUBSTRATA.ID))
+        )
+
+    val substrata =
+        dslContext
+            .select(SUBSTRATA.ID, SUBSTRATA.NAME, STRATA.NAME, latestHistoryIdField)
+            .from(SUBSTRATA)
+            .join(STRATA)
+            .on(SUBSTRATA.STRATUM_ID.eq(STRATA.ID))
+            .where(SUBSTRATA.ID.`in`(substratumIds))
+            .fetchMap(SUBSTRATA.ID.asNonNullable()) { record ->
+              SubstratumInfo(
+                  stratumName = record.value3()!!,
+                  substratumName = record[SUBSTRATA.NAME]!!,
+                  substratumHistoryId = record.value4()!!,
+              )
+            }
+
+    substratumIds.forEach { id ->
+      if (id !in substrata) {
+        throw SubstratumNotFoundException(id)
+      }
+    }
+
+    return substrata
+  }
+
+  private fun <T> withLockedDate(
+      scheduledDateId: ScheduledPlantingDateId,
+      func: () -> T,
+  ): T {
+    return dslContext.transactionResult { _ ->
+      dslContext
+          .selectOne()
+          .from(SCHEDULED_PLANTING_DATES)
+          .where(SCHEDULED_PLANTING_DATES.ID.eq(scheduledDateId))
+          .forUpdate()
+          .fetchOne() ?: throw PlantingSeasonScheduledDateNotFoundException(scheduledDateId)
+      func()
     }
   }
 }

--- a/src/main/kotlin/com/terraformation/backend/plantingmanagement/db/PlantingSeasonScheduledDatesStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/plantingmanagement/db/PlantingSeasonScheduledDatesStore.kt
@@ -166,10 +166,6 @@ class PlantingSeasonScheduledDatesStore(
 
     validateSeasonNotClosed(model.plantingSeasonId)
 
-    if (model.species.size != model.species.distinctBy { it.substratumId to it.speciesId }.size) {
-      throw IllegalArgumentException("Species listed multiple times for substratum")
-    }
-
     withLockedDate(scheduledDateId) {
       val oldModel = fetch(model.plantingSeasonId, scheduledDateId)
       val plantingSiteId =

--- a/src/main/resources/db/migration/0450/V494__PlantingSeasonScheduledDateSpeciesCreatedEvent.sql
+++ b/src/main/resources/db/migration/0450/V494__PlantingSeasonScheduledDateSpeciesCreatedEvent.sql
@@ -1,0 +1,32 @@
+CALL event_log_create_id_index('substratumId');
+
+INSERT INTO event_log (created_by, created_time, event_class, payload)
+SELECT
+    spd.created_by,
+    spd.created_time,
+    'com.terraformation.backend.plantingmanagement.event.PlantingSeasonScheduledDateSpeciesCreatedEventV1',
+    json_object(
+        '_historical' VALUE true,
+        'organizationId' VALUE sites.organization_id,
+        'plantingSeasonId' VALUE seasons.id,
+        'plantingSiteId' VALUE sites.id,
+        'quantity' VALUE spds.quantity,
+        'scheduledPlantingDateId' VALUE spd.id,
+        'speciesId' VALUE spds.species_id,
+        'stratumName' VALUE str.name,
+        'substratumHistoryId' VALUE latest_sub_hist.id,
+        'substratumId' VALUE spds.substratum_id,
+        'substratumName' VALUE sub.name
+        ABSENT ON NULL
+    )::JSONB
+FROM tracking.scheduled_planting_date_species spds
+JOIN tracking.scheduled_planting_dates spd ON spds.scheduled_planting_date_id = spd.id
+JOIN tracking.planting_seasons seasons ON spd.planting_season_id = seasons.id
+JOIN tracking.planting_sites sites ON seasons.planting_site_id = sites.id
+JOIN tracking.substrata sub ON spds.substratum_id = sub.id
+JOIN tracking.strata str ON sub.stratum_id = str.id
+JOIN LATERAL (
+    SELECT id FROM tracking.substratum_histories
+    WHERE substratum_id = spds.substratum_id
+    ORDER BY id DESC LIMIT 1
+) latest_sub_hist ON true;

--- a/src/test/kotlin/com/terraformation/backend/plantingmanagement/db/PlantingSeasonScheduledDatesStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/plantingmanagement/db/PlantingSeasonScheduledDatesStoreTest.kt
@@ -37,7 +37,6 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
-import org.springframework.dao.DuplicateKeyException
 import org.springframework.security.access.AccessDeniedException
 
 internal class PlantingSeasonScheduledDatesStoreTest : DatabaseTest(), RunsAsDatabaseUser {
@@ -391,8 +390,8 @@ internal class PlantingSeasonScheduledDatesStoreTest : DatabaseTest(), RunsAsDat
     }
 
     @Test
-    fun `throws DuplicateKeyException when same species-substratum combination is added twice`() {
-      assertThrows<DuplicateKeyException> {
+    fun `throws exception when same species-substratum combination is added twice`() {
+      assertThrows<IllegalArgumentException> {
         store.create(
             PlantingSeasonScheduledDateModel(
                 plantingSeasonId = plantingSeasonId,
@@ -688,11 +687,6 @@ internal class PlantingSeasonScheduledDatesStoreTest : DatabaseTest(), RunsAsDat
                     listOf(
                         PlantingSeasonScheduledDateSpecies(
                             quantity = 5,
-                            speciesId = speciesId,
-                            substratumId = substratumId,
-                        ),
-                        PlantingSeasonScheduledDateSpecies(
-                            quantity = 10,
                             speciesId = speciesId,
                             substratumId = substratumId,
                         ),

--- a/src/test/kotlin/com/terraformation/backend/plantingmanagement/db/PlantingSeasonScheduledDatesStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/plantingmanagement/db/PlantingSeasonScheduledDatesStoreTest.kt
@@ -23,8 +23,13 @@ import com.terraformation.backend.plantingmanagement.PlantingSeasonScheduledDate
 import com.terraformation.backend.plantingmanagement.PlantingSeasonScheduledDateSpecies
 import com.terraformation.backend.plantingmanagement.event.PlantingSeasonScheduledDateCreatedEvent
 import com.terraformation.backend.plantingmanagement.event.PlantingSeasonScheduledDateDeletedEvent
+import com.terraformation.backend.plantingmanagement.event.PlantingSeasonScheduledDateSpeciesCreatedEvent
+import com.terraformation.backend.plantingmanagement.event.PlantingSeasonScheduledDateSpeciesDeletedEvent
+import com.terraformation.backend.plantingmanagement.event.PlantingSeasonScheduledDateSpeciesUpdatedEvent
+import com.terraformation.backend.plantingmanagement.event.PlantingSeasonScheduledDateSpeciesUpdatedEventValues
 import com.terraformation.backend.plantingmanagement.event.PlantingSeasonScheduledDateUpdatedEvent
 import com.terraformation.backend.plantingmanagement.event.PlantingSeasonScheduledDateUpdatedEventValues
+import com.terraformation.backend.rectangle
 import java.time.Instant
 import java.time.LocalDate
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -256,11 +261,17 @@ internal class PlantingSeasonScheduledDatesStoreTest : DatabaseTest(), RunsAsDat
               scheduledPlantingDateId = scheduledPlantingDateId,
           )
       )
+
+      eventPublisher.assertEventNotPublished<PlantingSeasonScheduledDateSpeciesCreatedEvent>()
     }
 
     @Test
     fun `inserts a new scheduled date with species`() {
-      val substratumId2 = insertSubstratum()
+      insertPlantingSiteHistory(boundary = rectangle(1))
+      insertStratumHistory()
+      val substratum1HistoryId = insertSubstratumHistory(substratumId = substratumId)
+      val substratumId2 = insertSubstratum(insertHistory = false)
+      val substratum2HistoryId = insertSubstratumHistory(substratumId = substratumId2)
       val speciesId2 = insertSpecies()
 
       val model =
@@ -330,6 +341,50 @@ internal class PlantingSeasonScheduledDatesStoreTest : DatabaseTest(), RunsAsDat
                   scheduledPlantingDateId = scheduledDateId,
                   speciesId = speciesId2,
                   substratumId = substratumId2,
+              ),
+          )
+      )
+
+      val speciesCreatedEvent =
+          PlantingSeasonScheduledDateSpeciesCreatedEvent(
+              organizationId = organizationId,
+              plantingSeasonId = plantingSeasonId,
+              plantingSiteId = plantingSiteId,
+              quantity = 5,
+              scheduledPlantingDateId = scheduledDateId,
+              speciesId = speciesId,
+              stratumName = "S1",
+              substratumHistoryId = substratum1HistoryId,
+              substratumId = substratumId,
+              substratumName = "1",
+          )
+
+      eventPublisher.assertEventsPublished(
+          listOf(
+              PlantingSeasonScheduledDateCreatedEvent(
+                  date = LocalDate.EPOCH.plusDays(1),
+                  organizationId = organizationId,
+                  plantingSeasonId = plantingSeasonId,
+                  plantingSiteId = plantingSiteId,
+                  scheduledPlantingDateId = scheduledDateId,
+              ),
+              speciesCreatedEvent,
+              speciesCreatedEvent.copy(
+                  quantity = 10,
+                  speciesId = speciesId2,
+              ),
+              speciesCreatedEvent.copy(
+                  quantity = 15,
+                  substratumHistoryId = substratum2HistoryId,
+                  substratumId = substratumId2,
+                  substratumName = "2",
+              ),
+              speciesCreatedEvent.copy(
+                  quantity = 20,
+                  speciesId = speciesId2,
+                  substratumHistoryId = substratum2HistoryId,
+                  substratumId = substratumId2,
+                  substratumName = "2",
               ),
           )
       )
@@ -447,8 +502,12 @@ internal class PlantingSeasonScheduledDatesStoreTest : DatabaseTest(), RunsAsDat
 
     @Test
     fun `updates the species for the scheduled date`() {
+      insertPlantingSiteHistory(boundary = rectangle(1))
+      insertStratumHistory()
+      val sub1HistoryId = insertSubstratumHistory(substratumId = substratumId)
       val speciesId2 = insertSpecies()
-      val substratumId2 = insertSubstratum()
+      val substratumId2 = insertSubstratum(insertHistory = false)
+      val sub2HistoryId = insertSubstratumHistory(substratumId = substratumId2)
       val scheduledDateId = insertPlantingSeasonScheduledDate()
       insertScheduledPlantingDateSpecies(
           quantity = 5,
@@ -510,13 +569,87 @@ internal class PlantingSeasonScheduledDatesStoreTest : DatabaseTest(), RunsAsDat
               ),
           )
       )
+
+      eventPublisher.assertEventsPublished(
+          setOf(
+              PlantingSeasonScheduledDateSpeciesDeletedEvent(
+                  organizationId = organizationId,
+                  plantingSeasonId = plantingSeasonId,
+                  plantingSiteId = plantingSiteId,
+                  scheduledPlantingDateId = scheduledDateId,
+                  speciesId = speciesId,
+                  stratumName = "S1",
+                  substratumHistoryId = sub1HistoryId,
+                  substratumId = substratumId,
+                  substratumName = "1",
+              ),
+              PlantingSeasonScheduledDateSpeciesCreatedEvent(
+                  organizationId = organizationId,
+                  plantingSeasonId = plantingSeasonId,
+                  plantingSiteId = plantingSiteId,
+                  quantity = 15,
+                  scheduledPlantingDateId = scheduledDateId,
+                  speciesId = speciesId2,
+                  stratumName = "S1",
+                  substratumHistoryId = sub1HistoryId,
+                  substratumId = substratumId,
+                  substratumName = "1",
+              ),
+              PlantingSeasonScheduledDateSpeciesUpdatedEvent(
+                  changedFrom = PlantingSeasonScheduledDateSpeciesUpdatedEventValues(quantity = 10),
+                  changedTo = PlantingSeasonScheduledDateSpeciesUpdatedEventValues(quantity = 11),
+                  organizationId = organizationId,
+                  plantingSeasonId = plantingSeasonId,
+                  plantingSiteId = plantingSiteId,
+                  scheduledPlantingDateId = scheduledDateId,
+                  speciesId = speciesId2,
+                  stratumName = "S1",
+                  substratumHistoryId = sub2HistoryId,
+                  substratumId = substratumId2,
+                  substratumName = "2",
+              ),
+          )
+      )
     }
 
     @Test
-    fun `throws DuplicateKeyException when same species-substratum combination is added twice`() {
+    fun `does not publish species events when species list is unchanged`() {
+      insertPlantingSiteHistory(boundary = rectangle(1))
+      insertStratumHistory()
+      insertSubstratumHistory(substratumId = substratumId)
+      val scheduledDateId = insertPlantingSeasonScheduledDate()
+      insertScheduledPlantingDateSpecies(
+          quantity = 7,
+          speciesId = speciesId,
+          substratumId = substratumId,
+      )
+
+      store.update(
+          scheduledDateId,
+          PlantingSeasonScheduledDateModel(
+              plantingSeasonId = plantingSeasonId,
+              date = LocalDate.EPOCH,
+              species =
+                  listOf(
+                      PlantingSeasonScheduledDateSpecies(
+                          quantity = 7,
+                          speciesId = speciesId,
+                          substratumId = substratumId,
+                      )
+                  ),
+          ),
+      )
+
+      eventPublisher.assertEventNotPublished<PlantingSeasonScheduledDateSpeciesCreatedEvent>()
+      eventPublisher.assertEventNotPublished<PlantingSeasonScheduledDateSpeciesDeletedEvent>()
+      eventPublisher.assertEventNotPublished<PlantingSeasonScheduledDateSpeciesUpdatedEvent>()
+    }
+
+    @Test
+    fun `throws exception when same species-substratum combination is added twice`() {
       val scheduledDate = insertPlantingSeasonScheduledDate()
 
-      assertThrows<DuplicateKeyException> {
+      assertThrows<IllegalArgumentException> {
         store.update(
             scheduledDate,
             PlantingSeasonScheduledDateModel(


### PR DESCRIPTION
When the list of species quantities for a scheduled planting date is updated,
publish events so the changes will appear in the change history for the planting
date.

This requires reworking some of the update logic; we need to distinguish when
species are created or deleted or updated so we can publish the correct events.
The "delete everything and insert the new list" logic is replaced by a diff-based
implementation.