### PR TITLE
SW-8427 Publish species deletion events when substratum deleted

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/customer/db/ParentStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/db/ParentStore.kt
@@ -227,6 +227,9 @@ class ParentStore(private val dslContext: DSLContext) {
   fun getPlantingSiteId(plantingSeasonId: PlantingSeasonId): PlantingSiteId? =
       fetchFieldById(plantingSeasonId, PLANTING_SEASONS.ID, PLANTING_SEASONS.PLANTING_SITE_ID)
 
+  fun getPlantingSiteId(substratumId: SubstratumId): PlantingSiteId? =
+      fetchFieldById(substratumId, SUBSTRATA.ID, SUBSTRATA.PLANTING_SITE_ID)
+
   fun getUserId(notificationId: NotificationId): UserId? =
       fetchFieldById(notificationId, NOTIFICATIONS.ID, NOTIFICATIONS.USER_ID)
 

--- a/src/main/kotlin/com/terraformation/backend/plantingmanagement/PlantingSeasonService.kt
+++ b/src/main/kotlin/com/terraformation/backend/plantingmanagement/PlantingSeasonService.kt
@@ -1,15 +1,19 @@
 package com.terraformation.backend.plantingmanagement
 
 import com.terraformation.backend.db.tracking.PlantingSeasonId
+import com.terraformation.backend.plantingmanagement.db.PlantingSeasonScheduledDatesStore
 import com.terraformation.backend.plantingmanagement.db.PlantingSeasonSpeciesTargetsStore
 import com.terraformation.backend.plantingmanagement.db.PlantingSeasonStore
+import com.terraformation.backend.tracking.event.SubstratumDeletionStartedEvent
 import jakarta.inject.Named
 import org.jooq.DSLContext
+import org.springframework.context.event.EventListener
 
 @Named
 class PlantingSeasonService(
     private val dslContext: DSLContext,
     private val plantingSeasonStore: PlantingSeasonStore,
+    private val plantingSeasonScheduledDatesStore: PlantingSeasonScheduledDatesStore,
     private val plantingSeasonSpeciesTargetsStore: PlantingSeasonSpeciesTargetsStore,
 ) {
   fun create(newModel: NewPlantingSeasonModel): PlantingSeasonId {
@@ -24,5 +28,10 @@ class PlantingSeasonService(
       }
       newSeasonId
     }
+  }
+
+  @EventListener
+  fun on(event: SubstratumDeletionStartedEvent) {
+    plantingSeasonScheduledDatesStore.publishSpeciesDeletedEvents(event.substratumId)
   }
 }

--- a/src/main/kotlin/com/terraformation/backend/plantingmanagement/db/PlantingSeasonScheduledDatesStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/plantingmanagement/db/PlantingSeasonScheduledDatesStore.kt
@@ -354,6 +354,59 @@ class PlantingSeasonScheduledDatesStore(
     )
   }
 
+  /**
+   * Publishes "species deleted" events for all the scheduled planting date species associated with
+   * a substratum. This is called when a substratum is about to be deleted.
+   */
+  fun publishSpeciesDeletedEvents(substratumId: SubstratumId) {
+    val speciesForSubstratum =
+        dslContext
+            .select(
+                SCHEDULED_PLANTING_DATES.ID,
+                SCHEDULED_PLANTING_DATE_SPECIES.SPECIES_ID,
+                PLANTING_SEASONS.ID,
+                PLANTING_SEASONS.PLANTING_SITE_ID,
+            )
+            .from(SCHEDULED_PLANTING_DATE_SPECIES)
+            .join(SCHEDULED_PLANTING_DATES)
+            .on(
+                SCHEDULED_PLANTING_DATE_SPECIES.SCHEDULED_PLANTING_DATE_ID.eq(
+                    SCHEDULED_PLANTING_DATES.ID
+                )
+            )
+            .join(PLANTING_SEASONS)
+            .on(SCHEDULED_PLANTING_DATES.PLANTING_SEASON_ID.eq(PLANTING_SEASONS.ID))
+            .where(SCHEDULED_PLANTING_DATE_SPECIES.SUBSTRATUM_ID.eq(substratumId))
+            .fetch()
+    if (speciesForSubstratum.isEmpty()) {
+      return
+    }
+
+    val plantingSiteId =
+        parentStore.getPlantingSiteId(substratumId)
+            ?: throw SubstratumNotFoundException(substratumId)
+    val organizationId =
+        parentStore.getOrganizationId(substratumId)
+            ?: throw SubstratumNotFoundException(substratumId)
+    val substratumInfo = fetchSubstratumInfo(listOf(substratumId)).getValue(substratumId)
+
+    speciesForSubstratum.forEach { record ->
+      eventPublisher.publishEvent(
+          PlantingSeasonScheduledDateSpeciesDeletedEvent(
+              organizationId = organizationId,
+              plantingSeasonId = record[PLANTING_SEASONS.ID]!!,
+              plantingSiteId = plantingSiteId,
+              scheduledPlantingDateId = record[SCHEDULED_PLANTING_DATES.ID]!!,
+              speciesId = record[SCHEDULED_PLANTING_DATE_SPECIES.SPECIES_ID]!!,
+              stratumName = substratumInfo.stratumName,
+              substratumHistoryId = substratumInfo.substratumHistoryId,
+              substratumId = substratumId,
+              substratumName = substratumInfo.substratumName,
+          )
+      )
+    }
+  }
+
   private fun fetchByCondition(
       condition: Condition
   ): List<ExistingPlantingSeasonScheduledDateModel> {

--- a/src/main/kotlin/com/terraformation/backend/tracking/db/PlantingSiteStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/db/PlantingSiteStore.kt
@@ -70,6 +70,7 @@ import com.terraformation.backend.tracking.event.PlantingSiteDeletionStartedEven
 import com.terraformation.backend.tracking.event.PlantingSiteHistoryCreatedEvent
 import com.terraformation.backend.tracking.event.PlantingSiteMapEditedEvent
 import com.terraformation.backend.tracking.event.RateLimitedT0DataAssignedEvent
+import com.terraformation.backend.tracking.event.SubstratumDeletionStartedEvent
 import com.terraformation.backend.tracking.model.AnyPlantingSiteModel
 import com.terraformation.backend.tracking.model.AnyStratumModel
 import com.terraformation.backend.tracking.model.AnySubstratumModel
@@ -960,9 +961,13 @@ class PlantingSiteStore(
         }
       }
       is SubstratumEdit.Delete -> {
+        val substratumIdToDelete = edit.existingModel.id
+
+        eventPublisher.publishEvent(SubstratumDeletionStartedEvent(substratumIdToDelete))
+
         // Plots will be deleted by ON DELETE CASCADE. This may legitimately delete 0 rows if the
         // parent stratum has already been deleted.
-        dslContext.deleteFrom(SUBSTRATA).where(SUBSTRATA.ID.eq(edit.existingModel.id)).execute()
+        dslContext.deleteFrom(SUBSTRATA).where(SUBSTRATA.ID.eq(substratumIdToDelete)).execute()
 
         replacementResults.add(
             ReplacementResult(emptySet(), edit.existingModel.monitoringPlots.map { it.id }.toSet())

--- a/src/main/kotlin/com/terraformation/backend/tracking/event/Events.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/event/Events.kt
@@ -21,6 +21,7 @@ import com.terraformation.backend.db.tracking.RecordedPlantStatus
 import com.terraformation.backend.db.tracking.RecordedSpeciesCertainty
 import com.terraformation.backend.db.tracking.RecordedTreeId
 import com.terraformation.backend.db.tracking.StratumId
+import com.terraformation.backend.db.tracking.SubstratumId
 import com.terraformation.backend.db.tracking.TreeGrowthForm
 import com.terraformation.backend.eventlog.EntityCreatedPersistentEvent
 import com.terraformation.backend.eventlog.EntityDeletedPersistentEvent
@@ -109,6 +110,8 @@ data class ObservationStateUpdatedEvent(
 )
 
 data class PlantingSiteDeletionStartedEvent(val plantingSiteId: PlantingSiteId)
+
+data class SubstratumDeletionStartedEvent(val substratumId: SubstratumId)
 
 data class PlantingSeasonRescheduledEvent(
     val plantingSeasonId: PlantingSeasonId,

--- a/src/test/kotlin/com/terraformation/backend/plantingmanagement/PlantingSeasonServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/plantingmanagement/PlantingSeasonServiceTest.kt
@@ -13,6 +13,7 @@ import com.terraformation.backend.db.tracking.PlantingSiteId
 import com.terraformation.backend.db.tracking.SubstratumId
 import com.terraformation.backend.db.tracking.tables.records.PlantingSeasonSpeciesTargetsRecord
 import com.terraformation.backend.db.tracking.tables.references.PLANTING_SEASON_SPECIES_TARGETS
+import com.terraformation.backend.plantingmanagement.db.PlantingSeasonScheduledDatesStore
 import com.terraformation.backend.plantingmanagement.db.PlantingSeasonSpeciesTargetsStore
 import com.terraformation.backend.plantingmanagement.db.PlantingSeasonStore
 import java.time.Instant
@@ -27,6 +28,9 @@ internal class PlantingSeasonServiceTest : DatabaseTest(), RunsAsDatabaseUser {
   private val clock = TestClock()
   private val eventPublisher = TestEventPublisher()
   private val parentStore: ParentStore by lazy { ParentStore(dslContext) }
+  private val plantingSeasonScheduledDatesStore by lazy {
+    PlantingSeasonScheduledDatesStore(clock, dslContext, eventPublisher, parentStore)
+  }
   private val plantingSeasonSpeciesTargetsStore: PlantingSeasonSpeciesTargetsStore by lazy {
     PlantingSeasonSpeciesTargetsStore(clock, dslContext, eventPublisher)
   }
@@ -34,7 +38,12 @@ internal class PlantingSeasonServiceTest : DatabaseTest(), RunsAsDatabaseUser {
     PlantingSeasonStore(clock, dslContext, eventPublisher, parentStore)
   }
   private val service: PlantingSeasonService by lazy {
-    PlantingSeasonService(dslContext, plantingSeasonStore, plantingSeasonSpeciesTargetsStore)
+    PlantingSeasonService(
+        dslContext,
+        plantingSeasonStore,
+        plantingSeasonScheduledDatesStore,
+        plantingSeasonSpeciesTargetsStore,
+    )
   }
 
   private lateinit var plantingSeasonId: PlantingSeasonId

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/plantingSiteStore/PlantingSiteStoreApplyEditTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/plantingSiteStore/PlantingSiteStoreApplyEditTest.kt
@@ -1,15 +1,21 @@
 package com.terraformation.backend.tracking.db.plantingSiteStore
 
+import com.terraformation.backend.customer.db.ParentStore
 import com.terraformation.backend.db.NumericIdentifierType
 import com.terraformation.backend.db.StableId
 import com.terraformation.backend.db.tracking.StratumId
+import com.terraformation.backend.db.tracking.SubstratumHistoryId
 import com.terraformation.backend.db.tracking.SubstratumId
 import com.terraformation.backend.db.tracking.tables.pojos.PlantingSiteHistoriesRow
 import com.terraformation.backend.db.tracking.tables.pojos.StratumHistoriesRow
 import com.terraformation.backend.db.tracking.tables.records.MonitoringPlotHistoriesRecord
 import com.terraformation.backend.db.tracking.tables.records.SubstratumHistoriesRecord
 import com.terraformation.backend.db.tracking.tables.references.MONITORING_PLOT_HISTORIES
+import com.terraformation.backend.db.tracking.tables.references.STRATA
+import com.terraformation.backend.db.tracking.tables.references.SUBSTRATA
 import com.terraformation.backend.db.tracking.tables.references.SUBSTRATUM_HISTORIES
+import com.terraformation.backend.plantingmanagement.db.PlantingSeasonScheduledDatesStore
+import com.terraformation.backend.plantingmanagement.event.PlantingSeasonScheduledDateSpeciesDeletedEvent
 import com.terraformation.backend.point
 import com.terraformation.backend.rectangle
 import com.terraformation.backend.tracking.edit.MonitoringPlotEdit
@@ -19,6 +25,7 @@ import com.terraformation.backend.tracking.edit.PlantingSiteEditCalculatorTest
 import com.terraformation.backend.tracking.edit.StratumEdit
 import com.terraformation.backend.tracking.event.PlantingSiteHistoryCreatedEvent
 import com.terraformation.backend.tracking.event.PlantingSiteMapEditedEvent
+import com.terraformation.backend.tracking.event.SubstratumDeletionStartedEvent
 import com.terraformation.backend.tracking.model.AnyPlantingSiteModel
 import com.terraformation.backend.tracking.model.ExistingPlantingSiteModel
 import com.terraformation.backend.tracking.model.NewPlantingSiteModel
@@ -149,6 +156,91 @@ internal class PlantingSiteStoreApplyEditTest : BasePlantingSiteStoreTest() {
               },
           desired = newSite(width = 500),
       )
+    }
+
+    @Test
+    fun `publishes species deleted events when substratum has scheduled date species`() {
+      val plantingSeasonScheduledDatesStore =
+          PlantingSeasonScheduledDatesStore(
+              clock,
+              dslContext,
+              eventPublisher,
+              ParentStore(dslContext),
+          )
+      eventPublisher.register<SubstratumDeletionStartedEvent> {
+        plantingSeasonScheduledDatesStore.publishSpeciesDeletedEvents(it.substratumId)
+      }
+
+      val initial =
+          newSite(width = 750) {
+            stratum(width = 750) {
+              substratum(width = 500)
+              substratum()
+            }
+          }
+      val desired = newSite(width = 500)
+
+      val existing = createSite(initial)
+      val deletedSubstratum = existing.strata[0].substrata[1]
+      val deletedSubstratumId = deletedSubstratum.id
+
+      val speciesId = insertSpecies()
+      val plantingSeasonId = insertPlantingSeason(plantingSiteId = existing.id)
+      val scheduledDateId = insertPlantingSeasonScheduledDate(plantingSeasonId = plantingSeasonId)
+      insertScheduledPlantingDateSpecies(
+          quantity = 42,
+          scheduledPlantingDateId = scheduledDateId,
+          speciesId = speciesId,
+          substratumId = deletedSubstratumId,
+      )
+
+      val (stratumName, substratumName, substratumHistoryId) =
+          substratumInfoFromDb(deletedSubstratumId)
+
+      val plantingSiteEdit = calculateSiteEdit(existing, desired)
+
+      clock.instant = editTime
+      store.applyPlantingSiteEdit(plantingSiteEdit)
+
+      eventPublisher.assertEventPublished(
+          PlantingSeasonScheduledDateSpeciesDeletedEvent(
+              organizationId = existing.organizationId,
+              plantingSeasonId = plantingSeasonId,
+              plantingSiteId = existing.id,
+              scheduledPlantingDateId = scheduledDateId,
+              speciesId = speciesId,
+              stratumName = stratumName,
+              substratumHistoryId = substratumHistoryId,
+              substratumId = deletedSubstratumId,
+              substratumName = substratumName,
+          )
+      )
+    }
+
+    private fun substratumInfoFromDb(
+        substratumId: SubstratumId
+    ): Triple<String, String, SubstratumHistoryId> {
+      val sub =
+          dslContext
+              .select(SUBSTRATA.NAME, SUBSTRATA.STRATUM_ID)
+              .from(SUBSTRATA)
+              .where(SUBSTRATA.ID.eq(substratumId))
+              .fetchOne()!!
+      val stratumName =
+          dslContext
+              .select(STRATA.NAME)
+              .from(STRATA)
+              .where(STRATA.ID.eq(sub[SUBSTRATA.STRATUM_ID]!!))
+              .fetchOne(STRATA.NAME)!!
+      val historyId =
+          dslContext
+              .select(SUBSTRATUM_HISTORIES.ID)
+              .from(SUBSTRATUM_HISTORIES)
+              .where(SUBSTRATUM_HISTORIES.SUBSTRATUM_ID.eq(substratumId))
+              .orderBy(SUBSTRATUM_HISTORIES.ID.desc())
+              .limit(1)
+              .fetchOne(SUBSTRATUM_HISTORIES.ID)!!
+      return Triple(stratumName, sub[SUBSTRATA.NAME]!!, historyId)
     }
 
     @Test


### PR DESCRIPTION
When parent entities are deleted, scheduled planting date species rows are deleted
by cascading-delete foreign keys. In the case of deleting a scheduled planting
date, that's fine: the event log will indicate that the date was deleted, which
implies deletion of all the date's species.

But when a substratum is deleted, there won't be an obvious deletion event that
shows up in the activity log for a scheduled planting date; it'll just look like
the species entries vanished with no explanation.

Add logic to publish deleted events for all the scheduled date species that
referred to the deleted substratum.