### PR TITLE
SW-8443 Add planting date request id to fetch withdrawal endpoint

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/nursery/api/WithdrawalsController.kt
+++ b/src/main/kotlin/com/terraformation/backend/nursery/api/WithdrawalsController.kt
@@ -25,6 +25,7 @@ import com.terraformation.backend.db.default_schema.FileId
 import com.terraformation.backend.db.nursery.BatchId
 import com.terraformation.backend.db.nursery.WithdrawalId
 import com.terraformation.backend.db.nursery.WithdrawalPurpose
+import com.terraformation.backend.db.tracking.PlantingDateRequestId
 import com.terraformation.backend.db.tracking.PlantingSeasonId
 import com.terraformation.backend.db.tracking.PlantingSiteId
 import com.terraformation.backend.db.tracking.SubstratumId
@@ -234,6 +235,7 @@ data class NurseryWithdrawalPayload(
     val facilityId: FacilityId,
     val id: WithdrawalId,
     val notes: String?,
+    val plantingDateRequestId: PlantingDateRequestId?,
     val plantingSeasonId: PlantingSeasonId?,
     val purpose: WithdrawalPurpose,
     val withdrawnDate: LocalDate,
@@ -250,6 +252,7 @@ data class NurseryWithdrawalPayload(
       model.facilityId,
       model.id,
       model.notes,
+      model.plantingDateRequestId,
       model.plantingSeasonId,
       model.purpose,
       model.withdrawnDate,

--- a/src/main/kotlin/com/terraformation/backend/nursery/api/WithdrawalsController.kt
+++ b/src/main/kotlin/com/terraformation/backend/nursery/api/WithdrawalsController.kt
@@ -25,9 +25,9 @@ import com.terraformation.backend.db.default_schema.FileId
 import com.terraformation.backend.db.nursery.BatchId
 import com.terraformation.backend.db.nursery.WithdrawalId
 import com.terraformation.backend.db.nursery.WithdrawalPurpose
-import com.terraformation.backend.db.tracking.PlantingDateRequestId
 import com.terraformation.backend.db.tracking.PlantingSeasonId
 import com.terraformation.backend.db.tracking.PlantingSiteId
+import com.terraformation.backend.db.tracking.ScheduledPlantingDateId
 import com.terraformation.backend.db.tracking.SubstratumId
 import com.terraformation.backend.file.SUPPORTED_PHOTO_TYPES
 import com.terraformation.backend.file.model.FileMetadata
@@ -235,7 +235,7 @@ data class NurseryWithdrawalPayload(
     val facilityId: FacilityId,
     val id: WithdrawalId,
     val notes: String?,
-    val plantingDateRequestId: PlantingDateRequestId?,
+    val scheduledPlantingDateRequestId: ScheduledPlantingDateId?,
     val plantingSeasonId: PlantingSeasonId?,
     val purpose: WithdrawalPurpose,
     val withdrawnDate: LocalDate,
@@ -252,7 +252,7 @@ data class NurseryWithdrawalPayload(
       model.facilityId,
       model.id,
       model.notes,
-      model.plantingDateRequestId,
+      model.scheduledPlantingDateRequestId,
       model.plantingSeasonId,
       model.purpose,
       model.withdrawnDate,

--- a/src/main/kotlin/com/terraformation/backend/nursery/db/BatchStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/nursery/db/BatchStore.kt
@@ -689,15 +689,6 @@ class BatchStore(
     } else if (withdrawal.destinationFacilityId != null) {
       throw IllegalArgumentException("Only nursery transfers may include destination facility ID")
     }
-    if (
-        withdrawal.plantingSeasonId != null &&
-            withdrawal.purpose != WithdrawalPurpose.OutPlant &&
-            withdrawal.purpose != WithdrawalPurpose.Undo
-    ) {
-      throw IllegalArgumentException(
-          "Planting season may only be specified for out-plant or undo withdrawals"
-      )
-    }
 
     return dslContext.transactionResult { _ ->
       val withdrawalsRow =

--- a/src/main/kotlin/com/terraformation/backend/nursery/model/WithdrawalModel.kt
+++ b/src/main/kotlin/com/terraformation/backend/nursery/model/WithdrawalModel.kt
@@ -7,6 +7,7 @@ import com.terraformation.backend.db.nursery.WithdrawalPurpose
 import com.terraformation.backend.db.nursery.tables.pojos.BatchWithdrawalsRow
 import com.terraformation.backend.db.nursery.tables.pojos.WithdrawalsRow
 import com.terraformation.backend.db.tracking.DeliveryId
+import com.terraformation.backend.db.tracking.PlantingDateRequestId
 import com.terraformation.backend.db.tracking.PlantingSeasonId
 import java.time.LocalDate
 
@@ -45,6 +46,7 @@ data class WithdrawalModel<ID : WithdrawalId?>(
     val facilityId: FacilityId,
     val id: ID,
     val notes: String? = null,
+    val plantingDateRequestId: PlantingDateRequestId? = null,
     val plantingSeasonId: PlantingSeasonId? = null,
     val purpose: WithdrawalPurpose,
     val withdrawnDate: LocalDate,
@@ -61,6 +63,22 @@ data class WithdrawalModel<ID : WithdrawalId?>(
             undoesWithdrawalId == null && purpose == WithdrawalPurpose.Undo
     ) {
       throw IllegalArgumentException("Must specify original withdrawal ID if purpose is Undo")
+    }
+
+    if (
+        plantingSeasonId != null &&
+            purpose != WithdrawalPurpose.OutPlant &&
+            purpose != WithdrawalPurpose.Undo
+    ) {
+      throw IllegalArgumentException(
+          "Planting season may only be specified for out-plant or undo withdrawals"
+      )
+    }
+
+    if (plantingDateRequestId != null && plantingSeasonId == null) {
+      throw IllegalArgumentException(
+          "Must specify planting season ID if planting date request ID is specified"
+      )
     }
   }
 }
@@ -91,6 +109,7 @@ fun WithdrawalsRow.toModel(
         facilityId = facilityId!!,
         id = id!!,
         notes = notes,
+        plantingDateRequestId = plantingDateRequestId,
         plantingSeasonId = plantingSeasonId,
         purpose = purposeId!!,
         withdrawnDate = withdrawnDate!!,

--- a/src/main/kotlin/com/terraformation/backend/nursery/model/WithdrawalModel.kt
+++ b/src/main/kotlin/com/terraformation/backend/nursery/model/WithdrawalModel.kt
@@ -7,8 +7,8 @@ import com.terraformation.backend.db.nursery.WithdrawalPurpose
 import com.terraformation.backend.db.nursery.tables.pojos.BatchWithdrawalsRow
 import com.terraformation.backend.db.nursery.tables.pojos.WithdrawalsRow
 import com.terraformation.backend.db.tracking.DeliveryId
-import com.terraformation.backend.db.tracking.PlantingDateRequestId
 import com.terraformation.backend.db.tracking.PlantingSeasonId
+import com.terraformation.backend.db.tracking.ScheduledPlantingDateId
 import java.time.LocalDate
 
 /**
@@ -46,7 +46,7 @@ data class WithdrawalModel<ID : WithdrawalId?>(
     val facilityId: FacilityId,
     val id: ID,
     val notes: String? = null,
-    val plantingDateRequestId: PlantingDateRequestId? = null,
+    val scheduledPlantingDateRequestId: ScheduledPlantingDateId? = null,
     val plantingSeasonId: PlantingSeasonId? = null,
     val purpose: WithdrawalPurpose,
     val withdrawnDate: LocalDate,
@@ -75,7 +75,7 @@ data class WithdrawalModel<ID : WithdrawalId?>(
       )
     }
 
-    if (plantingDateRequestId != null && plantingSeasonId == null) {
+    if (scheduledPlantingDateRequestId != null && plantingSeasonId == null) {
       throw IllegalArgumentException(
           "Must specify planting season ID if planting date request ID is specified"
       )
@@ -109,7 +109,7 @@ fun WithdrawalsRow.toModel(
         facilityId = facilityId!!,
         id = id!!,
         notes = notes,
-        plantingDateRequestId = plantingDateRequestId,
+        scheduledPlantingDateRequestId = scheduledPlantingDateRequestId,
         plantingSeasonId = plantingSeasonId,
         purpose = purposeId!!,
         withdrawnDate = withdrawnDate!!,

--- a/src/test/kotlin/com/terraformation/backend/db/DatabaseBackedTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/db/DatabaseBackedTest.kt
@@ -422,6 +422,8 @@ import com.terraformation.backend.db.tracking.ObservationPlotStatus
 import com.terraformation.backend.db.tracking.ObservationState
 import com.terraformation.backend.db.tracking.ObservationType
 import com.terraformation.backend.db.tracking.ObservedPlotCoordinatesId
+import com.terraformation.backend.db.tracking.PlantingDateRequestId
+import com.terraformation.backend.db.tracking.PlantingDateRequestStatus
 import com.terraformation.backend.db.tracking.PlantingId
 import com.terraformation.backend.db.tracking.PlantingSeasonId
 import com.terraformation.backend.db.tracking.PlantingSeasonStatus
@@ -458,6 +460,8 @@ import com.terraformation.backend.db.tracking.tables.daos.ObservationStratumResu
 import com.terraformation.backend.db.tracking.tables.daos.ObservationSubstratumResultsDao
 import com.terraformation.backend.db.tracking.tables.daos.ObservationsDao
 import com.terraformation.backend.db.tracking.tables.daos.ObservedPlotCoordinatesDao
+import com.terraformation.backend.db.tracking.tables.daos.PlantingDateRequestSpeciesDao
+import com.terraformation.backend.db.tracking.tables.daos.PlantingDateRequestsDao
 import com.terraformation.backend.db.tracking.tables.daos.PlantingSeasonAllocatedSpeciesDao
 import com.terraformation.backend.db.tracking.tables.daos.PlantingSeasonSpeciesTargetsDao
 import com.terraformation.backend.db.tracking.tables.daos.PlantingSeasonsDao
@@ -504,6 +508,8 @@ import com.terraformation.backend.db.tracking.tables.pojos.ObservedPlotCoordinat
 import com.terraformation.backend.db.tracking.tables.pojos.ObservedSiteSpeciesTotalsRow
 import com.terraformation.backend.db.tracking.tables.pojos.ObservedStratumSpeciesTotalsRow
 import com.terraformation.backend.db.tracking.tables.pojos.ObservedSubstratumSpeciesTotalsRow
+import com.terraformation.backend.db.tracking.tables.pojos.PlantingDateRequestSpeciesRow
+import com.terraformation.backend.db.tracking.tables.pojos.PlantingDateRequestsRow
 import com.terraformation.backend.db.tracking.tables.pojos.PlantingSeasonAllocatedSpeciesRow
 import com.terraformation.backend.db.tracking.tables.pojos.PlantingSeasonSpeciesTargetsRow
 import com.terraformation.backend.db.tracking.tables.pojos.PlantingSeasonsRow
@@ -739,6 +745,8 @@ abstract class DatabaseBackedTest {
   protected val organizationsDao: OrganizationsDao by lazyDao()
   protected val organizationUsersDao: OrganizationUsersDao by lazyDao()
   protected val participantProjectSpeciesDao: ParticipantProjectSpeciesDao by lazyDao()
+  protected val plantingDateRequestsDao: PlantingDateRequestsDao by lazyDao()
+  protected val plantingDateRequestSpeciesDao: PlantingDateRequestSpeciesDao by lazyDao()
   protected val plantingsDao: PlantingsDao by lazyDao()
   protected val plantingSeasonsDao: PlantingSeasonsDao by lazyDao()
   protected val plantingSeasonAllocatedSpeciesDao: PlantingSeasonAllocatedSpeciesDao by lazyDao()
@@ -2405,6 +2413,54 @@ abstract class DatabaseBackedTest {
         )
 
     scheduledPlantingDateSpeciesDao.insert(rowWithDefaults)
+  }
+
+  fun insertPlantingDateRequest(
+      row: PlantingDateRequestsRow = PlantingDateRequestsRow(),
+      createdBy: UserId = row.createdBy ?: currentUser().userId,
+      createdTime: Instant = row.createdTime ?: Instant.EPOCH,
+      date: LocalDate = LocalDate.EPOCH,
+      modifiedBy: UserId = row.modifiedBy ?: createdBy,
+      modifiedTime: Instant = row.modifiedTime ?: createdTime,
+      notes: String? = null,
+      scheduledPlantingDateId: ScheduledPlantingDateId =
+          row.scheduledPlantingDateId ?: inserted.scheduledPlantingDateId,
+      status: PlantingDateRequestStatus = PlantingDateRequestStatus.Pending,
+  ): PlantingDateRequestId {
+    val rowWithDefaults =
+        row.copy(
+            createdBy = createdBy,
+            createdTime = createdTime,
+            date = date,
+            modifiedBy = modifiedBy,
+            modifiedTime = modifiedTime,
+            notes = notes,
+            scheduledPlantingDateId = scheduledPlantingDateId,
+            statusId = status,
+        )
+
+    plantingDateRequestsDao.insert(rowWithDefaults)
+
+    return rowWithDefaults.id!!.also { inserted.plantingDateRequestIds.add(it) }
+  }
+
+  fun insertPlantingDateRequestSpecies(
+      row: PlantingDateRequestSpeciesRow = PlantingDateRequestSpeciesRow(),
+      plantingDateRequestId: PlantingDateRequestId =
+          row.plantingDateRequestId ?: inserted.plantingDateRequestId,
+      quantity: Int = row.quantity ?: 1,
+      speciesId: SpeciesId = row.speciesId ?: inserted.speciesId,
+      substratumId: SubstratumId = row.substratumId ?: inserted.substratumId,
+  ) {
+    val rowWithDefaults =
+        row.copy(
+            plantingDateRequestId = plantingDateRequestId,
+            quantity = quantity,
+            speciesId = speciesId,
+            substratumId = substratumId,
+        )
+
+    plantingDateRequestSpeciesDao.insert(rowWithDefaults)
   }
 
   var nextPlantingSiteNumber: Int = 1
@@ -5938,6 +5994,7 @@ abstract class DatabaseBackedTest {
     val observationIds = mutableListOf<ObservationId>()
     val organizationIds = mutableListOf<OrganizationId>()
     val participantProjectSpeciesIds = mutableListOf<ParticipantProjectSpeciesId>()
+    val plantingDateRequestIds = mutableListOf<PlantingDateRequestId>()
     val plantingIds = mutableListOf<PlantingId>()
     val plantingSeasonIds = mutableListOf<PlantingSeasonId>()
     val plantingSiteHistoryIds = mutableListOf<PlantingSiteHistoryId>()
@@ -6060,6 +6117,9 @@ abstract class DatabaseBackedTest {
 
     val participantProjectSpeciesId
       get() = participantProjectSpeciesIds.last()
+
+    val plantingDateRequestId
+      get() = plantingDateRequestIds.last()
 
     val plantingId
       get() = plantingIds.last()

--- a/src/test/kotlin/com/terraformation/backend/db/DatabaseBackedTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/db/DatabaseBackedTest.kt
@@ -422,7 +422,6 @@ import com.terraformation.backend.db.tracking.ObservationPlotStatus
 import com.terraformation.backend.db.tracking.ObservationState
 import com.terraformation.backend.db.tracking.ObservationType
 import com.terraformation.backend.db.tracking.ObservedPlotCoordinatesId
-import com.terraformation.backend.db.tracking.PlantingDateRequestId
 import com.terraformation.backend.db.tracking.PlantingDateRequestStatus
 import com.terraformation.backend.db.tracking.PlantingId
 import com.terraformation.backend.db.tracking.PlantingSeasonId
@@ -2426,7 +2425,7 @@ abstract class DatabaseBackedTest {
       scheduledPlantingDateId: ScheduledPlantingDateId =
           row.scheduledPlantingDateId ?: inserted.scheduledPlantingDateId,
       status: PlantingDateRequestStatus = PlantingDateRequestStatus.Pending,
-  ): PlantingDateRequestId {
+  ) {
     val rowWithDefaults =
         row.copy(
             createdBy = createdBy,
@@ -2440,21 +2439,19 @@ abstract class DatabaseBackedTest {
         )
 
     plantingDateRequestsDao.insert(rowWithDefaults)
-
-    return rowWithDefaults.id!!.also { inserted.plantingDateRequestIds.add(it) }
   }
 
   fun insertPlantingDateRequestSpecies(
       row: PlantingDateRequestSpeciesRow = PlantingDateRequestSpeciesRow(),
-      plantingDateRequestId: PlantingDateRequestId =
-          row.plantingDateRequestId ?: inserted.plantingDateRequestId,
+      scheduledPlantingDateId: ScheduledPlantingDateId =
+          row.scheduledPlantingDateId ?: inserted.scheduledPlantingDateId,
       quantity: Int = row.quantity ?: 1,
       speciesId: SpeciesId = row.speciesId ?: inserted.speciesId,
       substratumId: SubstratumId = row.substratumId ?: inserted.substratumId,
   ) {
     val rowWithDefaults =
         row.copy(
-            plantingDateRequestId = plantingDateRequestId,
+            scheduledPlantingDateId = scheduledPlantingDateId,
             quantity = quantity,
             speciesId = speciesId,
             substratumId = substratumId,
@@ -5994,7 +5991,6 @@ abstract class DatabaseBackedTest {
     val observationIds = mutableListOf<ObservationId>()
     val organizationIds = mutableListOf<OrganizationId>()
     val participantProjectSpeciesIds = mutableListOf<ParticipantProjectSpeciesId>()
-    val plantingDateRequestIds = mutableListOf<PlantingDateRequestId>()
     val plantingIds = mutableListOf<PlantingId>()
     val plantingSeasonIds = mutableListOf<PlantingSeasonId>()
     val plantingSiteHistoryIds = mutableListOf<PlantingSiteHistoryId>()
@@ -6117,9 +6113,6 @@ abstract class DatabaseBackedTest {
 
     val participantProjectSpeciesId
       get() = participantProjectSpeciesIds.last()
-
-    val plantingDateRequestId
-      get() = plantingDateRequestIds.last()
 
     val plantingId
       get() = plantingIds.last()

--- a/src/test/kotlin/com/terraformation/backend/nursery/db/batchStore/BatchStoreWithdrawTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/nursery/db/batchStore/BatchStoreWithdrawTest.kt
@@ -1378,8 +1378,8 @@ internal class BatchStoreWithdrawTest : BatchStoreTest() {
     insertStratum()
     insertSubstratum()
     insertPlantingSeason()
-    insertPlantingSeasonScheduledDate()
-    val plantingDateRequestId = insertPlantingDateRequest()
+    val scheduledPlantingDateId = insertPlantingSeasonScheduledDate()
+    insertPlantingDateRequest()
     insertPlantingDateRequestSpecies()
 
     assertThrows<IllegalArgumentException> {
@@ -1397,7 +1397,7 @@ internal class BatchStoreWithdrawTest : BatchStoreTest() {
                   ),
               facilityId = facilityId,
               id = null,
-              plantingDateRequestId = plantingDateRequestId,
+              scheduledPlantingDateRequestId = scheduledPlantingDateId,
               purpose = WithdrawalPurpose.OutPlant,
               withdrawnDate = LocalDate.EPOCH,
           )

--- a/src/test/kotlin/com/terraformation/backend/nursery/db/batchStore/BatchStoreWithdrawTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/nursery/db/batchStore/BatchStoreWithdrawTest.kt
@@ -1364,9 +1364,42 @@ internal class BatchStoreWithdrawTest : BatchStoreTest() {
                   ),
               facilityId = facilityId,
               id = null,
+              plantingSeasonId = plantingSeasonId,
               purpose = WithdrawalPurpose.Other,
               withdrawnDate = LocalDate.EPOCH,
-              plantingSeasonId = plantingSeasonId,
+          )
+      )
+    }
+  }
+
+  @Test
+  fun `throws exception if planting date request id and no planting season id`() {
+    insertPlantingSite()
+    insertStratum()
+    insertSubstratum()
+    insertPlantingSeason()
+    insertPlantingSeasonScheduledDate()
+    val plantingDateRequestId = insertPlantingDateRequest()
+    insertPlantingDateRequestSpecies()
+
+    assertThrows<IllegalArgumentException> {
+      store.withdraw(
+          NewWithdrawalModel(
+              batchWithdrawals =
+                  listOf(
+                      BatchWithdrawalModel(
+                          batchId = species1Batch1Id,
+                          germinatingQuantityWithdrawn = 1,
+                          activeGrowthQuantityWithdrawn = 0,
+                          readyQuantityWithdrawn = 0,
+                          hardeningOffQuantityWithdrawn = 0,
+                      )
+                  ),
+              facilityId = facilityId,
+              id = null,
+              plantingDateRequestId = plantingDateRequestId,
+              purpose = WithdrawalPurpose.OutPlant,
+              withdrawnDate = LocalDate.EPOCH,
           )
       )
     }


### PR DESCRIPTION
Include the `plantingDateRequestId` when fetching a nursery withdrawal.

Also move some initialization logic from the `BatchStore` to the `WithdrawalModel`.