### PR TITLE
SW-8442 Create planting date request with scheduled planting date

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/plantingmanagement/Models.kt
+++ b/src/main/kotlin/com/terraformation/backend/plantingmanagement/Models.kt
@@ -39,7 +39,9 @@ data class PlantingSeasonScheduledDateSpecies(
 )
 
 data class PlantingSeasonScheduledDateModel(
+    val createNurseryRequest: Boolean? = false,
     val date: LocalDate,
+    val nurseryRequestNotes: String? = null,
     val plantingSeasonId: PlantingSeasonId,
     val species: List<PlantingSeasonScheduledDateSpecies> = emptyList(),
 ) {
@@ -47,6 +49,11 @@ data class PlantingSeasonScheduledDateModel(
     require(species.all { it.quantity >= 0 }) { "All quantities must be >= 0" }
     require(species.size == species.distinctBy { it.substratumId to it.speciesId }.size) {
       "Species listed multiple times for substratum"
+    }
+    require(
+        (nurseryRequestNotes != null && createNurseryRequest == true) || nurseryRequestNotes == null
+    ) {
+      "createNurseryRequest must be true if nurseryRequestNotes are specified"
     }
   }
 }

--- a/src/main/kotlin/com/terraformation/backend/plantingmanagement/Models.kt
+++ b/src/main/kotlin/com/terraformation/backend/plantingmanagement/Models.kt
@@ -50,11 +50,6 @@ data class PlantingSeasonScheduledDateModel(
     require(species.size == species.distinctBy { it.substratumId to it.speciesId }.size) {
       "Species listed multiple times for substratum"
     }
-    require(
-        (nurseryRequestNotes != null && createNurseryRequest == true) || nurseryRequestNotes == null
-    ) {
-      "createNurseryRequest must be true if nurseryRequestNotes are specified"
-    }
   }
 }
 

--- a/src/main/kotlin/com/terraformation/backend/plantingmanagement/PlantingSeasonScheduledDatesService.kt
+++ b/src/main/kotlin/com/terraformation/backend/plantingmanagement/PlantingSeasonScheduledDatesService.kt
@@ -1,0 +1,31 @@
+package com.terraformation.backend.plantingmanagement
+
+import com.terraformation.backend.db.tracking.ScheduledPlantingDateId
+import com.terraformation.backend.plantingmanagement.db.PlantingDateRequestsStore
+import com.terraformation.backend.plantingmanagement.db.PlantingSeasonScheduledDatesStore
+import jakarta.inject.Named
+import org.jooq.DSLContext
+
+@Named
+class PlantingSeasonScheduledDatesService(
+    private val dslContext: DSLContext,
+    private val plantingDateRequestsStore: PlantingDateRequestsStore,
+    private val plantingSeasonScheduledDatesStore: PlantingSeasonScheduledDatesStore,
+) {
+
+  fun create(model: PlantingSeasonScheduledDateModel): ScheduledPlantingDateId {
+    return dslContext.transactionResult { _ ->
+      val scheduledPlantingDateId = plantingSeasonScheduledDatesStore.create(model)
+
+      if (model.createNurseryRequest == true) {
+        plantingDateRequestsStore.create(
+            scheduledPlantingDateId,
+            model.plantingSeasonId,
+            model.nurseryRequestNotes,
+        )
+      }
+
+      scheduledPlantingDateId
+    }
+  }
+}

--- a/src/main/kotlin/com/terraformation/backend/plantingmanagement/PlantingSeasonScheduledDatesService.kt
+++ b/src/main/kotlin/com/terraformation/backend/plantingmanagement/PlantingSeasonScheduledDatesService.kt
@@ -13,15 +13,19 @@ class PlantingSeasonScheduledDatesService(
     private val plantingSeasonScheduledDatesStore: PlantingSeasonScheduledDatesStore,
 ) {
 
-  fun create(model: PlantingSeasonScheduledDateModel): ScheduledPlantingDateId {
+  fun create(
+      model: PlantingSeasonScheduledDateModel,
+      createNurseryRequest: Boolean,
+      nurseryRequestNotes: String? = null,
+  ): ScheduledPlantingDateId {
     return dslContext.transactionResult { _ ->
       val scheduledPlantingDateId = plantingSeasonScheduledDatesStore.create(model)
 
-      if (model.createNurseryRequest == true) {
+      if (createNurseryRequest) {
         plantingDateRequestsStore.create(
             scheduledPlantingDateId,
             model.plantingSeasonId,
-            model.nurseryRequestNotes,
+            nurseryRequestNotes,
         )
       }
 

--- a/src/main/kotlin/com/terraformation/backend/plantingmanagement/api/PlantingSeasonScheduledDatesController.kt
+++ b/src/main/kotlin/com/terraformation/backend/plantingmanagement/api/PlantingSeasonScheduledDatesController.kt
@@ -13,6 +13,7 @@ import com.terraformation.backend.db.tracking.SubstratumId
 import com.terraformation.backend.plantingmanagement.ExistingPlantingSeasonScheduledDateModel
 import com.terraformation.backend.plantingmanagement.PlantingSeasonScheduledDateModel
 import com.terraformation.backend.plantingmanagement.PlantingSeasonScheduledDateSpecies
+import com.terraformation.backend.plantingmanagement.PlantingSeasonScheduledDatesService
 import com.terraformation.backend.plantingmanagement.db.PlantingSeasonScheduledDatesStore
 import io.swagger.v3.oas.annotations.Operation
 import jakarta.validation.Valid
@@ -31,6 +32,7 @@ import org.springframework.web.bind.annotation.RestController
 @RestController
 @TrackingEndpoint
 class PlantingSeasonScheduledDatesController(
+    private val plantingSeasonScheduledDatesService: PlantingSeasonScheduledDatesService,
     private val plantingSeasonScheduledDatesStore: PlantingSeasonScheduledDatesStore,
 ) {
   @ApiResponse200
@@ -68,7 +70,7 @@ class PlantingSeasonScheduledDatesController(
       @PathVariable plantingSeasonId: PlantingSeasonId,
       @RequestBody @Valid payload: ScheduledPlantingDateRequestPayload,
   ): SimpleSuccessResponsePayload {
-    plantingSeasonScheduledDatesStore.create(payload.toModel(plantingSeasonId))
+    plantingSeasonScheduledDatesService.create(payload.toModel(plantingSeasonId))
 
     return SimpleSuccessResponsePayload()
   }
@@ -122,13 +124,17 @@ data class ScheduledPlantingDateSpeciesPayload(
 }
 
 data class ScheduledPlantingDateRequestPayload(
+    val createNurseryRequest: Boolean? = false,
     val date: LocalDate,
+    val nurseryRequestNotes: String? = null,
     val species: List<ScheduledPlantingDateSpeciesPayload>,
 ) {
   fun toModel(plantingSeasonId: PlantingSeasonId): PlantingSeasonScheduledDateModel =
       PlantingSeasonScheduledDateModel(
-          plantingSeasonId = plantingSeasonId,
+          createNurseryRequest = createNurseryRequest,
           date = date,
+          nurseryRequestNotes = nurseryRequestNotes,
+          plantingSeasonId = plantingSeasonId,
           species = species.map { it.toModel() },
       )
 }

--- a/src/main/kotlin/com/terraformation/backend/plantingmanagement/api/PlantingSeasonScheduledDatesController.kt
+++ b/src/main/kotlin/com/terraformation/backend/plantingmanagement/api/PlantingSeasonScheduledDatesController.kt
@@ -70,7 +70,11 @@ class PlantingSeasonScheduledDatesController(
       @PathVariable plantingSeasonId: PlantingSeasonId,
       @RequestBody @Valid payload: ScheduledPlantingDateRequestPayload,
   ): SimpleSuccessResponsePayload {
-    plantingSeasonScheduledDatesService.create(payload.toModel(plantingSeasonId))
+    plantingSeasonScheduledDatesService.create(
+        payload.toModel(plantingSeasonId),
+        payload.createNurseryRequest == true,
+        payload.nurseryRequestNotes,
+    )
 
     return SimpleSuccessResponsePayload()
   }
@@ -131,9 +135,7 @@ data class ScheduledPlantingDateRequestPayload(
 ) {
   fun toModel(plantingSeasonId: PlantingSeasonId): PlantingSeasonScheduledDateModel =
       PlantingSeasonScheduledDateModel(
-          createNurseryRequest = createNurseryRequest,
           date = date,
-          nurseryRequestNotes = nurseryRequestNotes,
           plantingSeasonId = plantingSeasonId,
           species = species.map { it.toModel() },
       )

--- a/src/main/kotlin/com/terraformation/backend/plantingmanagement/db/Exceptions.kt
+++ b/src/main/kotlin/com/terraformation/backend/plantingmanagement/db/Exceptions.kt
@@ -2,7 +2,6 @@ package com.terraformation.backend.plantingmanagement.db
 
 import com.terraformation.backend.db.EntityNotFoundException
 import com.terraformation.backend.db.MismatchedStateException
-import com.terraformation.backend.db.tracking.PlantingDateRequestId
 import com.terraformation.backend.db.tracking.PlantingSeasonId
 import com.terraformation.backend.db.tracking.PlantingSiteId
 import com.terraformation.backend.db.tracking.ScheduledPlantingDateId

--- a/src/main/kotlin/com/terraformation/backend/plantingmanagement/db/Exceptions.kt
+++ b/src/main/kotlin/com/terraformation/backend/plantingmanagement/db/Exceptions.kt
@@ -2,6 +2,7 @@ package com.terraformation.backend.plantingmanagement.db
 
 import com.terraformation.backend.db.EntityNotFoundException
 import com.terraformation.backend.db.MismatchedStateException
+import com.terraformation.backend.db.tracking.PlantingDateRequestId
 import com.terraformation.backend.db.tracking.PlantingSeasonId
 import com.terraformation.backend.db.tracking.PlantingSiteId
 import com.terraformation.backend.db.tracking.ScheduledPlantingDateId
@@ -29,3 +30,10 @@ class PlantingSeasonScheduledDateNotFoundException(
 
 class PlantingSeasonClosedException(val plantingSeasonId: PlantingSeasonId) :
     MismatchedStateException("Planting season $plantingSeasonId already closed")
+
+class PlantingSeasonDateRequestExistsException(
+    scheduledPlantingDateId: ScheduledPlantingDateId,
+) :
+    MismatchedStateException(
+        "Date request already exists for scheduled planting date $scheduledPlantingDateId"
+    )

--- a/src/main/kotlin/com/terraformation/backend/plantingmanagement/db/PlantingDateRequestsStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/plantingmanagement/db/PlantingDateRequestsStore.kt
@@ -2,7 +2,6 @@ package com.terraformation.backend.plantingmanagement.db
 
 import com.terraformation.backend.auth.currentUser
 import com.terraformation.backend.customer.model.requirePermissions
-import com.terraformation.backend.db.tracking.PlantingDateRequestId
 import com.terraformation.backend.db.tracking.PlantingDateRequestStatus
 import com.terraformation.backend.db.tracking.PlantingSeasonId
 import com.terraformation.backend.db.tracking.PlantingSeasonStatus
@@ -26,7 +25,7 @@ class PlantingDateRequestsStore(
       scheduledPlantingDateId: ScheduledPlantingDateId,
       plantingSeasonId: PlantingSeasonId,
       notes: String? = null,
-  ): PlantingDateRequestId {
+  ) {
     requirePermissions { updatePlantingSeason(plantingSeasonId) }
 
     validateSeasonNotClosed(plantingSeasonId)
@@ -34,8 +33,8 @@ class PlantingDateRequestsStore(
     val userId = currentUser().userId
     val now = clock.instant()
 
-    return dslContext.transactionResult { _ ->
-      val newRequestId =
+    dslContext.transaction { _ ->
+      val rowsInserted =
           with(PLANTING_DATE_REQUESTS) {
             dslContext
                 .insertInto(PLANTING_DATE_REQUESTS)
@@ -53,27 +52,24 @@ class PlantingDateRequestsStore(
                 .set(MODIFIED_TIME, now)
                 .set(STATUS_ID, PlantingDateRequestStatus.Pending)
                 .onConflictDoNothing()
-                .returning(ID)
-                .fetchOne(ID)
-                ?: throw PlantingSeasonDateRequestExistsException(scheduledPlantingDateId)
+                .execute()
           }
 
-      insertRequestSpecies(newRequestId, scheduledPlantingDateId)
+      if (rowsInserted == 0) {
+        throw PlantingSeasonDateRequestExistsException(scheduledPlantingDateId)
+      }
 
-      newRequestId
+      insertRequestSpecies(scheduledPlantingDateId)
     }
   }
 
-  private fun insertRequestSpecies(
-      plantingDateRequestId: PlantingDateRequestId,
-      scheduledPlantingDateId: ScheduledPlantingDateId,
-  ) {
+  private fun insertRequestSpecies(scheduledPlantingDateId: ScheduledPlantingDateId) {
     with(SCHEDULED_PLANTING_DATE_SPECIES) {
       dslContext
           .insertInto(PLANTING_DATE_REQUEST_SPECIES)
           .select(
               DSL.select(
-                      DSL.`val`(plantingDateRequestId),
+                      DSL.`val`(scheduledPlantingDateId),
                       SUBSTRATUM_ID,
                       SPECIES_ID,
                       QUANTITY,

--- a/src/main/kotlin/com/terraformation/backend/plantingmanagement/db/PlantingDateRequestsStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/plantingmanagement/db/PlantingDateRequestsStore.kt
@@ -1,0 +1,102 @@
+package com.terraformation.backend.plantingmanagement.db
+
+import com.terraformation.backend.auth.currentUser
+import com.terraformation.backend.customer.model.requirePermissions
+import com.terraformation.backend.db.tracking.PlantingDateRequestId
+import com.terraformation.backend.db.tracking.PlantingDateRequestStatus
+import com.terraformation.backend.db.tracking.PlantingSeasonId
+import com.terraformation.backend.db.tracking.PlantingSeasonStatus
+import com.terraformation.backend.db.tracking.ScheduledPlantingDateId
+import com.terraformation.backend.db.tracking.tables.references.PLANTING_DATE_REQUESTS
+import com.terraformation.backend.db.tracking.tables.references.PLANTING_DATE_REQUEST_SPECIES
+import com.terraformation.backend.db.tracking.tables.references.PLANTING_SEASONS
+import com.terraformation.backend.db.tracking.tables.references.SCHEDULED_PLANTING_DATES
+import com.terraformation.backend.db.tracking.tables.references.SCHEDULED_PLANTING_DATE_SPECIES
+import jakarta.inject.Named
+import java.time.InstantSource
+import org.jooq.DSLContext
+import org.jooq.impl.DSL
+
+@Named
+class PlantingDateRequestsStore(
+    private val clock: InstantSource,
+    private val dslContext: DSLContext,
+) {
+  fun create(
+      scheduledPlantingDateId: ScheduledPlantingDateId,
+      plantingSeasonId: PlantingSeasonId,
+      notes: String? = null,
+  ): PlantingDateRequestId {
+    requirePermissions { updatePlantingSeason(plantingSeasonId) }
+
+    validateSeasonNotClosed(plantingSeasonId)
+
+    val userId = currentUser().userId
+    val now = clock.instant()
+
+    return dslContext.transactionResult { _ ->
+      val newRequestId =
+          with(PLANTING_DATE_REQUESTS) {
+            dslContext
+                .insertInto(PLANTING_DATE_REQUESTS)
+                .set(SCHEDULED_PLANTING_DATE_ID, scheduledPlantingDateId)
+                .set(
+                    DATE,
+                    DSL.select(SCHEDULED_PLANTING_DATES.DATE)
+                        .from(SCHEDULED_PLANTING_DATES)
+                        .where(SCHEDULED_PLANTING_DATES.ID.eq(scheduledPlantingDateId)),
+                )
+                .set(NOTES, notes)
+                .set(CREATED_BY, userId)
+                .set(CREATED_TIME, now)
+                .set(MODIFIED_BY, userId)
+                .set(MODIFIED_TIME, now)
+                .set(STATUS_ID, PlantingDateRequestStatus.Pending)
+                .onConflictDoNothing()
+                .returning(ID)
+                .fetchOne(ID)
+                ?: throw PlantingSeasonDateRequestExistsException(scheduledPlantingDateId)
+          }
+
+      insertRequestSpecies(newRequestId, scheduledPlantingDateId)
+
+      newRequestId
+    }
+  }
+
+  private fun insertRequestSpecies(
+      plantingDateRequestId: PlantingDateRequestId,
+      scheduledPlantingDateId: ScheduledPlantingDateId,
+  ) {
+    with(SCHEDULED_PLANTING_DATE_SPECIES) {
+      dslContext
+          .insertInto(PLANTING_DATE_REQUEST_SPECIES)
+          .select(
+              DSL.select(
+                      DSL.`val`(plantingDateRequestId),
+                      SUBSTRATUM_ID,
+                      SPECIES_ID,
+                      QUANTITY,
+                  )
+                  .from(SCHEDULED_PLANTING_DATE_SPECIES)
+                  .where(SCHEDULED_PLANTING_DATE_ID.eq(scheduledPlantingDateId))
+          )
+          .execute()
+    }
+  }
+
+  private fun validateSeasonNotClosed(plantingSeasonId: PlantingSeasonId) {
+    with(PLANTING_SEASONS) {
+      val status =
+          dslContext
+              .select(STATUS_ID)
+              .from(PLANTING_SEASONS)
+              .where(ID.eq(plantingSeasonId))
+              .fetchOne(STATUS_ID) ?: throw PlantingSeasonNotFoundException(plantingSeasonId)
+
+      if (status == PlantingSeasonStatus.Closed) {
+        throw PlantingSeasonClosedException(plantingSeasonId)
+      }
+    }
+  }
+}

--- a/src/test/kotlin/com/terraformation/backend/plantingmanagement/PlantingSeasonScheduledDatesServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/plantingmanagement/PlantingSeasonScheduledDatesServiceTest.kt
@@ -2,6 +2,8 @@ package com.terraformation.backend.plantingmanagement
 
 import com.terraformation.backend.RunsAsDatabaseUser
 import com.terraformation.backend.TestClock
+import com.terraformation.backend.TestEventPublisher
+import com.terraformation.backend.customer.db.ParentStore
 import com.terraformation.backend.customer.model.TerrawareUser
 import com.terraformation.backend.db.DatabaseTest
 import com.terraformation.backend.db.default_schema.Role
@@ -21,11 +23,17 @@ import org.junit.jupiter.api.Test
 internal class PlantingSeasonScheduledDatesServiceTest : DatabaseTest(), RunsAsDatabaseUser {
   override lateinit var user: TerrawareUser
   private val clock = TestClock()
+  private val eventPublisher = TestEventPublisher()
   private val service: PlantingSeasonScheduledDatesService by lazy {
     PlantingSeasonScheduledDatesService(
         dslContext,
         PlantingDateRequestsStore(clock, dslContext),
-        PlantingSeasonScheduledDatesStore(clock, dslContext),
+        PlantingSeasonScheduledDatesStore(
+            clock,
+            dslContext,
+            eventPublisher,
+            ParentStore(dslContext),
+        ),
     )
   }
 

--- a/src/test/kotlin/com/terraformation/backend/plantingmanagement/PlantingSeasonScheduledDatesServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/plantingmanagement/PlantingSeasonScheduledDatesServiceTest.kt
@@ -58,10 +58,10 @@ internal class PlantingSeasonScheduledDatesServiceTest : DatabaseTest(), RunsAsD
     fun `does not insert request if createNurseryRequest is false`() {
       service.create(
           PlantingSeasonScheduledDateModel(
-              createNurseryRequest = false,
               date = LocalDate.EPOCH,
               plantingSeasonId = plantingSeasonId,
-          )
+          ),
+          createNurseryRequest = false,
       )
 
       assertTableEmpty(PLANTING_DATE_REQUESTS)
@@ -72,10 +72,11 @@ internal class PlantingSeasonScheduledDatesServiceTest : DatabaseTest(), RunsAsD
       val scheduledPlantingDateId =
           service.create(
               PlantingSeasonScheduledDateModel(
-                  createNurseryRequest = true,
                   date = LocalDate.EPOCH,
                   plantingSeasonId = plantingSeasonId,
-              )
+              ),
+              createNurseryRequest = true,
+              nurseryRequestNotes = "Notes",
           )
 
       assertTableEquals(
@@ -87,6 +88,7 @@ internal class PlantingSeasonScheduledDatesServiceTest : DatabaseTest(), RunsAsD
               createdTime = clock.instant,
               modifiedBy = user.userId,
               modifiedTime = clock.instant,
+              notes = "Notes",
           )
       )
     }

--- a/src/test/kotlin/com/terraformation/backend/plantingmanagement/PlantingSeasonScheduledDatesServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/plantingmanagement/PlantingSeasonScheduledDatesServiceTest.kt
@@ -1,0 +1,86 @@
+package com.terraformation.backend.plantingmanagement
+
+import com.terraformation.backend.RunsAsDatabaseUser
+import com.terraformation.backend.TestClock
+import com.terraformation.backend.customer.model.TerrawareUser
+import com.terraformation.backend.db.DatabaseTest
+import com.terraformation.backend.db.default_schema.Role
+import com.terraformation.backend.db.default_schema.SpeciesId
+import com.terraformation.backend.db.tracking.PlantingDateRequestStatus
+import com.terraformation.backend.db.tracking.PlantingSeasonId
+import com.terraformation.backend.db.tracking.SubstratumId
+import com.terraformation.backend.db.tracking.tables.records.PlantingDateRequestsRecord
+import com.terraformation.backend.db.tracking.tables.references.PLANTING_DATE_REQUESTS
+import com.terraformation.backend.plantingmanagement.db.PlantingDateRequestsStore
+import com.terraformation.backend.plantingmanagement.db.PlantingSeasonScheduledDatesStore
+import java.time.LocalDate
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+internal class PlantingSeasonScheduledDatesServiceTest : DatabaseTest(), RunsAsDatabaseUser {
+  override lateinit var user: TerrawareUser
+  private val clock = TestClock()
+  private val service: PlantingSeasonScheduledDatesService by lazy {
+    PlantingSeasonScheduledDatesService(
+        dslContext,
+        PlantingDateRequestsStore(clock, dslContext),
+        PlantingSeasonScheduledDatesStore(clock, dslContext),
+    )
+  }
+
+  private lateinit var plantingSeasonId: PlantingSeasonId
+  private lateinit var substratumId: SubstratumId
+  private lateinit var speciesId: SpeciesId
+
+  @BeforeEach
+  fun setUp() {
+    insertOrganization()
+    insertPlantingSite()
+    insertOrganizationUser(role = Role.Manager)
+    insertStratum()
+    plantingSeasonId = insertPlantingSeason()
+    substratumId = insertSubstratum()
+    speciesId = insertSpecies()
+  }
+
+  @Nested
+  inner class Create {
+    @Test
+    fun `does not insert request if createNurseryRequest is false`() {
+      service.create(
+          PlantingSeasonScheduledDateModel(
+              createNurseryRequest = false,
+              date = LocalDate.EPOCH,
+              plantingSeasonId = plantingSeasonId,
+          )
+      )
+
+      assertTableEmpty(PLANTING_DATE_REQUESTS)
+    }
+
+    @Test
+    fun `inserts request if createNurseryRequest is true`() {
+      val scheduledPlantingDateId =
+          service.create(
+              PlantingSeasonScheduledDateModel(
+                  createNurseryRequest = true,
+                  date = LocalDate.EPOCH,
+                  plantingSeasonId = plantingSeasonId,
+              )
+          )
+
+      assertTableEquals(
+          PlantingDateRequestsRecord(
+              scheduledPlantingDateId = scheduledPlantingDateId,
+              date = LocalDate.EPOCH,
+              statusId = PlantingDateRequestStatus.Pending,
+              createdBy = user.userId,
+              createdTime = clock.instant,
+              modifiedBy = user.userId,
+              modifiedTime = clock.instant,
+          )
+      )
+    }
+  }
+}

--- a/src/test/kotlin/com/terraformation/backend/plantingmanagement/db/PlantingDateRequestsStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/plantingmanagement/db/PlantingDateRequestsStoreTest.kt
@@ -74,7 +74,7 @@ internal class PlantingDateRequestsStoreTest : DatabaseTest(), RunsAsDatabaseUse
       val speciesId2 = insertSpecies()
       insertScheduledPlantingDateSpecies(quantity = 10)
 
-      val newRequestId = store.create(scheduledPlantingDateId, plantingSeasonId)
+      store.create(scheduledPlantingDateId, plantingSeasonId)
 
       assertTableEquals(
           PlantingDateRequestsRecord(
@@ -91,13 +91,13 @@ internal class PlantingDateRequestsStoreTest : DatabaseTest(), RunsAsDatabaseUse
       assertTableEquals(
           listOf(
               PlantingDateRequestSpeciesRecord(
-                  plantingDateRequestId = newRequestId,
+                  scheduledPlantingDateId = scheduledPlantingDateId,
                   substratumId = substratumId,
                   speciesId = speciesId,
                   quantity = 5,
               ),
               PlantingDateRequestSpeciesRecord(
-                  plantingDateRequestId = newRequestId,
+                  scheduledPlantingDateId = scheduledPlantingDateId,
                   substratumId = substratumId,
                   speciesId = speciesId2,
                   quantity = 10,

--- a/src/test/kotlin/com/terraformation/backend/plantingmanagement/db/PlantingDateRequestsStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/plantingmanagement/db/PlantingDateRequestsStoreTest.kt
@@ -1,0 +1,165 @@
+package com.terraformation.backend.plantingmanagement.db
+
+import com.terraformation.backend.RunsAsDatabaseUser
+import com.terraformation.backend.TestClock
+import com.terraformation.backend.customer.model.TerrawareUser
+import com.terraformation.backend.db.DatabaseTest
+import com.terraformation.backend.db.default_schema.Role
+import com.terraformation.backend.db.default_schema.SpeciesId
+import com.terraformation.backend.db.tracking.PlantingDateRequestStatus
+import com.terraformation.backend.db.tracking.PlantingSeasonId
+import com.terraformation.backend.db.tracking.PlantingSeasonStatus
+import com.terraformation.backend.db.tracking.SubstratumId
+import com.terraformation.backend.db.tracking.tables.records.PlantingDateRequestSpeciesRecord
+import com.terraformation.backend.db.tracking.tables.records.PlantingDateRequestsRecord
+import com.terraformation.backend.db.tracking.tables.references.PLANTING_DATE_REQUEST_SPECIES
+import java.time.LocalDate
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.springframework.security.access.AccessDeniedException
+
+internal class PlantingDateRequestsStoreTest : DatabaseTest(), RunsAsDatabaseUser {
+  override lateinit var user: TerrawareUser
+  private val clock = TestClock()
+  private val store: PlantingDateRequestsStore by lazy {
+    PlantingDateRequestsStore(clock, dslContext)
+  }
+
+  private lateinit var plantingSeasonId: PlantingSeasonId
+  private lateinit var substratumId: SubstratumId
+  private lateinit var speciesId: SpeciesId
+
+  @BeforeEach
+  fun setUp() {
+    insertOrganization()
+    insertPlantingSite()
+    insertOrganizationUser(role = Role.Manager)
+    insertStratum()
+    plantingSeasonId = insertPlantingSeason()
+    substratumId = insertSubstratum()
+    speciesId = insertSpecies()
+  }
+
+  @Nested
+  inner class Create {
+    @Test
+    fun `inserts a new request with no species`() {
+      val date = LocalDate.of(2026, 1, 1)
+      val scheduledPlantingDateId = insertPlantingSeasonScheduledDate(date = date)
+
+      store.create(scheduledPlantingDateId, plantingSeasonId)
+
+      assertTableEquals(
+          PlantingDateRequestsRecord(
+              date = date,
+              createdBy = user.userId,
+              createdTime = clock.instant,
+              modifiedBy = user.userId,
+              modifiedTime = clock.instant,
+              scheduledPlantingDateId = scheduledPlantingDateId,
+              statusId = PlantingDateRequestStatus.Pending,
+          )
+      )
+
+      assertTableEmpty(PLANTING_DATE_REQUEST_SPECIES)
+    }
+
+    @Test
+    fun `inserts a new request with species`() {
+      val date = LocalDate.of(2026, 1, 2)
+      val scheduledPlantingDateId = insertPlantingSeasonScheduledDate(date = date)
+      insertScheduledPlantingDateSpecies(quantity = 5)
+      val speciesId2 = insertSpecies()
+      insertScheduledPlantingDateSpecies(quantity = 10)
+
+      val newRequestId = store.create(scheduledPlantingDateId, plantingSeasonId)
+
+      assertTableEquals(
+          PlantingDateRequestsRecord(
+              date = date,
+              createdBy = user.userId,
+              createdTime = clock.instant,
+              modifiedBy = user.userId,
+              modifiedTime = clock.instant,
+              scheduledPlantingDateId = scheduledPlantingDateId,
+              statusId = PlantingDateRequestStatus.Pending,
+          )
+      )
+
+      assertTableEquals(
+          listOf(
+              PlantingDateRequestSpeciesRecord(
+                  plantingDateRequestId = newRequestId,
+                  substratumId = substratumId,
+                  speciesId = speciesId,
+                  quantity = 5,
+              ),
+              PlantingDateRequestSpeciesRecord(
+                  plantingDateRequestId = newRequestId,
+                  substratumId = substratumId,
+                  speciesId = speciesId2,
+                  quantity = 10,
+              ),
+          )
+      )
+    }
+
+    @Test
+    fun `includes optional notes`() {
+      val date = LocalDate.of(2026, 1, 3)
+      val scheduledPlantingDateId = insertPlantingSeasonScheduledDate(date = date)
+
+      store.create(scheduledPlantingDateId, plantingSeasonId, "notes")
+
+      assertTableEquals(
+          PlantingDateRequestsRecord(
+              date = date,
+              createdBy = user.userId,
+              createdTime = clock.instant,
+              modifiedBy = user.userId,
+              modifiedTime = clock.instant,
+              notes = "notes",
+              scheduledPlantingDateId = scheduledPlantingDateId,
+              statusId = PlantingDateRequestStatus.Pending,
+          )
+      )
+
+      assertTableEmpty(PLANTING_DATE_REQUEST_SPECIES)
+    }
+
+    @Test
+    fun `throws PlantingSeasonClosedException if season is closed`() {
+      val plantingSeasonId = insertPlantingSeason(status = PlantingSeasonStatus.Closed)
+      val scheduledPlantingDateId = insertPlantingSeasonScheduledDate()
+      assertThrows<PlantingSeasonClosedException> {
+        store.create(scheduledPlantingDateId, plantingSeasonId)
+      }
+    }
+
+    @Test
+    fun `throws AccessDeniedException when user lacks permission`() {
+      val scheduledPlantingDateId = insertPlantingSeasonScheduledDate()
+      deleteOrganizationUser()
+      insertOrganizationUser(role = Role.Contributor)
+
+      assertThrows<AccessDeniedException> {
+        store.create(scheduledPlantingDateId, plantingSeasonId)
+      }
+    }
+
+    @Test
+    fun `throws PlantingSeasonDateRequestExistsException when date already exists`() {
+      val scheduledPlantingDateId = insertPlantingSeasonScheduledDate()
+      insertPlantingDateRequest()
+
+      assertThrows<PlantingSeasonDateRequestExistsException> {
+        store.create(
+            scheduledPlantingDateId,
+            plantingSeasonId,
+        )
+      }
+    }
+  }
+}

--- a/src/test/kotlin/com/terraformation/backend/plantingmanagement/db/PlantingSeasonScheduledDatesStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/plantingmanagement/db/PlantingSeasonScheduledDatesStoreTest.kt
@@ -801,4 +801,56 @@ internal class PlantingSeasonScheduledDatesStoreTest : DatabaseTest(), RunsAsDat
       assertThrows<AccessDeniedException> { store.delete(plantingSeasonId, scheduledDateId) }
     }
   }
+
+  @Nested
+  inner class Model {
+    @Test
+    fun `throws IllegalArgumentException when a quantity is negative`() {
+      assertThrows<IllegalArgumentException> {
+        PlantingSeasonScheduledDateModel(
+            plantingSeasonId = plantingSeasonId,
+            date = LocalDate.EPOCH,
+            species =
+                listOf(
+                    PlantingSeasonScheduledDateSpecies(
+                        quantity = 5,
+                        speciesId = speciesId,
+                        substratumId = substratumId,
+                    ),
+                    PlantingSeasonScheduledDateSpecies(
+                        quantity = -1,
+                        speciesId = speciesId,
+                        substratumId = substratumId,
+                    ),
+                ),
+        )
+      }
+    }
+
+    @Test
+    fun `throws IllegalArgumentException when nurseryRequestNotes specified without createNurseryRequest`() {
+      assertThrows<IllegalArgumentException> {
+        PlantingSeasonScheduledDateModel(
+            plantingSeasonId = plantingSeasonId,
+            date = LocalDate.EPOCH,
+            species = emptyList(),
+            createNurseryRequest = null,
+            nurseryRequestNotes = "Stuff",
+        )
+      }
+    }
+
+    @Test
+    fun `throws IllegalArgumentException when nurseryRequestNotes specified createNurseryRequest false`() {
+      assertThrows<IllegalArgumentException> {
+        PlantingSeasonScheduledDateModel(
+            plantingSeasonId = plantingSeasonId,
+            date = LocalDate.EPOCH,
+            species = emptyList(),
+            createNurseryRequest = false,
+            nurseryRequestNotes = "Stuff",
+        )
+      }
+    }
+  }
 }

--- a/src/test/kotlin/com/terraformation/backend/plantingmanagement/db/PlantingSeasonScheduledDatesStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/plantingmanagement/db/PlantingSeasonScheduledDatesStoreTest.kt
@@ -826,31 +826,5 @@ internal class PlantingSeasonScheduledDatesStoreTest : DatabaseTest(), RunsAsDat
         )
       }
     }
-
-    @Test
-    fun `throws IllegalArgumentException when nurseryRequestNotes specified without createNurseryRequest`() {
-      assertThrows<IllegalArgumentException> {
-        PlantingSeasonScheduledDateModel(
-            plantingSeasonId = plantingSeasonId,
-            date = LocalDate.EPOCH,
-            species = emptyList(),
-            createNurseryRequest = null,
-            nurseryRequestNotes = "Stuff",
-        )
-      }
-    }
-
-    @Test
-    fun `throws IllegalArgumentException when nurseryRequestNotes specified createNurseryRequest false`() {
-      assertThrows<IllegalArgumentException> {
-        PlantingSeasonScheduledDateModel(
-            plantingSeasonId = plantingSeasonId,
-            date = LocalDate.EPOCH,
-            species = emptyList(),
-            createNurseryRequest = false,
-            nurseryRequestNotes = "Stuff",
-        )
-      }
-    }
   }
 }


### PR DESCRIPTION
Add a boolean flag and optional `notes` field to the api for scheduled dates. When true, snapshot the scheduled date and its species to the requests tables, including the optional notes. 