### PR TITLE
SW-8442 Update planting date request

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/plantingmanagement/Models.kt
+++ b/src/main/kotlin/com/terraformation/backend/plantingmanagement/Models.kt
@@ -39,9 +39,7 @@ data class PlantingSeasonScheduledDateSpecies(
 )
 
 data class PlantingSeasonScheduledDateModel(
-    val createNurseryRequest: Boolean? = false,
     val date: LocalDate,
-    val nurseryRequestNotes: String? = null,
     val plantingSeasonId: PlantingSeasonId,
     val species: List<PlantingSeasonScheduledDateSpecies> = emptyList(),
 ) {

--- a/src/main/kotlin/com/terraformation/backend/plantingmanagement/PlantingSeasonScheduledDatesService.kt
+++ b/src/main/kotlin/com/terraformation/backend/plantingmanagement/PlantingSeasonScheduledDatesService.kt
@@ -32,4 +32,32 @@ class PlantingSeasonScheduledDatesService(
       scheduledPlantingDateId
     }
   }
+
+  fun update(
+      scheduledPlantingDateId: ScheduledPlantingDateId,
+      model: PlantingSeasonScheduledDateModel,
+  ) {
+    dslContext.transaction { _ ->
+      plantingSeasonScheduledDatesStore.update(scheduledPlantingDateId, model)
+
+      val plantingDateRequestId = plantingDateRequestsStore.fetchId(scheduledPlantingDateId)
+
+      if (model.createNurseryRequest == true) {
+        if (plantingDateRequestId != null) {
+          plantingDateRequestsStore.update(
+              scheduledPlantingDateId,
+              model.plantingSeasonId,
+              plantingDateRequestId,
+              model.nurseryRequestNotes,
+          )
+        } else {
+          plantingDateRequestsStore.create(
+              scheduledPlantingDateId,
+              model.plantingSeasonId,
+              model.nurseryRequestNotes,
+          )
+        }
+      }
+    }
+  }
 }

--- a/src/main/kotlin/com/terraformation/backend/plantingmanagement/PlantingSeasonScheduledDatesService.kt
+++ b/src/main/kotlin/com/terraformation/backend/plantingmanagement/PlantingSeasonScheduledDatesService.kt
@@ -1,6 +1,7 @@
 package com.terraformation.backend.plantingmanagement
 
 import com.terraformation.backend.db.tracking.ScheduledPlantingDateId
+import com.terraformation.backend.db.tracking.tables.references.PLANTING_DATE_REQUESTS
 import com.terraformation.backend.plantingmanagement.db.PlantingDateRequestsStore
 import com.terraformation.backend.plantingmanagement.db.PlantingSeasonScheduledDatesStore
 import jakarta.inject.Named
@@ -40,14 +41,17 @@ class PlantingSeasonScheduledDatesService(
     dslContext.transaction { _ ->
       plantingSeasonScheduledDatesStore.update(scheduledPlantingDateId, model)
 
-      val plantingDateRequestId = plantingDateRequestsStore.fetchId(scheduledPlantingDateId)
+      val requestExists =
+          dslContext.fetchExists(
+              PLANTING_DATE_REQUESTS,
+              PLANTING_DATE_REQUESTS.SCHEDULED_PLANTING_DATE_ID.eq(scheduledPlantingDateId),
+          )
 
       if (model.createNurseryRequest == true) {
-        if (plantingDateRequestId != null) {
+        if (requestExists) {
           plantingDateRequestsStore.update(
               scheduledPlantingDateId,
               model.plantingSeasonId,
-              plantingDateRequestId,
               model.nurseryRequestNotes,
           )
         } else {

--- a/src/main/kotlin/com/terraformation/backend/plantingmanagement/PlantingSeasonScheduledDatesService.kt
+++ b/src/main/kotlin/com/terraformation/backend/plantingmanagement/PlantingSeasonScheduledDatesService.kt
@@ -37,6 +37,8 @@ class PlantingSeasonScheduledDatesService(
   fun update(
       scheduledPlantingDateId: ScheduledPlantingDateId,
       model: PlantingSeasonScheduledDateModel,
+      createNurseryRequest: Boolean,
+      nurseryRequestNotes: String? = null,
   ) {
     dslContext.transaction { _ ->
       plantingSeasonScheduledDatesStore.update(scheduledPlantingDateId, model)
@@ -47,18 +49,18 @@ class PlantingSeasonScheduledDatesService(
               PLANTING_DATE_REQUESTS.SCHEDULED_PLANTING_DATE_ID.eq(scheduledPlantingDateId),
           )
 
-      if (model.createNurseryRequest == true) {
+      if (createNurseryRequest) {
         if (requestExists) {
           plantingDateRequestsStore.update(
               scheduledPlantingDateId,
               model.plantingSeasonId,
-              model.nurseryRequestNotes,
+              nurseryRequestNotes,
           )
         } else {
           plantingDateRequestsStore.create(
               scheduledPlantingDateId,
               model.plantingSeasonId,
-              model.nurseryRequestNotes,
+              nurseryRequestNotes,
           )
         }
       }

--- a/src/main/kotlin/com/terraformation/backend/plantingmanagement/api/PlantingSeasonScheduledDatesController.kt
+++ b/src/main/kotlin/com/terraformation/backend/plantingmanagement/api/PlantingSeasonScheduledDatesController.kt
@@ -90,7 +90,7 @@ class PlantingSeasonScheduledDatesController(
       @PathVariable scheduledPlantingDateId: ScheduledPlantingDateId,
       @RequestBody @Valid payload: ScheduledPlantingDateRequestPayload,
   ): SimpleSuccessResponsePayload {
-    plantingSeasonScheduledDatesStore.update(
+    plantingSeasonScheduledDatesService.update(
         scheduledPlantingDateId,
         payload.toModel(plantingSeasonId),
     )

--- a/src/main/kotlin/com/terraformation/backend/plantingmanagement/api/PlantingSeasonScheduledDatesController.kt
+++ b/src/main/kotlin/com/terraformation/backend/plantingmanagement/api/PlantingSeasonScheduledDatesController.kt
@@ -93,6 +93,8 @@ class PlantingSeasonScheduledDatesController(
     plantingSeasonScheduledDatesService.update(
         scheduledPlantingDateId,
         payload.toModel(plantingSeasonId),
+        payload.createNurseryRequest == true,
+        payload.nurseryRequestNotes,
     )
 
     return SimpleSuccessResponsePayload()

--- a/src/main/kotlin/com/terraformation/backend/plantingmanagement/db/Exceptions.kt
+++ b/src/main/kotlin/com/terraformation/backend/plantingmanagement/db/Exceptions.kt
@@ -2,7 +2,6 @@ package com.terraformation.backend.plantingmanagement.db
 
 import com.terraformation.backend.db.EntityNotFoundException
 import com.terraformation.backend.db.MismatchedStateException
-import com.terraformation.backend.db.tracking.PlantingDateRequestId
 import com.terraformation.backend.db.tracking.PlantingSeasonId
 import com.terraformation.backend.db.tracking.PlantingSiteId
 import com.terraformation.backend.db.tracking.ScheduledPlantingDateId
@@ -38,5 +37,7 @@ class PlantingSeasonDateRequestExistsException(
         "Date request already exists for scheduled planting date $scheduledPlantingDateId"
     )
 
-class PlantingSeasonDateRequestNotFoundException(plantingDateRequestId: PlantingDateRequestId) :
-    EntityNotFoundException("Planting date request $plantingDateRequestId not found")
+class PlantingSeasonDateRequestNotFoundException(scheduledPlantingDateId: ScheduledPlantingDateId) :
+    EntityNotFoundException(
+        "Planting date request for scheduled planting date $scheduledPlantingDateId not found"
+    )

--- a/src/main/kotlin/com/terraformation/backend/plantingmanagement/db/Exceptions.kt
+++ b/src/main/kotlin/com/terraformation/backend/plantingmanagement/db/Exceptions.kt
@@ -36,3 +36,6 @@ class PlantingSeasonDateRequestExistsException(
     MismatchedStateException(
         "Date request already exists for scheduled planting date $scheduledPlantingDateId"
     )
+
+class PlantingSeasonDateRequestNotFoundException(plantingDateRequestId: PlantingDateRequestId) :
+    EntityNotFoundException("Planting date request $plantingDateRequestId not found")

--- a/src/main/kotlin/com/terraformation/backend/plantingmanagement/db/Exceptions.kt
+++ b/src/main/kotlin/com/terraformation/backend/plantingmanagement/db/Exceptions.kt
@@ -2,6 +2,7 @@ package com.terraformation.backend.plantingmanagement.db
 
 import com.terraformation.backend.db.EntityNotFoundException
 import com.terraformation.backend.db.MismatchedStateException
+import com.terraformation.backend.db.tracking.PlantingDateRequestId
 import com.terraformation.backend.db.tracking.PlantingSeasonId
 import com.terraformation.backend.db.tracking.PlantingSiteId
 import com.terraformation.backend.db.tracking.ScheduledPlantingDateId

--- a/src/main/kotlin/com/terraformation/backend/plantingmanagement/db/PlantingDateRequestsStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/plantingmanagement/db/PlantingDateRequestsStore.kt
@@ -21,6 +21,15 @@ class PlantingDateRequestsStore(
     private val clock: InstantSource,
     private val dslContext: DSLContext,
 ) {
+  fun fetchId(scheduledPlantingDateId: ScheduledPlantingDateId): PlantingDateRequestId? =
+      with(PLANTING_DATE_REQUESTS) {
+        dslContext
+            .select(ID)
+            .from(PLANTING_DATE_REQUESTS)
+            .where(SCHEDULED_PLANTING_DATE_ID.eq(scheduledPlantingDateId))
+            .fetchOne(ID)
+      }
+
   fun create(
       scheduledPlantingDateId: ScheduledPlantingDateId,
       plantingSeasonId: PlantingSeasonId,
@@ -60,6 +69,50 @@ class PlantingDateRequestsStore(
       }
 
       insertRequestSpecies(scheduledPlantingDateId)
+    }
+  }
+
+  fun update(
+      scheduledPlantingDateId: ScheduledPlantingDateId,
+      plantingSeasonId: PlantingSeasonId,
+      plantingDateRequestId: PlantingDateRequestId,
+      notes: String? = null,
+  ) {
+    requirePermissions { updatePlantingSeason(plantingSeasonId) }
+
+    validateSeasonNotClosed(plantingSeasonId)
+
+    val userId = currentUser().userId
+    val now = clock.instant()
+
+    dslContext.transaction { _ ->
+      val updatedCount =
+          with(PLANTING_DATE_REQUESTS) {
+            dslContext
+                .update(PLANTING_DATE_REQUESTS)
+                .set(
+                    DATE,
+                    DSL.select(SCHEDULED_PLANTING_DATES.DATE)
+                        .from(SCHEDULED_PLANTING_DATES)
+                        .where(SCHEDULED_PLANTING_DATES.ID.eq(scheduledPlantingDateId)),
+                )
+                .set(NOTES, notes)
+                .set(MODIFIED_BY, userId)
+                .set(MODIFIED_TIME, now)
+                .where(ID.eq(plantingDateRequestId))
+                .execute()
+          }
+
+      if (updatedCount == 0) {
+        throw PlantingSeasonDateRequestNotFoundException(plantingDateRequestId)
+      }
+
+      dslContext
+          .deleteFrom(PLANTING_DATE_REQUEST_SPECIES)
+          .where(PLANTING_DATE_REQUEST_SPECIES.PLANTING_DATE_REQUEST_ID.eq(plantingDateRequestId))
+          .execute()
+
+      insertRequestSpecies(plantingDateRequestId, scheduledPlantingDateId)
     }
   }
 

--- a/src/main/kotlin/com/terraformation/backend/plantingmanagement/db/PlantingDateRequestsStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/plantingmanagement/db/PlantingDateRequestsStore.kt
@@ -21,14 +21,6 @@ class PlantingDateRequestsStore(
     private val clock: InstantSource,
     private val dslContext: DSLContext,
 ) {
-  fun fetchId(scheduledPlantingDateId: ScheduledPlantingDateId): PlantingDateRequestId? =
-      with(PLANTING_DATE_REQUESTS) {
-        dslContext
-            .select(ID)
-            .from(PLANTING_DATE_REQUESTS)
-            .where(SCHEDULED_PLANTING_DATE_ID.eq(scheduledPlantingDateId))
-            .fetchOne(ID)
-      }
 
   fun create(
       scheduledPlantingDateId: ScheduledPlantingDateId,
@@ -75,7 +67,6 @@ class PlantingDateRequestsStore(
   fun update(
       scheduledPlantingDateId: ScheduledPlantingDateId,
       plantingSeasonId: PlantingSeasonId,
-      plantingDateRequestId: PlantingDateRequestId,
       notes: String? = null,
   ) {
     requirePermissions { updatePlantingSeason(plantingSeasonId) }
@@ -99,20 +90,22 @@ class PlantingDateRequestsStore(
                 .set(NOTES, notes)
                 .set(MODIFIED_BY, userId)
                 .set(MODIFIED_TIME, now)
-                .where(ID.eq(plantingDateRequestId))
+                .where(SCHEDULED_PLANTING_DATE_ID.eq(scheduledPlantingDateId))
                 .execute()
           }
 
       if (updatedCount == 0) {
-        throw PlantingSeasonDateRequestNotFoundException(plantingDateRequestId)
+        throw PlantingSeasonDateRequestNotFoundException(scheduledPlantingDateId)
       }
 
       dslContext
           .deleteFrom(PLANTING_DATE_REQUEST_SPECIES)
-          .where(PLANTING_DATE_REQUEST_SPECIES.PLANTING_DATE_REQUEST_ID.eq(plantingDateRequestId))
+          .where(
+              PLANTING_DATE_REQUEST_SPECIES.SCHEDULED_PLANTING_DATE_ID.eq(scheduledPlantingDateId)
+          )
           .execute()
 
-      insertRequestSpecies(plantingDateRequestId, scheduledPlantingDateId)
+      insertRequestSpecies(scheduledPlantingDateId)
     }
   }
 

--- a/src/test/kotlin/com/terraformation/backend/plantingmanagement/PlantingSeasonScheduledDatesServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/plantingmanagement/PlantingSeasonScheduledDatesServiceTest.kt
@@ -12,9 +12,11 @@ import com.terraformation.backend.db.tracking.PlantingDateRequestStatus
 import com.terraformation.backend.db.tracking.PlantingSeasonId
 import com.terraformation.backend.db.tracking.SubstratumId
 import com.terraformation.backend.db.tracking.tables.records.PlantingDateRequestsRecord
+import com.terraformation.backend.db.tracking.tables.records.ScheduledPlantingDatesRecord
 import com.terraformation.backend.db.tracking.tables.references.PLANTING_DATE_REQUESTS
 import com.terraformation.backend.plantingmanagement.db.PlantingDateRequestsStore
 import com.terraformation.backend.plantingmanagement.db.PlantingSeasonScheduledDatesStore
+import java.time.Instant
 import java.time.LocalDate
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
@@ -89,6 +91,100 @@ internal class PlantingSeasonScheduledDatesServiceTest : DatabaseTest(), RunsAsD
               modifiedBy = user.userId,
               modifiedTime = clock.instant,
               notes = "Notes",
+          )
+      )
+    }
+  }
+
+  @Nested
+  inner class Update {
+    @Test
+    fun `creates a new request if one doesn't exist and request is true`() {
+      val scheduledPlantingDateId = insertPlantingSeasonScheduledDate()
+      service.update(
+          scheduledPlantingDateId,
+          PlantingSeasonScheduledDateModel(
+              createNurseryRequest = true,
+              date = LocalDate.EPOCH,
+              plantingSeasonId = plantingSeasonId,
+          ),
+      )
+
+      assertTableEquals(
+          PlantingDateRequestsRecord(
+              scheduledPlantingDateId = scheduledPlantingDateId,
+              date = LocalDate.EPOCH,
+              statusId = PlantingDateRequestStatus.Pending,
+              createdBy = user.userId,
+              createdTime = clock.instant,
+              modifiedBy = user.userId,
+              modifiedTime = clock.instant,
+          )
+      )
+    }
+
+    @Test
+    fun `updates request if one exist and request is true`() {
+      val scheduledPlantingDateId = insertPlantingSeasonScheduledDate(date = LocalDate.EPOCH)
+      insertPlantingDateRequest(date = LocalDate.EPOCH)
+
+      clock.instant = Instant.ofEpochSecond(100)
+      service.update(
+          scheduledPlantingDateId,
+          PlantingSeasonScheduledDateModel(
+              createNurseryRequest = true,
+              date = LocalDate.EPOCH.plusDays(1),
+              plantingSeasonId = plantingSeasonId,
+          ),
+      )
+
+      assertTableEquals(
+          PlantingDateRequestsRecord(
+              scheduledPlantingDateId = scheduledPlantingDateId,
+              date = LocalDate.EPOCH.plusDays(1),
+              statusId = PlantingDateRequestStatus.Pending,
+              createdBy = user.userId,
+              createdTime = Instant.EPOCH,
+              modifiedBy = user.userId,
+              modifiedTime = clock.instant,
+          )
+      )
+    }
+
+    @Test
+    fun `does not update request if createNurseryRequest is false`() {
+      val scheduledPlantingDateId = insertPlantingSeasonScheduledDate(date = LocalDate.EPOCH)
+      insertPlantingDateRequest(date = LocalDate.EPOCH)
+
+      service.update(
+          scheduledPlantingDateId,
+          PlantingSeasonScheduledDateModel(
+              createNurseryRequest = false,
+              date = LocalDate.EPOCH.plusDays(1),
+              plantingSeasonId = plantingSeasonId,
+          ),
+      )
+
+      assertTableEquals(
+          ScheduledPlantingDatesRecord(
+              date = LocalDate.EPOCH.plusDays(1),
+              createdBy = user.userId,
+              createdTime = Instant.EPOCH,
+              modifiedBy = user.userId,
+              modifiedTime = clock.instant,
+              plantingSeasonId = plantingSeasonId,
+          )
+      )
+
+      assertTableEquals(
+          PlantingDateRequestsRecord(
+              scheduledPlantingDateId = scheduledPlantingDateId,
+              date = LocalDate.EPOCH,
+              statusId = PlantingDateRequestStatus.Pending,
+              createdBy = user.userId,
+              createdTime = Instant.EPOCH,
+              modifiedBy = user.userId,
+              modifiedTime = clock.instant,
           )
       )
     }

--- a/src/test/kotlin/com/terraformation/backend/plantingmanagement/PlantingSeasonScheduledDatesServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/plantingmanagement/PlantingSeasonScheduledDatesServiceTest.kt
@@ -104,10 +104,10 @@ internal class PlantingSeasonScheduledDatesServiceTest : DatabaseTest(), RunsAsD
       service.update(
           scheduledPlantingDateId,
           PlantingSeasonScheduledDateModel(
-              createNurseryRequest = true,
               date = LocalDate.EPOCH,
               plantingSeasonId = plantingSeasonId,
           ),
+          createNurseryRequest = true,
       )
 
       assertTableEquals(
@@ -126,16 +126,17 @@ internal class PlantingSeasonScheduledDatesServiceTest : DatabaseTest(), RunsAsD
     @Test
     fun `updates request if one exist and request is true`() {
       val scheduledPlantingDateId = insertPlantingSeasonScheduledDate(date = LocalDate.EPOCH)
-      insertPlantingDateRequest(date = LocalDate.EPOCH)
+      insertPlantingDateRequest(date = LocalDate.EPOCH, notes = "old notes")
 
       clock.instant = Instant.ofEpochSecond(100)
       service.update(
           scheduledPlantingDateId,
           PlantingSeasonScheduledDateModel(
-              createNurseryRequest = true,
               date = LocalDate.EPOCH.plusDays(1),
               plantingSeasonId = plantingSeasonId,
           ),
+          createNurseryRequest = true,
+          nurseryRequestNotes = "new notes",
       )
 
       assertTableEquals(
@@ -147,6 +148,7 @@ internal class PlantingSeasonScheduledDatesServiceTest : DatabaseTest(), RunsAsD
               createdTime = Instant.EPOCH,
               modifiedBy = user.userId,
               modifiedTime = clock.instant,
+              notes = "new notes",
           )
       )
     }
@@ -159,10 +161,10 @@ internal class PlantingSeasonScheduledDatesServiceTest : DatabaseTest(), RunsAsD
       service.update(
           scheduledPlantingDateId,
           PlantingSeasonScheduledDateModel(
-              createNurseryRequest = false,
               date = LocalDate.EPOCH.plusDays(1),
               plantingSeasonId = plantingSeasonId,
           ),
+          createNurseryRequest = false,
       )
 
       assertTableEquals(

--- a/src/test/kotlin/com/terraformation/backend/plantingmanagement/db/PlantingDateRequestsStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/plantingmanagement/db/PlantingDateRequestsStoreTest.kt
@@ -6,6 +6,7 @@ import com.terraformation.backend.customer.model.TerrawareUser
 import com.terraformation.backend.db.DatabaseTest
 import com.terraformation.backend.db.default_schema.Role
 import com.terraformation.backend.db.default_schema.SpeciesId
+import com.terraformation.backend.db.tracking.PlantingDateRequestId
 import com.terraformation.backend.db.tracking.PlantingDateRequestStatus
 import com.terraformation.backend.db.tracking.PlantingSeasonId
 import com.terraformation.backend.db.tracking.PlantingSeasonStatus
@@ -13,6 +14,7 @@ import com.terraformation.backend.db.tracking.SubstratumId
 import com.terraformation.backend.db.tracking.tables.records.PlantingDateRequestSpeciesRecord
 import com.terraformation.backend.db.tracking.tables.records.PlantingDateRequestsRecord
 import com.terraformation.backend.db.tracking.tables.references.PLANTING_DATE_REQUEST_SPECIES
+import java.time.Instant
 import java.time.LocalDate
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
@@ -158,6 +160,90 @@ internal class PlantingDateRequestsStoreTest : DatabaseTest(), RunsAsDatabaseUse
         store.create(
             scheduledPlantingDateId,
             plantingSeasonId,
+        )
+      }
+    }
+  }
+
+  @Nested
+  inner class Update {
+    @Test
+    fun `updates the request and species`() {
+      val oldDate = LocalDate.EPOCH
+      val newDate = LocalDate.EPOCH.plusDays(1)
+      val scheduledPlantingDateId = insertPlantingSeasonScheduledDate(date = newDate)
+      insertScheduledPlantingDateSpecies(quantity = 10)
+      val plantingDateRequestId = insertPlantingDateRequest(date = oldDate, notes = "old notes")
+      insertPlantingDateRequestSpecies(quantity = 5)
+
+      clock.instant = Instant.ofEpochSecond(100)
+      store.update(scheduledPlantingDateId, plantingSeasonId, plantingDateRequestId, "new notes")
+
+      assertTableEquals(
+          PlantingDateRequestsRecord(
+              date = newDate,
+              createdBy = user.userId,
+              createdTime = Instant.EPOCH,
+              modifiedBy = user.userId,
+              modifiedTime = clock.instant,
+              notes = "new notes",
+              scheduledPlantingDateId = scheduledPlantingDateId,
+              statusId = PlantingDateRequestStatus.Pending,
+          )
+      )
+
+      assertTableEquals(
+          PlantingDateRequestSpeciesRecord(
+              plantingDateRequestId = plantingDateRequestId,
+              substratumId = substratumId,
+              speciesId = speciesId,
+              quantity = 10,
+          )
+      )
+    }
+
+    @Test
+    fun `deletes species no longer in scheduled planting date`() {
+      val scheduledPlantingDateId = insertPlantingSeasonScheduledDate()
+      val plantingDateRequestId = insertPlantingDateRequest()
+      insertPlantingDateRequestSpecies()
+
+      store.update(scheduledPlantingDateId, plantingSeasonId, plantingDateRequestId)
+
+      assertTableEmpty(PLANTING_DATE_REQUEST_SPECIES)
+    }
+
+    @Test
+    fun `throws PlantingSeasonClosedException if season is closed`() {
+      val plantingSeasonId = insertPlantingSeason(status = PlantingSeasonStatus.Closed)
+      val scheduledPlantingDateId = insertPlantingSeasonScheduledDate()
+      val plantingDateRequestId = insertPlantingDateRequest()
+      assertThrows<PlantingSeasonClosedException> {
+        store.update(scheduledPlantingDateId, plantingSeasonId, plantingDateRequestId)
+      }
+    }
+
+    @Test
+    fun `throws AccessDeniedException when user lacks permission`() {
+      val scheduledPlantingDateId = insertPlantingSeasonScheduledDate()
+      val plantingDateRequestId = insertPlantingDateRequest()
+      deleteOrganizationUser()
+      insertOrganizationUser(role = Role.Contributor)
+
+      assertThrows<AccessDeniedException> {
+        store.update(scheduledPlantingDateId, plantingSeasonId, plantingDateRequestId)
+      }
+    }
+
+    @Test
+    fun `throws PlantingSeasonDateRequestNotFoundException when request doesn't exist`() {
+      val scheduledPlantingDateId = insertPlantingSeasonScheduledDate()
+
+      assertThrows<PlantingSeasonDateRequestNotFoundException> {
+        store.update(
+            scheduledPlantingDateId,
+            plantingSeasonId,
+            PlantingDateRequestId(99999L),
         )
       }
     }

--- a/src/test/kotlin/com/terraformation/backend/plantingmanagement/db/PlantingDateRequestsStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/plantingmanagement/db/PlantingDateRequestsStoreTest.kt
@@ -217,6 +217,7 @@ internal class PlantingDateRequestsStoreTest : DatabaseTest(), RunsAsDatabaseUse
       val plantingSeasonId = insertPlantingSeason(status = PlantingSeasonStatus.Closed)
       val scheduledPlantingDateId = insertPlantingSeasonScheduledDate()
       insertPlantingDateRequest()
+
       assertThrows<PlantingSeasonClosedException> {
         store.update(scheduledPlantingDateId, plantingSeasonId)
       }

--- a/src/test/kotlin/com/terraformation/backend/plantingmanagement/db/PlantingDateRequestsStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/plantingmanagement/db/PlantingDateRequestsStoreTest.kt
@@ -6,7 +6,6 @@ import com.terraformation.backend.customer.model.TerrawareUser
 import com.terraformation.backend.db.DatabaseTest
 import com.terraformation.backend.db.default_schema.Role
 import com.terraformation.backend.db.default_schema.SpeciesId
-import com.terraformation.backend.db.tracking.PlantingDateRequestId
 import com.terraformation.backend.db.tracking.PlantingDateRequestStatus
 import com.terraformation.backend.db.tracking.PlantingSeasonId
 import com.terraformation.backend.db.tracking.PlantingSeasonStatus
@@ -173,11 +172,11 @@ internal class PlantingDateRequestsStoreTest : DatabaseTest(), RunsAsDatabaseUse
       val newDate = LocalDate.EPOCH.plusDays(1)
       val scheduledPlantingDateId = insertPlantingSeasonScheduledDate(date = newDate)
       insertScheduledPlantingDateSpecies(quantity = 10)
-      val plantingDateRequestId = insertPlantingDateRequest(date = oldDate, notes = "old notes")
+      insertPlantingDateRequest(date = oldDate, notes = "old notes")
       insertPlantingDateRequestSpecies(quantity = 5)
 
       clock.instant = Instant.ofEpochSecond(100)
-      store.update(scheduledPlantingDateId, plantingSeasonId, plantingDateRequestId, "new notes")
+      store.update(scheduledPlantingDateId, plantingSeasonId, "new notes")
 
       assertTableEquals(
           PlantingDateRequestsRecord(
@@ -194,7 +193,7 @@ internal class PlantingDateRequestsStoreTest : DatabaseTest(), RunsAsDatabaseUse
 
       assertTableEquals(
           PlantingDateRequestSpeciesRecord(
-              plantingDateRequestId = plantingDateRequestId,
+              scheduledPlantingDateId = scheduledPlantingDateId,
               substratumId = substratumId,
               speciesId = speciesId,
               quantity = 10,
@@ -205,10 +204,10 @@ internal class PlantingDateRequestsStoreTest : DatabaseTest(), RunsAsDatabaseUse
     @Test
     fun `deletes species no longer in scheduled planting date`() {
       val scheduledPlantingDateId = insertPlantingSeasonScheduledDate()
-      val plantingDateRequestId = insertPlantingDateRequest()
+      insertPlantingDateRequest()
       insertPlantingDateRequestSpecies()
 
-      store.update(scheduledPlantingDateId, plantingSeasonId, plantingDateRequestId)
+      store.update(scheduledPlantingDateId, plantingSeasonId)
 
       assertTableEmpty(PLANTING_DATE_REQUEST_SPECIES)
     }
@@ -217,21 +216,21 @@ internal class PlantingDateRequestsStoreTest : DatabaseTest(), RunsAsDatabaseUse
     fun `throws PlantingSeasonClosedException if season is closed`() {
       val plantingSeasonId = insertPlantingSeason(status = PlantingSeasonStatus.Closed)
       val scheduledPlantingDateId = insertPlantingSeasonScheduledDate()
-      val plantingDateRequestId = insertPlantingDateRequest()
+      insertPlantingDateRequest()
       assertThrows<PlantingSeasonClosedException> {
-        store.update(scheduledPlantingDateId, plantingSeasonId, plantingDateRequestId)
+        store.update(scheduledPlantingDateId, plantingSeasonId)
       }
     }
 
     @Test
     fun `throws AccessDeniedException when user lacks permission`() {
       val scheduledPlantingDateId = insertPlantingSeasonScheduledDate()
-      val plantingDateRequestId = insertPlantingDateRequest()
+      insertPlantingDateRequest()
       deleteOrganizationUser()
       insertOrganizationUser(role = Role.Contributor)
 
       assertThrows<AccessDeniedException> {
-        store.update(scheduledPlantingDateId, plantingSeasonId, plantingDateRequestId)
+        store.update(scheduledPlantingDateId, plantingSeasonId)
       }
     }
 
@@ -240,11 +239,7 @@ internal class PlantingDateRequestsStoreTest : DatabaseTest(), RunsAsDatabaseUse
       val scheduledPlantingDateId = insertPlantingSeasonScheduledDate()
 
       assertThrows<PlantingSeasonDateRequestNotFoundException> {
-        store.update(
-            scheduledPlantingDateId,
-            plantingSeasonId,
-            PlantingDateRequestId(99999L),
-        )
+        store.update(scheduledPlantingDateId, plantingSeasonId)
       }
     }
   }


### PR DESCRIPTION
Create or update a planting date request when a scheduled date is updated. If the client does not set `createNurseryRequest` to true, do nothing with any existing requests.