### PR TITLE
Add more details to observation activities

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/accelerator/api/ActivitiesController.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/api/ActivitiesController.kt
@@ -26,6 +26,7 @@ import com.terraformation.backend.db.default_schema.ProjectId
 import com.terraformation.backend.db.tracking.ObservationId
 import com.terraformation.backend.db.tracking.ObservationMediaType
 import com.terraformation.backend.db.tracking.ObservationPlotPosition
+import com.terraformation.backend.db.tracking.ObservationType
 import com.terraformation.backend.file.SUPPORTED_MEDIA_TYPES
 import com.terraformation.backend.file.api.GetMuxStreamResponsePayload
 import com.terraformation.backend.file.model.FileMetadata
@@ -261,6 +262,7 @@ data class ActivityMediaFilePayload(
 }
 
 data class ActivityObservationPayload(
+    val isAdHoc: Boolean,
     @Schema(
         description =
             "If this was an ad-hoc observation, its plot number. Not set for assigned " +
@@ -268,10 +270,16 @@ data class ActivityObservationPayload(
     )
     val monitoringPlotNumber: Long?,
     val observationId: ObservationId,
+    val observationType: ObservationType,
 ) {
   constructor(
       model: ExistingActivityModel.Observation
-  ) : this(model.monitoringPlotNumber, model.observationId)
+  ) : this(
+      isAdHoc = model.isAdHoc,
+      monitoringPlotNumber = model.monitoringPlotNumber,
+      observationId = model.observationId,
+      observationType = model.observationType,
+  )
 }
 
 data class ActivityPayload(

--- a/src/main/kotlin/com/terraformation/backend/accelerator/api/ActivitiesController.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/api/ActivitiesController.kt
@@ -261,9 +261,17 @@ data class ActivityMediaFilePayload(
 }
 
 data class ActivityObservationPayload(
+    @Schema(
+        description =
+            "If this was an ad-hoc observation, its plot number. Not set for assigned " +
+                "observations because they can include multiple plots."
+    )
+    val monitoringPlotNumber: Long?,
     val observationId: ObservationId,
 ) {
-  constructor(model: ExistingActivityModel.Observation) : this(model.observationId)
+  constructor(
+      model: ExistingActivityModel.Observation
+  ) : this(model.monitoringPlotNumber, model.observationId)
 }
 
 data class ActivityPayload(

--- a/src/main/kotlin/com/terraformation/backend/accelerator/db/ActivityStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/db/ActivityStore.kt
@@ -19,7 +19,9 @@ import com.terraformation.backend.db.default_schema.tables.references.FILES
 import com.terraformation.backend.db.forMultiset
 import com.terraformation.backend.db.funder.tables.references.PUBLISHED_ACTIVITIES
 import com.terraformation.backend.db.tracking.tables.references.MONITORING_PLOTS
+import com.terraformation.backend.db.tracking.tables.references.OBSERVATIONS
 import com.terraformation.backend.db.tracking.tables.references.OBSERVATION_MEDIA_FILES
+import com.terraformation.backend.db.tracking.tables.references.OBSERVATION_PLOTS
 import jakarta.inject.Named
 import java.time.InstantSource
 import org.jooq.Condition
@@ -283,22 +285,38 @@ class ActivityStore(
             null
           }
 
+      val monitoringPlotNumberField =
+          DSL.field(
+              DSL.select(MONITORING_PLOTS.PLOT_NUMBER)
+                  .from(MONITORING_PLOTS)
+                  .join(OBSERVATION_PLOTS)
+                  .on(MONITORING_PLOTS.ID.eq(OBSERVATION_PLOTS.MONITORING_PLOT_ID))
+                  .where(OBSERVATIONS.IS_AD_HOC)
+                  .and(OBSERVATIONS.ID.eq(OBSERVATION_PLOTS.OBSERVATION_ID))
+                  .limit(1)
+          )
+
       dslContext
           .select(
               asterisk(),
               ACTIVITY_OBSERVATIONS.OBSERVATION_ID,
+              OBSERVATIONS.IS_AD_HOC,
+              OBSERVATIONS.OBSERVATION_TYPE_ID,
               PUBLISHED_ACTIVITIES.PUBLISHED_BY,
               PUBLISHED_ACTIVITIES.PUBLISHED_TIME,
               mediaField ?: DSL.one(),
+              monitoringPlotNumberField,
           )
           .from(ACTIVITIES)
           .leftJoin(ACTIVITY_OBSERVATIONS)
           .on(ID.eq(ACTIVITY_OBSERVATIONS.ACTIVITY_ID))
+          .leftJoin(OBSERVATIONS)
+          .on(ACTIVITY_OBSERVATIONS.OBSERVATION_ID.eq(OBSERVATIONS.ID))
           .leftJoin(PUBLISHED_ACTIVITIES)
           .on(ID.eq(PUBLISHED_ACTIVITIES.ACTIVITY_ID))
           .where(condition)
           .orderBy(ID)
-          .fetch { ExistingActivityModel.of(it, mediaField) }
+          .fetch { ExistingActivityModel.of(it, mediaField, monitoringPlotNumberField) }
     }
   }
 

--- a/src/main/kotlin/com/terraformation/backend/accelerator/model/ActivityModel.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/model/ActivityModel.kt
@@ -9,6 +9,8 @@ import com.terraformation.backend.db.default_schema.ProjectId
 import com.terraformation.backend.db.default_schema.UserId
 import com.terraformation.backend.db.funder.tables.references.PUBLISHED_ACTIVITIES
 import com.terraformation.backend.db.tracking.ObservationId
+import com.terraformation.backend.db.tracking.ObservationType
+import com.terraformation.backend.db.tracking.tables.references.OBSERVATIONS
 import java.time.Instant
 import java.time.LocalDate
 import org.jooq.Field
@@ -34,15 +36,29 @@ data class ExistingActivityModel(
     val verifiedTime: Instant? = null,
 ) {
   data class Observation(
+      val isAdHoc: Boolean,
+      val monitoringPlotNumber: Long?,
       val observationId: ObservationId,
+      val observationType: ObservationType,
   )
 
   companion object {
     fun of(
         record: Record,
         mediaField: Field<List<ActivityMediaModel>>?,
+        monitoringPlotNumberField: Field<Long?>,
     ): ExistingActivityModel {
       return with(ACTIVITIES) {
+        val observation =
+            record[ACTIVITY_OBSERVATIONS.OBSERVATION_ID]?.let { observationId ->
+              Observation(
+                  isAdHoc = record[OBSERVATIONS.IS_AD_HOC]!!,
+                  monitoringPlotNumber = record[monitoringPlotNumberField],
+                  observationId = observationId,
+                  observationType = record[OBSERVATIONS.OBSERVATION_TYPE_ID]!!,
+              )
+            }
+
         ExistingActivityModel(
             activityDate = record[ACTIVITY_DATE]!!,
             activityStatus = record[ACTIVITY_STATUS_ID]!!,
@@ -55,7 +71,7 @@ data class ExistingActivityModel(
             media = mediaField?.let { record[it] } ?: emptyList(),
             modifiedBy = record[MODIFIED_BY]!!,
             modifiedTime = record[MODIFIED_TIME]!!,
-            observation = record[ACTIVITY_OBSERVATIONS.OBSERVATION_ID]?.let { Observation(it) },
+            observation = observation,
             projectId = record[PROJECT_ID]!!,
             publishedBy = record[PUBLISHED_ACTIVITIES.PUBLISHED_BY],
             publishedTime = record[PUBLISHED_ACTIVITIES.PUBLISHED_TIME],

--- a/src/main/kotlin/com/terraformation/backend/funder/api/FunderActivitiesController.kt
+++ b/src/main/kotlin/com/terraformation/backend/funder/api/FunderActivitiesController.kt
@@ -13,6 +13,7 @@ import com.terraformation.backend.db.default_schema.FileId
 import com.terraformation.backend.db.default_schema.ProjectId
 import com.terraformation.backend.db.tracking.ObservationMediaType
 import com.terraformation.backend.db.tracking.ObservationPlotPosition
+import com.terraformation.backend.db.tracking.ObservationType
 import com.terraformation.backend.file.api.GetMuxStreamResponsePayload
 import com.terraformation.backend.funder.PublishedActivityService
 import com.terraformation.backend.funder.db.PublishedActivityStore
@@ -134,7 +135,15 @@ data class FunderActivityMediaFilePayload(
 
 data class FunderActivityObservationPayload(
     val completedTime: Instant,
+    val isAdHoc: Boolean,
     val livePlants: Int?,
+    @Schema(
+        description =
+            "If this was an ad-hoc observation, its plot number. Not set for assigned " +
+                "observations because they can include multiple plots."
+    )
+    val monitoringPlotNumber: Long?,
+    val observationType: ObservationType,
     val plantDensity: Int?,
     val survivalRate: Int?,
 ) {
@@ -142,7 +151,10 @@ data class FunderActivityObservationPayload(
       model: PublishedActivityModel.Observation
   ) : this(
       completedTime = model.completedTime,
+      isAdHoc = model.isAdHoc,
       livePlants = model.livePlants,
+      monitoringPlotNumber = model.monitoringPlotNumber,
+      observationType = model.observationType,
       plantDensity = model.plantDensity,
       survivalRate = model.survivalRate,
   )

--- a/src/main/kotlin/com/terraformation/backend/funder/db/PublishedActivityStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/funder/db/PublishedActivityStore.kt
@@ -22,6 +22,7 @@ import com.terraformation.backend.db.funder.tables.references.PUBLISHED_ACTIVITY
 import com.terraformation.backend.db.tracking.tables.references.MONITORING_PLOTS
 import com.terraformation.backend.db.tracking.tables.references.OBSERVATIONS
 import com.terraformation.backend.db.tracking.tables.references.OBSERVATION_MEDIA_FILES
+import com.terraformation.backend.db.tracking.tables.references.OBSERVATION_PLOTS
 import com.terraformation.backend.db.tracking.tables.references.OBSERVATION_SITE_RESULTS
 import com.terraformation.backend.file.event.FileReferenceDeletedEvent
 import com.terraformation.backend.funder.model.PublishedActivityMediaModel
@@ -151,6 +152,17 @@ class PublishedActivityStore(
       condition: Condition,
       includeMedia: Boolean,
   ): List<PublishedActivityModel> {
+    val monitoringPlotNumberField =
+        DSL.field(
+            DSL.select(MONITORING_PLOTS.PLOT_NUMBER)
+                .from(MONITORING_PLOTS)
+                .join(OBSERVATION_PLOTS)
+                .on(MONITORING_PLOTS.ID.eq(OBSERVATION_PLOTS.MONITORING_PLOT_ID))
+                .where(OBSERVATIONS.IS_AD_HOC)
+                .and(OBSERVATIONS.ID.eq(OBSERVATION_PLOTS.OBSERVATION_ID))
+                .limit(1)
+        )
+
     return with(PUBLISHED_ACTIVITIES) {
       if (includeMedia) {
         dslContext
@@ -158,7 +170,10 @@ class PublishedActivityStore(
                 asterisk(),
                 PUBLISHED_ACTIVITY_OBSERVATIONS.asterisk(),
                 OBSERVATIONS.COMPLETED_TIME,
+                OBSERVATIONS.IS_AD_HOC,
+                OBSERVATIONS.OBSERVATION_TYPE_ID,
                 mediaMultiset,
+                monitoringPlotNumberField,
             )
             .from(PUBLISHED_ACTIVITIES)
             .leftJoin(PUBLISHED_ACTIVITY_OBSERVATIONS)
@@ -167,13 +182,16 @@ class PublishedActivityStore(
             .on(PUBLISHED_ACTIVITY_OBSERVATIONS.OBSERVATION_ID.eq(OBSERVATIONS.ID))
             .where(condition)
             .orderBy(ACTIVITY_DATE, ACTIVITY_ID)
-            .fetch { PublishedActivityModel.of(it, mediaMultiset) }
+            .fetch { PublishedActivityModel.of(it, mediaMultiset, monitoringPlotNumberField) }
       } else {
         dslContext
             .select(
                 asterisk(),
                 PUBLISHED_ACTIVITY_OBSERVATIONS.asterisk(),
                 OBSERVATIONS.COMPLETED_TIME,
+                OBSERVATIONS.IS_AD_HOC,
+                OBSERVATIONS.OBSERVATION_TYPE_ID,
+                monitoringPlotNumberField,
             )
             .from(PUBLISHED_ACTIVITIES)
             .leftJoin(PUBLISHED_ACTIVITY_OBSERVATIONS)
@@ -182,7 +200,7 @@ class PublishedActivityStore(
             .on(PUBLISHED_ACTIVITY_OBSERVATIONS.OBSERVATION_ID.eq(OBSERVATIONS.ID))
             .where(condition)
             .orderBy(ACTIVITY_DATE, ACTIVITY_ID)
-            .fetch { PublishedActivityModel.of(it, null) }
+            .fetch { PublishedActivityModel.of(it, null, monitoringPlotNumberField) }
       }
     }
   }

--- a/src/main/kotlin/com/terraformation/backend/funder/model/PublishedActivityModel.kt
+++ b/src/main/kotlin/com/terraformation/backend/funder/model/PublishedActivityModel.kt
@@ -7,6 +7,7 @@ import com.terraformation.backend.db.default_schema.UserId
 import com.terraformation.backend.db.funder.tables.references.PUBLISHED_ACTIVITIES
 import com.terraformation.backend.db.funder.tables.references.PUBLISHED_ACTIVITY_OBSERVATIONS
 import com.terraformation.backend.db.tracking.ObservationId
+import com.terraformation.backend.db.tracking.ObservationType
 import com.terraformation.backend.db.tracking.tables.references.OBSERVATIONS
 import java.time.Instant
 import java.time.LocalDate
@@ -26,20 +27,29 @@ data class PublishedActivityModel(
     val publishedTime: Instant? = null,
 ) {
   data class Observation(
-      val observationId: ObservationId,
       val completedTime: Instant,
+      val isAdHoc: Boolean,
       val livePlants: Int?,
+      val monitoringPlotNumber: Long?,
+      val observationId: ObservationId,
+      val observationType: ObservationType,
       val plantDensity: Int?,
       val survivalRate: Int?,
   ) {
     companion object {
-      fun ofOrNull(record: Record): Observation? {
+      fun ofOrNull(
+          record: Record,
+          monitoringPlotNumberField: Field<Long?>,
+      ): Observation? {
         return with(PUBLISHED_ACTIVITY_OBSERVATIONS) {
           record[OBSERVATION_ID]?.let { observationId ->
             Observation(
-                observationId = observationId,
                 completedTime = record[OBSERVATIONS.COMPLETED_TIME]!!,
+                isAdHoc = record[OBSERVATIONS.IS_AD_HOC]!!,
                 livePlants = record[LIVE_PLANTS],
+                monitoringPlotNumber = record[monitoringPlotNumberField],
+                observationId = observationId,
+                observationType = record[OBSERVATIONS.OBSERVATION_TYPE_ID]!!,
                 plantDensity = record[PLANT_DENSITY],
                 survivalRate = record[SURVIVAL_RATE],
             )
@@ -53,6 +63,7 @@ data class PublishedActivityModel(
     fun of(
         record: Record,
         mediaField: Field<List<PublishedActivityMediaModel>>?,
+        monitoringPlotNumberField: Field<Long?>,
     ): PublishedActivityModel {
       return with(PUBLISHED_ACTIVITIES) {
         PublishedActivityModel(
@@ -62,7 +73,7 @@ data class PublishedActivityModel(
             id = record[ACTIVITY_ID]!!,
             isHighlight = record[IS_HIGHLIGHT]!!,
             media = mediaField?.let { record[it] } ?: emptyList(),
-            observation = Observation.ofOrNull(record),
+            observation = Observation.ofOrNull(record, monitoringPlotNumberField),
             projectId = record[PROJECT_ID]!!,
             publishedBy = record[PUBLISHED_ACTIVITIES.PUBLISHED_BY],
             publishedTime = record[PUBLISHED_ACTIVITIES.PUBLISHED_TIME],

--- a/src/test/kotlin/com/terraformation/backend/accelerator/db/ActivityStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/db/ActivityStoreTest.kt
@@ -27,6 +27,7 @@ import com.terraformation.backend.db.default_schema.Role
 import com.terraformation.backend.db.default_schema.tables.references.PROJECTS
 import com.terraformation.backend.db.tracking.ObservationMediaType
 import com.terraformation.backend.db.tracking.ObservationPlotPosition
+import com.terraformation.backend.db.tracking.ObservationType
 import com.terraformation.backend.point
 import java.time.Instant
 import java.time.LocalDate
@@ -374,7 +375,13 @@ class ActivityStoreTest : DatabaseTest(), RunsAsDatabaseUser {
                   ),
               modifiedBy = user.userId,
               modifiedTime = Instant.EPOCH,
-              observation = ExistingActivityModel.Observation(observationId),
+              observation =
+                  ExistingActivityModel.Observation(
+                      isAdHoc = false,
+                      monitoringPlotNumber = null,
+                      observationId = observationId,
+                      observationType = ObservationType.Monitoring,
+                  ),
               projectId = projectId,
           )
 

--- a/src/test/kotlin/com/terraformation/backend/funder/db/PublishedActivityStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/funder/db/PublishedActivityStoreTest.kt
@@ -26,6 +26,7 @@ import com.terraformation.backend.db.funder.tables.records.PublishedActivityObse
 import com.terraformation.backend.db.funder.tables.references.FUNDING_ENTITY_PROJECTS
 import com.terraformation.backend.db.tracking.ObservationMediaType
 import com.terraformation.backend.db.tracking.ObservationPlotPosition
+import com.terraformation.backend.db.tracking.ObservationType
 import com.terraformation.backend.file.event.FileReferenceDeletedEvent
 import com.terraformation.backend.funder.model.PublishedActivityMediaModel
 import com.terraformation.backend.funder.model.PublishedActivityModel
@@ -95,9 +96,9 @@ class PublishedActivityStoreTest : DatabaseTest(), RunsAsDatabaseUser {
       insertPlantingSite(x = 0, width = 10)
       insertStratum()
       insertSubstratum()
-      insertMonitoringPlot(plotNumber = 123)
+      insertMonitoringPlot(plotNumber = 123, isAdHoc = true)
       val completedTime = Instant.ofEpochSecond(12345)
-      val observationId = insertObservation(completedTime = completedTime)
+      val observationId = insertObservation(completedTime = completedTime, isAdHoc = true)
       insertObservationPlot(completedBy = user.userId)
 
       val activityId2 =
@@ -188,9 +189,12 @@ class PublishedActivityStoreTest : DatabaseTest(), RunsAsDatabaseUser {
                       ),
                   observation =
                       PublishedActivityModel.Observation(
+                          isAdHoc = true,
                           livePlants = 100,
                           completedTime = completedTime,
+                          monitoringPlotNumber = 123,
                           observationId = observationId,
+                          observationType = ObservationType.Monitoring,
                           plantDensity = 20,
                           survivalRate = 90,
                       ),


### PR DESCRIPTION
To allow clients to show nicer-looking activity log entries for observations, add
more fields to both the regular and published (funder) activity payloads, under
the `observation` child object:

* `isAdHoc`
* `monitoringPlotNumber` (for ad-hoc observations only)
* `observationType`