### PR TITLE
SW-8446 Use WGS84 spheroid for area calculation

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -127,6 +127,7 @@ dependencies {
   implementation("jakarta.inject:jakarta.inject-api:2.0.1")
   implementation("jakarta.ws.rs:jakarta.ws.rs-api:4.0.0")
   implementation("net.coobird:thumbnailator:0.4.21")
+  implementation("net.sf.geographiclib:GeographicLib-Java:2.1")
   implementation("org.apache.tika:tika-core:3.3.1")
   implementation("org.bouncycastle:bcpkix-jdk18on:1.84")
   implementation("org.commonmark:commonmark:0.28.0")

--- a/src/main/kotlin/com/terraformation/backend/util/Extensions.kt
+++ b/src/main/kotlin/com/terraformation/backend/util/Extensions.kt
@@ -1,5 +1,6 @@
 package com.terraformation.backend.util
 
+import com.terraformation.backend.db.SRID
 import com.terraformation.backend.tracking.model.HECTARES_SCALE
 import freemarker.template.Template
 import java.io.StringWriter
@@ -13,17 +14,21 @@ import java.time.LocalTime
 import java.time.ZoneId
 import java.time.ZonedDateTime
 import java.util.Optional
+import kotlin.math.absoluteValue
 import kotlin.math.ceil
 import kotlin.math.log10
+import net.sf.geographiclib.Geodesic
+import net.sf.geographiclib.PolygonArea
 import org.geotools.api.referencing.FactoryException
-import org.geotools.api.referencing.crs.CoordinateReferenceSystem
 import org.geotools.geometry.jts.JTS
 import org.geotools.referencing.CRS
+import org.geotools.referencing.crs.DefaultGeographicCRS
 import org.jooq.Field
 import org.locationtech.jts.geom.Coordinate
 import org.locationtech.jts.geom.Geometry
 import org.locationtech.jts.geom.GeometryCollection
 import org.locationtech.jts.geom.GeometryFactory
+import org.locationtech.jts.geom.LinearRing
 import org.locationtech.jts.geom.MultiPolygon
 import org.locationtech.jts.geom.Polygon
 import org.locationtech.jts.geom.util.GeometryFixer
@@ -184,25 +189,59 @@ fun Geometry.fixIfNeeded(): Geometry {
 }
 
 /**
- * Calculates the approximate area of a geometry in hectares. If this feature isn't already in a UTM
- * coordinate system, converts it to the appropriate one first.
- *
- * @throws FactoryException The geometry couldn't be converted to UTM.
+ * Returns the area of a geometry in square meters. The geometry must already be in the WGS84
+ * coordinate system.
  */
-fun Geometry.calculateAreaHectares(originalCrs: CoordinateReferenceSystem? = null): BigDecimal {
+private fun Geometry.calculateAreaSquareMeters(): Double {
+  return when (this) {
+    is MultiPolygon -> {
+      (0..<numGeometries).map { getGeometryN(it) }.sumOf { it.calculateAreaSquareMeters() }
+    }
+    is Polygon -> {
+      val holesTotal =
+          (0..<numInteriorRing)
+              .map { getInteriorRingN(it) }
+              .sumOf { it.calculateAreaSquareMeters() }
+      exteriorRing.calculateAreaSquareMeters() - holesTotal
+    }
+    is LinearRing -> {
+      val polygonArea = PolygonArea(Geodesic.WGS84, false)
+      coordinates.forEach { coord -> polygonArea.AddPoint(coord.y, coord.x) }
+
+      // absoluteValue is because Compute() returns negative areas for counterclockwise polygons.
+      polygonArea.Compute().area.absoluteValue
+    }
+    else -> {
+      throw IllegalArgumentException("Area calculation not supported for ${javaClass.simpleName}")
+    }
+  }
+}
+
+/**
+ * Calculates the approximate area of a geometry in hectares.
+ *
+ * @throws FactoryException The geometry couldn't be converted to WGS84.
+ */
+fun Geometry.calculateAreaHectares(): BigDecimal {
   if (isEmpty) {
     return BigDecimal.ZERO.setScale(HECTARES_SCALE)
   }
 
-  val crs = originalCrs ?: CRS.decode("EPSG:$srid", true)
+  val wgs84Geometry =
+      if (srid == SRID.LONG_LAT) {
+        this
+      } else {
+        JTS.transform(
+            this,
+            CRS.findMathTransform(
+                CRS.decode("EPSG:${this.srid}", true),
+                DefaultGeographicCRS.WGS84,
+            ),
+        )
+      }
 
-  // Transform to Equal Earth coordinates for consistent area calculations.
-  val equalEarthCrs = CRS.decode("EPSG:8857", true)
-  val equalEarthGeometry = JTS.transform(this, CRS.findMathTransform(crs, equalEarthCrs))
-  val hectares = equalEarthGeometry.area / SQUARE_METERS_PER_HECTARE
+  val hectares = wgs84Geometry.calculateAreaSquareMeters() / SQUARE_METERS_PER_HECTARE
 
-  // Use a default number of decimal places unless the area is very small, in which case use as
-  // many decimal places as needed to capture the first significant digit.
   val scale =
       if (hectares > 0 && hectares < 0.1) {
         ceil(-log10(hectares)).toInt()

--- a/src/main/kotlin/com/terraformation/backend/util/Extensions.kt
+++ b/src/main/kotlin/com/terraformation/backend/util/Extensions.kt
@@ -1,6 +1,5 @@
 package com.terraformation.backend.util
 
-import com.terraformation.backend.db.SRID
 import com.terraformation.backend.tracking.model.HECTARES_SCALE
 import freemarker.template.Template
 import java.io.StringWriter
@@ -20,15 +19,12 @@ import org.geotools.api.referencing.FactoryException
 import org.geotools.api.referencing.crs.CoordinateReferenceSystem
 import org.geotools.geometry.jts.JTS
 import org.geotools.referencing.CRS
-import org.geotools.referencing.crs.DefaultGeographicCRS
-import org.geotools.referencing.operation.projection.TransverseMercator
 import org.jooq.Field
 import org.locationtech.jts.geom.Coordinate
 import org.locationtech.jts.geom.Geometry
 import org.locationtech.jts.geom.GeometryCollection
 import org.locationtech.jts.geom.GeometryFactory
 import org.locationtech.jts.geom.MultiPolygon
-import org.locationtech.jts.geom.Point
 import org.locationtech.jts.geom.Polygon
 import org.locationtech.jts.geom.util.GeometryFixer
 
@@ -200,28 +196,10 @@ fun Geometry.calculateAreaHectares(originalCrs: CoordinateReferenceSystem? = nul
 
   val crs = originalCrs ?: CRS.decode("EPSG:$srid", true)
 
-  // Transform to UTM if it isn't already.
-  val utmGeometry =
-      if (CRS.getProjectedCRS(crs) is TransverseMercator) {
-        this
-      } else {
-        // To use the "look up the right UTM for a location" feature of GeoTools, we need to
-        // know the location in WGS84 (EPSG:4326) longitude and latitude; transform the feature's
-        // centroid coordinates to WGS84.
-        val wgs84Centroid =
-            if (CRS.lookupEpsgCode(crs, false) == SRID.LONG_LAT) {
-              centroid
-            } else {
-              val wgs84Transform = CRS.findMathTransform(crs, DefaultGeographicCRS.WGS84)
-              JTS.transform(centroid, wgs84Transform) as Point
-            }
-
-        val utmCrs = CRS.decode("AUTO2:42001,${wgs84Centroid.x},${wgs84Centroid.y}")
-
-        JTS.transform(this, CRS.findMathTransform(crs, utmCrs))
-      }
-
-  val hectares = utmGeometry.area / SQUARE_METERS_PER_HECTARE
+  // Transform to Equal Earth coordinates for consistent area calculations.
+  val equalEarthCrs = CRS.decode("EPSG:8857", true)
+  val equalEarthGeometry = JTS.transform(this, CRS.findMathTransform(crs, equalEarthCrs))
+  val hectares = equalEarthGeometry.area / SQUARE_METERS_PER_HECTARE
 
   // Use a default number of decimal places unless the area is very small, in which case use as
   // many decimal places as needed to capture the first significant digit.

--- a/src/main/kotlin/com/terraformation/backend/util/Turtle.kt
+++ b/src/main/kotlin/com/terraformation/backend/util/Turtle.kt
@@ -13,6 +13,7 @@ import org.geotools.referencing.CRS
 import org.geotools.referencing.GeodeticCalculator
 import org.locationtech.jts.geom.Coordinate
 import org.locationtech.jts.geom.GeometryFactory
+import org.locationtech.jts.geom.LinearRing
 import org.locationtech.jts.geom.MultiPolygon
 import org.locationtech.jts.geom.Point
 import org.locationtech.jts.geom.Polygon
@@ -61,6 +62,16 @@ class Turtle(
    */
   fun makeMultiPolygon(func: Turtle.() -> Unit): MultiPolygon {
     return geometryFactory.createMultiPolygon(arrayOf(makePolygon(func)))
+  }
+
+  /**
+   * Returns the linear ring formed by a series of turtle moves from a starting point. Automatically
+   * closes the ring; you don't need to move back to the starting point explicitly.
+   */
+  fun makeLinearRing(func: Turtle.() -> Unit): LinearRing {
+    this.func()
+    moveTo(startPosition)
+    return geometryFactory.createLinearRing(coordinates.toTypedArray())
   }
 
   fun north(meters: Number) {

--- a/src/test/kotlin/com/terraformation/backend/accelerator/ApplicationServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/ApplicationServiceTest.kt
@@ -272,7 +272,7 @@ class ApplicationServiceTest : DatabaseTest(), RunsAsUser {
 
       val updatedVariableValues =
           ProjectAcceleratorVariableValuesModel(
-              applicationReforestableLand = BigDecimal("99.950"),
+              applicationReforestableLand = BigDecimal("100.674"),
               countryCode = "KE",
               dealName = internalName,
               landUseModelTypes = setOf(LandUseModelType.Mangroves, LandUseModelType.NativeForest),
@@ -296,7 +296,7 @@ class ApplicationServiceTest : DatabaseTest(), RunsAsUser {
 
       assertEquals(
           ProjectAcceleratorDetailsModel(
-              applicationReforestableLand = BigDecimal("99.950"),
+              applicationReforestableLand = BigDecimal("100.674"),
               countryCode = "KE",
               dealName = internalName,
               fileNaming = internalName,

--- a/src/test/kotlin/com/terraformation/backend/accelerator/ApplicationServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/ApplicationServiceTest.kt
@@ -272,7 +272,7 @@ class ApplicationServiceTest : DatabaseTest(), RunsAsUser {
 
       val updatedVariableValues =
           ProjectAcceleratorVariableValuesModel(
-              applicationReforestableLand = BigDecimal("100.674"),
+              applicationReforestableLand = BigDecimal("100.000"),
               countryCode = "KE",
               dealName = internalName,
               landUseModelTypes = setOf(LandUseModelType.Mangroves, LandUseModelType.NativeForest),
@@ -296,7 +296,7 @@ class ApplicationServiceTest : DatabaseTest(), RunsAsUser {
 
       assertEquals(
           ProjectAcceleratorDetailsModel(
-              applicationReforestableLand = BigDecimal("100.674"),
+              applicationReforestableLand = BigDecimal("100.000"),
               countryCode = "KE",
               dealName = internalName,
               fileNaming = internalName,

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/plantingSiteStore/PlantingSiteStoreApplyEditTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/plantingSiteStore/PlantingSiteStoreApplyEditTest.kt
@@ -251,17 +251,17 @@ internal class PlantingSiteStoreApplyEditTest : BasePlantingSiteStoreTest() {
               newSite { exclusion = rectangle(width = 200, height = 500) },
           )
 
-      assertEquals(BigDecimal("20.135"), existing.areaHa, "Site area before edit")
-      assertEquals(BigDecimal("15.101"), edited.areaHa, "Site area after edit")
-      assertEquals(BigDecimal("20.135"), existing.strata[0].areaHa, "Stratum area before edit")
-      assertEquals(BigDecimal("15.101"), edited.strata[0].areaHa, "Stratum area after edit")
+      assertEquals(BigDecimal("20.000"), existing.areaHa, "Site area before edit")
+      assertEquals(BigDecimal("15.000"), edited.areaHa, "Site area after edit")
+      assertEquals(BigDecimal("20.000"), existing.strata[0].areaHa, "Stratum area before edit")
+      assertEquals(BigDecimal("15.000"), edited.strata[0].areaHa, "Stratum area after edit")
       assertEquals(
-          BigDecimal("20.135"),
+          BigDecimal("20.000"),
           existing.strata[0].substrata[0].areaHa,
           "Substratum area before edit",
       )
       assertEquals(
-          BigDecimal("15.101"),
+          BigDecimal("15.000"),
           edited.strata[0].substrata[0].areaHa,
           "Substratum area after edit",
       )

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/plantingSiteStore/PlantingSiteStoreApplyEditTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/plantingSiteStore/PlantingSiteStoreApplyEditTest.kt
@@ -251,17 +251,17 @@ internal class PlantingSiteStoreApplyEditTest : BasePlantingSiteStoreTest() {
               newSite { exclusion = rectangle(width = 200, height = 500) },
           )
 
-      assertEquals(BigDecimal("20.008"), existing.areaHa, "Site area before edit")
-      assertEquals(BigDecimal("15.006"), edited.areaHa, "Site area after edit")
-      assertEquals(BigDecimal("20.008"), existing.strata[0].areaHa, "Stratum area before edit")
-      assertEquals(BigDecimal("15.006"), edited.strata[0].areaHa, "Stratum area after edit")
+      assertEquals(BigDecimal("20.135"), existing.areaHa, "Site area before edit")
+      assertEquals(BigDecimal("15.101"), edited.areaHa, "Site area after edit")
+      assertEquals(BigDecimal("20.135"), existing.strata[0].areaHa, "Stratum area before edit")
+      assertEquals(BigDecimal("15.101"), edited.strata[0].areaHa, "Stratum area after edit")
       assertEquals(
-          BigDecimal("20.008"),
+          BigDecimal("20.135"),
           existing.strata[0].substrata[0].areaHa,
           "Substratum area before edit",
       )
       assertEquals(
-          BigDecimal("15.006"),
+          BigDecimal("15.101"),
           edited.strata[0].substrata[0].areaHa,
           "Substratum area after edit",
       )

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/plantingSiteStore/PlantingSiteStoreCreateSiteTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/plantingSiteStore/PlantingSiteStoreCreateSiteTest.kt
@@ -87,7 +87,7 @@ internal class PlantingSiteStoreCreateSiteTest : BasePlantingSiteStoreTest() {
       assertEquals(
           listOf(
               PlantingSitesRow(
-                  areaHa = BigDecimal("2.265"),
+                  areaHa = BigDecimal("2.250"),
                   boundary = boundary,
                   createdBy = user.userId,
                   createdTime = Instant.EPOCH,
@@ -193,7 +193,7 @@ internal class PlantingSiteStoreCreateSiteTest : BasePlantingSiteStoreTest() {
       assertGeometryEquals(gridOrigin, plantingSitesRow.gridOrigin, "Planting site grid origin")
       assertEquals(
           PlantingSitesRow(
-              areaHa = BigDecimal("2.996"),
+              areaHa = BigDecimal("3.000"),
               countryCode = "GB",
               createdBy = user.userId,
               createdTime = Instant.EPOCH,
@@ -210,7 +210,7 @@ internal class PlantingSiteStoreCreateSiteTest : BasePlantingSiteStoreTest() {
 
       val commonStrataRow =
           StrataRow(
-              areaHa = BigDecimal("1.498"),
+              areaHa = BigDecimal("1.500"),
               boundaryModifiedBy = user.userId,
               boundaryModifiedTime = Instant.EPOCH,
               createdBy = user.userId,
@@ -263,7 +263,7 @@ internal class PlantingSiteStoreCreateSiteTest : BasePlantingSiteStoreTest() {
 
       val commonSubstrataRow =
           SubstrataRow(
-              areaHa = BigDecimal("0.749"),
+              areaHa = BigDecimal("0.750"),
               createdBy = user.userId,
               createdTime = Instant.EPOCH,
               modifiedBy = user.userId,
@@ -346,7 +346,7 @@ internal class PlantingSiteStoreCreateSiteTest : BasePlantingSiteStoreTest() {
       assertEquals(
           listOf(
               PlantingSiteHistoriesRow(
-                  areaHa = BigDecimal("2.255"),
+                  areaHa = BigDecimal("2.240"),
                   boundary = boundary,
                   createdBy = user.userId,
                   createdTime = clock.instant,
@@ -399,7 +399,7 @@ internal class PlantingSiteStoreCreateSiteTest : BasePlantingSiteStoreTest() {
       assertEquals(
           listOf(
               PlantingSiteHistoriesRow(
-                  areaHa = BigDecimal("4.024"),
+                  areaHa = BigDecimal("3.997"),
                   boundary = siteBoundary,
                   createdBy = user.userId,
                   createdTime = clock.instant,
@@ -417,7 +417,7 @@ internal class PlantingSiteStoreCreateSiteTest : BasePlantingSiteStoreTest() {
       assertEquals(
           listOf(
               StratumHistoriesRow(
-                  areaHa = BigDecimal("4.020"),
+                  areaHa = BigDecimal("3.993"),
                   boundary = stratumBoundary,
                   name = "stratum",
                   plantingSiteHistoryId = model.historyId,
@@ -432,7 +432,7 @@ internal class PlantingSiteStoreCreateSiteTest : BasePlantingSiteStoreTest() {
       assertEquals(
           listOf(
               SubstratumHistoriesRow(
-                  areaHa = BigDecimal("4.016"),
+                  areaHa = BigDecimal("3.990"),
                   boundary = substratumBoundary,
                   fullName = "stratum-substratum",
                   name = "substratum",

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/plantingSiteStore/PlantingSiteStoreCreateSiteTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/plantingSiteStore/PlantingSiteStoreCreateSiteTest.kt
@@ -87,7 +87,7 @@ internal class PlantingSiteStoreCreateSiteTest : BasePlantingSiteStoreTest() {
       assertEquals(
           listOf(
               PlantingSitesRow(
-                  areaHa = BigDecimal("2.251"),
+                  areaHa = BigDecimal("2.265"),
                   boundary = boundary,
                   createdBy = user.userId,
                   createdTime = Instant.EPOCH,
@@ -193,7 +193,7 @@ internal class PlantingSiteStoreCreateSiteTest : BasePlantingSiteStoreTest() {
       assertGeometryEquals(gridOrigin, plantingSitesRow.gridOrigin, "Planting site grid origin")
       assertEquals(
           PlantingSitesRow(
-              areaHa = BigDecimal("3.001"),
+              areaHa = BigDecimal("2.996"),
               countryCode = "GB",
               createdBy = user.userId,
               createdTime = Instant.EPOCH,
@@ -210,7 +210,7 @@ internal class PlantingSiteStoreCreateSiteTest : BasePlantingSiteStoreTest() {
 
       val commonStrataRow =
           StrataRow(
-              areaHa = BigDecimal("1.500"),
+              areaHa = BigDecimal("1.498"),
               boundaryModifiedBy = user.userId,
               boundaryModifiedTime = Instant.EPOCH,
               createdBy = user.userId,
@@ -263,7 +263,7 @@ internal class PlantingSiteStoreCreateSiteTest : BasePlantingSiteStoreTest() {
 
       val commonSubstrataRow =
           SubstrataRow(
-              areaHa = BigDecimal("0.750"),
+              areaHa = BigDecimal("0.749"),
               createdBy = user.userId,
               createdTime = Instant.EPOCH,
               modifiedBy = user.userId,
@@ -346,7 +346,7 @@ internal class PlantingSiteStoreCreateSiteTest : BasePlantingSiteStoreTest() {
       assertEquals(
           listOf(
               PlantingSiteHistoriesRow(
-                  areaHa = BigDecimal("2.241"),
+                  areaHa = BigDecimal("2.255"),
                   boundary = boundary,
                   createdBy = user.userId,
                   createdTime = clock.instant,
@@ -399,7 +399,7 @@ internal class PlantingSiteStoreCreateSiteTest : BasePlantingSiteStoreTest() {
       assertEquals(
           listOf(
               PlantingSiteHistoriesRow(
-                  areaHa = BigDecimal("3.999"),
+                  areaHa = BigDecimal("4.024"),
                   boundary = siteBoundary,
                   createdBy = user.userId,
                   createdTime = clock.instant,
@@ -417,7 +417,7 @@ internal class PlantingSiteStoreCreateSiteTest : BasePlantingSiteStoreTest() {
       assertEquals(
           listOf(
               StratumHistoriesRow(
-                  areaHa = BigDecimal("3.995"),
+                  areaHa = BigDecimal("4.020"),
                   boundary = stratumBoundary,
                   name = "stratum",
                   plantingSiteHistoryId = model.historyId,
@@ -432,7 +432,7 @@ internal class PlantingSiteStoreCreateSiteTest : BasePlantingSiteStoreTest() {
       assertEquals(
           listOf(
               SubstratumHistoriesRow(
-                  areaHa = BigDecimal("3.991"),
+                  areaHa = BigDecimal("4.016"),
                   boundary = substratumBoundary,
                   fullName = "stratum-substratum",
                   name = "substratum",

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/plantingSiteStore/PlantingSiteStoreRecalculateAreasTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/plantingSiteStore/PlantingSiteStoreRecalculateAreasTest.kt
@@ -39,10 +39,10 @@ internal class PlantingSiteStoreRecalculateAreasTest : BasePlantingSiteStoreTest
             boundary = siteBoundary,
             exclusion = exclusion,
             gridOrigin = gridOrigin,
-            areaHa = BigDecimal("2.0"),
+            areaHa = BigDecimal("3.0"),
         )
-    val stratumId = insertStratum(boundary = siteBoundary, areaHa = BigDecimal("2.0"))
-    val substratumId = insertSubstratum(boundary = siteBoundary, areaHa = BigDecimal("2.0"))
+    val stratumId = insertStratum(boundary = siteBoundary, areaHa = BigDecimal("3.0"))
+    val substratumId = insertSubstratum(boundary = siteBoundary, areaHa = BigDecimal("3.0"))
 
     store.recalculatePlantingSiteAreas(successMessages::add, failureMessages::add)
 

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/plantingSiteStore/PlantingSiteStoreUpdateSiteTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/plantingSiteStore/PlantingSiteStoreUpdateSiteTest.kt
@@ -55,7 +55,7 @@ internal class PlantingSiteStoreUpdateSiteTest : BasePlantingSiteStoreTest() {
       assertEquals(
           listOf(
               PlantingSitesRow(
-                  areaHa = BigDecimal("4.002"),
+                  areaHa = BigDecimal("4.027"),
                   boundary = newBoundary,
                   gridOrigin = initialModel.gridOrigin,
                   id = initialModel.id,
@@ -77,7 +77,7 @@ internal class PlantingSiteStoreUpdateSiteTest : BasePlantingSiteStoreTest() {
       assertSetEquals(
           setOf(
               PlantingSiteHistoriesRow(
-                  areaHa = BigDecimal("1.002"),
+                  areaHa = BigDecimal("1.007"),
                   boundary = initialModel.boundary,
                   createdBy = user.userId,
                   createdTime = createdTime,
@@ -85,7 +85,7 @@ internal class PlantingSiteStoreUpdateSiteTest : BasePlantingSiteStoreTest() {
                   plantingSiteId = initialModel.id,
               ),
               PlantingSiteHistoriesRow(
-                  areaHa = BigDecimal("4.002"),
+                  areaHa = BigDecimal("4.027"),
                   boundary = newBoundary,
                   createdBy = user.userId,
                   createdTime = clock.instant,

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/plantingSiteStore/PlantingSiteStoreUpdateSiteTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/plantingSiteStore/PlantingSiteStoreUpdateSiteTest.kt
@@ -55,7 +55,7 @@ internal class PlantingSiteStoreUpdateSiteTest : BasePlantingSiteStoreTest() {
       assertEquals(
           listOf(
               PlantingSitesRow(
-                  areaHa = BigDecimal("4.027"),
+                  areaHa = BigDecimal("4.000"),
                   boundary = newBoundary,
                   gridOrigin = initialModel.gridOrigin,
                   id = initialModel.id,
@@ -77,7 +77,7 @@ internal class PlantingSiteStoreUpdateSiteTest : BasePlantingSiteStoreTest() {
       assertSetEquals(
           setOf(
               PlantingSiteHistoriesRow(
-                  areaHa = BigDecimal("1.007"),
+                  areaHa = BigDecimal("1.000"),
                   boundary = initialModel.boundary,
                   createdBy = user.userId,
                   createdTime = createdTime,
@@ -85,7 +85,7 @@ internal class PlantingSiteStoreUpdateSiteTest : BasePlantingSiteStoreTest() {
                   plantingSiteId = initialModel.id,
               ),
               PlantingSiteHistoriesRow(
-                  areaHa = BigDecimal("4.027"),
+                  areaHa = BigDecimal("4.000"),
                   boundary = newBoundary,
                   createdBy = user.userId,
                   createdTime = clock.instant,

--- a/src/test/kotlin/com/terraformation/backend/tracking/edit/PlantingSiteEditCalculatorTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/edit/PlantingSiteEditCalculatorTest.kt
@@ -29,7 +29,7 @@ class PlantingSiteEditCalculatorTest {
 
     assertEditResult(
         PlantingSiteEdit(
-            areaHaDifference = BigDecimal("12.505"),
+            areaHaDifference = BigDecimal("12.585"),
             desiredModel = desired,
             existingModel = existing,
             stratumEdits =
@@ -75,14 +75,14 @@ class PlantingSiteEditCalculatorTest {
 
     assertEditResult(
         PlantingSiteEdit(
-            areaHaDifference = BigDecimal("12.505"),
+            areaHaDifference = BigDecimal("12.585"),
             desiredModel = desired,
             existingModel = existing,
             stratumEdits =
                 listOf(
                     StratumEdit.Update(
                         addedRegion = newSubstratumBoundary,
-                        areaHaDifference = BigDecimal("12.505"),
+                        areaHaDifference = BigDecimal("12.585"),
                         desiredModel = desired.strata[0],
                         existingModel = existing.strata[0],
                         monitoringPlotEdits =
@@ -173,14 +173,14 @@ class PlantingSiteEditCalculatorTest {
 
     assertEditResult(
         PlantingSiteEdit(
-            areaHaDifference = BigDecimal("5.002"),
+            areaHaDifference = BigDecimal("5.034"),
             desiredModel = desired,
             existingModel = existing,
             stratumEdits =
                 listOf(
                     StratumEdit.Update(
                         addedRegion = rectangle(x = 500, width = 200, height = 500),
-                        areaHaDifference = BigDecimal("5.002"),
+                        areaHaDifference = BigDecimal("5.034"),
                         desiredModel = desired.strata[0],
                         existingModel = existing.strata[0],
                         monitoringPlotEdits =
@@ -194,7 +194,7 @@ class PlantingSiteEditCalculatorTest {
                             listOf(
                                 SubstratumEdit.Update(
                                     addedRegion = rectangle(x = 500, width = 200, height = 500),
-                                    areaHaDifference = BigDecimal("5.002"),
+                                    areaHaDifference = BigDecimal("5.034"),
                                     desiredModel = desired.strata[0].substrata[0],
                                     existingModel = existing.strata[0].substrata[0],
                                     removedRegion = rectangle(x = 0, width = 100, height = 500),
@@ -232,7 +232,7 @@ class PlantingSiteEditCalculatorTest {
                     // Stratum B moves to west edge of site and grows from 200m to 500m wide
                     StratumEdit.Update(
                         addedRegion = rectangle(x = 0, width = 500, height = 500),
-                        areaHaDifference = BigDecimal("15.007"),
+                        areaHaDifference = BigDecimal("15.101"),
                         desiredModel = desired.strata[0],
                         existingModel = existing.strata[1],
                         monitoringPlotEdits = emptyList(),
@@ -240,7 +240,7 @@ class PlantingSiteEditCalculatorTest {
                             listOf(
                                 SubstratumEdit.Update(
                                     addedRegion = rectangle(x = 0, width = 500, height = 500),
-                                    areaHaDifference = BigDecimal("15.007"),
+                                    areaHaDifference = BigDecimal("15.101"),
                                     desiredModel = desired.strata[0].substrata[0],
                                     existingModel = existing.strata[1].substrata[0],
                                     monitoringPlotEdits =
@@ -255,7 +255,7 @@ class PlantingSiteEditCalculatorTest {
                     // Stratum A moves to east edge of site and shrinks from 800m to 500m wide
                     StratumEdit.Update(
                         addedRegion = rectangle(x = 800, width = 200, height = 500),
-                        areaHaDifference = BigDecimal("-15.007"),
+                        areaHaDifference = BigDecimal("-15.101"),
                         desiredModel = desired.strata[1],
                         existingModel = existing.strata[0],
                         monitoringPlotEdits =
@@ -271,7 +271,7 @@ class PlantingSiteEditCalculatorTest {
                             listOf(
                                 SubstratumEdit.Update(
                                     addedRegion = rectangle(x = 800, width = 200, height = 500),
-                                    areaHaDifference = BigDecimal("-15.007"),
+                                    areaHaDifference = BigDecimal("-15.101"),
                                     desiredModel = desired.strata[1].substrata[0],
                                     existingModel = existing.strata[0].substrata[0],
                                     monitoringPlotEdits =
@@ -342,7 +342,7 @@ class PlantingSiteEditCalculatorTest {
                     // Stratum A shrinks
                     StratumEdit.Update(
                         addedRegion = rectangle(0),
-                        areaHaDifference = BigDecimal("-12.506"),
+                        areaHaDifference = BigDecimal("-12.584"),
                         desiredModel = desired.strata[0],
                         existingModel = existing.strata[0],
                         monitoringPlotEdits = emptyList(),
@@ -393,7 +393,7 @@ class PlantingSiteEditCalculatorTest {
                     // Stratum A shrinks
                     StratumEdit.Update(
                         addedRegion = rectangle(0),
-                        areaHaDifference = BigDecimal("-12.506"),
+                        areaHaDifference = BigDecimal("-12.584"),
                         desiredModel = desired.strata[0],
                         existingModel = existing.strata[0],
                         monitoringPlotEdits = emptyList(),
@@ -402,7 +402,7 @@ class PlantingSiteEditCalculatorTest {
                     ),
                     StratumEdit.Update(
                         addedRegion = rectangle(x = 250, width = 250, height = 500),
-                        areaHaDifference = BigDecimal("12.506"),
+                        areaHaDifference = BigDecimal("12.584"),
                         desiredModel = desired.strata[1],
                         existingModel = existing.strata[1],
                         monitoringPlotEdits = emptyList(),
@@ -477,7 +477,7 @@ class PlantingSiteEditCalculatorTest {
                     ),
                     StratumEdit.Update(
                         addedRegion = rectangle(0),
-                        areaHaDifference = BigDecimal("-25.010"),
+                        areaHaDifference = BigDecimal("-25.169"),
                         desiredModel = desired.strata[0],
                         existingModel = existing.strata[0],
                         monitoringPlotEdits =
@@ -491,7 +491,7 @@ class PlantingSiteEditCalculatorTest {
                             listOf(
                                 SubstratumEdit.Update(
                                     addedRegion = rectangle(0),
-                                    areaHaDifference = BigDecimal("-25.010"),
+                                    areaHaDifference = BigDecimal("-25.169"),
                                     desiredModel = desired.strata[0].substrata[0],
                                     existingModel = existing.strata[0].substrata[0],
                                     monitoringPlotEdits = emptyList(),
@@ -538,14 +538,14 @@ class PlantingSiteEditCalculatorTest {
 
     assertEditResult(
         PlantingSiteEdit(
-            areaHaDifference = BigDecimal("-25.011"),
+            areaHaDifference = BigDecimal("-25.169"),
             desiredModel = desired,
             existingModel = existing,
             stratumEdits =
                 listOf(
                     StratumEdit.Update(
                         addedRegion = rectangle(x = 500, width = 280, height = 500),
-                        areaHaDifference = BigDecimal("-0.001"),
+                        areaHaDifference = BigDecimal.ZERO,
                         desiredModel = desired.strata[0],
                         existingModel = existing.strata[0],
                         monitoringPlotEdits =
@@ -559,7 +559,7 @@ class PlantingSiteEditCalculatorTest {
                             listOf(
                                 SubstratumEdit.Update(
                                     addedRegion = rectangle(x = 500, width = 280, height = 500),
-                                    areaHaDifference = BigDecimal("-0.001"),
+                                    areaHaDifference = BigDecimal.ZERO,
                                     desiredModel = desired.strata[0].substrata[0],
                                     existingModel = existing.strata[0].substrata[0],
                                     monitoringPlotEdits =
@@ -638,14 +638,14 @@ class PlantingSiteEditCalculatorTest {
 
     assertEditResult(
         PlantingSiteEdit(
-            areaHaDifference = BigDecimal("25.011"),
+            areaHaDifference = BigDecimal("25.168"),
             desiredModel = desired,
             existingModel = existing,
             stratumEdits =
                 listOf(
                     StratumEdit.Update(
                         addedRegion = rectangle(x = 100, width = 500, height = 500),
-                        areaHaDifference = BigDecimal("25.011"),
+                        areaHaDifference = BigDecimal("25.168"),
                         desiredModel = desired.strata[0],
                         existingModel = existing.strata[0],
                         monitoringPlotEdits = emptyList(),
@@ -653,7 +653,7 @@ class PlantingSiteEditCalculatorTest {
                             listOf(
                                 SubstratumEdit.Update(
                                     addedRegion = rectangle(x = 100, width = 500, height = 500),
-                                    areaHaDifference = BigDecimal("25.011"),
+                                    areaHaDifference = BigDecimal("25.168"),
                                     desiredModel = desired.strata[0].substrata[0],
                                     existingModel = existing.strata[0].substrata[0],
                                     monitoringPlotEdits =
@@ -691,13 +691,13 @@ class PlantingSiteEditCalculatorTest {
 
     assertEditResult(
         PlantingSiteEdit(
-            areaHaDifference = BigDecimal("5.003"),
+            areaHaDifference = BigDecimal("5.033"),
             desiredModel = desired,
             existingModel = existing,
             stratumEdits =
                 listOf(
                     StratumEdit.Update(
-                        areaHaDifference = BigDecimal("5.003"),
+                        areaHaDifference = BigDecimal("5.033"),
                         addedRegion = rectangle(x = 400, width = 100, height = 500),
                         desiredModel = desired.strata[0],
                         existingModel = existing.strata[0],
@@ -709,7 +709,7 @@ class PlantingSiteEditCalculatorTest {
                             listOf(
                                 SubstratumEdit.Update(
                                     addedRegion = rectangle(x = 400, width = 100, height = 500),
-                                    areaHaDifference = BigDecimal("5.003"),
+                                    areaHaDifference = BigDecimal("5.033"),
                                     desiredModel = desired.strata[0].substrata[0],
                                     existingModel = existing.strata[0].substrata[0],
                                     // The unqualified plots are already in the correct substratum
@@ -744,14 +744,14 @@ class PlantingSiteEditCalculatorTest {
 
     assertEditResult(
         PlantingSiteEdit(
-            areaHaDifference = BigDecimal("10.004"),
+            areaHaDifference = BigDecimal("10.067"),
             desiredModel = desired,
             existingModel = existing,
             stratumEdits =
                 listOf(
                     StratumEdit.Update(
                         addedRegion = addedRegion,
-                        areaHaDifference = BigDecimal("10.004"),
+                        areaHaDifference = BigDecimal("10.067"),
                         desiredModel = desired.strata[0],
                         existingModel = existing.strata[0],
                         monitoringPlotEdits =
@@ -774,7 +774,7 @@ class PlantingSiteEditCalculatorTest {
                             listOf(
                                 SubstratumEdit.Update(
                                     addedRegion = addedRegion,
-                                    areaHaDifference = BigDecimal("10.004"),
+                                    areaHaDifference = BigDecimal("10.067"),
                                     desiredModel = desired.strata[0].substrata[0],
                                     existingModel = existing.strata[0].substrata[0],
                                     monitoringPlotEdits = emptyList(),
@@ -884,7 +884,7 @@ class PlantingSiteEditCalculatorTest {
 
     assertEditResult(
         PlantingSiteEdit(
-            areaHaDifference = BigDecimal("-12.505"),
+            areaHaDifference = BigDecimal("-12.584"),
             desiredModel = desired,
             existingModel = existing,
             stratumEdits =
@@ -920,14 +920,14 @@ class PlantingSiteEditCalculatorTest {
 
     assertEditResult(
         PlantingSiteEdit(
-            areaHaDifference = BigDecimal("-25.010"),
+            areaHaDifference = BigDecimal("-25.169"),
             desiredModel = desired,
             existingModel = existing,
             stratumEdits =
                 listOf(
                     StratumEdit.Update(
                         addedRegion = rectangle(0),
-                        areaHaDifference = BigDecimal("-25.010"),
+                        areaHaDifference = BigDecimal("-25.169"),
                         desiredModel = desired.strata[0],
                         existingModel = existing.strata[0],
                         monitoringPlotEdits =

--- a/src/test/kotlin/com/terraformation/backend/tracking/edit/PlantingSiteEditCalculatorTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/edit/PlantingSiteEditCalculatorTest.kt
@@ -29,7 +29,7 @@ class PlantingSiteEditCalculatorTest {
 
     assertEditResult(
         PlantingSiteEdit(
-            areaHaDifference = BigDecimal("12.585"),
+            areaHaDifference = BigDecimal("12.500"),
             desiredModel = desired,
             existingModel = existing,
             stratumEdits =
@@ -75,14 +75,14 @@ class PlantingSiteEditCalculatorTest {
 
     assertEditResult(
         PlantingSiteEdit(
-            areaHaDifference = BigDecimal("12.585"),
+            areaHaDifference = BigDecimal("12.500"),
             desiredModel = desired,
             existingModel = existing,
             stratumEdits =
                 listOf(
                     StratumEdit.Update(
                         addedRegion = newSubstratumBoundary,
-                        areaHaDifference = BigDecimal("12.585"),
+                        areaHaDifference = BigDecimal("12.500"),
                         desiredModel = desired.strata[0],
                         existingModel = existing.strata[0],
                         monitoringPlotEdits =
@@ -173,14 +173,14 @@ class PlantingSiteEditCalculatorTest {
 
     assertEditResult(
         PlantingSiteEdit(
-            areaHaDifference = BigDecimal("5.034"),
+            areaHaDifference = BigDecimal("5.000"),
             desiredModel = desired,
             existingModel = existing,
             stratumEdits =
                 listOf(
                     StratumEdit.Update(
                         addedRegion = rectangle(x = 500, width = 200, height = 500),
-                        areaHaDifference = BigDecimal("5.034"),
+                        areaHaDifference = BigDecimal("5.000"),
                         desiredModel = desired.strata[0],
                         existingModel = existing.strata[0],
                         monitoringPlotEdits =
@@ -194,7 +194,7 @@ class PlantingSiteEditCalculatorTest {
                             listOf(
                                 SubstratumEdit.Update(
                                     addedRegion = rectangle(x = 500, width = 200, height = 500),
-                                    areaHaDifference = BigDecimal("5.034"),
+                                    areaHaDifference = BigDecimal("5.000"),
                                     desiredModel = desired.strata[0].substrata[0],
                                     existingModel = existing.strata[0].substrata[0],
                                     removedRegion = rectangle(x = 0, width = 100, height = 500),
@@ -232,7 +232,7 @@ class PlantingSiteEditCalculatorTest {
                     // Stratum B moves to west edge of site and grows from 200m to 500m wide
                     StratumEdit.Update(
                         addedRegion = rectangle(x = 0, width = 500, height = 500),
-                        areaHaDifference = BigDecimal("15.101"),
+                        areaHaDifference = BigDecimal("15.000"),
                         desiredModel = desired.strata[0],
                         existingModel = existing.strata[1],
                         monitoringPlotEdits = emptyList(),
@@ -240,7 +240,7 @@ class PlantingSiteEditCalculatorTest {
                             listOf(
                                 SubstratumEdit.Update(
                                     addedRegion = rectangle(x = 0, width = 500, height = 500),
-                                    areaHaDifference = BigDecimal("15.101"),
+                                    areaHaDifference = BigDecimal("15.000"),
                                     desiredModel = desired.strata[0].substrata[0],
                                     existingModel = existing.strata[1].substrata[0],
                                     monitoringPlotEdits =
@@ -255,7 +255,7 @@ class PlantingSiteEditCalculatorTest {
                     // Stratum A moves to east edge of site and shrinks from 800m to 500m wide
                     StratumEdit.Update(
                         addedRegion = rectangle(x = 800, width = 200, height = 500),
-                        areaHaDifference = BigDecimal("-15.101"),
+                        areaHaDifference = BigDecimal("-15.000"),
                         desiredModel = desired.strata[1],
                         existingModel = existing.strata[0],
                         monitoringPlotEdits =
@@ -271,7 +271,7 @@ class PlantingSiteEditCalculatorTest {
                             listOf(
                                 SubstratumEdit.Update(
                                     addedRegion = rectangle(x = 800, width = 200, height = 500),
-                                    areaHaDifference = BigDecimal("-15.101"),
+                                    areaHaDifference = BigDecimal("-15.000"),
                                     desiredModel = desired.strata[1].substrata[0],
                                     existingModel = existing.strata[0].substrata[0],
                                     monitoringPlotEdits =
@@ -342,7 +342,7 @@ class PlantingSiteEditCalculatorTest {
                     // Stratum A shrinks
                     StratumEdit.Update(
                         addedRegion = rectangle(0),
-                        areaHaDifference = BigDecimal("-12.584"),
+                        areaHaDifference = BigDecimal("-12.500"),
                         desiredModel = desired.strata[0],
                         existingModel = existing.strata[0],
                         monitoringPlotEdits = emptyList(),
@@ -393,7 +393,7 @@ class PlantingSiteEditCalculatorTest {
                     // Stratum A shrinks
                     StratumEdit.Update(
                         addedRegion = rectangle(0),
-                        areaHaDifference = BigDecimal("-12.584"),
+                        areaHaDifference = BigDecimal("-12.500"),
                         desiredModel = desired.strata[0],
                         existingModel = existing.strata[0],
                         monitoringPlotEdits = emptyList(),
@@ -402,7 +402,7 @@ class PlantingSiteEditCalculatorTest {
                     ),
                     StratumEdit.Update(
                         addedRegion = rectangle(x = 250, width = 250, height = 500),
-                        areaHaDifference = BigDecimal("12.584"),
+                        areaHaDifference = BigDecimal("12.500"),
                         desiredModel = desired.strata[1],
                         existingModel = existing.strata[1],
                         monitoringPlotEdits = emptyList(),
@@ -477,7 +477,7 @@ class PlantingSiteEditCalculatorTest {
                     ),
                     StratumEdit.Update(
                         addedRegion = rectangle(0),
-                        areaHaDifference = BigDecimal("-25.169"),
+                        areaHaDifference = BigDecimal("-25.000"),
                         desiredModel = desired.strata[0],
                         existingModel = existing.strata[0],
                         monitoringPlotEdits =
@@ -491,7 +491,7 @@ class PlantingSiteEditCalculatorTest {
                             listOf(
                                 SubstratumEdit.Update(
                                     addedRegion = rectangle(0),
-                                    areaHaDifference = BigDecimal("-25.169"),
+                                    areaHaDifference = BigDecimal("-25.000"),
                                     desiredModel = desired.strata[0].substrata[0],
                                     existingModel = existing.strata[0].substrata[0],
                                     monitoringPlotEdits = emptyList(),
@@ -538,7 +538,7 @@ class PlantingSiteEditCalculatorTest {
 
     assertEditResult(
         PlantingSiteEdit(
-            areaHaDifference = BigDecimal("-25.169"),
+            areaHaDifference = BigDecimal("-25.000"),
             desiredModel = desired,
             existingModel = existing,
             stratumEdits =
@@ -638,14 +638,14 @@ class PlantingSiteEditCalculatorTest {
 
     assertEditResult(
         PlantingSiteEdit(
-            areaHaDifference = BigDecimal("25.168"),
+            areaHaDifference = BigDecimal("25.000"),
             desiredModel = desired,
             existingModel = existing,
             stratumEdits =
                 listOf(
                     StratumEdit.Update(
                         addedRegion = rectangle(x = 100, width = 500, height = 500),
-                        areaHaDifference = BigDecimal("25.168"),
+                        areaHaDifference = BigDecimal("25.000"),
                         desiredModel = desired.strata[0],
                         existingModel = existing.strata[0],
                         monitoringPlotEdits = emptyList(),
@@ -653,7 +653,7 @@ class PlantingSiteEditCalculatorTest {
                             listOf(
                                 SubstratumEdit.Update(
                                     addedRegion = rectangle(x = 100, width = 500, height = 500),
-                                    areaHaDifference = BigDecimal("25.168"),
+                                    areaHaDifference = BigDecimal("25.000"),
                                     desiredModel = desired.strata[0].substrata[0],
                                     existingModel = existing.strata[0].substrata[0],
                                     monitoringPlotEdits =
@@ -691,13 +691,13 @@ class PlantingSiteEditCalculatorTest {
 
     assertEditResult(
         PlantingSiteEdit(
-            areaHaDifference = BigDecimal("5.033"),
+            areaHaDifference = BigDecimal("5.000"),
             desiredModel = desired,
             existingModel = existing,
             stratumEdits =
                 listOf(
                     StratumEdit.Update(
-                        areaHaDifference = BigDecimal("5.033"),
+                        areaHaDifference = BigDecimal("5.000"),
                         addedRegion = rectangle(x = 400, width = 100, height = 500),
                         desiredModel = desired.strata[0],
                         existingModel = existing.strata[0],
@@ -709,7 +709,7 @@ class PlantingSiteEditCalculatorTest {
                             listOf(
                                 SubstratumEdit.Update(
                                     addedRegion = rectangle(x = 400, width = 100, height = 500),
-                                    areaHaDifference = BigDecimal("5.033"),
+                                    areaHaDifference = BigDecimal("5.000"),
                                     desiredModel = desired.strata[0].substrata[0],
                                     existingModel = existing.strata[0].substrata[0],
                                     // The unqualified plots are already in the correct substratum
@@ -744,14 +744,14 @@ class PlantingSiteEditCalculatorTest {
 
     assertEditResult(
         PlantingSiteEdit(
-            areaHaDifference = BigDecimal("10.067"),
+            areaHaDifference = BigDecimal("10.000"),
             desiredModel = desired,
             existingModel = existing,
             stratumEdits =
                 listOf(
                     StratumEdit.Update(
                         addedRegion = addedRegion,
-                        areaHaDifference = BigDecimal("10.067"),
+                        areaHaDifference = BigDecimal("10.000"),
                         desiredModel = desired.strata[0],
                         existingModel = existing.strata[0],
                         monitoringPlotEdits =
@@ -774,7 +774,7 @@ class PlantingSiteEditCalculatorTest {
                             listOf(
                                 SubstratumEdit.Update(
                                     addedRegion = addedRegion,
-                                    areaHaDifference = BigDecimal("10.067"),
+                                    areaHaDifference = BigDecimal("10.000"),
                                     desiredModel = desired.strata[0].substrata[0],
                                     existingModel = existing.strata[0].substrata[0],
                                     monitoringPlotEdits = emptyList(),
@@ -884,7 +884,7 @@ class PlantingSiteEditCalculatorTest {
 
     assertEditResult(
         PlantingSiteEdit(
-            areaHaDifference = BigDecimal("-12.584"),
+            areaHaDifference = BigDecimal("-12.500"),
             desiredModel = desired,
             existingModel = existing,
             stratumEdits =
@@ -920,14 +920,14 @@ class PlantingSiteEditCalculatorTest {
 
     assertEditResult(
         PlantingSiteEdit(
-            areaHaDifference = BigDecimal("-25.169"),
+            areaHaDifference = BigDecimal("-25.000"),
             desiredModel = desired,
             existingModel = existing,
             stratumEdits =
                 listOf(
                     StratumEdit.Update(
                         addedRegion = rectangle(0),
-                        areaHaDifference = BigDecimal("-25.169"),
+                        areaHaDifference = BigDecimal("-25.000"),
                         desiredModel = desired.strata[0],
                         existingModel = existing.strata[0],
                         monitoringPlotEdits =

--- a/src/test/kotlin/com/terraformation/backend/util/ExtensionsTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/util/ExtensionsTest.kt
@@ -45,7 +45,7 @@ class ExtensionsTest {
               )
           )
 
-      assertEquals(BigDecimal("101.816"), geometry.calculateAreaHectares())
+      assertEquals(BigDecimal("102.529"), geometry.calculateAreaHectares())
     }
 
     @Test
@@ -66,7 +66,7 @@ class ExtensionsTest {
               )
           )
 
-      assertEquals(BigDecimal("101.816"), geometry.calculateAreaHectares())
+      assertEquals(BigDecimal("102.529"), geometry.calculateAreaHectares())
     }
 
     @Test
@@ -87,7 +87,7 @@ class ExtensionsTest {
               )
           )
 
-      assertEquals(BigDecimal("101.816"), geometry.calculateAreaHectares())
+      assertEquals(BigDecimal("102.529"), geometry.calculateAreaHectares())
     }
 
     @Test

--- a/src/test/kotlin/com/terraformation/backend/util/ExtensionsTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/util/ExtensionsTest.kt
@@ -45,7 +45,7 @@ class ExtensionsTest {
               )
           )
 
-      assertEquals(BigDecimal("102.529"), geometry.calculateAreaHectares())
+      assertEquals(BigDecimal("101.858"), geometry.calculateAreaHectares())
     }
 
     @Test
@@ -66,7 +66,55 @@ class ExtensionsTest {
               )
           )
 
-      assertEquals(BigDecimal("102.529"), geometry.calculateAreaHectares())
+      assertEquals(BigDecimal("101.858"), geometry.calculateAreaHectares())
+    }
+
+    @Test
+    fun `calculates total area of disjoint regions`() {
+      val factory = GeometryFactory(PrecisionModel(), SRID.LONG_LAT)
+      val geometry =
+          factory.createMultiPolygon(
+              arrayOf(
+                  factory.createPolygon(
+                      arrayOf(
+                          CoordinateXY(-76.13567116641384, 5.989357251936355),
+                          CoordinateXY(-76.12762679268639, 5.989357251773201),
+                          CoordinateXY(-76.12762679270281, 5.979015683955292),
+                          CoordinateXY(-76.13567116598097, 5.979015684419131),
+                          CoordinateXY(-76.13567116641384, 5.989357251936355),
+                      )
+                  ),
+                  factory.createPolygon(
+                      arrayOf(
+                          CoordinateXY(-77.13567116641384, 5.989357251936355),
+                          CoordinateXY(-77.12762679268639, 5.989357251773201),
+                          CoordinateXY(-77.12762679270281, 5.979015683955292),
+                          CoordinateXY(-77.13567116598097, 5.979015684419131),
+                          CoordinateXY(-77.13567116641384, 5.989357251936355),
+                      )
+                  ),
+              )
+          )
+
+      assertEquals(BigDecimal("203.715"), geometry.calculateAreaHectares())
+    }
+
+    @Test
+    fun `calculates area of geometry with holes`() {
+      val startingPoint = point(-76, 5)
+      val shell = Turtle(startingPoint).makeLinearRing { rectangle(1000, 1000) }
+      val hole =
+          Turtle(startingPoint).makeLinearRing {
+            east(25)
+            north(20)
+            rectangle(500, 500)
+          }
+
+      val factory = GeometryFactory(PrecisionModel(), SRID.LONG_LAT)
+      val geometry =
+          factory.createMultiPolygon(arrayOf(factory.createPolygon(shell, arrayOf(hole))))
+
+      assertEquals(BigDecimal("74.999"), geometry.calculateAreaHectares())
     }
 
     @Test
@@ -87,7 +135,7 @@ class ExtensionsTest {
               )
           )
 
-      assertEquals(BigDecimal("102.529"), geometry.calculateAreaHectares())
+      assertEquals(BigDecimal("101.858"), geometry.calculateAreaHectares())
     }
 
     @Test


### PR DESCRIPTION
The function to calculate the area in hectares for a geometry projects the
geometry onto the UTM coordinate system, which uses a 1-meter scale. But that
coordinate system is designed to preserve the angles of the vertices of a
shape, not the total area of the shape.

Switch to the area calculator from the GeographicLib library, which takes the
curvature of the earth into account in its calculations. The library only supports
area calculations on simple polygons, so this requires some added logic to
break complex geometries up into their component polygons.