### PR TITLE
SW-8440 Update request status when a withdrawal is recorded against request

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/nursery/db/BatchStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/nursery/db/BatchStore.kt
@@ -53,6 +53,8 @@ import com.terraformation.backend.db.nursery.tables.references.INVENTORIES
 import com.terraformation.backend.db.nursery.tables.references.WITHDRAWALS
 import com.terraformation.backend.db.seedbank.AccessionId
 import com.terraformation.backend.db.seedbank.tables.references.ACCESSIONS
+import com.terraformation.backend.db.tracking.tables.references.PLANTING_DATE_REQUESTS
+import com.terraformation.backend.db.tracking.tables.references.SCHEDULED_PLANTING_DATES
 import com.terraformation.backend.log.perClassLogger
 import com.terraformation.backend.nursery.event.BatchDeletionStartedEvent
 import com.terraformation.backend.nursery.event.NurserySeedlingBatchReadyEvent
@@ -67,6 +69,8 @@ import com.terraformation.backend.nursery.model.NurseryStats
 import com.terraformation.backend.nursery.model.SpeciesSummary
 import com.terraformation.backend.nursery.model.WithdrawalModel
 import com.terraformation.backend.nursery.model.toModel
+import com.terraformation.backend.plantingmanagement.db.PlantingSeasonDateRequestNotFoundException
+import com.terraformation.backend.plantingmanagement.db.PlantingSeasonScheduledDateNotFoundException
 import com.terraformation.backend.seedbank.event.AccessionSpeciesChangedEvent
 import jakarta.inject.Named
 import java.time.Clock
@@ -689,6 +693,39 @@ class BatchStore(
       }
     } else if (withdrawal.destinationFacilityId != null) {
       throw IllegalArgumentException("Only nursery transfers may include destination facility ID")
+    }
+    if (withdrawal.scheduledPlantingDateRequestId != null) {
+      val (plantingDateExists, requestExists) =
+          dslContext
+              .select(
+                  DSL.exists(
+                      DSL.selectOne()
+                          .from(SCHEDULED_PLANTING_DATES)
+                          .where(
+                              SCHEDULED_PLANTING_DATES.ID.eq(
+                                  withdrawal.scheduledPlantingDateRequestId
+                              )
+                          )
+                  ),
+                  DSL.exists(
+                      DSL.selectOne()
+                          .from(PLANTING_DATE_REQUESTS)
+                          .where(
+                              PLANTING_DATE_REQUESTS.SCHEDULED_PLANTING_DATE_ID.eq(
+                                  withdrawal.scheduledPlantingDateRequestId
+                              )
+                          )
+                  ),
+              )
+              .fetchOne()!!
+
+      if (!plantingDateExists) {
+        throw PlantingSeasonScheduledDateNotFoundException(
+            withdrawal.scheduledPlantingDateRequestId
+        )
+      } else if (!requestExists) {
+        throw PlantingSeasonDateRequestNotFoundException(withdrawal.scheduledPlantingDateRequestId)
+      }
     }
 
     return dslContext.transactionResult { _ ->

--- a/src/main/kotlin/com/terraformation/backend/plantingmanagement/db/PlantingDateRequestsStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/plantingmanagement/db/PlantingDateRequestsStore.kt
@@ -2,6 +2,10 @@ package com.terraformation.backend.plantingmanagement.db
 
 import com.terraformation.backend.auth.currentUser
 import com.terraformation.backend.customer.model.requirePermissions
+import com.terraformation.backend.db.default_schema.SpeciesId
+import com.terraformation.backend.db.nursery.tables.references.BATCHES
+import com.terraformation.backend.db.nursery.tables.references.BATCH_WITHDRAWALS
+import com.terraformation.backend.db.nursery.tables.references.WITHDRAWALS
 import com.terraformation.backend.db.tracking.PlantingDateRequestStatus
 import com.terraformation.backend.db.tracking.PlantingSeasonId
 import com.terraformation.backend.db.tracking.ScheduledPlantingDateId
@@ -9,10 +13,13 @@ import com.terraformation.backend.db.tracking.tables.references.PLANTING_DATE_RE
 import com.terraformation.backend.db.tracking.tables.references.PLANTING_DATE_REQUEST_SPECIES
 import com.terraformation.backend.db.tracking.tables.references.SCHEDULED_PLANTING_DATES
 import com.terraformation.backend.db.tracking.tables.references.SCHEDULED_PLANTING_DATE_SPECIES
+import com.terraformation.backend.nursery.event.WithdrawalAssociatedWithPlantingDateRequestEvent
 import jakarta.inject.Named
+import java.math.BigDecimal
 import java.time.InstantSource
 import org.jooq.DSLContext
 import org.jooq.impl.DSL
+import org.springframework.context.event.EventListener
 
 @Named
 class PlantingDateRequestsStore(
@@ -108,6 +115,11 @@ class PlantingDateRequestsStore(
     }
   }
 
+  @EventListener
+  fun on(event: WithdrawalAssociatedWithPlantingDateRequestEvent) {
+    updateRequestStatus(event.scheduledPlantingDateRequestId)
+  }
+
   private fun insertRequestSpecies(scheduledPlantingDateId: ScheduledPlantingDateId) {
     with(SCHEDULED_PLANTING_DATE_SPECIES) {
       dslContext
@@ -124,5 +136,51 @@ class PlantingDateRequestsStore(
           )
           .execute()
     }
+  }
+
+  private fun updateRequestStatus(scheduledPlantingDateId: ScheduledPlantingDateId) {
+    val requestedQuantities: Map<SpeciesId, BigDecimal> =
+        with(PLANTING_DATE_REQUEST_SPECIES) {
+          dslContext
+              .select(SPECIES_ID, DSL.sum(QUANTITY))
+              .from(PLANTING_DATE_REQUEST_SPECIES)
+              .where(SCHEDULED_PLANTING_DATE_ID.eq(scheduledPlantingDateId))
+              .groupBy(SPECIES_ID)
+              .associate { it[SPECIES_ID]!! to it[DSL.sum(QUANTITY)]!! }
+        }
+
+    val withdrawnQuantities: Map<SpeciesId, BigDecimal> =
+        dslContext
+            .select(BATCHES.SPECIES_ID, DSL.sum(BATCH_WITHDRAWALS.READY_QUANTITY_WITHDRAWN))
+            .from(BATCH_WITHDRAWALS)
+            .join(BATCHES)
+            .on(BATCHES.ID.eq(BATCH_WITHDRAWALS.BATCH_ID))
+            .join(WITHDRAWALS)
+            .on(WITHDRAWALS.ID.eq(BATCH_WITHDRAWALS.WITHDRAWAL_ID))
+            .where(WITHDRAWALS.SCHEDULED_PLANTING_DATE_REQUEST_ID.eq(scheduledPlantingDateId))
+            .groupBy(BATCHES.SPECIES_ID)
+            .associate {
+              it[BATCHES.SPECIES_ID]!! to it[DSL.sum(BATCH_WITHDRAWALS.READY_QUANTITY_WITHDRAWN)]!!
+            }
+
+    val newStatus =
+        when {
+          requestedQuantities.isEmpty() -> PlantingDateRequestStatus.Pending
+          requestedQuantities.all { (speciesId, quantity) ->
+            (withdrawnQuantities[speciesId] ?: BigDecimal.ZERO) >= quantity
+          } -> PlantingDateRequestStatus.Fulfilled
+          requestedQuantities.keys.any {
+            (withdrawnQuantities[it] ?: BigDecimal.ZERO) > BigDecimal.ZERO
+          } -> PlantingDateRequestStatus.Partial
+          else -> PlantingDateRequestStatus.Pending
+        }
+
+    // This runs as an automated recompute triggered by a withdrawal event rather than a user
+    // edit, so modified_by and modified_time are intentionally left unchanged.
+    dslContext
+        .update(PLANTING_DATE_REQUESTS)
+        .set(PLANTING_DATE_REQUESTS.STATUS_ID, newStatus)
+        .where(PLANTING_DATE_REQUESTS.SCHEDULED_PLANTING_DATE_ID.eq(scheduledPlantingDateId))
+        .execute()
   }
 }

--- a/src/test/kotlin/com/terraformation/backend/nursery/db/batchStore/BatchStoreWithdrawTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/nursery/db/batchStore/BatchStoreWithdrawTest.kt
@@ -19,6 +19,8 @@ import com.terraformation.backend.nursery.db.CrossOrganizationNurseryTransferNot
 import com.terraformation.backend.nursery.event.WithdrawalAssociatedWithPlantingDateRequestEvent
 import com.terraformation.backend.nursery.model.BatchWithdrawalModel
 import com.terraformation.backend.nursery.model.NewWithdrawalModel
+import com.terraformation.backend.plantingmanagement.db.PlantingSeasonDateRequestNotFoundException
+import com.terraformation.backend.plantingmanagement.db.PlantingSeasonScheduledDateNotFoundException
 import io.mockk.every
 import java.time.Instant
 import java.time.LocalDate
@@ -1426,7 +1428,7 @@ internal class BatchStoreWithdrawTest : BatchStoreTest() {
     insertPlantingSite()
     val plantingSeasonId = insertPlantingSeason()
 
-    assertThrows<DataIntegrityViolationException> {
+    assertThrows<PlantingSeasonScheduledDateNotFoundException> {
       store.withdraw(
           NewWithdrawalModel(
               batchWithdrawals =
@@ -1456,7 +1458,7 @@ internal class BatchStoreWithdrawTest : BatchStoreTest() {
     val plantingSeasonId = insertPlantingSeason()
     val scheduledPlantingDateId = insertPlantingSeasonScheduledDate()
 
-    assertThrows<DataIntegrityViolationException> {
+    assertThrows<PlantingSeasonDateRequestNotFoundException> {
       store.withdraw(
           NewWithdrawalModel(
               batchWithdrawals =

--- a/src/test/kotlin/com/terraformation/backend/plantingmanagement/db/PlantingDateRequestsStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/plantingmanagement/db/PlantingDateRequestsStoreTest.kt
@@ -6,15 +6,20 @@ import com.terraformation.backend.customer.model.TerrawareUser
 import com.terraformation.backend.db.DatabaseTest
 import com.terraformation.backend.db.default_schema.Role
 import com.terraformation.backend.db.default_schema.SpeciesId
+import com.terraformation.backend.db.nursery.WithdrawalId
+import com.terraformation.backend.db.nursery.WithdrawalPurpose
 import com.terraformation.backend.db.tracking.PlantingDateRequestStatus
 import com.terraformation.backend.db.tracking.PlantingSeasonId
 import com.terraformation.backend.db.tracking.PlantingSeasonStatus
+import com.terraformation.backend.db.tracking.ScheduledPlantingDateId
 import com.terraformation.backend.db.tracking.SubstratumId
 import com.terraformation.backend.db.tracking.tables.records.PlantingDateRequestSpeciesRecord
 import com.terraformation.backend.db.tracking.tables.records.PlantingDateRequestsRecord
 import com.terraformation.backend.db.tracking.tables.references.PLANTING_DATE_REQUEST_SPECIES
+import com.terraformation.backend.nursery.event.WithdrawalAssociatedWithPlantingDateRequestEvent
 import java.time.Instant
 import java.time.LocalDate
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
@@ -242,6 +247,159 @@ internal class PlantingDateRequestsStoreTest : DatabaseTest(), RunsAsDatabaseUse
       assertThrows<PlantingSeasonDateRequestNotFoundException> {
         store.update(scheduledPlantingDateId, plantingSeasonId)
       }
+    }
+  }
+
+  @Nested
+  inner class UpdateRequestStatus {
+    private lateinit var scheduledPlantingDateId: ScheduledPlantingDateId
+
+    @BeforeEach
+    fun setUp() {
+      insertFacility()
+      scheduledPlantingDateId = insertPlantingSeasonScheduledDate()
+      insertPlantingDateRequest(status = PlantingDateRequestStatus.Pending)
+    }
+
+    @Test
+    fun `marks request Fulfilled when every species is fully withdrawn`() {
+      val speciesId2 = insertSpecies()
+      insertPlantingDateRequestSpecies(speciesId = speciesId, quantity = 5)
+      insertPlantingDateRequestSpecies(speciesId = speciesId2, quantity = 10)
+
+      withdraw(species = speciesId, readyQuantity = 5)
+      withdraw(species = speciesId2, readyQuantity = 10)
+
+      store.on(WithdrawalAssociatedWithPlantingDateRequestEvent(scheduledPlantingDateId))
+
+      assertEquals(PlantingDateRequestStatus.Fulfilled, statusOf())
+    }
+
+    @Test
+    fun `marks request Pending when no species has positive net withdrawn`() {
+      insertPlantingDateRequestSpecies(speciesId = speciesId, quantity = 5)
+
+      store.on(WithdrawalAssociatedWithPlantingDateRequestEvent(scheduledPlantingDateId))
+
+      assertEquals(PlantingDateRequestStatus.Pending, statusOf())
+    }
+
+    @Test
+    fun `marks request Partial when one species is met but another is untouched`() {
+      val speciesId2 = insertSpecies()
+      insertPlantingDateRequestSpecies(speciesId = speciesId, quantity = 5)
+      insertPlantingDateRequestSpecies(speciesId = speciesId2, quantity = 10)
+
+      withdraw(species = speciesId, readyQuantity = 5)
+
+      store.on(WithdrawalAssociatedWithPlantingDateRequestEvent(scheduledPlantingDateId))
+
+      assertEquals(PlantingDateRequestStatus.Partial, statusOf())
+    }
+
+    @Test
+    fun `marks request Partial when a species is partially withdrawn`() {
+      insertPlantingDateRequestSpecies(speciesId = speciesId, quantity = 10)
+
+      withdraw(species = speciesId, readyQuantity = 4)
+
+      store.on(WithdrawalAssociatedWithPlantingDateRequestEvent(scheduledPlantingDateId))
+
+      assertEquals(PlantingDateRequestStatus.Partial, statusOf())
+    }
+
+    @Test
+    fun `marks request Fulfilled when a species is over-withdrawn`() {
+      insertPlantingDateRequestSpecies(speciesId = speciesId, quantity = 5)
+
+      withdraw(species = speciesId, readyQuantity = 8)
+
+      store.on(WithdrawalAssociatedWithPlantingDateRequestEvent(scheduledPlantingDateId))
+
+      assertEquals(PlantingDateRequestStatus.Fulfilled, statusOf())
+    }
+
+    @Test
+    fun `sums requested quantities across substrata per species`() {
+      val substratumId2 = insertSubstratum()
+      insertPlantingDateRequestSpecies(
+          speciesId = speciesId,
+          substratumId = substratumId,
+          quantity = 3,
+      )
+      insertPlantingDateRequestSpecies(
+          speciesId = speciesId,
+          substratumId = substratumId2,
+          quantity = 4,
+      )
+
+      withdraw(species = speciesId, readyQuantity = 7)
+
+      store.on(WithdrawalAssociatedWithPlantingDateRequestEvent(scheduledPlantingDateId))
+
+      assertEquals(PlantingDateRequestStatus.Fulfilled, statusOf())
+    }
+
+    @Test
+    fun `treats an undo withdrawal as subtracting from the net withdrawn quantity`() {
+      insertPlantingDateRequestSpecies(speciesId = speciesId, quantity = 5)
+
+      val originalWithdrawalId = withdraw(species = speciesId, readyQuantity = 5)
+      withdraw(
+          species = speciesId,
+          readyQuantity = -5,
+          purpose = WithdrawalPurpose.Undo,
+          undoesWithdrawalId = originalWithdrawalId,
+      )
+
+      store.on(WithdrawalAssociatedWithPlantingDateRequestEvent(scheduledPlantingDateId))
+
+      assertEquals(PlantingDateRequestStatus.Pending, statusOf())
+    }
+
+    @Test
+    fun `ignores withdrawn species that are not part of the request`() {
+      val unrequestedSpeciesId = insertSpecies()
+      insertPlantingDateRequestSpecies(speciesId = speciesId, quantity = 5)
+
+      withdraw(species = unrequestedSpeciesId, readyQuantity = 5)
+
+      store.on(WithdrawalAssociatedWithPlantingDateRequestEvent(scheduledPlantingDateId))
+
+      assertEquals(PlantingDateRequestStatus.Pending, statusOf())
+    }
+
+    @Test
+    fun `marks a request with no species Pending`() {
+      store.on(WithdrawalAssociatedWithPlantingDateRequestEvent(scheduledPlantingDateId))
+
+      assertEquals(PlantingDateRequestStatus.Pending, statusOf())
+    }
+
+    private fun statusOf(id: ScheduledPlantingDateId = scheduledPlantingDateId) =
+        plantingDateRequestsDao.fetchOneByScheduledPlantingDateId(id)!!.statusId
+
+    /** Inserts a batch + withdrawal + batch withdrawal tied to the request under test. */
+    private fun withdraw(
+        species: SpeciesId,
+        readyQuantity: Int,
+        purpose: WithdrawalPurpose = WithdrawalPurpose.OutPlant,
+        undoesWithdrawalId: WithdrawalId? = null,
+    ): WithdrawalId {
+      val batchId = insertBatch(speciesId = species)
+      val withdrawalId =
+          insertNurseryWithdrawal(
+              plantingSeasonId = plantingSeasonId,
+              scheduledPlantingDateRequestId = scheduledPlantingDateId,
+              purpose = purpose,
+              undoesWithdrawalId = undoesWithdrawalId,
+          )
+      insertBatchWithdrawal(
+          batchId = batchId,
+          withdrawalId = withdrawalId,
+          readyQuantityWithdrawn = readyQuantity,
+      )
+      return withdrawalId
     }
   }
 }


### PR DESCRIPTION
A planting date request's status is determined by all withdrawals attached to it. Use these withdrawals whenever a new one is attached to determine the statu of the request.

Co-authored-by: Claude Code Opus 4.8 [noreply@anthropic.com](mailto:noreply@anthropic.com)