### PR TITLE
SW-8439 Add planting date request status to search table

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/search/table/PlantingDateRequestsTable.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/table/PlantingDateRequestsTable.kt
@@ -37,6 +37,7 @@ class PlantingDateRequestsTable(private val tables: SearchTables) : SearchTable(
       listOf(
           dateField("date", PLANTING_DATE_REQUESTS.DATE),
           textField("notes", PLANTING_DATE_REQUESTS.NOTES),
+          enumField("status", PLANTING_DATE_REQUESTS.STATUS_ID),
       )
 
   override val defaultOrderFields: List<OrderField<*>>

--- a/src/main/resources/i18n/Messages_en.properties
+++ b/src/main/resources/i18n/Messages_en.properties
@@ -860,6 +860,7 @@ search.participantProjectSpecies.submissionStatus=Participant Project Species su
 search.plantingDateRequestSpecies.quantity=Planting date request species quantity
 search.plantingDateRequests.date=Planting date request date
 search.plantingDateRequests.notes=Planting date request notes
+search.plantingDateRequests.status=Planting date request status
 search.plantingSeasons.endDate=Planting season end date
 search.plantingSeasons.id=Planting season ID
 search.plantingSeasons.status=Planting season status

--- a/src/main/resources/i18n/Messages_es.properties
+++ b/src/main/resources/i18n/Messages_es.properties
@@ -1531,6 +1531,8 @@ search.participantProjectSpecies.submissionStatus=Estado de envío de especies d
 search.plantingDateRequests.date=Fecha de solicitud de plantación
 # ecdcddc7
 search.plantingDateRequests.notes=Notas de la solicitud de plantación
+# 51b8f17f
+search.plantingDateRequests.status=Estado de la solicitud de fecha de plantación
 # 80c1a631
 search.plantingDateRequestSpecies.quantity=Cantidad de especies solicitadas para la fecha de plantación
 # ec623b8c

--- a/src/main/resources/i18n/Messages_fr.properties
+++ b/src/main/resources/i18n/Messages_fr.properties
@@ -1531,6 +1531,8 @@ search.participantProjectSpecies.submissionStatus=Statut de la soumission de l''
 search.plantingDateRequests.date=Date de la demande de date de plantation
 # ecdcddc7
 search.plantingDateRequests.notes=Notes de la demande de date de plantation
+# 51b8f17f
+search.plantingDateRequests.status=Statut de la demande de date de plantation
 # 80c1a631
 search.plantingDateRequestSpecies.quantity=Quantité de la demande de date de plantation par espèce
 # ec623b8c

--- a/src/test/kotlin/com/terraformation/backend/tracking/TrackingSearchTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/TrackingSearchTest.kt
@@ -12,6 +12,7 @@ import com.terraformation.backend.db.tracking.MangroveTide
 import com.terraformation.backend.db.tracking.ObservableCondition
 import com.terraformation.backend.db.tracking.ObservationPlotPosition
 import com.terraformation.backend.db.tracking.ObservationType
+import com.terraformation.backend.db.tracking.PlantingDateRequestStatus
 import com.terraformation.backend.db.tracking.PlantingSeasonStatus
 import com.terraformation.backend.db.tracking.PlantingType
 import com.terraformation.backend.db.tracking.TreeGrowthForm
@@ -141,7 +142,11 @@ class TrackingSearchTest : DatabaseTest(), RunsAsUser {
     insertPlantingSeasonSpeciesTarget(quantity = 12)
     insertPlantingSeasonAllocatedSpecies(speciesId = speciesId1, quantity = 17)
 
-    insertPlantingDateRequest(date = LocalDate.of(1970, 1, 19), notes = "some notes")
+    insertPlantingDateRequest(
+        date = LocalDate.of(1970, 1, 19),
+        notes = "some notes",
+        status = PlantingDateRequestStatus.Partial,
+    )
     insertPlantingDateRequestSpecies(speciesId = speciesId1, quantity = 18)
 
     insertFacility(type = FacilityType.Nursery)
@@ -636,6 +641,7 @@ class TrackingSearchTest : DatabaseTest(), RunsAsUser {
                                                         "species_scientificName" to "Species 1",
                                                     )
                                                 ),
+                                            "status" to "Partial",
                                         )
                                     ),
                                 "allocatedSpecies" to
@@ -1065,6 +1071,7 @@ class TrackingSearchTest : DatabaseTest(), RunsAsUser {
                 "plantingSeasons.withdrawals.id",
                 "plantingSeasons.plantingDateRequests.date",
                 "plantingSeasons.plantingDateRequests.notes",
+                "plantingSeasons.plantingDateRequests.status",
                 "plantingSeasons.plantingDateRequests.plantingDateRequestSpecies.quantity",
                 "plantingSeasons.plantingDateRequests.plantingDateRequestSpecies.species_scientificName",
                 "strata.boundary",


### PR DESCRIPTION
The status of planting date requests will be displayed in the FE so include it in the search table.