### PR TITLE
Rename some leftover zone params to stratum

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/customer/db/ParentStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/db/ParentStore.kt
@@ -186,16 +186,16 @@ class ParentStore(private val dslContext: DSLContext) {
   fun getOrganizationId(plantingSiteId: PlantingSiteId): OrganizationId? =
       fetchFieldById(plantingSiteId, PLANTING_SITES.ID, PLANTING_SITES.ORGANIZATION_ID)
 
-  fun getOrganizationId(plantingSubzoneId: SubstratumId): OrganizationId? =
+  fun getOrganizationId(substratumId: SubstratumId): OrganizationId? =
       fetchFieldById(
-          plantingSubzoneId,
+          substratumId,
           SUBSTRATA.ID,
           SUBSTRATA.plantingSites.ORGANIZATION_ID,
       )
 
-  fun getOrganizationId(plantingZoneId: StratumId): OrganizationId? =
+  fun getOrganizationId(stratumId: StratumId): OrganizationId? =
       fetchFieldById(
-          plantingZoneId,
+          stratumId,
           STRATA.ID,
           STRATA.plantingSites.ORGANIZATION_ID,
       )
@@ -267,15 +267,15 @@ class ParentStore(private val dslContext: DSLContext) {
   fun getProjectId(plantingSiteId: PlantingSiteId): ProjectId? =
       fetchFieldById(plantingSiteId, PLANTING_SITES.ID, PLANTING_SITES.PROJECT_ID)
 
-  fun getProjectId(plantingSubzoneId: SubstratumId): ProjectId? =
+  fun getProjectId(substratumId: SubstratumId): ProjectId? =
       fetchFieldById(
-          plantingSubzoneId,
+          substratumId,
           SUBSTRATA.ID,
           SUBSTRATA.plantingSites.PROJECT_ID,
       )
 
-  fun getProjectId(plantingZoneId: StratumId): ProjectId? =
-      fetchFieldById(plantingZoneId, STRATA.ID, STRATA.plantingSites.PROJECT_ID)
+  fun getProjectId(stratumId: StratumId): ProjectId? =
+      fetchFieldById(stratumId, STRATA.ID, STRATA.plantingSites.PROJECT_ID)
 
   fun getProjectId(reportId: ReportId): ProjectId? =
       fetchFieldById(reportId, REPORTS.ID, REPORTS.PROJECT_ID)

--- a/src/main/kotlin/com/terraformation/backend/nursery/BatchService.kt
+++ b/src/main/kotlin/com/terraformation/backend/nursery/BatchService.kt
@@ -39,11 +39,11 @@ class BatchService(
       newWithdrawal: NewWithdrawalModel,
       readyByDate: LocalDate? = null,
       plantingSiteId: PlantingSiteId? = null,
-      plantingSubzoneId: SubstratumId? = null,
+      substratumId: SubstratumId? = null,
   ): ExistingWithdrawalModel {
     return when {
       newWithdrawal.purpose == WithdrawalPurpose.OutPlant && plantingSiteId != null ->
-          withdrawToPlantingSite(newWithdrawal, plantingSiteId, plantingSubzoneId)
+          withdrawToPlantingSite(newWithdrawal, plantingSiteId, substratumId)
       newWithdrawal.purpose == WithdrawalPurpose.OutPlant ->
           throw IllegalArgumentException("Planting site ID is required for outplanting withdrawals")
       else -> batchStore.withdraw(newWithdrawal, readyByDate)
@@ -53,7 +53,7 @@ class BatchService(
   private fun withdrawToPlantingSite(
       newWithdrawal: NewWithdrawalModel,
       plantingSiteId: PlantingSiteId,
-      plantingSubzoneId: SubstratumId? = null,
+      substratumId: SubstratumId? = null,
   ): ExistingWithdrawalModel {
     return dslContext.transactionResult { _ ->
       val withdrawal = batchStore.withdraw(newWithdrawal)
@@ -67,7 +67,7 @@ class BatchService(
           deliveryStore.createDelivery(
               withdrawal.id,
               plantingSiteId,
-              plantingSubzoneId,
+              substratumId,
               quantitiesBySpecies,
           )
 

--- a/src/main/kotlin/com/terraformation/backend/tracking/api/T0Controller.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/api/T0Controller.kt
@@ -21,7 +21,6 @@ import com.terraformation.backend.tracking.model.SiteT0DataModel
 import com.terraformation.backend.tracking.model.SpeciesDensityModel
 import com.terraformation.backend.tracking.model.StratumT0TempDataModel
 import io.swagger.v3.oas.annotations.Operation
-import io.swagger.v3.oas.annotations.media.Schema
 import java.math.BigDecimal
 import java.time.Instant
 import java.time.LocalDate
@@ -112,14 +111,7 @@ class T0Controller(
   fun assignT0TempSiteData(
       @RequestBody payload: AssignSiteT0TempDataRequestPayload
   ): SimpleSuccessResponsePayload {
-    require(payload.strata != null || payload.zones != null) {
-      "Must specify either strata or zones"
-    }
-    if (payload.strata != null) {
-      t0Service.assignT0TempStratumData(payload.strata.map { it.toModel() })
-    } else if (payload.zones != null) {
-      t0Service.assignT0TempStratumData(payload.zones.map { it.toModel() })
-    }
+    t0Service.assignT0TempStratumData(payload.strata.map { it.toModel() })
 
     return SimpleSuccessResponsePayload()
   }
@@ -163,24 +155,6 @@ data class PlotT0DataPayload(
       )
 }
 
-data class ZoneT0DataPayload(
-    val plantingZoneId: StratumId,
-    val densityData: List<SpeciesDensityPayload> = emptyList(),
-) {
-  constructor(
-      model: StratumT0TempDataModel
-  ) : this(
-      plantingZoneId = model.stratumId,
-      densityData = model.densityData.map { SpeciesDensityPayload(it) },
-  )
-
-  fun toModel() =
-      StratumT0TempDataModel(
-          stratumId = plantingZoneId,
-          densityData = densityData.map { it.toModel() },
-      )
-}
-
 data class StratumT0DataPayload(
     val stratumId: StratumId,
     val densityData: List<SpeciesDensityPayload> = emptyList(),
@@ -203,7 +177,6 @@ data class SiteT0DataResponsePayload(
     val plantingSiteId: PlantingSiteId,
     val survivalRateIncludesTempPlots: Boolean = false,
     val plots: List<PlotT0DataPayload> = emptyList(),
-    val zones: List<ZoneT0DataPayload> = emptyList(),
     val strata: List<StratumT0DataPayload> = emptyList(),
 ) {
   constructor(
@@ -212,7 +185,6 @@ data class SiteT0DataResponsePayload(
       plantingSiteId = model.plantingSiteId,
       survivalRateIncludesTempPlots = model.survivalRateIncludesTempPlots,
       plots = model.plots.map { PlotT0DataPayload(it) },
-      zones = model.strata.map { ZoneT0DataPayload(it) },
       strata = model.strata.map { StratumT0DataPayload(it) },
   )
 }
@@ -275,10 +247,7 @@ data class AssignSiteT0DataRequestPayload(
 
 data class AssignSiteT0TempDataRequestPayload(
     val plantingSiteId: PlantingSiteId,
-    @Schema(description = "Use strata instead", deprecated = true)
-    val zones: List<ZoneT0DataPayload>?,
-    // make non-nullable once FE is no longer using zones
-    val strata: List<StratumT0DataPayload>?,
+    val strata: List<StratumT0DataPayload>,
 )
 
 data class PlotObservationSpeciesDensityPayload(


### PR DESCRIPTION
Some methods were missed for renaming zones to strata in `ParentStore` and `BatchService`; update these.

The FE has been using the correct strata payloads for a while now in the t0 controller. Remove the zone versions and make strata required. This controller is unused by the mobile app so there is no risk in removing it. 