### PR TITLE
SW-8439 Add withdrawals as a sublist of plantingDateRequests

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/search/table/PlantingDateRequestsTable.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/table/PlantingDateRequestsTable.kt
@@ -1,5 +1,6 @@
 package com.terraformation.backend.search.table
 
+import com.terraformation.backend.db.nursery.tables.references.WITHDRAWAL_SUMMARIES
 import com.terraformation.backend.db.tracking.tables.references.PLANTING_DATE_REQUESTS
 import com.terraformation.backend.db.tracking.tables.references.PLANTING_DATE_REQUEST_SPECIES
 import com.terraformation.backend.db.tracking.tables.references.PLANTING_SEASONS
@@ -19,14 +20,20 @@ class PlantingDateRequestsTable(private val tables: SearchTables) : SearchTable(
   override val sublists: List<SublistField> by lazy {
     with(tables) {
       listOf(
-          plantingSeasonScheduledDates.asSingleValueSublist(
-              "scheduledPlantingDate",
-              PLANTING_DATE_REQUESTS.SCHEDULED_PLANTING_DATE_ID.eq(SCHEDULED_PLANTING_DATES.ID),
-          ),
           plantingDateRequestSpecies.asMultiValueSublist(
               "plantingDateRequestSpecies",
               PLANTING_DATE_REQUESTS.SCHEDULED_PLANTING_DATE_ID.eq(
                   PLANTING_DATE_REQUEST_SPECIES.SCHEDULED_PLANTING_DATE_ID
+              ),
+          ),
+          plantingSeasonScheduledDates.asSingleValueSublist(
+              "scheduledPlantingDate",
+              PLANTING_DATE_REQUESTS.SCHEDULED_PLANTING_DATE_ID.eq(SCHEDULED_PLANTING_DATES.ID),
+          ),
+          nurseryWithdrawals.asMultiValueSublist(
+              "withdrawals",
+              PLANTING_DATE_REQUESTS.SCHEDULED_PLANTING_DATE_ID.eq(
+                  WITHDRAWAL_SUMMARIES.SCHEDULED_PLANTING_DATE_REQUEST_ID
               ),
           ),
       )

--- a/src/test/kotlin/com/terraformation/backend/tracking/TrackingSearchTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/TrackingSearchTest.kt
@@ -155,6 +155,7 @@ class TrackingSearchTest : DatabaseTest(), RunsAsUser {
         insertNurseryWithdrawal(
             purpose = WithdrawalPurpose.OutPlant,
             plantingSeasonId = plantingSeasonId1,
+            scheduledPlantingDateRequestId = inserted.scheduledPlantingDateId,
         )
     val deliveryId1 = insertDelivery(plantingSiteId = plantingSiteId)
     val withdrawalId2 =
@@ -642,6 +643,8 @@ class TrackingSearchTest : DatabaseTest(), RunsAsUser {
                                                     )
                                                 ),
                                             "status" to "Partial",
+                                            "withdrawals" to
+                                                listOf(mapOf("id" to "$withdrawalId1")),
                                         )
                                     ),
                                 "allocatedSpecies" to
@@ -1072,6 +1075,7 @@ class TrackingSearchTest : DatabaseTest(), RunsAsUser {
                 "plantingSeasons.plantingDateRequests.date",
                 "plantingSeasons.plantingDateRequests.notes",
                 "plantingSeasons.plantingDateRequests.status",
+                "plantingSeasons.plantingDateRequests.withdrawals.id",
                 "plantingSeasons.plantingDateRequests.plantingDateRequestSpecies.quantity",
                 "plantingSeasons.plantingDateRequests.plantingDateRequestSpecies.species_scientificName",
                 "strata.boundary",


### PR DESCRIPTION
The search api was missing the connection between planting date requests and withdrawals associated with them. Add withdrawals as a sublist on `PlantingDateRequestsTable`.