### PR TITLE
Recalculate all survival rates from admin UI

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/admin/AdminControllerAdvice.kt
+++ b/src/main/kotlin/com/terraformation/backend/admin/AdminControllerAdvice.kt
@@ -2,6 +2,8 @@ package com.terraformation.backend.admin
 
 import com.terraformation.backend.db.default_schema.FacilityId
 import com.terraformation.backend.db.default_schema.UserId
+import com.terraformation.backend.db.tracking.ObservationId
+import com.terraformation.backend.db.tracking.PlantingSiteId
 import org.springframework.beans.propertyeditors.StringTrimmerEditor
 import org.springframework.web.bind.WebDataBinder
 import org.springframework.web.bind.annotation.ControllerAdvice
@@ -21,6 +23,8 @@ class AdminControllerAdvice {
     listOf(
             String::class.java,
             FacilityId::class.java,
+            ObservationId::class.java,
+            PlantingSiteId::class.java,
             UserId::class.java,
         )
         .forEach { clazz -> binder.registerCustomEditor(clazz, stringTrimmerEditor) }

--- a/src/main/kotlin/com/terraformation/backend/admin/AdminPlantingSitesController.kt
+++ b/src/main/kotlin/com/terraformation/backend/admin/AdminPlantingSitesController.kt
@@ -6,7 +6,6 @@ import com.terraformation.backend.api.RequireGlobalRole
 import com.terraformation.backend.auth.currentUser
 import com.terraformation.backend.customer.db.OrganizationStore
 import com.terraformation.backend.customer.model.SystemUser
-import com.terraformation.backend.customer.model.requirePermissions
 import com.terraformation.backend.db.SRID
 import com.terraformation.backend.db.default_schema.GlobalRole
 import com.terraformation.backend.db.default_schema.OrganizationId
@@ -612,17 +611,37 @@ class AdminPlantingSitesController(
   }
 
   @PostMapping("/recalculateSurvivalRates")
-  fun recalculateMortalityRates(
-      @RequestParam observationId: ObservationId,
-      @RequestParam plantingSiteId: PlantingSiteId,
+  fun recalculateSurvivalRates(
+      @RequestParam(required = false) observationId: ObservationId?,
+      @RequestParam(required = false) plantingSiteId: PlantingSiteId?,
       redirectAttributes: RedirectAttributes,
   ): String {
-    requirePermissions { manageObservation(observationId) }
-
     try {
-      observationStore.recalculateSurvivalRates(observationId, plantingSiteId)
-      redirectAttributes.successMessage =
-          "Recalculated survival rates for observation $observationId."
+      when {
+        observationId != null -> {
+          val siteId =
+              plantingSiteId ?: observationStore.fetchObservationById(observationId).plantingSiteId
+          observationStore.recalculateSurvivalRates(observationId, siteId)
+          redirectAttributes.successMessage =
+              "Recalculated survival rates for observation $observationId."
+        }
+        plantingSiteId != null -> {
+          observationStore.recalculateSurvivalRates(plantingSiteId)
+          redirectAttributes.successMessage =
+              "Recalculated survival rates for planting site $plantingSiteId."
+        }
+        else -> {
+          val failures = observationStore.recalculateAllSurvivalRates()
+          if (failures.isEmpty()) {
+            redirectAttributes.successMessage =
+                "Recalculated survival rates for all planting sites."
+          } else {
+            redirectAttributes.failureMessage =
+                "Failed to recalculate survival rates for some planting sites."
+            redirectAttributes.failureDetails = failures.map { (id, message) -> "$id: $message" }
+          }
+        }
+      }
     } catch (e: Exception) {
       log.warn("Survival rate recalculation failed", e)
       redirectAttributes.failureMessage = "Failed to recalculate survival rates: ${e.message}"

--- a/src/main/kotlin/com/terraformation/backend/admin/AdminPlantingSitesController.kt
+++ b/src/main/kotlin/com/terraformation/backend/admin/AdminPlantingSitesController.kt
@@ -610,6 +610,7 @@ class AdminPlantingSitesController(
     return redirectToPlantingSite(plantingSiteId)
   }
 
+  @RequireGlobalRole([GlobalRole.SuperAdmin])
   @PostMapping("/recalculateSurvivalRates")
   fun recalculateSurvivalRates(
       @RequestParam(required = false) observationId: ObservationId?,

--- a/src/main/kotlin/com/terraformation/backend/tracking/db/ObservationStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/db/ObservationStore.kt
@@ -1947,6 +1947,30 @@ class ObservationStore(
     recalculateSurvivalRateResults(ObservationResultsSite(plantingSiteId))
   }
 
+  /**
+   * Recalculates survival rates for all planting sites. Returns a map of error messages by planting
+   * site ID for any sites that failed.
+   */
+  fun recalculateAllSurvivalRates(): Map<PlantingSiteId, String?> {
+    val plantingSiteIds =
+        with(PLANTING_SITES) {
+          dslContext.select(ID).from(PLANTING_SITES).orderBy(ID).fetch(ID.asNonNullable())
+        }
+
+    val failures = mutableMapOf<PlantingSiteId, String?>()
+
+    plantingSiteIds.forEach { id ->
+      try {
+        recalculateSurvivalRates(id)
+      } catch (e: Exception) {
+        log.warn("Failed to recalculate survival rates for planting site $id", e)
+        failures[id] = e.message
+      }
+    }
+
+    return failures
+  }
+
   private fun <ID : Any, HistoryId : Any> recalculateSurvivalRate(
       updateScope: ObservationSpeciesScope<ID, HistoryId>
   ) {

--- a/src/main/resources/templates/admin/index.html
+++ b/src/main/resources/templates/admin/index.html
@@ -248,9 +248,10 @@
         <h3>Recalculate Survival Rates</h3>
 
         <p>
-            This updates the stratum- and site-level survival rates for a partial observation of a
-            planting site to take into account plants from substrata that weren't observed this
-            time.
+            This updates the stratum- and site-level survival rates using the latest survival
+            rate logic. Both fields are optional: specify an observation to recalculate just that
+            observation, a planting site to recalculate all of its observations, or leave both
+            blank to recalculate every planting site.
         </p>
 
         <form method="POST" action="/admin/recalculateSurvivalRates">


### PR DESCRIPTION
Make the observation and planting site ID fields optional on the
"recalculate survival rates" admin UI migration action. If neither is
specified, it recalculates survival rates for all sites.