### PR TITLE
SW-8450 Use stratum survival rate areas in site

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/tracking/util/ObservationResultsScope.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/util/ObservationResultsScope.kt
@@ -618,17 +618,20 @@ class ObservationResultsSite(
         DSL.field(
             DSL.select(
                     DSL.sum(
-                            SUBSTRATUM_HISTORIES.AREA_HA.mul(
+                            OBSERVATION_STRATUM_RESULTS.SURVIVAL_RATE_AREA.mul(
                                 OBSERVATION_STRATUM_RESULTS.SURVIVAL_RATE
                             )
                         )
-                        .div(DSL.nullif(DSL.sum(SUBSTRATUM_HISTORIES.AREA_HA), BigDecimal.ZERO))
+                        .div(
+                            DSL.nullif(
+                                DSL.sum(OBSERVATION_STRATUM_RESULTS.SURVIVAL_RATE_AREA),
+                                BigDecimal.ZERO,
+                            )
+                        )
                 )
                 .from(OBSERVATION_STRATUM_RESULTS)
                 .join(STRATUM_HISTORIES)
                 .on(STRATUM_HISTORIES.ID.eq(OBSERVATION_STRATUM_RESULTS.STRATUM_HISTORY_ID))
-                .join(SUBSTRATUM_HISTORIES)
-                .on(SUBSTRATUM_HISTORIES.STRATUM_HISTORY_ID.eq(STRATUM_HISTORIES.ID))
                 .where(
                     STRATUM_HISTORIES.PLANTING_SITE_HISTORY_ID.eq(
                         OBSERVATION_SITE_RESULTS.PLANTING_SITE_HISTORY_ID
@@ -636,12 +639,6 @@ class ObservationResultsSite(
                 )
                 .and(OBSERVATION_STRATUM_RESULTS.OBSERVATION_ID.eq(observationIdField))
                 .and(OBSERVATION_STRATUM_RESULTS.SURVIVAL_RATE.isNotNull)
-                .and(
-                    substratumObservedAtOrBefore(
-                        SUBSTRATUM_HISTORIES.SUBSTRATUM_ID,
-                        observationIdField,
-                    )
-                )
         )
 
     return DSL.case_()
@@ -649,10 +646,7 @@ class ObservationResultsSite(
             anyChildHasNullSurvivalRateCondition(observationIdField),
             DSL.castNull(SQLDataType.INTEGER),
         )
-        .`when`(
-            weightedAverage.isNull,
-            DSL.castNull(SQLDataType.INTEGER),
-        )
+        .`when`(weightedAverage.isNull, DSL.castNull(SQLDataType.INTEGER))
         .else_(weightedAverage.cast(SQLDataType.INTEGER))
   }
 


### PR DESCRIPTION
Update the survival rate calculation to use the survival rate areas from the
stratum results when calculating site-level survival rates.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>