### PR TITLE
SW-8450 Add endpoint for aggregated tracking stats

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/tracking/api/TrackingStatsController.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/api/TrackingStatsController.kt
@@ -6,6 +6,7 @@ import com.terraformation.backend.db.default_schema.OrganizationId
 import com.terraformation.backend.db.default_schema.ProjectId
 import com.terraformation.backend.tracking.db.TrackingStatsStore
 import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.Parameter
 import io.swagger.v3.oas.annotations.media.Schema
 import jakarta.ws.rs.BadRequestException
 import org.springframework.web.bind.annotation.GetMapping
@@ -22,7 +23,9 @@ class TrackingStatsController(
   @GetMapping
   @Operation(summary = "Gets aggregated statistics about planting sites.")
   fun getAggregatedTrackingStats(
-      @RequestParam organizationId: OrganizationId? = null,
+      @RequestParam
+      @Parameter(description = "Organization ID to summarize. Ignored if projectId is supplied.")
+      organizationId: OrganizationId? = null,
       @RequestParam projectId: ProjectId? = null,
   ): TrackingStatsResponsePayload {
     val survivalRate =

--- a/src/main/kotlin/com/terraformation/backend/tracking/api/TrackingStatsController.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/api/TrackingStatsController.kt
@@ -1,0 +1,46 @@
+package com.terraformation.backend.tracking.api
+
+import com.terraformation.backend.api.SuccessResponsePayload
+import com.terraformation.backend.api.TrackingEndpoint
+import com.terraformation.backend.db.default_schema.OrganizationId
+import com.terraformation.backend.db.default_schema.ProjectId
+import com.terraformation.backend.tracking.db.TrackingStatsStore
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.media.Schema
+import jakarta.ws.rs.BadRequestException
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+
+@RequestMapping("/api/v1/tracking/stats")
+@RestController
+@TrackingEndpoint
+class TrackingStatsController(
+    private val trackingStatsStore: TrackingStatsStore,
+) {
+  @GetMapping
+  @Operation(summary = "Gets aggregated statistics about planting sites.")
+  fun getAggregatedTrackingStats(
+      @RequestParam organizationId: OrganizationId? = null,
+      @RequestParam projectId: ProjectId? = null,
+  ): TrackingStatsResponsePayload {
+    val survivalRate =
+        when {
+          projectId != null -> trackingStatsStore.getSurvivalRate(projectId)
+          organizationId != null -> trackingStatsStore.getSurvivalRate(organizationId)
+          else -> throw BadRequestException("Must specify either organizationId or projectId")
+        }
+
+    return TrackingStatsResponsePayload(survivalRate = survivalRate)
+  }
+}
+
+data class TrackingStatsResponsePayload(
+    @Schema(
+        description =
+            "Aggregate survival rate. Not present if there have been no observations " +
+                "of the specified planting sites."
+    )
+    val survivalRate: Int?,
+) : SuccessResponsePayload

--- a/src/main/kotlin/com/terraformation/backend/tracking/db/TrackingStatsStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/db/TrackingStatsStore.kt
@@ -4,7 +4,7 @@ import com.terraformation.backend.customer.model.requirePermissions
 import com.terraformation.backend.db.default_schema.OrganizationId
 import com.terraformation.backend.db.default_schema.ProjectId
 import com.terraformation.backend.db.tracking.tables.references.OBSERVATIONS
-import com.terraformation.backend.db.tracking.tables.references.OBSERVATION_SITE_RESULTS
+import com.terraformation.backend.db.tracking.tables.references.OBSERVATION_STRATUM_RESULTS
 import com.terraformation.backend.db.tracking.tables.references.PLANTING_SITES
 import jakarta.inject.Named
 import java.math.BigDecimal
@@ -44,23 +44,22 @@ class TrackingStatsStore(
 
     val resultsPartitionedBySite =
         DSL.select(
-                OBSERVATION_SITE_RESULTS.SURVIVAL_RATE.`as`(survivalRateField),
-                OBSERVATION_SITE_RESULTS.SURVIVAL_RATE_AREA.`as`(survivalRateAreaField),
+                OBSERVATION_STRATUM_RESULTS.SURVIVAL_RATE.`as`(survivalRateField),
+                OBSERVATION_STRATUM_RESULTS.SURVIVAL_RATE_AREA.`as`(survivalRateAreaField),
                 DSL.rowNumber()
                     .over(
-                        DSL.partitionBy(OBSERVATION_SITE_RESULTS.PLANTING_SITE_ID)
+                        DSL.partitionBy(OBSERVATION_STRATUM_RESULTS.STRATUM_ID)
                             .orderBy(OBSERVATIONS.COMPLETED_TIME.desc())
                     )
                     .`as`(rowNumField),
             )
-            .from(OBSERVATION_SITE_RESULTS)
+            .from(OBSERVATION_STRATUM_RESULTS)
             .join(OBSERVATIONS)
-            .on(OBSERVATION_SITE_RESULTS.OBSERVATION_ID.eq(OBSERVATIONS.ID))
+            .on(OBSERVATION_STRATUM_RESULTS.OBSERVATION_ID.eq(OBSERVATIONS.ID))
             .join(PLANTING_SITES)
             .on(OBSERVATIONS.PLANTING_SITE_ID.eq(PLANTING_SITES.ID))
             .where(OBSERVATIONS.COMPLETED_TIME.isNotNull)
-            .and(OBSERVATION_SITE_RESULTS.SURVIVAL_RATE.isNotNull)
-            .and(OBSERVATION_SITE_RESULTS.SURVIVAL_RATE_AREA.isNotNull)
+            .and(OBSERVATION_STRATUM_RESULTS.STRATUM_ID.isNotNull)
             .and(plantingSitesCondition)
 
     val aggregateSurvivalRate =
@@ -71,6 +70,8 @@ class TrackingStatsStore(
             )
             .from(resultsPartitionedBySite)
             .where(rowNumField.eq(1))
+            .and(survivalRateField.isNotNull)
+            .and(survivalRateAreaField.isNotNull)
             .fetchOne()
             ?.value1()
 

--- a/src/main/kotlin/com/terraformation/backend/tracking/db/TrackingStatsStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/db/TrackingStatsStore.kt
@@ -1,0 +1,79 @@
+package com.terraformation.backend.tracking.db
+
+import com.terraformation.backend.customer.model.requirePermissions
+import com.terraformation.backend.db.default_schema.OrganizationId
+import com.terraformation.backend.db.default_schema.ProjectId
+import com.terraformation.backend.db.tracking.tables.references.OBSERVATIONS
+import com.terraformation.backend.db.tracking.tables.references.OBSERVATION_SITE_RESULTS
+import com.terraformation.backend.db.tracking.tables.references.PLANTING_SITES
+import jakarta.inject.Named
+import java.math.BigDecimal
+import java.math.RoundingMode
+import org.jooq.Condition
+import org.jooq.DSLContext
+import org.jooq.impl.DSL
+
+@Named
+class TrackingStatsStore(
+    private val dslContext: DSLContext,
+) {
+  /**
+   * Returns the aggregated area-weighted survival rate for all the planting sites associated with a
+   * project.
+   */
+  fun getSurvivalRate(projectId: ProjectId): Int? {
+    requirePermissions { readProject(projectId) }
+
+    return getSurvivalRate(PLANTING_SITES.PROJECT_ID.eq(projectId))
+  }
+
+  /**
+   * Returns the aggregated area-weighted survival rate for all the planting sites associated with
+   * an organization.
+   */
+  fun getSurvivalRate(organizationId: OrganizationId): Int? {
+    requirePermissions { readOrganization(organizationId) }
+
+    return getSurvivalRate(PLANTING_SITES.ORGANIZATION_ID.eq(organizationId))
+  }
+
+  private fun getSurvivalRate(plantingSitesCondition: Condition): Int? {
+    val rowNumField = DSL.field("rownum", Int::class.java)
+    val survivalRateField = DSL.field("survival_rate", Int::class.java)
+    val survivalRateAreaField = DSL.field("survival_rate_area", BigDecimal::class.java)
+
+    val resultsPartitionedBySite =
+        DSL.select(
+                OBSERVATION_SITE_RESULTS.SURVIVAL_RATE.`as`(survivalRateField),
+                OBSERVATION_SITE_RESULTS.SURVIVAL_RATE_AREA.`as`(survivalRateAreaField),
+                DSL.rowNumber()
+                    .over(
+                        DSL.partitionBy(OBSERVATION_SITE_RESULTS.PLANTING_SITE_ID)
+                            .orderBy(OBSERVATIONS.COMPLETED_TIME.desc())
+                    )
+                    .`as`(rowNumField),
+            )
+            .from(OBSERVATION_SITE_RESULTS)
+            .join(OBSERVATIONS)
+            .on(OBSERVATION_SITE_RESULTS.OBSERVATION_ID.eq(OBSERVATIONS.ID))
+            .join(PLANTING_SITES)
+            .on(OBSERVATIONS.PLANTING_SITE_ID.eq(PLANTING_SITES.ID))
+            .where(OBSERVATIONS.COMPLETED_TIME.isNotNull)
+            .and(OBSERVATION_SITE_RESULTS.SURVIVAL_RATE.isNotNull)
+            .and(OBSERVATION_SITE_RESULTS.SURVIVAL_RATE_AREA.isNotNull)
+            .and(plantingSitesCondition)
+
+    val aggregateSurvivalRate =
+        dslContext
+            .select(
+                DSL.sum(survivalRateField.mul(survivalRateAreaField))
+                    .div(DSL.nullif(DSL.sum(survivalRateAreaField), BigDecimal.ZERO))
+            )
+            .from(resultsPartitionedBySite)
+            .where(rowNumField.eq(1))
+            .fetchOne()
+            ?.value1()
+
+    return aggregateSurvivalRate?.setScale(0, RoundingMode.HALF_UP)?.toInt()
+  }
+}

--- a/src/test/kotlin/com/terraformation/backend/db/DatabaseBackedTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/db/DatabaseBackedTest.kt
@@ -3721,6 +3721,7 @@ abstract class DatabaseBackedTest {
       totalExisting: Int = row.totalExisting ?: 0,
       permanentLive: Int = row.permanentLive ?: 0,
       survivalRate: Int? = row.survivalRate,
+      survivalRateArea: Number? = row.survivalRateArea,
       survivalRateStdDev: Int? = row.survivalRateStdDev,
       plantDensity: Int? = row.plantDensity,
       plantDensityStdDev: Int? = row.plantDensityStdDev,
@@ -3728,16 +3729,17 @@ abstract class DatabaseBackedTest {
     observationStratumResultsDao.insert(
         row.copy(
             observationId = observationId,
-            stratumId = stratumId,
-            stratumHistoryId = stratumHistoryId,
-            totalLive = totalLive,
-            totalDead = totalDead,
-            totalExisting = totalExisting,
             permanentLive = permanentLive,
-            survivalRate = survivalRate,
-            survivalRateStdDev = survivalRateStdDev,
             plantDensity = plantDensity,
             plantDensityStdDev = plantDensityStdDev,
+            stratumHistoryId = stratumHistoryId,
+            stratumId = stratumId,
+            survivalRate = survivalRate,
+            survivalRateArea = survivalRateArea?.toBigDecimal(),
+            survivalRateStdDev = survivalRateStdDev,
+            totalDead = totalDead,
+            totalExisting = totalExisting,
+            totalLive = totalLive,
         )
     )
   }
@@ -3753,6 +3755,7 @@ abstract class DatabaseBackedTest {
       totalExisting: Int = row.totalExisting ?: 0,
       permanentLive: Int = row.permanentLive ?: 0,
       survivalRate: Int? = row.survivalRate,
+      survivalRateArea: Number? = row.survivalRateArea,
       survivalRateStdDev: Int? = row.survivalRateStdDev,
       plantDensity: Int? = row.plantDensity,
       plantDensityStdDev: Int? = row.plantDensityStdDev,
@@ -3760,16 +3763,17 @@ abstract class DatabaseBackedTest {
     observationSubstratumResultsDao.insert(
         row.copy(
             observationId = observationId,
-            substratumId = substratumId,
-            substratumHistoryId = substratumHistoryId,
-            totalLive = totalLive,
-            totalDead = totalDead,
-            totalExisting = totalExisting,
             permanentLive = permanentLive,
-            survivalRate = survivalRate,
-            survivalRateStdDev = survivalRateStdDev,
             plantDensity = plantDensity,
             plantDensityStdDev = plantDensityStdDev,
+            substratumHistoryId = substratumHistoryId,
+            substratumId = substratumId,
+            survivalRate = survivalRate,
+            survivalRateArea = survivalRateArea?.toBigDecimal(),
+            survivalRateStdDev = survivalRateStdDev,
+            totalDead = totalDead,
+            totalExisting = totalExisting,
+            totalLive = totalLive,
         )
     )
   }

--- a/src/test/kotlin/com/terraformation/backend/db/DatabaseBackedTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/db/DatabaseBackedTest.kt
@@ -3688,6 +3688,7 @@ abstract class DatabaseBackedTest {
       totalExisting: Int = row.totalExisting ?: 0,
       permanentLive: Int = row.permanentLive ?: 0,
       survivalRate: Int? = row.survivalRate,
+      survivalRateArea: Number? = row.survivalRateArea,
       survivalRateStdDev: Int? = row.survivalRateStdDev,
       plantDensity: Int? = row.plantDensity,
       plantDensityStdDev: Int? = row.plantDensityStdDev,
@@ -3695,16 +3696,17 @@ abstract class DatabaseBackedTest {
     observationSiteResultsDao.insert(
         row.copy(
             observationId = observationId,
-            plantingSiteId = plantingSiteId,
-            plantingSiteHistoryId = plantingSiteHistoryId,
-            totalLive = totalLive,
-            totalDead = totalDead,
-            totalExisting = totalExisting,
             permanentLive = permanentLive,
-            survivalRate = survivalRate,
-            survivalRateStdDev = survivalRateStdDev,
             plantDensity = plantDensity,
             plantDensityStdDev = plantDensityStdDev,
+            plantingSiteHistoryId = plantingSiteHistoryId,
+            plantingSiteId = plantingSiteId,
+            survivalRate = survivalRate,
+            survivalRateArea = survivalRateArea?.toBigDecimal(),
+            survivalRateStdDev = survivalRateStdDev,
+            totalDead = totalDead,
+            totalExisting = totalExisting,
+            totalLive = totalLive,
         )
     )
   }

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/TrackingStatsStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/TrackingStatsStoreTest.kt
@@ -1,0 +1,109 @@
+package com.terraformation.backend.tracking.db
+
+import com.terraformation.backend.RunsAsDatabaseUser
+import com.terraformation.backend.customer.model.TerrawareUser
+import com.terraformation.backend.db.DatabaseTest
+import com.terraformation.backend.db.OrganizationNotFoundException
+import com.terraformation.backend.db.ProjectNotFoundException
+import com.terraformation.backend.db.default_schema.OrganizationId
+import java.time.Instant
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertNull
+import org.junit.jupiter.api.assertThrows
+
+class TrackingStatsStoreTest : DatabaseTest(), RunsAsDatabaseUser {
+  override lateinit var user: TerrawareUser
+
+  private val store: TrackingStatsStore by lazy { TrackingStatsStore(dslContext) }
+
+  private lateinit var organizationId: OrganizationId
+
+  @BeforeEach
+  fun setUp() {
+    organizationId = insertOrganization()
+    insertOrganizationUser()
+  }
+
+  @Nested
+  inner class GetSurvivalRate {
+    @Test
+    fun `returns aggregate survival rates based on site-level rates`() {
+      insertSpecies()
+      val projectId1 = insertProject()
+      val projectId2 = insertProject()
+
+      // Project 1: Sites 1 and 2
+      // Project 2: Sites 3 and 4
+      //
+      // Observation 1: Site 1, site-level survival rate 90, area 5
+      // Observation 2: Site 1, site-level survival rate 70, area 10
+      // Observation 3: Site 2, site-level survival rate 50, area 20
+      // Observation 4: Site 3, site-level survival rate 10, area 40
+      // Observation 5: Site 4, no survival rate
+      //
+      // So the project-level survival rate for project 1 should be
+      //
+      // (70 * 10 + 50 * 20) / (10 + 20) = 57
+      //
+      // And the org-level rate should be
+      //
+      // (70 * 10 + 50 * 20 + 10 * 40) / (10 + 20 + 40) = 30
+
+      insertPlantingSite(projectId = projectId1, x = 0)
+      insertObservation(completedTime = Instant.ofEpochSecond(100))
+      insertObservationSiteResult(survivalRate = 90, survivalRateArea = 5)
+      insertObservation(completedTime = Instant.ofEpochSecond(200))
+      insertObservationSiteResult(survivalRate = 70, survivalRateArea = 10)
+
+      insertPlantingSite(projectId = projectId1, x = 0)
+      insertObservation(completedTime = Instant.ofEpochSecond(300))
+      insertObservationSiteResult(survivalRate = 50, survivalRateArea = 20)
+
+      insertPlantingSite(projectId = projectId2, x = 0)
+      insertObservation(completedTime = Instant.ofEpochSecond(400))
+      insertObservationSiteResult(survivalRate = 10, survivalRateArea = 40)
+
+      insertPlantingSite(projectId = projectId2, x = 0)
+      insertObservation(completedTime = Instant.ofEpochSecond(500))
+      insertObservationSiteResult()
+
+      // Other organization's site should be ignored
+      insertOrganization()
+      insertPlantingSite(x = 0)
+      insertObservation(completedTime = Instant.ofEpochSecond(600))
+      insertObservationSiteResult(survivalRate = 30, survivalRateArea = 80)
+
+      assertEquals(57, store.getSurvivalRate(projectId1), "Project survival rate")
+      assertEquals(30, store.getSurvivalRate(organizationId), "Organization survival rate")
+    }
+
+    @Test
+    fun `returns null if no sites in scope have survival rates`() {
+      val projectId = insertProject()
+      insertPlantingSite(projectId = projectId, x = 0)
+      insertObservation(completedTime = Instant.ofEpochSecond(100))
+      insertObservationSiteResult()
+
+      assertNull(store.getSurvivalRate(projectId), "Project survival rate")
+      assertNull(store.getSurvivalRate(organizationId), "Organization survival rate")
+    }
+
+    @Test
+    fun `throws exception if no permission to read project`() {
+      insertOrganization()
+      val projectId = insertProject()
+
+      assertThrows<ProjectNotFoundException> { store.getSurvivalRate(projectId) }
+    }
+
+    @Test
+    fun `throws exception if no permission to read organization`() {
+      val otherOrganizationId = insertOrganization()
+
+      assertThrows<OrganizationNotFoundException> { store.getSurvivalRate(otherOrganizationId) }
+    }
+  }
+}

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/TrackingStatsStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/TrackingStatsStoreTest.kt
@@ -38,11 +38,12 @@ class TrackingStatsStoreTest : DatabaseTest(), RunsAsDatabaseUser {
       // Project 1: Sites 1 and 2
       // Project 2: Sites 3 and 4
       //
-      // Observation 1: Site 1, site-level survival rate 90, area 5
-      // Observation 2: Site 1, site-level survival rate 70, area 10
-      // Observation 3: Site 2, site-level survival rate 50, area 20
-      // Observation 4: Site 3, site-level survival rate 10, area 40
-      // Observation 5: Site 4, no survival rate
+      // Observation 1: Site 1, survival rate 90, area 5
+      // Observation 2: Site 1, survival rate 70, area 10
+      // Observation 3: Site 2, survival rate 50, area 20
+      // Observation 4: Site 3, survival rate 10, area 40
+      // Observation 5: Site 4, survival rate 30, area 80
+      // Observation 6: Site 4, no survival rate or area (causes site 4 to be omitted)
       //
       // So the project-level survival rate for project 1 should be
       //
@@ -53,28 +54,35 @@ class TrackingStatsStoreTest : DatabaseTest(), RunsAsDatabaseUser {
       // (70 * 10 + 50 * 20 + 10 * 40) / (10 + 20 + 40) = 30
 
       insertPlantingSite(projectId = projectId1, x = 0)
+      insertStratum()
       insertObservation(completedTime = Instant.ofEpochSecond(100))
-      insertObservationSiteResult(survivalRate = 90, survivalRateArea = 5)
+      insertObservationStratumResult(survivalRate = 90, survivalRateArea = 5)
       insertObservation(completedTime = Instant.ofEpochSecond(200))
-      insertObservationSiteResult(survivalRate = 70, survivalRateArea = 10)
+      insertObservationStratumResult(survivalRate = 70, survivalRateArea = 10)
 
       insertPlantingSite(projectId = projectId1, x = 0)
+      insertStratum()
       insertObservation(completedTime = Instant.ofEpochSecond(300))
-      insertObservationSiteResult(survivalRate = 50, survivalRateArea = 20)
+      insertObservationStratumResult(survivalRate = 50, survivalRateArea = 20)
 
       insertPlantingSite(projectId = projectId2, x = 0)
+      insertStratum()
       insertObservation(completedTime = Instant.ofEpochSecond(400))
-      insertObservationSiteResult(survivalRate = 10, survivalRateArea = 40)
+      insertObservationStratumResult(survivalRate = 10, survivalRateArea = 40)
 
       insertPlantingSite(projectId = projectId2, x = 0)
+      insertStratum()
       insertObservation(completedTime = Instant.ofEpochSecond(500))
-      insertObservationSiteResult()
+      insertObservationStratumResult(survivalRate = 30, survivalRateArea = 80)
+      insertObservation(completedTime = Instant.ofEpochSecond(600))
+      insertObservationStratumResult()
 
       // Other organization's site should be ignored
       insertOrganization()
       insertPlantingSite(x = 0)
+      insertStratum()
       insertObservation(completedTime = Instant.ofEpochSecond(600))
-      insertObservationSiteResult(survivalRate = 30, survivalRateArea = 80)
+      insertObservationStratumResult(survivalRate = 30, survivalRateArea = 80)
 
       assertEquals(57, store.getSurvivalRate(projectId1), "Project survival rate")
       assertEquals(30, store.getSurvivalRate(organizationId), "Organization survival rate")
@@ -84,8 +92,9 @@ class TrackingStatsStoreTest : DatabaseTest(), RunsAsDatabaseUser {
     fun `returns null if no sites in scope have survival rates`() {
       val projectId = insertProject()
       insertPlantingSite(projectId = projectId, x = 0)
+      insertStratum()
       insertObservation(completedTime = Instant.ofEpochSecond(100))
-      insertObservationSiteResult()
+      insertObservationStratumResult()
 
       assertNull(store.getSurvivalRate(projectId), "Project survival rate")
       assertNull(store.getSurvivalRate(organizationId), "Organization survival rate")


### PR DESCRIPTION
We need to display the project-level survival rate (aggregated across planting
sites) in the UI. Add an endpoint to calculate it. The endpoint can also calculate
organization-level survival rates.