### PR TITLE
Move planting site/org lookup to SeasonHelper

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/plantingmanagement/db/PlantingSeasonScheduledDatesStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/plantingmanagement/db/PlantingSeasonScheduledDatesStore.kt
@@ -64,12 +64,8 @@ class PlantingSeasonScheduledDatesStore(
 
     seasonHelper.validateSeasonNotClosed(model.plantingSeasonId)
 
-    val plantingSiteId =
-        parentStore.getPlantingSiteId(model.plantingSeasonId)
-            ?: throw PlantingSeasonNotFoundException(model.plantingSeasonId)
-    val organizationId =
-        parentStore.getOrganizationId(plantingSiteId)
-            ?: throw PlantingSeasonNotFoundException(model.plantingSeasonId)
+    val (plantingSiteId, organizationId) =
+        seasonHelper.fetchPlantingSiteAndOrganization(model.plantingSeasonId)
     val userId = currentUser().userId
     val now = clock.instant()
 
@@ -164,12 +160,8 @@ class PlantingSeasonScheduledDatesStore(
 
     withLockedDate(scheduledDateId) {
       val oldModel = fetch(model.plantingSeasonId, scheduledDateId)
-      val plantingSiteId =
-          parentStore.getPlantingSiteId(model.plantingSeasonId)
-              ?: throw PlantingSeasonNotFoundException(model.plantingSeasonId)
-      val organizationId =
-          parentStore.getOrganizationId(plantingSiteId)
-              ?: throw PlantingSeasonNotFoundException(model.plantingSeasonId)
+      val (plantingSiteId, organizationId) =
+          seasonHelper.fetchPlantingSiteAndOrganization(model.plantingSeasonId)
 
       val updatedCount =
           with(SCHEDULED_PLANTING_DATES) {
@@ -320,12 +312,8 @@ class PlantingSeasonScheduledDatesStore(
 
     seasonHelper.validateSeasonNotClosed(plantingSeasonId)
 
-    val plantingSiteId =
-        parentStore.getPlantingSiteId(plantingSeasonId)
-            ?: throw PlantingSeasonNotFoundException(plantingSeasonId)
-    val organizationId =
-        parentStore.getOrganizationId(plantingSiteId)
-            ?: throw PlantingSeasonNotFoundException(plantingSeasonId)
+    val (plantingSiteId, organizationId) =
+        seasonHelper.fetchPlantingSiteAndOrganization(plantingSeasonId)
 
     with(SCHEDULED_PLANTING_DATES) {
       val rowsDeleted =

--- a/src/main/kotlin/com/terraformation/backend/plantingmanagement/db/SeasonHelper.kt
+++ b/src/main/kotlin/com/terraformation/backend/plantingmanagement/db/SeasonHelper.kt
@@ -1,11 +1,14 @@
 package com.terraformation.backend.plantingmanagement.db
 
 import com.terraformation.backend.db.asNonNullable
+import com.terraformation.backend.db.default_schema.OrganizationId
 import com.terraformation.backend.db.tracking.PlantingSeasonId
 import com.terraformation.backend.db.tracking.PlantingSeasonStatus
+import com.terraformation.backend.db.tracking.PlantingSiteId
 import com.terraformation.backend.db.tracking.SubstratumHistoryId
 import com.terraformation.backend.db.tracking.SubstratumId
 import com.terraformation.backend.db.tracking.tables.references.PLANTING_SEASONS
+import com.terraformation.backend.db.tracking.tables.references.PLANTING_SITES
 import com.terraformation.backend.db.tracking.tables.references.STRATA
 import com.terraformation.backend.db.tracking.tables.references.SUBSTRATA
 import com.terraformation.backend.db.tracking.tables.references.SUBSTRATUM_HISTORIES
@@ -62,6 +65,20 @@ class SeasonHelper(private val dslContext: DSLContext) {
   fun fetchSubstratumInfo(substratumId: SubstratumId): SubstratumInfo {
     return fetchSubstrataInfo(listOf(substratumId))[substratumId]
         ?: throw SubstratumNotFoundException(substratumId)
+  }
+
+  fun fetchPlantingSiteAndOrganization(
+      plantingSeasonId: PlantingSeasonId
+  ): Pair<PlantingSiteId, OrganizationId> {
+    return dslContext
+        .select(PLANTING_SITES.ID.asNonNullable(), PLANTING_SITES.ORGANIZATION_ID.asNonNullable())
+        .from(PLANTING_SEASONS)
+        .join(PLANTING_SITES)
+        .on(PLANTING_SEASONS.PLANTING_SITE_ID.eq(PLANTING_SITES.ID))
+        .where(PLANTING_SEASONS.ID.eq(plantingSeasonId))
+        .fetchOne()
+        ?.let { it.value1() to it.value2() }
+        ?: throw PlantingSeasonNotFoundException(plantingSeasonId)
   }
 
   fun validateSeasonNotClosed(plantingSeasonId: PlantingSeasonId) {


### PR DESCRIPTION
For publishing persistent events, we need to get the planting site and
organization IDs for a planting season. We'll need to do it in multiple
store classes, so move it to a little helper function that fetches both
IDs in one query rather than two separate queries.