### PR TITLE
Move withLockedPlantingSeason to SeasonHelper

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/plantingmanagement/db/PlantingSeasonStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/plantingmanagement/db/PlantingSeasonStore.kt
@@ -44,6 +44,7 @@ class PlantingSeasonStore(
     private val dslContext: DSLContext,
     private val eventPublisher: ApplicationEventPublisher,
     private val parentStore: ParentStore,
+    private val seasonHelper: SeasonHelper,
 ) {
   private val log = perClassLogger()
 
@@ -133,7 +134,7 @@ class PlantingSeasonStore(
   ) {
     requirePermissions { updatePlantingSeason(plantingSeasonId) }
 
-    withLockedPlantingSeason(plantingSeasonId) {
+    seasonHelper.withLockedPlantingSeason(plantingSeasonId) {
       val existingSeason =
           fetchByCondition(PLANTING_SEASONS.ID.eq(plantingSeasonId)).firstOrNull()
               ?: throw PlantingSeasonNotFoundException(plantingSeasonId)
@@ -216,7 +217,7 @@ class PlantingSeasonStore(
   fun close(plantingSeasonId: PlantingSeasonId) {
     requirePermissions { updatePlantingSeason(plantingSeasonId) }
 
-    withLockedPlantingSeason(plantingSeasonId) {
+    seasonHelper.withLockedPlantingSeason(plantingSeasonId) {
       val existingSeason =
           fetchByCondition(PLANTING_SEASONS.ID.eq(plantingSeasonId)).firstOrNull()
               ?: throw PlantingSeasonNotFoundException(plantingSeasonId)
@@ -499,18 +500,5 @@ class PlantingSeasonStore(
             )
         )
         .execute()
-  }
-
-  private fun <T> withLockedPlantingSeason(plantingSeasonId: PlantingSeasonId, func: () -> T): T {
-    return dslContext.transactionResult { _ ->
-      dslContext
-          .selectOne()
-          .from(PLANTING_SEASONS)
-          .where(PLANTING_SEASONS.ID.eq(plantingSeasonId))
-          .forUpdate()
-          .fetchOne() ?: throw PlantingSeasonNotFoundException(plantingSeasonId)
-
-      func()
-    }
   }
 }

--- a/src/main/kotlin/com/terraformation/backend/plantingmanagement/db/SeasonHelper.kt
+++ b/src/main/kotlin/com/terraformation/backend/plantingmanagement/db/SeasonHelper.kt
@@ -81,6 +81,19 @@ class SeasonHelper(private val dslContext: DSLContext) {
         ?: throw PlantingSeasonNotFoundException(plantingSeasonId)
   }
 
+  fun <T> withLockedPlantingSeason(plantingSeasonId: PlantingSeasonId, func: () -> T): T {
+    return dslContext.transactionResult { _ ->
+      dslContext
+          .selectOne()
+          .from(PLANTING_SEASONS)
+          .where(PLANTING_SEASONS.ID.eq(plantingSeasonId))
+          .forUpdate()
+          .fetchOne() ?: throw PlantingSeasonNotFoundException(plantingSeasonId)
+
+      func()
+    }
+  }
+
   fun validateSeasonNotClosed(plantingSeasonId: PlantingSeasonId) {
     with(PLANTING_SEASONS) {
       val status =

--- a/src/test/kotlin/com/terraformation/backend/daily/PlantingSeasonSchedulerTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/daily/PlantingSeasonSchedulerTest.kt
@@ -13,6 +13,7 @@ import com.terraformation.backend.db.tracking.PlantingSeasonStatus
 import com.terraformation.backend.db.tracking.PlantingSiteId
 import com.terraformation.backend.mockUser
 import com.terraformation.backend.plantingmanagement.db.PlantingSeasonStore
+import com.terraformation.backend.plantingmanagement.db.SeasonHelper
 import com.terraformation.backend.tracking.db.PlantingSiteNotificationStore
 import com.terraformation.backend.tracking.event.PlantingSeasonNotScheduledNotificationEvent
 import com.terraformation.backend.tracking.event.PlantingSeasonNotScheduledSupportNotificationEvent
@@ -36,7 +37,13 @@ class PlantingSeasonSchedulerTest : DatabaseTest(), RunsAsUser {
     PlantingSeasonScheduler(
         config,
         eventPublisher,
-        PlantingSeasonStore(clock, dslContext, eventPublisher, ParentStore(dslContext)),
+        PlantingSeasonStore(
+            clock,
+            dslContext,
+            eventPublisher,
+            ParentStore(dslContext),
+            SeasonHelper(dslContext),
+        ),
         PlantingSiteNotificationStore(clock, dslContext),
         SystemUser(usersDao),
     )

--- a/src/test/kotlin/com/terraformation/backend/plantingmanagement/PlantingSeasonServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/plantingmanagement/PlantingSeasonServiceTest.kt
@@ -37,7 +37,7 @@ internal class PlantingSeasonServiceTest : DatabaseTest(), RunsAsDatabaseUser {
     PlantingSeasonSpeciesTargetsStore(clock, dslContext, eventPublisher, seasonHelper)
   }
   private val plantingSeasonStore: PlantingSeasonStore by lazy {
-    PlantingSeasonStore(clock, dslContext, eventPublisher, parentStore)
+    PlantingSeasonStore(clock, dslContext, eventPublisher, parentStore, seasonHelper)
   }
   private val service: PlantingSeasonService by lazy {
     PlantingSeasonService(

--- a/src/test/kotlin/com/terraformation/backend/plantingmanagement/db/PlantingSeasonStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/plantingmanagement/db/PlantingSeasonStoreTest.kt
@@ -39,7 +39,13 @@ internal class PlantingSeasonStoreTest : DatabaseTest(), RunsAsDatabaseUser {
   private val clock = TestClock()
   private val eventPublisher = TestEventPublisher()
   private val store: PlantingSeasonStore by lazy {
-    PlantingSeasonStore(clock, dslContext, eventPublisher, ParentStore(dslContext))
+    PlantingSeasonStore(
+        clock,
+        dslContext,
+        eventPublisher,
+        ParentStore(dslContext),
+        SeasonHelper(dslContext),
+    )
   }
 
   private lateinit var organizationId: OrganizationId

--- a/src/test/kotlin/com/terraformation/backend/plantingmanagement/db/PlantingSeasonStoreTransitionTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/plantingmanagement/db/PlantingSeasonStoreTransitionTest.kt
@@ -24,7 +24,13 @@ internal class PlantingSeasonStoreTransitionTest : DatabaseTest(), RunsAsUser {
   private val clock = TestClock()
   private val eventPublisher = TestEventPublisher()
   private val store: PlantingSeasonStore by lazy {
-    PlantingSeasonStore(clock, dslContext, eventPublisher, ParentStore(dslContext))
+    PlantingSeasonStore(
+        clock,
+        dslContext,
+        eventPublisher,
+        ParentStore(dslContext),
+        SeasonHelper(dslContext),
+    )
   }
 
   private lateinit var timeZone: ZoneId


### PR DESCRIPTION
We're going to need to lock planting seasons from multiple store classes, so move
the lock function to the helper class.