### PR TITLE
SW-8427 Publish events for target create/update

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/plantingmanagement/db/PlantingSeasonSpeciesTargetsStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/plantingmanagement/db/PlantingSeasonSpeciesTargetsStore.kt
@@ -2,12 +2,16 @@ package com.terraformation.backend.plantingmanagement.db
 
 import com.terraformation.backend.auth.currentUser
 import com.terraformation.backend.customer.model.requirePermissions
+import com.terraformation.backend.db.asNonNullable
 import com.terraformation.backend.db.default_schema.SpeciesId
 import com.terraformation.backend.db.tracking.PlantingSeasonId
 import com.terraformation.backend.db.tracking.SubstratumId
 import com.terraformation.backend.db.tracking.tables.references.PLANTING_SEASON_SPECIES_TARGETS
 import com.terraformation.backend.plantingmanagement.PlantingSeasonSpeciesTargetModel
+import com.terraformation.backend.plantingmanagement.event.PlantingSeasonSpeciesTargetCreatedEvent
 import com.terraformation.backend.plantingmanagement.event.PlantingSeasonSpeciesTargetDeletedEvent
+import com.terraformation.backend.plantingmanagement.event.PlantingSeasonSpeciesTargetUpdatedEvent
+import com.terraformation.backend.plantingmanagement.event.PlantingSeasonSpeciesTargetUpdatedEventValues
 import jakarta.inject.Named
 import java.time.InstantSource
 import org.jooq.Condition
@@ -42,23 +46,70 @@ class PlantingSeasonSpeciesTargetsStore(
     val userId = currentUser().userId
     val now = clock.instant()
 
-    with(PLANTING_SEASON_SPECIES_TARGETS) {
-      dslContext
-          .insertInto(PLANTING_SEASON_SPECIES_TARGETS)
-          .set(PLANTING_SEASON_ID, plantingSeasonId)
-          .set(SUBSTRATUM_ID, substratumId)
-          .set(SPECIES_ID, speciesId)
-          .set(QUANTITY, quantity)
-          .set(CREATED_BY, userId)
-          .set(CREATED_TIME, now)
-          .set(MODIFIED_BY, userId)
-          .set(MODIFIED_TIME, now)
-          .onConflict(PLANTING_SEASON_ID, SUBSTRATUM_ID, SPECIES_ID)
-          .doUpdate()
-          .set(QUANTITY, quantity)
-          .set(MODIFIED_BY, userId)
-          .set(MODIFIED_TIME, now)
-          .execute()
+    val (plantingSiteId, organizationId) =
+        seasonHelper.fetchPlantingSiteAndOrganization(plantingSeasonId)
+    val substratumInfo = seasonHelper.fetchSubstratumInfo(substratumId)
+
+    seasonHelper.withLockedPlantingSeason(plantingSeasonId) {
+      with(PLANTING_SEASON_SPECIES_TARGETS) {
+        val oldQuantity =
+            dslContext
+                .select(QUANTITY)
+                .from(PLANTING_SEASON_SPECIES_TARGETS)
+                .where(PLANTING_SEASON_ID.eq(plantingSeasonId))
+                .and(SUBSTRATUM_ID.eq(substratumId))
+                .and(SPECIES_ID.eq(speciesId))
+                .fetchOne(QUANTITY)
+
+        dslContext
+            .insertInto(PLANTING_SEASON_SPECIES_TARGETS)
+            .set(PLANTING_SEASON_ID, plantingSeasonId)
+            .set(SUBSTRATUM_ID, substratumId)
+            .set(SPECIES_ID, speciesId)
+            .set(QUANTITY, quantity)
+            .set(CREATED_BY, userId)
+            .set(CREATED_TIME, now)
+            .set(MODIFIED_BY, userId)
+            .set(MODIFIED_TIME, now)
+            .onConflict(PLANTING_SEASON_ID, SUBSTRATUM_ID, SPECIES_ID)
+            .doUpdate()
+            .set(QUANTITY, quantity)
+            .set(MODIFIED_BY, userId)
+            .set(MODIFIED_TIME, now)
+            .execute()
+
+        if (oldQuantity == null) {
+          eventPublisher.publishEvent(
+              PlantingSeasonSpeciesTargetCreatedEvent(
+                  organizationId = organizationId,
+                  plantingSeasonId = plantingSeasonId,
+                  plantingSiteId = plantingSiteId,
+                  quantity = quantity,
+                  speciesId = speciesId,
+                  stratumName = substratumInfo.stratumName,
+                  substratumHistoryId = substratumInfo.substratumHistoryId,
+                  substratumId = substratumId,
+                  substratumName = substratumInfo.substratumName,
+              )
+          )
+        } else {
+          eventPublisher.publishEvent(
+              PlantingSeasonSpeciesTargetUpdatedEvent(
+                  changedFrom =
+                      PlantingSeasonSpeciesTargetUpdatedEventValues(quantity = oldQuantity),
+                  changedTo = PlantingSeasonSpeciesTargetUpdatedEventValues(quantity = quantity),
+                  organizationId = organizationId,
+                  plantingSeasonId = plantingSeasonId,
+                  plantingSiteId = plantingSiteId,
+                  speciesId = speciesId,
+                  stratumName = substratumInfo.stratumName,
+                  substratumHistoryId = substratumInfo.substratumHistoryId,
+                  substratumId = substratumId,
+                  substratumName = substratumInfo.substratumName,
+              )
+          )
+        }
+      }
     }
   }
 
@@ -74,34 +125,66 @@ class PlantingSeasonSpeciesTargetsStore(
     val userId = currentUser().userId
     val now = clock.instant()
 
-    with(PLANTING_SEASON_SPECIES_TARGETS) {
-      dslContext
-          .insertInto(
-              PLANTING_SEASON_SPECIES_TARGETS,
-              PLANTING_SEASON_ID,
-              SUBSTRATUM_ID,
-              SPECIES_ID,
-              QUANTITY,
-              CREATED_BY,
-              CREATED_TIME,
-              MODIFIED_BY,
-              MODIFIED_TIME,
+    val (plantingSiteId, organizationId) =
+        seasonHelper.fetchPlantingSiteAndOrganization(toPlantingSeasonId)
+
+    seasonHelper.withLockedPlantingSeason(toPlantingSeasonId) {
+      with(PLANTING_SEASON_SPECIES_TARGETS) {
+        val substrataAndSpecies =
+            dslContext
+                .insertInto(
+                    PLANTING_SEASON_SPECIES_TARGETS,
+                    PLANTING_SEASON_ID,
+                    SUBSTRATUM_ID,
+                    SPECIES_ID,
+                    QUANTITY,
+                    CREATED_BY,
+                    CREATED_TIME,
+                    MODIFIED_BY,
+                    MODIFIED_TIME,
+                )
+                .select(
+                    DSL.select(
+                            DSL.`val`(toPlantingSeasonId),
+                            SUBSTRATUM_ID,
+                            SPECIES_ID,
+                            DSL.`val`(0),
+                            DSL.`val`(userId),
+                            DSL.`val`(now),
+                            DSL.`val`(userId),
+                            DSL.`val`(now),
+                        )
+                        .from(PLANTING_SEASON_SPECIES_TARGETS)
+                        .where(PLANTING_SEASON_ID.eq(fromPlantingSeasonId))
+                )
+                .returningResult(
+                    // DSL.field works around a jOOQ behavior/bug where it will add an "excluded."
+                    // prefix to the fields in the "returning" clause.
+                    DSL.field(SUBSTRATUM_ID.name, SUBSTRATUM_ID.dataType).asNonNullable(),
+                    DSL.field(SPECIES_ID.name, SPECIES_ID.dataType).asNonNullable(),
+                )
+                .fetch()
+
+        val substrataInfo = seasonHelper.fetchSubstrataInfo(substrataAndSpecies.map { it.value1() })
+
+        substrataAndSpecies.forEach { (substratumId, speciesId) ->
+          val substratumInfo = substrataInfo[substratumId]!!
+
+          eventPublisher.publishEvent(
+              PlantingSeasonSpeciesTargetCreatedEvent(
+                  organizationId = organizationId,
+                  plantingSeasonId = toPlantingSeasonId,
+                  plantingSiteId = plantingSiteId,
+                  quantity = 0,
+                  speciesId = speciesId,
+                  stratumName = substratumInfo.stratumName,
+                  substratumHistoryId = substratumInfo.substratumHistoryId,
+                  substratumId = substratumId,
+                  substratumName = substratumInfo.substratumName,
+              )
           )
-          .select(
-              DSL.select(
-                      DSL.`val`(toPlantingSeasonId),
-                      SUBSTRATUM_ID,
-                      SPECIES_ID,
-                      DSL.`val`(0),
-                      DSL.`val`(userId),
-                      DSL.`val`(now),
-                      DSL.`val`(userId),
-                      DSL.`val`(now),
-                  )
-                  .from(PLANTING_SEASON_SPECIES_TARGETS)
-                  .where(PLANTING_SEASON_ID.eq(fromPlantingSeasonId))
-          )
-          .execute()
+        }
+      }
     }
   }
 
@@ -114,32 +197,34 @@ class PlantingSeasonSpeciesTargetsStore(
 
     seasonHelper.validateSeasonNotClosed(plantingSeasonId)
 
-    with(PLANTING_SEASON_SPECIES_TARGETS) {
-      val rowsDeleted =
-          dslContext
-              .deleteFrom(PLANTING_SEASON_SPECIES_TARGETS)
-              .where(PLANTING_SEASON_ID.eq(plantingSeasonId))
-              .and(SUBSTRATUM_ID.eq(substratumId))
-              .and(SPECIES_ID.eq(speciesId))
-              .execute()
+    seasonHelper.withLockedPlantingSeason(plantingSeasonId) {
+      with(PLANTING_SEASON_SPECIES_TARGETS) {
+        val rowsDeleted =
+            dslContext
+                .deleteFrom(PLANTING_SEASON_SPECIES_TARGETS)
+                .where(PLANTING_SEASON_ID.eq(plantingSeasonId))
+                .and(SUBSTRATUM_ID.eq(substratumId))
+                .and(SPECIES_ID.eq(speciesId))
+                .execute()
 
-      if (rowsDeleted > 0) {
-        val (plantingSiteId, organizationId) =
-            seasonHelper.fetchPlantingSiteAndOrganization(plantingSeasonId)
-        val substratumInfo = seasonHelper.fetchSubstratumInfo(substratumId)
+        if (rowsDeleted > 0) {
+          val (plantingSiteId, organizationId) =
+              seasonHelper.fetchPlantingSiteAndOrganization(plantingSeasonId)
+          val substratumInfo = seasonHelper.fetchSubstratumInfo(substratumId)
 
-        eventPublisher.publishEvent(
-            PlantingSeasonSpeciesTargetDeletedEvent(
-                organizationId = organizationId,
-                plantingSeasonId = plantingSeasonId,
-                plantingSiteId = plantingSiteId,
-                speciesId = speciesId,
-                stratumName = substratumInfo.stratumName,
-                substratumHistoryId = substratumInfo.substratumHistoryId,
-                substratumId = substratumId,
-                substratumName = substratumInfo.substratumName,
-            )
-        )
+          eventPublisher.publishEvent(
+              PlantingSeasonSpeciesTargetDeletedEvent(
+                  organizationId = organizationId,
+                  plantingSeasonId = plantingSeasonId,
+                  plantingSiteId = plantingSiteId,
+                  speciesId = speciesId,
+                  stratumName = substratumInfo.stratumName,
+                  substratumHistoryId = substratumInfo.substratumHistoryId,
+                  substratumId = substratumId,
+                  substratumName = substratumInfo.substratumName,
+              )
+          )
+        }
       }
     }
   }

--- a/src/main/kotlin/com/terraformation/backend/plantingmanagement/db/PlantingSeasonSpeciesTargetsStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/plantingmanagement/db/PlantingSeasonSpeciesTargetsStore.kt
@@ -92,7 +92,7 @@ class PlantingSeasonSpeciesTargetsStore(
                   substratumName = substratumInfo.substratumName,
               )
           )
-        } else {
+        } else if (oldQuantity != quantity) {
           eventPublisher.publishEvent(
               PlantingSeasonSpeciesTargetUpdatedEvent(
                   changedFrom =

--- a/src/main/resources/db/migration/0450/V499__PlantingSeasonSpeciesTargetCreatedEvent.sql
+++ b/src/main/resources/db/migration/0450/V499__PlantingSeasonSpeciesTargetCreatedEvent.sql
@@ -1,0 +1,28 @@
+INSERT INTO event_log (created_by, created_time, event_class, payload)
+SELECT
+    psst.created_by,
+    psst.created_time,
+    'com.terraformation.backend.plantingmanagement.event.PlantingSeasonSpeciesTargetCreatedEventV1',
+    json_object(
+        '_historical' VALUE true,
+        'organizationId' VALUE sites.organization_id,
+        'plantingSeasonId' VALUE seasons.id,
+        'plantingSiteId' VALUE sites.id,
+        'quantity' VALUE psst.quantity,
+        'speciesId' VALUE psst.species_id,
+        'stratumName' VALUE str.name,
+        'substratumHistoryId' VALUE latest_sub_hist.id,
+        'substratumId' VALUE psst.substratum_id,
+        'substratumName' VALUE sub.name
+        ABSENT ON NULL
+    )::JSONB
+FROM tracking.planting_season_species_targets psst
+JOIN tracking.planting_seasons seasons ON psst.planting_season_id = seasons.id
+JOIN tracking.planting_sites sites ON seasons.planting_site_id = sites.id
+JOIN tracking.substrata sub ON psst.substratum_id = sub.id
+JOIN tracking.strata str ON sub.stratum_id = str.id
+JOIN LATERAL (
+    SELECT id FROM tracking.substratum_histories
+    WHERE substratum_id = psst.substratum_id
+    ORDER BY id DESC LIMIT 1
+) latest_sub_hist ON true;

--- a/src/test/kotlin/com/terraformation/backend/plantingmanagement/PlantingSeasonServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/plantingmanagement/PlantingSeasonServiceTest.kt
@@ -56,7 +56,7 @@ internal class PlantingSeasonServiceTest : DatabaseTest(), RunsAsDatabaseUser {
   @BeforeEach
   fun setUp() {
     insertOrganization()
-    plantingSiteId = insertPlantingSite()
+    plantingSiteId = insertPlantingSite(x = 0)
     insertOrganizationUser(role = Role.Manager)
     insertStratum()
     plantingSeasonId = insertPlantingSeason()

--- a/src/test/kotlin/com/terraformation/backend/plantingmanagement/db/PlantingSeasonSpeciesTargetsStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/plantingmanagement/db/PlantingSeasonSpeciesTargetsStoreTest.kt
@@ -5,14 +5,19 @@ import com.terraformation.backend.TestClock
 import com.terraformation.backend.TestEventPublisher
 import com.terraformation.backend.customer.model.TerrawareUser
 import com.terraformation.backend.db.DatabaseTest
+import com.terraformation.backend.db.default_schema.OrganizationId
 import com.terraformation.backend.db.default_schema.Role
 import com.terraformation.backend.db.default_schema.SpeciesId
 import com.terraformation.backend.db.tracking.PlantingSeasonId
 import com.terraformation.backend.db.tracking.PlantingSeasonStatus
+import com.terraformation.backend.db.tracking.PlantingSiteId
 import com.terraformation.backend.db.tracking.SubstratumId
 import com.terraformation.backend.db.tracking.tables.records.PlantingSeasonSpeciesTargetsRecord
 import com.terraformation.backend.plantingmanagement.PlantingSeasonSpeciesTargetModel
+import com.terraformation.backend.plantingmanagement.event.PlantingSeasonSpeciesTargetCreatedEvent
 import com.terraformation.backend.plantingmanagement.event.PlantingSeasonSpeciesTargetDeletedEvent
+import com.terraformation.backend.plantingmanagement.event.PlantingSeasonSpeciesTargetUpdatedEvent
+import com.terraformation.backend.plantingmanagement.event.PlantingSeasonSpeciesTargetUpdatedEventValues
 import java.time.Instant
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
@@ -35,14 +40,16 @@ internal class PlantingSeasonSpeciesTargetsStoreTest : DatabaseTest(), RunsAsDat
     )
   }
 
+  private lateinit var organizationId: OrganizationId
   private lateinit var plantingSeasonId: PlantingSeasonId
+  private lateinit var plantingSiteId: PlantingSiteId
   private lateinit var substratumId: SubstratumId
   private lateinit var speciesId: SpeciesId
 
   @BeforeEach
   fun setUp() {
-    insertOrganization()
-    insertPlantingSite(x = 0)
+    organizationId = insertOrganization()
+    plantingSiteId = insertPlantingSite(x = 0)
     insertOrganizationUser(role = Role.Manager)
     insertStratum()
     plantingSeasonId = insertPlantingSeason()
@@ -138,12 +145,27 @@ internal class PlantingSeasonSpeciesTargetsStoreTest : DatabaseTest(), RunsAsDat
               modifiedTime = clock.instant,
           )
       )
+
+      eventPublisher.assertEventPublished(
+          PlantingSeasonSpeciesTargetCreatedEvent(
+              organizationId = organizationId,
+              plantingSeasonId = plantingSeasonId,
+              plantingSiteId = plantingSiteId,
+              quantity = 5,
+              speciesId = speciesId,
+              stratumName = "S1",
+              substratumHistoryId = inserted.substratumHistoryId,
+              substratumId = substratumId,
+              substratumName = "1",
+          )
+      )
     }
 
     @Test
     fun `updates quantity when row already exists`() {
       store.upsert(plantingSeasonId, substratumId, speciesId, quantity = 5)
       clock.instant = Instant.ofEpochSecond(100)
+      eventPublisher.clear()
       store.upsert(plantingSeasonId, substratumId, speciesId, quantity = 20)
 
       assertTableEquals(
@@ -156,6 +178,21 @@ internal class PlantingSeasonSpeciesTargetsStoreTest : DatabaseTest(), RunsAsDat
               createdTime = Instant.EPOCH,
               modifiedBy = user.userId,
               modifiedTime = clock.instant,
+          )
+      )
+
+      eventPublisher.assertEventPublished(
+          PlantingSeasonSpeciesTargetUpdatedEvent(
+              changedFrom = PlantingSeasonSpeciesTargetUpdatedEventValues(quantity = 5),
+              changedTo = PlantingSeasonSpeciesTargetUpdatedEventValues(quantity = 20),
+              organizationId = organizationId,
+              plantingSeasonId = plantingSeasonId,
+              plantingSiteId = plantingSiteId,
+              speciesId = speciesId,
+              stratumName = "S1",
+              substratumHistoryId = inserted.substratumHistoryId,
+              substratumId = substratumId,
+              substratumName = "1",
           )
       )
     }
@@ -249,6 +286,26 @@ internal class PlantingSeasonSpeciesTargetsStoreTest : DatabaseTest(), RunsAsDat
                   modifiedBy = user.userId,
                   modifiedTime = laterTime,
               ),
+          )
+      )
+
+      val createdEvent =
+          PlantingSeasonSpeciesTargetCreatedEvent(
+              organizationId = organizationId,
+              plantingSeasonId = plantingSeasonId,
+              plantingSiteId = plantingSiteId,
+              quantity = 0,
+              speciesId = speciesId,
+              stratumName = "S1",
+              substratumHistoryId = inserted.substratumHistoryId,
+              substratumId = substratumId,
+              substratumName = "1",
+          )
+
+      eventPublisher.assertEventsPublished(
+          setOf(
+              createdEvent,
+              createdEvent.copy(speciesId = speciesId2),
           )
       )
     }


### PR DESCRIPTION
When a planting season species target is created or updated, publish the
appropriate persistent event to record the change.

Backfill creation events for existing targets.