### PR TITLE
SW-8420 Add method to query since an id to EventLogStore

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/eventlog/db/EventLogStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/eventlog/db/EventLogStore.kt
@@ -100,6 +100,40 @@ class EventLogStore(
     return fetchByCondition(condition, requestedConcreteClasses)
   }
 
+  /**
+   * Fetches events matching any of the given IDs, where each ID has its own lower bound on the
+   * event log ID. An event is returned if it matches one of the [sinceEventLogIds] keys and was
+   * logged after that key's associated event log ID. This is the union of a separate "since" query
+   * per ID, which lets callers track a different watermark for each ID (for example, the last
+   * notification each planting season dismissed).
+   */
+  fun <T : PersistentEvent> fetchByIdsSince(
+      sinceEventLogIds: Map<out LongIdWrapper<*>, EventLogId>,
+      requestedClasses: Collection<KClass<out T>>? = null,
+  ): List<EventLogEntry<T>> {
+    require(sinceEventLogIds.isNotEmpty()) { "No IDs specified" }
+
+    val requestedConcreteClasses = requestedClasses?.let { getConcreteClasses(it) }
+    val classConditions = requestedConcreteClasses?.let { getLikeConditions(it) } ?: emptyList()
+
+    val idConditions = sinceEventLogIds.map { (id, sinceEventLogId) ->
+      DSL.and(
+          payloadField(id.eventLogPropertyName, SQLDataType.BIGINT).eq(id.value),
+          EVENT_LOG.ID.gt(sinceEventLogId),
+      )
+    }
+
+    val condition =
+        DSL.and(
+            listOfNotNull(
+                DSL.or(idConditions),
+                if (classConditions.isNotEmpty()) DSL.or(classConditions) else null,
+            )
+        )
+
+    return fetchByCondition(condition, requestedConcreteClasses)
+  }
+
   fun <T : PersistentEvent> fetchLastByIds(
       ids: Collection<LongIdWrapper<*>>,
       requestedClasses: Collection<KClass<out T>>? = null,

--- a/src/main/kotlin/com/terraformation/backend/eventlog/db/EventLogStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/eventlog/db/EventLogStore.kt
@@ -105,10 +105,11 @@ class EventLogStore(
    * event log ID. An event is returned if it matches one of the [sinceEventLogIds] keys and was
    * logged after that key's associated event log ID. This is the union of a separate "since" query
    * per ID, which lets callers track a different watermark for each ID (for example, the last
-   * notification each planting season dismissed).
+   * notification each planting season dismissed). A null value means there is no lower bound for
+   * that ID, so all of its events are returned.
    */
   fun <T : PersistentEvent> fetchByIdsSince(
-      sinceEventLogIds: Map<out LongIdWrapper<*>, EventLogId>,
+      sinceEventLogIds: Map<out LongIdWrapper<*>, EventLogId?>,
       requestedClasses: Collection<KClass<out T>>? = null,
   ): List<EventLogEntry<T>> {
     require(sinceEventLogIds.isNotEmpty()) { "No IDs specified" }
@@ -118,8 +119,10 @@ class EventLogStore(
 
     val idConditions = sinceEventLogIds.map { (id, sinceEventLogId) ->
       DSL.and(
-          payloadField(id.eventLogPropertyName, SQLDataType.BIGINT).eq(id.value),
-          EVENT_LOG.ID.gt(sinceEventLogId),
+          listOfNotNull(
+              payloadField(id.eventLogPropertyName, SQLDataType.BIGINT).eq(id.value),
+              sinceEventLogId?.let { EVENT_LOG.ID.gt(it) },
+          )
       )
     }
 

--- a/src/test/kotlin/com/terraformation/backend/eventlog/db/EventLogStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/eventlog/db/EventLogStoreTest.kt
@@ -142,6 +142,73 @@ class EventLogStoreTest : DatabaseTest(), RunsAsDatabaseUser {
   }
 
   @Nested
+  inner class FetchByIdsSince {
+    val org1Event1 = TestOrganizationCreatedEventV1(OrganizationId(1), "Org 1 a")
+    val org2Event1 = TestOrganizationCreatedEventV1(OrganizationId(2), "Org 2 a")
+    val org1Event2 = TestOrganizationCreatedEventV1(OrganizationId(1), "Org 1 b")
+    val org2Event2 = TestOrganizationCreatedEventV1(OrganizationId(2), "Org 2 b")
+    val org1Project1Event = TestProjectCreatedEventV1(OrganizationId(1), ProjectId(1), "Project 1")
+
+    lateinit var org1Event1Id: EventLogId
+    lateinit var org2Event1Id: EventLogId
+    lateinit var org1Event2Id: EventLogId
+    lateinit var org2Event2Id: EventLogId
+    lateinit var org1Project1EventId: EventLogId
+
+    @BeforeEach
+    fun setUp() {
+      org1Event1Id = store.insertEvent(org1Event1)
+      org2Event1Id = store.insertEvent(org2Event1)
+      org1Event2Id = store.insertEvent(org1Event2)
+      org2Event2Id = store.insertEvent(org2Event2)
+      org1Project1EventId = store.insertEvent(org1Project1Event)
+    }
+
+    @Test
+    fun `applies a separate event log id bound for each id`() {
+      assertEquals(
+          listOf(
+              EventLogEntry(user.userId, Instant.EPOCH, org1Event2, org1Event2Id),
+              EventLogEntry(user.userId, Instant.EPOCH, org2Event2, org2Event2Id),
+              EventLogEntry(user.userId, Instant.EPOCH, org1Project1Event, org1Project1EventId),
+          ),
+          store.fetchByIdsSince<PersistentEvent>(
+              mapOf(
+                  OrganizationId(1) to org1Event1Id,
+                  OrganizationId(2) to org2Event1Id,
+              )
+          ),
+      )
+    }
+
+    @Test
+    fun `excludes the event whose id equals the bound`() {
+      assertEquals(
+          emptyList<EventLogEntry<PersistentEvent>>(),
+          store.fetchByIdsSince<PersistentEvent>(mapOf(OrganizationId(2) to org2Event2Id)),
+      )
+    }
+
+    @Test
+    fun `only returns events of requested classes`() {
+      assertEquals(
+          listOf(
+              EventLogEntry(user.userId, Instant.EPOCH, org1Project1Event, org1Project1EventId),
+          ),
+          store.fetchByIdsSince(
+              mapOf(OrganizationId(1) to org1Event1Id),
+              listOf(TestProjectEvent::class),
+          ),
+      )
+    }
+
+    @Test
+    fun `throws exception when no IDs specified`() {
+      assertThrows<IllegalArgumentException> { store.fetchByIdsSince<PersistentEvent>(emptyMap()) }
+    }
+  }
+
+  @Nested
   inner class FetchByIntegerField {
     @Test
     fun `can fetch by organization id`() {

--- a/src/test/kotlin/com/terraformation/backend/eventlog/db/EventLogStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/eventlog/db/EventLogStoreTest.kt
@@ -190,6 +190,36 @@ class EventLogStoreTest : DatabaseTest(), RunsAsDatabaseUser {
     }
 
     @Test
+    fun `returns all events for an id when its bound is null`() {
+      assertEquals(
+          listOf(
+              EventLogEntry(user.userId, Instant.EPOCH, org1Event1, org1Event1Id),
+              EventLogEntry(user.userId, Instant.EPOCH, org1Event2, org1Event2Id),
+              EventLogEntry(user.userId, Instant.EPOCH, org1Project1Event, org1Project1EventId),
+          ),
+          store.fetchByIdsSince<PersistentEvent>(mapOf(OrganizationId(1) to null)),
+      )
+    }
+
+    @Test
+    fun `applies bounds per id when some bounds are null`() {
+      assertEquals(
+          listOf(
+              EventLogEntry(user.userId, Instant.EPOCH, org1Event1, org1Event1Id),
+              EventLogEntry(user.userId, Instant.EPOCH, org1Event2, org1Event2Id),
+              EventLogEntry(user.userId, Instant.EPOCH, org2Event2, org2Event2Id),
+              EventLogEntry(user.userId, Instant.EPOCH, org1Project1Event, org1Project1EventId),
+          ),
+          store.fetchByIdsSince<PersistentEvent>(
+              mapOf(
+                  OrganizationId(1) to null,
+                  OrganizationId(2) to org2Event1Id,
+              )
+          ),
+      )
+    }
+
+    @Test
     fun `only returns events of requested classes`() {
       assertEquals(
           listOf(


### PR DESCRIPTION
Planting Season Notifications will use the event log, and wil store a `last_dismissed_event_log_id` per `planting_season_id`. Add a method to be able to fetch a list of `EventLogEntry`s with a separate `sinceEventLogId` per `LongIdWrapper` passed in. 

Co-authored-by: Claude Opus 4.8 <noreply@anthropic.com>