### PR TITLE
Fix jOOQ static type registry warnings

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/tracking/db/ObservationStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/db/ObservationStore.kt
@@ -8,13 +8,12 @@ import com.terraformation.backend.customer.model.requirePermissions
 import com.terraformation.backend.db.asNonNullable
 import com.terraformation.backend.db.default_schema.OrganizationId
 import com.terraformation.backend.db.default_schema.SpeciesId
-import com.terraformation.backend.db.default_schema.SpeciesIdConverter
+import com.terraformation.backend.db.default_schema.tables.references.SPECIES
 import com.terraformation.backend.db.default_schema.tables.references.USERS
 import com.terraformation.backend.db.tracking.MonitoringPlotHistoryId
 import com.terraformation.backend.db.tracking.MonitoringPlotId
 import com.terraformation.backend.db.tracking.ObservableCondition
 import com.terraformation.backend.db.tracking.ObservationId
-import com.terraformation.backend.db.tracking.ObservationIdConverter
 import com.terraformation.backend.db.tracking.ObservationPlotStatus
 import com.terraformation.backend.db.tracking.ObservationState
 import com.terraformation.backend.db.tracking.ObservationType
@@ -22,7 +21,6 @@ import com.terraformation.backend.db.tracking.PlantingSiteHistoryId
 import com.terraformation.backend.db.tracking.PlantingSiteId
 import com.terraformation.backend.db.tracking.RecordedPlantStatus
 import com.terraformation.backend.db.tracking.RecordedSpeciesCertainty
-import com.terraformation.backend.db.tracking.RecordedSpeciesCertaintyConverter
 import com.terraformation.backend.db.tracking.StratumHistoryId
 import com.terraformation.backend.db.tracking.StratumId
 import com.terraformation.backend.db.tracking.SubstratumHistoryId
@@ -1699,7 +1697,7 @@ class ObservationStore(
               .and(
                   OBSERVATION_ID.eq(
                       latestObservationForSubstratumField(
-                          DSL.inline(observationId),
+                          DSL.inline(observationId, OBSERVATIONS.ID.dataType),
                           OBSERVED_SUBSTRATUM_SPECIES_TOTALS.SUBSTRATUM_ID,
                       )
                   )
@@ -1748,13 +1746,13 @@ class ObservationStore(
               getSurvivalRateDenominator(
                   updateScope,
                   PLOT_T0_DENSITIES.SPECIES_ID.eq(speciesKey.id),
-                  DSL.value(observationId),
+                  DSL.value(observationId, OBSERVATIONS.ID.dataType),
               )
           val survivalRateTempDenominator =
               getSurvivalRateTempDenominator(
                   updateScope,
                   STRATUM_T0_TEMP_DENSITIES.SPECIES_ID.eq(speciesKey.id),
-                  DSL.value(observationId),
+                  DSL.value(observationId, OBSERVATIONS.ID.dataType),
               )
           val survivalRateDenominator =
               DSL.coalesce(
@@ -1806,13 +1804,13 @@ class ObservationStore(
             getSurvivalRateDenominator(
                 updateScope,
                 PLOT_T0_DENSITIES.SPECIES_ID.eq(speciesKey.id),
-                DSL.value(observationId),
+                DSL.value(observationId, OBSERVATIONS.ID.dataType),
             )
         val survivalRateTempDenominator =
             getSurvivalRateTempDenominator(
                 updateScope,
                 STRATUM_T0_TEMP_DENSITIES.SPECIES_ID.eq(speciesKey.id),
-                DSL.value(observationId),
+                DSL.value(observationId, OBSERVATIONS.ID.dataType),
             )
         val survivalRateDenominator =
             DSL.coalesce(
@@ -1975,8 +1973,7 @@ class ObservationStore(
       updateScope: ObservationSpeciesScope<ID, HistoryId>
   ) {
     val table = updateScope.observedTotalsTable
-    val speciesIdField =
-        table.field("species_id", SQLDataType.BIGINT.asConvertedDataType(SpeciesIdConverter()))!!
+    val speciesIdField = table.field("species_id", SPECIES.ID.dataType)
     val observationIdField = table.field("observation_id", ObservationId::class.java)!!
     val survivalRatePermanentDenominator =
         getSurvivalRateDenominator(
@@ -2138,18 +2135,18 @@ class ObservationStore(
       observationId: ObservationId,
   ) {
     val table = updateScope.observedTotalsTable
-    val observationIdField = table.field("observation_id", ObservationId::class.java)!!
+    val observationIdField = table.field("observation_id", OBSERVATIONS.ID.dataType)!!
     val survivalRatePermanentDenominator =
         getSurvivalRateDenominator(
             updateScope,
             DSL.trueCondition(),
-            DSL.value(observationId),
+            DSL.value(observationId, OBSERVATIONS.ID.dataType),
         )
     val survivalRateTempDenominator =
         getSurvivalRateTempDenominator(
             updateScope,
             DSL.trueCondition(),
-            DSL.value(observationId),
+            DSL.value(observationId, OBSERVATIONS.ID.dataType),
         )
     val survivalRateDenominator =
         DSL.coalesce(survivalRatePermanentDenominator, BigDecimal.ZERO)
@@ -2162,7 +2159,7 @@ class ObservationStore(
 
     val survivalRateValue =
         updateScope.survivalRateValue(
-            DSL.value(observationId),
+            DSL.value(observationId, OBSERVATIONS.ID.dataType),
             survivalRateDenominator,
             latestLiveField,
             permanentLiveField,
@@ -2173,7 +2170,11 @@ class ObservationStore(
             .fetchExists(
                 DSL.selectOne()
                     .from(OBSERVATION_PLOTS)
-                    .where(updateScope.observationPlotsCondition(DSL.value(observationId)))
+                    .where(
+                        updateScope.observationPlotsCondition(
+                            DSL.value(observationId, OBSERVATIONS.ID.dataType)
+                        )
+                    )
                     .and(OBSERVATION_PLOTS.COMPLETED_TIME.isNull)
             )
             .not()
@@ -2206,7 +2207,9 @@ class ObservationStore(
                 survivalRateAreaField,
                 DSL.if_(
                     survivalRateField.isNotNull,
-                    updateScope.survivalRateAreaValue(DSL.value(observationId)),
+                    updateScope.survivalRateAreaValue(
+                        DSL.value(observationId, OBSERVATIONS.ID.dataType)
+                    ),
                     DSL.castNull(SQLDataType.NUMERIC),
                 ),
             )
@@ -2510,8 +2513,7 @@ class ObservationStore(
     val resultsTable = scope.observedTotalsTable
     val rollupTable = scope.rollupSpeciesTable
 
-    val resultsObservationIdField =
-        resultsTable.field("observation_id", ObservationId::class.java)!!
+    val resultsObservationIdField = resultsTable.field("observation_id", OBSERVATIONS.ID.dataType)!!
     val resultsTotalLiveField = resultsTable.field("total_live", Int::class.java)!!
     val resultsTotalDeadField = resultsTable.field("total_dead", Int::class.java)!!
     val resultsTotalExistingField = resultsTable.field("total_existing", Int::class.java)!!
@@ -2520,7 +2522,7 @@ class ObservationStore(
     val resultsPlantDensityStdDevField =
         resultsTable.field("plant_density_std_dev", Int::class.java)
 
-    val rollupObservationIdField = rollupTable.field("observation_id", ObservationId::class.java)!!
+    val rollupObservationIdField = rollupTable.field("observation_id", OBSERVATIONS.ID.dataType)!!
     val rollupTotalLiveField = rollupTable.field("total_live", Int::class.java)!!
     val rollupTotalDeadField = rollupTable.field("total_dead", Int::class.java)!!
     val rollupTotalExistingField = rollupTable.field("total_existing", Int::class.java)!!
@@ -2889,18 +2891,9 @@ class ObservationStore(
       updateScope: ObservationSpeciesScope<ID, HistoryId>,
   ) {
     val table = updateScope.observedTotalsTable
-    val observationIdField =
-        table.field(
-            "observation_id",
-            SQLDataType.BIGINT.asConvertedDataType(ObservationIdConverter()),
-        )!!
-    val certaintyField =
-        table.field(
-            "certainty_id",
-            SQLDataType.INTEGER.asConvertedDataType(RecordedSpeciesCertaintyConverter()),
-        )!!
-    val speciesIdField =
-        table.field("species_id", SQLDataType.BIGINT.asConvertedDataType(SpeciesIdConverter()))!!
+    val observationIdField = table.field("observation_id", OBSERVATIONS.ID.dataType)!!
+    val certaintyField = table.field("certainty_id", RECORDED_PLANTS.CERTAINTY_ID.dataType)!!
+    val speciesIdField = table.field("species_id", SPECIES.ID.dataType)!!
     val speciesNameField = table.field("species_name", String::class.java)!!
     val totalLiveField = table.field("total_live", Int::class.java)!!
     val totalDeadField = table.field("total_dead", Int::class.java)!!
@@ -2924,13 +2917,13 @@ class ObservationStore(
             getSurvivalRateDenominator(
                 updateScope,
                 PLOT_T0_DENSITIES.SPECIES_ID.eq(speciesKey.id),
-                DSL.value(observationId),
+                DSL.value(observationId, OBSERVATIONS.ID.dataType),
             )
         val survivalRateTempDenominator =
             getSurvivalRateTempDenominator(
                 updateScope,
                 STRATUM_T0_TEMP_DENSITIES.SPECIES_ID.eq(speciesKey.id),
-                DSL.value(observationId),
+                DSL.value(observationId, OBSERVATIONS.ID.dataType),
             )
         val survivalRateDenominator =
             DSL.coalesce(

--- a/src/main/kotlin/com/terraformation/backend/tracking/util/ObservationResultsScope.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/util/ObservationResultsScope.kt
@@ -24,10 +24,13 @@ import com.terraformation.backend.db.tracking.tables.references.OBSERVED_PLOT_SP
 import com.terraformation.backend.db.tracking.tables.references.OBSERVED_SITE_SPECIES_TOTALS
 import com.terraformation.backend.db.tracking.tables.references.OBSERVED_STRATUM_SPECIES_TOTALS
 import com.terraformation.backend.db.tracking.tables.references.OBSERVED_SUBSTRATUM_SPECIES_TOTALS
+import com.terraformation.backend.db.tracking.tables.references.PLANTING_SITES
+import com.terraformation.backend.db.tracking.tables.references.PLANTING_SITE_HISTORIES
 import com.terraformation.backend.db.tracking.tables.references.PLOT_T0_DENSITIES
 import com.terraformation.backend.db.tracking.tables.references.STRATA
 import com.terraformation.backend.db.tracking.tables.references.STRATUM_HISTORIES
 import com.terraformation.backend.db.tracking.tables.references.STRATUM_T0_TEMP_DENSITIES
+import com.terraformation.backend.db.tracking.tables.references.SUBSTRATA
 import com.terraformation.backend.db.tracking.tables.references.SUBSTRATUM_HISTORIES
 import com.terraformation.backend.tracking.db.latestObservationForSubstratumField
 import com.terraformation.backend.tracking.db.substratumObservedAtOrBefore
@@ -114,7 +117,7 @@ class ObservationResultsPlot(
   constructor(
       plotHistoryId: MonitoringPlotHistoryId,
       plotId: MonitoringPlotId,
-  ) : this(DSL.select(DSL.inline(plotHistoryId)), plotId)
+  ) : this(DSL.select(DSL.inline(plotHistoryId, MONITORING_PLOT_HISTORIES.ID.dataType)), plotId)
 
   constructor(
       plotId: MonitoringPlotId
@@ -125,7 +128,8 @@ class ObservationResultsPlot(
       plotId,
   )
 
-  override val scopeId: Select<Record1<MonitoringPlotId?>> = DSL.select(DSL.inline(plotId))
+  override val scopeId: Select<Record1<MonitoringPlotId?>> =
+      DSL.select(DSL.inline(plotId, MONITORING_PLOTS.ID.dataType))
 
   override val scopeHistoryId = plotHistorySelect
 
@@ -182,7 +186,11 @@ class ObservationResultsSubstratum(
       substratumHistoryId: SubstratumHistoryId,
       substratumId: SubstratumId? = null,
       plotId: MonitoringPlotId? = null,
-  ) : this(DSL.select(DSL.inline(substratumHistoryId)), substratumId, plotId)
+  ) : this(
+      DSL.select(DSL.inline(substratumHistoryId, SUBSTRATUM_HISTORIES.ID.dataType)),
+      substratumId,
+      plotId,
+  )
 
   constructor(
       plotId: MonitoringPlotId
@@ -196,9 +204,9 @@ class ObservationResultsSubstratum(
 
   override val scopeId: Select<Record1<SubstratumId?>> =
       if (substratumId != null) {
-        DSL.select(DSL.inline(substratumId))
+        DSL.select(DSL.inline(substratumId, SUBSTRATA.ID.dataType))
       } else {
-        DSL.select(DSL.castNull(OBSERVATION_SUBSTRATUM_RESULTS.SUBSTRATUM_ID.dataType))
+        DSL.select(DSL.castNull(SUBSTRATA.ID.dataType))
       }
 
   override val scopeHistoryId = substratumHistorySelect
@@ -310,7 +318,11 @@ class ObservationResultsStratum(
       stratumHistoryId: StratumHistoryId,
       stratumId: StratumId? = null,
       plotId: MonitoringPlotId? = null,
-  ) : this(DSL.select(DSL.inline(stratumHistoryId)), stratumId, plotId)
+  ) : this(
+      DSL.select(DSL.inline(stratumHistoryId, STRATUM_HISTORIES.ID.dataType)),
+      stratumId,
+      plotId,
+  )
 
   constructor(
       plotId: MonitoringPlotId
@@ -333,9 +345,9 @@ class ObservationResultsStratum(
 
   override val scopeId: Select<Record1<StratumId?>> =
       if (stratumId != null) {
-        DSL.select(DSL.inline(stratumId))
+        DSL.select(DSL.inline(stratumId, STRATA.ID.dataType))
       } else {
-        DSL.select(DSL.castNull(OBSERVATION_STRATUM_RESULTS.STRATUM_ID.dataType))
+        DSL.select(DSL.castNull(STRATA.ID.dataType))
       }
 
   override val scopeHistoryId = stratumHistorySelect
@@ -498,7 +510,11 @@ class ObservationResultsSite(
       siteHistoryId: PlantingSiteHistoryId,
       siteId: PlantingSiteId,
       plotId: MonitoringPlotId? = null,
-  ) : this(DSL.select(DSL.inline(siteHistoryId)), DSL.select(DSL.inline(siteId)), plotId)
+  ) : this(
+      DSL.select(DSL.inline(siteHistoryId, PLANTING_SITE_HISTORIES.ID.dataType)),
+      DSL.select(DSL.inline(siteId, PLANTING_SITES.ID.dataType)),
+      plotId,
+  )
 
   constructor(
       siteId: PlantingSiteId
@@ -506,7 +522,7 @@ class ObservationResultsSite(
       DSL.select(OBSERVATIONS.PLANTING_SITE_HISTORY_ID)
           .from(OBSERVATIONS)
           .where(OBSERVATIONS.ID.eq(OBSERVATION_SITE_RESULTS.OBSERVATION_ID)),
-      DSL.select(DSL.inline(siteId)),
+      DSL.select(DSL.inline(siteId, PLANTING_SITES.ID.dataType)),
   )
 
   constructor(

--- a/src/main/kotlin/com/terraformation/backend/tracking/util/ObservationSpeciesScope.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/util/ObservationSpeciesScope.kt
@@ -17,10 +17,14 @@ import com.terraformation.backend.db.tracking.tables.references.OBSERVED_PLOT_SP
 import com.terraformation.backend.db.tracking.tables.references.OBSERVED_SITE_SPECIES_TOTALS
 import com.terraformation.backend.db.tracking.tables.references.OBSERVED_STRATUM_SPECIES_TOTALS
 import com.terraformation.backend.db.tracking.tables.references.OBSERVED_SUBSTRATUM_SPECIES_TOTALS
+import com.terraformation.backend.db.tracking.tables.references.PLANTING_SITES
+import com.terraformation.backend.db.tracking.tables.references.PLANTING_SITE_HISTORIES
 import com.terraformation.backend.db.tracking.tables.references.PLOT_T0_DENSITIES
 import com.terraformation.backend.db.tracking.tables.references.STRATA
 import com.terraformation.backend.db.tracking.tables.references.STRATUM_HISTORIES
 import com.terraformation.backend.db.tracking.tables.references.STRATUM_T0_TEMP_DENSITIES
+import com.terraformation.backend.db.tracking.tables.references.SUBSTRATA
+import com.terraformation.backend.db.tracking.tables.references.SUBSTRATUM_HISTORIES
 import org.jooq.Condition
 import org.jooq.Record
 import org.jooq.Record1
@@ -53,7 +57,7 @@ class ObservationSpeciesPlot(
   constructor(
       plotId: MonitoringPlotId,
       plotHistoryId: MonitoringPlotHistoryId,
-  ) : this(plotId, DSL.select(DSL.inline(plotHistoryId)))
+  ) : this(plotId, DSL.select(DSL.inline(plotHistoryId, MONITORING_PLOT_HISTORIES.ID.dataType)))
 
   constructor(
       plotId: MonitoringPlotId
@@ -64,7 +68,8 @@ class ObservationSpeciesPlot(
           .where(MONITORING_PLOT_HISTORIES.MONITORING_PLOT_ID.eq(plotId)),
   )
 
-  override val scopeId: Select<Record1<MonitoringPlotId?>> = DSL.select(DSL.inline(plotId))
+  override val scopeId: Select<Record1<MonitoringPlotId?>> =
+      DSL.select(DSL.inline(plotId, MONITORING_PLOTS.ID.dataType))
 
   override val scopeHistoryId = plotHistorySelect
 
@@ -100,7 +105,11 @@ class ObservationSpeciesSubstratum(
       substratumHistoryId: SubstratumHistoryId,
       substratumId: SubstratumId? = null,
       plotId: MonitoringPlotId? = null,
-  ) : this(DSL.select(DSL.inline(substratumHistoryId)), substratumId, plotId)
+  ) : this(
+      DSL.select(DSL.inline(substratumHistoryId, SUBSTRATUM_HISTORIES.ID.dataType)),
+      substratumId,
+      plotId,
+  )
 
   constructor(
       plotId: MonitoringPlotId
@@ -116,9 +125,9 @@ class ObservationSpeciesSubstratum(
 
   override val scopeId: Select<Record1<SubstratumId?>> =
       if (substratumId != null) {
-        DSL.select(DSL.inline(substratumId))
+        DSL.select(DSL.inline(substratumId, SUBSTRATA.ID.dataType))
       } else {
-        DSL.select(DSL.castNull(OBSERVED_SUBSTRATUM_SPECIES_TOTALS.SUBSTRATUM_ID.dataType))
+        DSL.select(DSL.castNull(SUBSTRATA.ID.dataType))
       }
 
   override val scopeHistoryId = substratumHistorySelect
@@ -156,7 +165,11 @@ class ObservationSpeciesStratum(
       stratumHistoryId: StratumHistoryId,
       stratumId: StratumId? = null,
       plotId: MonitoringPlotId? = null,
-  ) : this(DSL.select(DSL.inline(stratumHistoryId)), stratumId, plotId)
+  ) : this(
+      DSL.select(DSL.inline(stratumHistoryId, STRATUM_HISTORIES.ID.dataType)),
+      stratumId,
+      plotId,
+  )
 
   constructor(
       stratumId: StratumId,
@@ -181,9 +194,9 @@ class ObservationSpeciesStratum(
 
   override val scopeId: Select<Record1<StratumId?>> =
       if (stratumId != null) {
-        DSL.select(DSL.inline(stratumId))
+        DSL.select(DSL.inline(stratumId, STRATA.ID.dataType))
       } else {
-        DSL.select(DSL.castNull(OBSERVED_STRATUM_SPECIES_TOTALS.STRATUM_ID.dataType))
+        DSL.select(DSL.castNull(STRATA.ID.dataType))
       }
 
   override val scopeHistoryId = stratumHistorySelect
@@ -227,7 +240,11 @@ class ObservationSpeciesSite(
       siteId: PlantingSiteId,
       siteHistoryId: PlantingSiteHistoryId,
       plotId: MonitoringPlotId? = null,
-  ) : this(DSL.select(DSL.inline(siteId)), DSL.select(DSL.inline(siteHistoryId)), plotId)
+  ) : this(
+      DSL.select(DSL.inline(siteId, PLANTING_SITES.ID.dataType)),
+      DSL.select(DSL.inline(siteHistoryId, PLANTING_SITE_HISTORIES.ID.dataType)),
+      plotId,
+  )
 
   constructor(
       plotId: MonitoringPlotId
@@ -253,7 +270,7 @@ class ObservationSpeciesSite(
   constructor(
       plantingSiteId: PlantingSiteId
   ) : this(
-      DSL.select(DSL.inline(plantingSiteId)),
+      DSL.select(DSL.inline(plantingSiteId, PLANTING_SITES.ID.dataType)),
       DSL.select(OBSERVATIONS.PLANTING_SITE_HISTORY_ID)
           .from(OBSERVATIONS)
           .where(OBSERVATIONS.ID.eq(OBSERVED_SITE_SPECIES_TOTALS.OBSERVATION_ID)),

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/ObservationScenarioTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/ObservationScenarioTest.kt
@@ -1158,7 +1158,10 @@ abstract class ObservationScenarioTest : DatabaseTest(), RunsAsUser {
       dslContext
           .insertInto(OBSERVATION_REQUESTED_SUBSTRATA, OBSERVATION_ID, SUBSTRATUM_ID)
           .select(
-              DSL.selectDistinct(DSL.value(observationId), MONITORING_PLOTS.SUBSTRATUM_ID)
+              DSL.selectDistinct(
+                      DSL.value(observationId, OBSERVATION_ID.dataType),
+                      MONITORING_PLOTS.SUBSTRATUM_ID,
+                  )
                   .from(MONITORING_PLOTS)
                   .where(MONITORING_PLOTS.PLOT_NUMBER.`in`(observedPlotNames.map { it.toLong() }))
           )


### PR DESCRIPTION
Explicitly supply the appropriate jOOQ DataType when injecting ID constants
into queries. This elimiates the warnings about relying on the static type
registry, which caused a lot of bothersome clutter when running the observation
results tests.