### PR TITLE
Fix intermittent T0StoreTest failures

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/tracking/db/T0Store.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/db/T0Store.kt
@@ -201,6 +201,7 @@ class T0Store(
                   OBSERVED_PLOT_SPECIES_TOTALS.TOTAL_DEAD.gt(0),
               )
           )
+          .orderBy(MONITORING_PLOT_ID, OBSERVATION_ID, SPECIES_ID)
           .fetchGroups(MONITORING_PLOT_ID.asNonNullable())
           .map { (monitoringPlotId, plotRecords) ->
             PlotObservationSpeciesDensityModel(


### PR DESCRIPTION
The test was relying on species being returned in ID order, but the actual result
was unordered.