### PR TITLE
SW-8420 Fetch and combine events for planting season notifications

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/plantingmanagement/db/PlantingSeasonNotificationsService.kt
+++ b/src/main/kotlin/com/terraformation/backend/plantingmanagement/db/PlantingSeasonNotificationsService.kt
@@ -83,6 +83,10 @@ class PlantingSeasonNotificationsService(
   private fun combineEvents(
       entries: List<EventLogEntry<PlantingSeasonPersistentEvent>>
   ): List<EventLogEntry<PlantingSeasonPersistentEvent>> {
+    require(entries.mapTo(mutableSetOf()) { it.event.plantingSeasonId }.size <= 1) {
+      "combineEvents must be called with entries for a single planting season"
+    }
+
     val combinableUpdates = entries.filter {
       val event = it.event
       event is PlantingSeasonUpdatedEvent && event.changedTo.status != PlantingSeasonStatus.Closed

--- a/src/main/kotlin/com/terraformation/backend/plantingmanagement/db/PlantingSeasonNotificationsService.kt
+++ b/src/main/kotlin/com/terraformation/backend/plantingmanagement/db/PlantingSeasonNotificationsService.kt
@@ -1,0 +1,152 @@
+package com.terraformation.backend.plantingmanagement.db
+
+import com.terraformation.backend.customer.model.requirePermissions
+import com.terraformation.backend.db.default_schema.EventLogId
+import com.terraformation.backend.db.default_schema.OrganizationId
+import com.terraformation.backend.db.tracking.PlantingSeasonId
+import com.terraformation.backend.db.tracking.PlantingSeasonStatus
+import com.terraformation.backend.db.tracking.tables.references.PLANTING_SEASONS
+import com.terraformation.backend.db.tracking.tables.references.PLANTING_SEASON_NOTIFICATIONS
+import com.terraformation.backend.eventlog.db.EventLogStore
+import com.terraformation.backend.eventlog.model.EventLogEntry
+import com.terraformation.backend.plantingmanagement.event.PlantingSeasonPersistentEvent
+import com.terraformation.backend.plantingmanagement.event.PlantingSeasonUpdatedEvent
+import com.terraformation.backend.plantingmanagement.event.PlantingSeasonUpdatedEventValues
+import jakarta.inject.Named
+import org.jooq.Condition
+import org.jooq.DSLContext
+
+@Named
+class PlantingSeasonNotificationsService(
+    private val dslContext: DSLContext,
+    private val eventLogStore: EventLogStore,
+) {
+
+  /**
+   * Returns the undismissed events for every planting season in an organization, grouped by
+   * planting season. A season that has never dismissed a notification has all of its events
+   * returned; a season with no undismissed events is absent from the result.
+   */
+  fun getNotifications(
+      organizationId: OrganizationId
+  ): Map<PlantingSeasonId, List<EventLogEntry<PlantingSeasonPersistentEvent>>> {
+    val dismissedEventIds =
+        fetchLastDismissedEventLogIdsByCondition(
+            PLANTING_SEASONS.plantingSites.ORGANIZATION_ID.eq(organizationId)
+        )
+
+    requirePermissions { dismissedEventIds.keys.forEach { readPlantingSeason(it) } }
+
+    if (dismissedEventIds.isEmpty()) {
+      return emptyMap()
+    }
+
+    return eventLogStore
+        .fetchByIdsSince(dismissedEventIds, listOf(PlantingSeasonPersistentEvent::class))
+        .groupBy { it.event.plantingSeasonId }
+        .mapValues { (_, events) -> combineEvents(events) }
+  }
+
+  /**
+   * Returns the undismissed events for a single planting season, ordered by the time they were
+   * logged. If the season has never dismissed a notification, all of its events are returned.
+   */
+  fun getNotifications(
+      plantingSeasonId: PlantingSeasonId
+  ): List<EventLogEntry<PlantingSeasonPersistentEvent>> {
+    requirePermissions { readPlantingSeason(plantingSeasonId) }
+
+    val dismissedEventIds =
+        fetchLastDismissedEventLogIdsByCondition(PLANTING_SEASONS.ID.eq(plantingSeasonId))
+
+    return combineEvents(
+        eventLogStore.fetchByIdsSince(
+            dismissedEventIds,
+            listOf(PlantingSeasonPersistentEvent::class),
+        )
+    )
+  }
+
+  /**
+   * Collapses the update events for a planting season into a single event, so that the result
+   * contains at most one update notification. For every field, the combined event keeps the
+   * [changedFrom][PlantingSeasonUpdatedEvent.changedFrom] value from the earliest update that
+   * changed it and the [changedTo][PlantingSeasonUpdatedEvent.changedTo] value from the latest
+   * update that changed it.
+   *
+   * Updates that change the status to [PlantingSeasonStatus.Closed] are excluded from the combined
+   * event and remain as separate events in the result. Non-update events are also left untouched.
+   *
+   * [entries] is expected to be ordered by the time each event was logged, which is the order
+   * returned by [EventLogStore.fetchByIdsSince].
+   */
+  private fun combineEvents(
+      entries: List<EventLogEntry<PlantingSeasonPersistentEvent>>
+  ): List<EventLogEntry<PlantingSeasonPersistentEvent>> {
+    val combinableUpdates = entries.filter {
+      val event = it.event
+      event is PlantingSeasonUpdatedEvent && event.changedTo.status != PlantingSeasonStatus.Closed
+    }
+
+    if (combinableUpdates.size < 2) {
+      return entries
+    }
+
+    val updateEvents = combinableUpdates.map { it.event as PlantingSeasonUpdatedEvent }
+    val combinedFrom =
+        PlantingSeasonUpdatedEventValues(
+            endDate = updateEvents.firstNotNullOfOrNull { it.changedFrom.endDate },
+            name = updateEvents.firstNotNullOfOrNull { it.changedFrom.name },
+            startDate = updateEvents.firstNotNullOfOrNull { it.changedFrom.startDate },
+            status = updateEvents.firstNotNullOfOrNull { it.changedFrom.status },
+        )
+    val combinedTo =
+        PlantingSeasonUpdatedEventValues(
+            endDate = updateEvents.lastNotNullOfOrNull { it.changedTo.endDate },
+            name = updateEvents.lastNotNullOfOrNull { it.changedTo.name },
+            startDate = updateEvents.lastNotNullOfOrNull { it.changedTo.startDate },
+            status = updateEvents.lastNotNullOfOrNull { it.changedTo.status },
+        )
+
+    val lastUpdateEntry = combinableUpdates.last()
+    val combinedEntry =
+        lastUpdateEntry.copy(
+            event = updateEvents.last().copy(changedFrom = combinedFrom, changedTo = combinedTo)
+        )
+
+    return entries.mapNotNull { entry ->
+      val event = entry.event
+      when {
+        event !is PlantingSeasonUpdatedEvent -> entry
+        event.changedTo.status == PlantingSeasonStatus.Closed -> entry
+        entry.id == lastUpdateEntry.id -> combinedEntry
+        else -> null
+      }
+    }
+  }
+
+  private fun <T, R> List<T>.lastNotNullOfOrNull(transform: (T) -> R?): R? =
+      asReversed().firstNotNullOfOrNull(transform)
+
+  /**
+   * Returns the dismissal watermark for every planting season matching [condition]. Every matching
+   * season is included; the value is null for seasons that have never dismissed a notification,
+   * which means all of their events should be treated as undismissed.
+   */
+  private fun fetchLastDismissedEventLogIdsByCondition(
+      condition: Condition
+  ): Map<PlantingSeasonId, EventLogId?> =
+      dslContext
+          .select(
+              PLANTING_SEASONS.ID,
+              PLANTING_SEASON_NOTIFICATIONS.LAST_DISMISSED_EVENT_LOG_ID,
+          )
+          .from(PLANTING_SEASONS)
+          .leftJoin(PLANTING_SEASON_NOTIFICATIONS)
+          .on(PLANTING_SEASON_NOTIFICATIONS.PLANTING_SEASON_ID.eq(PLANTING_SEASONS.ID))
+          .where(condition)
+          .associate { record ->
+            record[PLANTING_SEASONS.ID]!! to
+                record[PLANTING_SEASON_NOTIFICATIONS.LAST_DISMISSED_EVENT_LOG_ID]
+          }
+}

--- a/src/test/kotlin/com/terraformation/backend/db/DatabaseBackedTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/db/DatabaseBackedTest.kt
@@ -138,6 +138,7 @@ import com.terraformation.backend.db.default_schema.ConservationCategory
 import com.terraformation.backend.db.default_schema.DeviceId
 import com.terraformation.backend.db.default_schema.DisclaimerId
 import com.terraformation.backend.db.default_schema.EcosystemType
+import com.terraformation.backend.db.default_schema.EventLogId
 import com.terraformation.backend.db.default_schema.FacilityConnectionState
 import com.terraformation.backend.db.default_schema.FacilityId
 import com.terraformation.backend.db.default_schema.FacilityType
@@ -462,6 +463,7 @@ import com.terraformation.backend.db.tracking.tables.daos.ObservedPlotCoordinate
 import com.terraformation.backend.db.tracking.tables.daos.PlantingDateRequestSpeciesDao
 import com.terraformation.backend.db.tracking.tables.daos.PlantingDateRequestsDao
 import com.terraformation.backend.db.tracking.tables.daos.PlantingSeasonAllocatedSpeciesDao
+import com.terraformation.backend.db.tracking.tables.daos.PlantingSeasonNotificationsDao
 import com.terraformation.backend.db.tracking.tables.daos.PlantingSeasonSpeciesTargetsDao
 import com.terraformation.backend.db.tracking.tables.daos.PlantingSeasonsDao
 import com.terraformation.backend.db.tracking.tables.daos.PlantingSiteHistoriesDao
@@ -511,6 +513,7 @@ import com.terraformation.backend.db.tracking.tables.pojos.ObservedSubstratumSpe
 import com.terraformation.backend.db.tracking.tables.pojos.PlantingDateRequestSpeciesRow
 import com.terraformation.backend.db.tracking.tables.pojos.PlantingDateRequestsRow
 import com.terraformation.backend.db.tracking.tables.pojos.PlantingSeasonAllocatedSpeciesRow
+import com.terraformation.backend.db.tracking.tables.pojos.PlantingSeasonNotificationsRow
 import com.terraformation.backend.db.tracking.tables.pojos.PlantingSeasonSpeciesTargetsRow
 import com.terraformation.backend.db.tracking.tables.pojos.PlantingSeasonsRow
 import com.terraformation.backend.db.tracking.tables.pojos.PlantingSiteHistoriesRow
@@ -751,6 +754,7 @@ abstract class DatabaseBackedTest {
   protected val plantingsDao: PlantingsDao by lazyDao()
   protected val plantingSeasonsDao: PlantingSeasonsDao by lazyDao()
   protected val plantingSeasonAllocatedSpeciesDao: PlantingSeasonAllocatedSpeciesDao by lazyDao()
+  protected val plantingSeasonNotificationsDao: PlantingSeasonNotificationsDao by lazyDao()
   protected val plantingSeasonSpeciesTargetsDao: PlantingSeasonSpeciesTargetsDao by lazyDao()
   protected val plantingSiteHistoriesDao: PlantingSiteHistoriesDao by lazyDao()
   protected val plantingSiteNotificationsDao: PlantingSiteNotificationsDao by lazyDao()
@@ -2349,6 +2353,20 @@ abstract class DatabaseBackedTest {
         )
 
     plantingSeasonAllocatedSpeciesDao.insert(rowWithDefaults)
+  }
+
+  fun insertPlantingSeasonNotification(
+      row: PlantingSeasonNotificationsRow = PlantingSeasonNotificationsRow(),
+      plantingSeasonId: PlantingSeasonId = row.plantingSeasonId ?: inserted.plantingSeasonId,
+      lastDismissedEventLogId: EventLogId,
+  ) {
+    val rowWithDefaults =
+        row.copy(
+            plantingSeasonId = plantingSeasonId,
+            lastDismissedEventLogId = lastDismissedEventLogId,
+        )
+
+    plantingSeasonNotificationsDao.insert(rowWithDefaults)
   }
 
   fun insertPlantingSeasonSpeciesTarget(

--- a/src/test/kotlin/com/terraformation/backend/plantingmanagement/db/PlantingSeasonNotificationsServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/plantingmanagement/db/PlantingSeasonNotificationsServiceTest.kt
@@ -1,0 +1,322 @@
+package com.terraformation.backend.plantingmanagement.db
+
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.terraformation.backend.RunsAsDatabaseUser
+import com.terraformation.backend.TestClock
+import com.terraformation.backend.customer.model.TerrawareUser
+import com.terraformation.backend.db.DatabaseTest
+import com.terraformation.backend.db.default_schema.OrganizationId
+import com.terraformation.backend.db.default_schema.Role
+import com.terraformation.backend.db.tracking.PlantingSeasonId
+import com.terraformation.backend.db.tracking.PlantingSeasonStatus
+import com.terraformation.backend.db.tracking.PlantingSiteId
+import com.terraformation.backend.eventlog.db.EventLogStore
+import com.terraformation.backend.eventlog.model.EventLogEntry
+import com.terraformation.backend.plantingmanagement.event.PlantingSeasonCreatedEvent
+import com.terraformation.backend.plantingmanagement.event.PlantingSeasonDeletedEvent
+import com.terraformation.backend.plantingmanagement.event.PlantingSeasonPersistentEvent
+import com.terraformation.backend.plantingmanagement.event.PlantingSeasonUpdatedEvent
+import com.terraformation.backend.plantingmanagement.event.PlantingSeasonUpdatedEventValues
+import java.time.LocalDate
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+internal class PlantingSeasonNotificationsServiceTest : DatabaseTest(), RunsAsDatabaseUser {
+  override lateinit var user: TerrawareUser
+
+  private val clock = TestClock()
+  private val objectMapper = jacksonObjectMapper().registerModule(JavaTimeModule())
+  private val eventLogStore: EventLogStore by lazy {
+    EventLogStore(clock, dslContext, objectMapper)
+  }
+  private val service: PlantingSeasonNotificationsService by lazy {
+    PlantingSeasonNotificationsService(dslContext, eventLogStore)
+  }
+
+  private lateinit var organizationId: OrganizationId
+  private lateinit var plantingSiteId: PlantingSiteId
+  private lateinit var plantingSeasonId: PlantingSeasonId
+
+  @BeforeEach
+  fun setUp() {
+    organizationId = insertOrganization()
+    insertOrganizationUser(role = Role.Manager)
+    plantingSiteId = insertPlantingSite()
+    plantingSeasonId = insertPlantingSeason()
+  }
+
+  @Nested
+  inner class GetNotificationsByPlantingSeason {
+    @Test
+    fun `returns all events when the season has never dismissed a notification`() {
+      val created = insertCreatedEvent()
+      val deleted = insertDeletedEvent()
+
+      assertEquals(listOf(created, deleted), service.getNotifications(plantingSeasonId))
+    }
+
+    @Test
+    fun `returns only events logged after the dismissal watermark`() {
+      val dismissed = insertCreatedEvent()
+      val newer = insertCreatedEvent(name = "Newer")
+      val newest = insertDeletedEvent()
+      insertPlantingSeasonNotification(lastDismissedEventLogId = dismissed.id)
+
+      assertEquals(listOf(newer, newest), service.getNotifications(plantingSeasonId))
+    }
+
+    @Test
+    fun `returns a single combined update event per season`() {
+      insertUpdatedEvent(
+          changedFrom = PlantingSeasonUpdatedEventValues(name = "A"),
+          changedTo = PlantingSeasonUpdatedEventValues(name = "B"),
+      )
+      clock.instant = clock.instant.plusSeconds(1)
+      val second =
+          insertUpdatedEvent(
+              changedFrom = PlantingSeasonUpdatedEventValues(name = "B"),
+              changedTo = PlantingSeasonUpdatedEventValues(name = "C"),
+          )
+
+      val combined =
+          second.copy(
+              event =
+                  (second.event as PlantingSeasonUpdatedEvent).copy(
+                      changedFrom = PlantingSeasonUpdatedEventValues(name = "A")
+                  )
+          )
+
+      assertEquals(listOf(combined), service.getNotifications(plantingSeasonId))
+    }
+
+    @Test
+    fun `excludes events for other planting seasons`() {
+      val otherSeasonId = insertPlantingSeason()
+      val expected = insertCreatedEvent()
+      insertCreatedEvent(plantingSeasonId = otherSeasonId)
+
+      assertEquals(listOf(expected), service.getNotifications(plantingSeasonId))
+    }
+
+    @Test
+    fun `returns empty list when there are no undismissed events`() {
+      val dismissed = insertCreatedEvent()
+      insertPlantingSeasonNotification(lastDismissedEventLogId = dismissed.id)
+
+      assertEquals(
+          emptyList<EventLogEntry<PlantingSeasonPersistentEvent>>(),
+          service.getNotifications(plantingSeasonId),
+      )
+    }
+
+    @Test
+    fun `throws exception when user has no permission to read the planting season`() {
+      deleteOrganizationUser()
+
+      assertThrows<PlantingSeasonNotFoundException> { service.getNotifications(plantingSeasonId) }
+    }
+  }
+
+  @Nested
+  inner class GetNotificationsByOrganization {
+    @Test
+    fun `groups undismissed events by planting season`() {
+      val otherSeasonId = insertPlantingSeason()
+      val firstSeasonEvent = insertCreatedEvent()
+      val otherSeasonEvent = insertCreatedEvent(plantingSeasonId = otherSeasonId)
+
+      assertEquals(
+          mapOf(
+              plantingSeasonId to listOf(firstSeasonEvent),
+              otherSeasonId to listOf(otherSeasonEvent),
+          ),
+          service.getNotifications(organizationId),
+      )
+    }
+
+    @Test
+    fun `applies each season's dismissal watermark independently`() {
+      val otherSeasonId = insertPlantingSeason()
+      val dismissed = insertCreatedEvent()
+      val firstSeasonNewer = insertCreatedEvent(name = "Newer")
+      val otherSeasonEvent = insertCreatedEvent(plantingSeasonId = otherSeasonId)
+      insertPlantingSeasonNotification(
+          plantingSeasonId = plantingSeasonId,
+          lastDismissedEventLogId = dismissed.id,
+      )
+
+      assertEquals(
+          mapOf(
+              plantingSeasonId to listOf(firstSeasonNewer),
+              otherSeasonId to listOf(otherSeasonEvent),
+          ),
+          service.getNotifications(organizationId),
+      )
+    }
+
+    @Test
+    fun `excludes events from other organizations`() {
+      val expected = insertCreatedEvent()
+
+      val otherOrganizationId = insertOrganization()
+      val otherSiteId = insertPlantingSite(organizationId = otherOrganizationId)
+      val otherSeasonId = insertPlantingSeason(plantingSiteId = otherSiteId)
+      insertCreatedEvent(
+          organizationId = otherOrganizationId,
+          plantingSiteId = otherSiteId,
+          plantingSeasonId = otherSeasonId,
+      )
+
+      assertEquals(
+          mapOf(plantingSeasonId to listOf(expected)),
+          service.getNotifications(organizationId),
+      )
+    }
+
+    @Test
+    fun `returns empty map when the organization has no planting seasons`() {
+      val emptyOrganizationId = insertOrganization()
+
+      assertEquals(
+          emptyMap<PlantingSeasonId, List<EventLogEntry<PlantingSeasonPersistentEvent>>>(),
+          service.getNotifications(emptyOrganizationId),
+      )
+    }
+
+    @Test
+    fun `throws exception when user lacks permission for a season in the organization`() {
+      deleteOrganizationUser()
+
+      assertThrows<PlantingSeasonNotFoundException> { service.getNotifications(organizationId) }
+    }
+  }
+
+  @Nested
+  inner class CombineEvents {
+    @Test
+    fun `merges correctly and keeps non-update events`() {
+      val firstStart = LocalDate.of(2024, 1, 1)
+      val secondStart = LocalDate.of(2024, 2, 1)
+      val firstEnd = LocalDate.of(2024, 6, 1)
+      val secondEnd = LocalDate.of(2024, 7, 1)
+
+      val created = insertCreatedEvent()
+      insertUpdatedEvent(
+          changedFrom = PlantingSeasonUpdatedEventValues(name = "A", startDate = firstStart),
+          changedTo = PlantingSeasonUpdatedEventValues(name = "B", startDate = secondStart),
+      )
+      clock.instant = clock.instant.plusSeconds(1)
+      val second =
+          insertUpdatedEvent(
+              changedFrom =
+                  PlantingSeasonUpdatedEventValues(
+                      endDate = firstEnd,
+                      status = PlantingSeasonStatus.Upcoming,
+                  ),
+              changedTo =
+                  PlantingSeasonUpdatedEventValues(
+                      endDate = secondEnd,
+                      status = PlantingSeasonStatus.Active,
+                  ),
+          )
+      clock.instant = clock.instant.plusSeconds(1)
+      val third =
+          insertUpdatedEvent(
+              changedFrom = PlantingSeasonUpdatedEventValues(status = PlantingSeasonStatus.Active),
+              changedTo = PlantingSeasonUpdatedEventValues(status = PlantingSeasonStatus.Closed),
+          )
+
+      val combined =
+          second.copy(
+              event =
+                  (second.event as PlantingSeasonUpdatedEvent).copy(
+                      changedFrom =
+                          PlantingSeasonUpdatedEventValues(
+                              endDate = firstEnd,
+                              name = "A",
+                              startDate = firstStart,
+                              status = PlantingSeasonStatus.Upcoming,
+                          ),
+                      changedTo =
+                          PlantingSeasonUpdatedEventValues(
+                              endDate = secondEnd,
+                              name = "B",
+                              startDate = secondStart,
+                              status = PlantingSeasonStatus.Active,
+                          ),
+                  )
+          )
+
+      assertEquals(listOf(created, combined, third), service.getNotifications(plantingSeasonId))
+    }
+
+    @Test
+    fun `leaves a single update event unchanged`() {
+      val update =
+          insertUpdatedEvent(
+              changedFrom = PlantingSeasonUpdatedEventValues(name = "A"),
+              changedTo = PlantingSeasonUpdatedEventValues(name = "B"),
+          )
+
+      assertEquals(listOf(update), service.getNotifications(plantingSeasonId))
+    }
+  }
+
+  private fun insertUpdatedEvent(
+      changedFrom: PlantingSeasonUpdatedEventValues = PlantingSeasonUpdatedEventValues(),
+      changedTo: PlantingSeasonUpdatedEventValues = PlantingSeasonUpdatedEventValues(),
+      plantingSeasonId: PlantingSeasonId = this.plantingSeasonId,
+      plantingSiteId: PlantingSiteId = this.plantingSiteId,
+      organizationId: OrganizationId = this.organizationId,
+  ): EventLogEntry<PlantingSeasonPersistentEvent> {
+    val event =
+        PlantingSeasonUpdatedEvent(
+            changedFrom = changedFrom,
+            changedTo = changedTo,
+            organizationId = organizationId,
+            plantingSeasonId = plantingSeasonId,
+            plantingSiteId = plantingSiteId,
+        )
+
+    return EventLogEntry(user.userId, clock.instant, event, eventLogStore.insertEvent(event))
+  }
+
+  private fun insertCreatedEvent(
+      plantingSeasonId: PlantingSeasonId = this.plantingSeasonId,
+      name: String = "Season",
+      plantingSiteId: PlantingSiteId = this.plantingSiteId,
+      organizationId: OrganizationId = this.organizationId,
+  ): EventLogEntry<PlantingSeasonPersistentEvent> {
+    val event =
+        PlantingSeasonCreatedEvent(
+            endDate = LocalDate.EPOCH.plusDays(1),
+            name = name,
+            organizationId = organizationId,
+            plantingSeasonId = plantingSeasonId,
+            plantingSiteId = plantingSiteId,
+            startDate = LocalDate.EPOCH,
+            status = PlantingSeasonStatus.Upcoming,
+        )
+
+    return EventLogEntry(user.userId, clock.instant, event, eventLogStore.insertEvent(event))
+  }
+
+  private fun insertDeletedEvent(
+      plantingSeasonId: PlantingSeasonId = this.plantingSeasonId,
+      plantingSiteId: PlantingSiteId = this.plantingSiteId,
+      organizationId: OrganizationId = this.organizationId,
+  ): EventLogEntry<PlantingSeasonPersistentEvent> {
+    val event =
+        PlantingSeasonDeletedEvent(
+            organizationId = organizationId,
+            plantingSeasonId = plantingSeasonId,
+            plantingSiteId = plantingSiteId,
+        )
+
+    return EventLogEntry(user.userId, clock.instant, event, eventLogStore.insertEvent(event))
+  }
+}


### PR DESCRIPTION
Create a `PlantingSeasonNotificationService` to query the `event_log` by org or planting season and group the results by planting season. Include a method to combine update events such that only the first From and the last To for each (value type) are included in a single event, excluding a Closed event.

Co-authored-by: Claude Opus 4.8 [noreply@anthropic.com](mailto:noreply@anthropic.com)