### PR TITLE
SW-8420 Fetch and combine events for planting season target notifications

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/plantingmanagement/db/PlantingSeasonNotificationsService.kt
+++ b/src/main/kotlin/com/terraformation/backend/plantingmanagement/db/PlantingSeasonNotificationsService.kt
@@ -8,7 +8,6 @@ import com.terraformation.backend.db.tracking.PlantingSeasonStatus
 import com.terraformation.backend.db.tracking.tables.references.PLANTING_SEASONS
 import com.terraformation.backend.db.tracking.tables.references.PLANTING_SEASON_NOTIFICATIONS
 import com.terraformation.backend.eventlog.db.EventLogStore
-import com.terraformation.backend.eventlog.model.EventLogEntry
 import com.terraformation.backend.plantingmanagement.event.PlantingSeasonPersistentEvent
 import com.terraformation.backend.plantingmanagement.event.PlantingSeasonRelatedPersistentEvent
 import com.terraformation.backend.plantingmanagement.event.PlantingSeasonSpeciesTargetPersistentEvent
@@ -16,6 +15,7 @@ import com.terraformation.backend.plantingmanagement.event.PlantingSeasonSpecies
 import com.terraformation.backend.plantingmanagement.event.PlantingSeasonUpdatedEvent
 import com.terraformation.backend.plantingmanagement.event.PlantingSeasonUpdatedEventValues
 import jakarta.inject.Named
+import kotlin.reflect.KClass
 import org.jooq.Condition
 import org.jooq.DSLContext
 
@@ -24,7 +24,7 @@ class PlantingSeasonNotificationsService(
     private val dslContext: DSLContext,
     private val eventLogStore: EventLogStore,
 ) {
-  private val notificationEventClasses =
+  private val notificationEventClasses: List<KClass<out PlantingSeasonRelatedPersistentEvent>> =
       listOf(
           PlantingSeasonPersistentEvent::class,
           PlantingSeasonSpeciesTargetPersistentEvent::class,
@@ -37,7 +37,7 @@ class PlantingSeasonNotificationsService(
    */
   fun getNotifications(
       organizationId: OrganizationId
-  ): Map<PlantingSeasonId, List<EventLogEntry<PlantingSeasonRelatedPersistentEvent>>> {
+  ): Map<PlantingSeasonId, List<PlantingSeasonRelatedPersistentEvent>> {
     val dismissedEventIds =
         fetchLastDismissedEventLogIdsByCondition(
             PLANTING_SEASONS.plantingSites.ORGANIZATION_ID.eq(organizationId)
@@ -54,7 +54,8 @@ class PlantingSeasonNotificationsService(
             dismissedEventIds,
             notificationEventClasses,
         )
-        .groupBy { it.event.plantingSeasonId }
+        .map { it.event }
+        .groupBy { it.plantingSeasonId }
         .mapValues { (_, events) -> combineEvents(events) }
   }
 
@@ -64,17 +65,19 @@ class PlantingSeasonNotificationsService(
    */
   fun getNotifications(
       plantingSeasonId: PlantingSeasonId
-  ): List<EventLogEntry<PlantingSeasonRelatedPersistentEvent>> {
+  ): List<PlantingSeasonRelatedPersistentEvent> {
     requirePermissions { readPlantingSeason(plantingSeasonId) }
 
     val dismissedEventIds =
         fetchLastDismissedEventLogIdsByCondition(PLANTING_SEASONS.ID.eq(plantingSeasonId))
 
     return combineEvents(
-        eventLogStore.fetchByIdsSince(
-            dismissedEventIds,
-            notificationEventClasses,
-        )
+        eventLogStore
+            .fetchByIdsSince(
+                dismissedEventIds,
+                notificationEventClasses,
+            )
+            .map { it.event }
     )
   }
 
@@ -82,13 +85,17 @@ class PlantingSeasonNotificationsService(
    * Collapses the update events for a planting season into at most one update notification per kind
    * of update. Non-update events are left untouched.
    *
-   * [entries] is expected to be ordered by the time each event was logged, which is the order
+   * [events] is expected to be ordered by the time each event was logged, which is the order
    * returned by [EventLogStore.fetchByIdsSince].
    */
   private fun combineEvents(
-      entries: List<EventLogEntry<PlantingSeasonRelatedPersistentEvent>>
-  ): List<EventLogEntry<PlantingSeasonRelatedPersistentEvent>> {
-    return combineSpeciesTargetUpdates(combineSeasonUpdates(entries))
+      events: List<PlantingSeasonRelatedPersistentEvent>
+  ): List<PlantingSeasonRelatedPersistentEvent> {
+    require(events.mapTo(mutableSetOf()) { it.plantingSeasonId }.size <= 1) {
+      "combineEvents must be called with events for a single planting season"
+    }
+
+    return combineSpeciesTargetUpdates(combineSeasonUpdates(events))
   }
 
   /**
@@ -101,48 +108,39 @@ class PlantingSeasonNotificationsService(
    * event and remain as separate events in the result.
    */
   private fun combineSeasonUpdates(
-      entries: List<EventLogEntry<PlantingSeasonRelatedPersistentEvent>>
-  ): List<EventLogEntry<PlantingSeasonRelatedPersistentEvent>> {
-    require(entries.mapTo(mutableSetOf()) { it.event.plantingSeasonId }.size <= 1) {
-      "combineEvents must be called with entries for a single planting season"
-    }
-    val combinableUpdates = entries.filter {
-      val event = it.event
-      event is PlantingSeasonUpdatedEvent && event.changedTo.status != PlantingSeasonStatus.Closed
-    }
+      events: List<PlantingSeasonRelatedPersistentEvent>
+  ): List<PlantingSeasonRelatedPersistentEvent> {
+    val combinableUpdates =
+        events.filterIsInstance<PlantingSeasonUpdatedEvent>().filter {
+          it.changedTo.status != PlantingSeasonStatus.Closed
+        }
 
     if (combinableUpdates.size < 2) {
-      return entries
+      return events
     }
 
-    val updateEvents = combinableUpdates.map { it.event as PlantingSeasonUpdatedEvent }
     val combinedFrom =
         PlantingSeasonUpdatedEventValues(
-            endDate = updateEvents.firstNotNullOfOrNull { it.changedFrom.endDate },
-            name = updateEvents.firstNotNullOfOrNull { it.changedFrom.name },
-            startDate = updateEvents.firstNotNullOfOrNull { it.changedFrom.startDate },
-            status = updateEvents.firstNotNullOfOrNull { it.changedFrom.status },
+            endDate = combinableUpdates.firstNotNullOfOrNull { it.changedFrom.endDate },
+            name = combinableUpdates.firstNotNullOfOrNull { it.changedFrom.name },
+            startDate = combinableUpdates.firstNotNullOfOrNull { it.changedFrom.startDate },
+            status = combinableUpdates.firstNotNullOfOrNull { it.changedFrom.status },
         )
     val combinedTo =
         PlantingSeasonUpdatedEventValues(
-            endDate = updateEvents.lastNotNullOfOrNull { it.changedTo.endDate },
-            name = updateEvents.lastNotNullOfOrNull { it.changedTo.name },
-            startDate = updateEvents.lastNotNullOfOrNull { it.changedTo.startDate },
-            status = updateEvents.lastNotNullOfOrNull { it.changedTo.status },
+            endDate = combinableUpdates.lastNotNullOfOrNull { it.changedTo.endDate },
+            name = combinableUpdates.lastNotNullOfOrNull { it.changedTo.name },
+            startDate = combinableUpdates.lastNotNullOfOrNull { it.changedTo.startDate },
+            status = combinableUpdates.lastNotNullOfOrNull { it.changedTo.status },
         )
 
-    val lastUpdateEntry = combinableUpdates.last()
-    val combinedEntry =
-        lastUpdateEntry.copy(
-            event = updateEvents.last().copy(changedFrom = combinedFrom, changedTo = combinedTo)
-        )
+    val lastCombinable = combinableUpdates.last()
 
-    return entries.mapNotNull { entry ->
-      val event = entry.event
+    return events.mapNotNull { event ->
       when {
-        event !is PlantingSeasonUpdatedEvent -> entry
-        event.changedTo.status == PlantingSeasonStatus.Closed -> entry
-        entry.id == lastUpdateEntry.id -> combinedEntry
+        event !is PlantingSeasonUpdatedEvent -> event
+        event.changedTo.status == PlantingSeasonStatus.Closed -> event
+        event === lastCombinable -> event.copy(changedFrom = combinedFrom, changedTo = combinedTo)
         else -> null
       }
     }
@@ -156,41 +154,28 @@ class PlantingSeasonNotificationsService(
    * keeps that target's last update as a representative.
    */
   private fun combineSpeciesTargetUpdates(
-      entries: List<EventLogEntry<PlantingSeasonRelatedPersistentEvent>>
-  ): List<EventLogEntry<PlantingSeasonRelatedPersistentEvent>> {
+      events: List<PlantingSeasonRelatedPersistentEvent>
+  ): List<PlantingSeasonRelatedPersistentEvent> {
     val updatesByTarget =
-        entries
-            .filter { it.event is PlantingSeasonSpeciesTargetUpdatedEvent }
-            .groupBy {
-              val event = it.event as PlantingSeasonSpeciesTargetUpdatedEvent
-              event.speciesId to event.substratumId
-            }
+        events
+            .filterIsInstance<PlantingSeasonSpeciesTargetUpdatedEvent>()
+            .groupBy { it.speciesId to it.substratumId }
+            .filterValues { it.size >= 2 }
 
-    val combinedByLastId =
-        mutableMapOf<EventLogId, EventLogEntry<PlantingSeasonRelatedPersistentEvent>>()
-    val combinedIds = mutableSetOf<EventLogId>()
-
-    updatesByTarget.values
-        .filter { it.size >= 2 }
-        .forEach { group ->
-          val updateEvents = group.map { it.event as PlantingSeasonSpeciesTargetUpdatedEvent }
-          val lastEntry = group.last()
-          combinedByLastId[lastEntry.id] =
-              lastEntry.copy(
-                  event = updateEvents.last().copy(changedFrom = updateEvents.first().changedFrom)
-              )
-          group.forEach { combinedIds += it.id }
-        }
-
-    if (combinedByLastId.isEmpty()) {
-      return entries
+    if (updatesByTarget.isEmpty()) {
+      return events
     }
 
-    return entries.mapNotNull { entry ->
-      when {
-        entry.id in combinedByLastId -> combinedByLastId[entry.id]
-        entry.id in combinedIds -> null
-        else -> entry
+    return events.mapNotNull { event ->
+      if (event !is PlantingSeasonSpeciesTargetUpdatedEvent) {
+        event
+      } else {
+        val group = updatesByTarget[event.speciesId to event.substratumId]
+        when {
+          group == null -> event
+          event === group.last() -> group.last().copy(changedFrom = group.first().changedFrom)
+          else -> null
+        }
       }
     }
   }

--- a/src/main/kotlin/com/terraformation/backend/plantingmanagement/db/PlantingSeasonNotificationsService.kt
+++ b/src/main/kotlin/com/terraformation/backend/plantingmanagement/db/PlantingSeasonNotificationsService.kt
@@ -10,6 +10,9 @@ import com.terraformation.backend.db.tracking.tables.references.PLANTING_SEASON_
 import com.terraformation.backend.eventlog.db.EventLogStore
 import com.terraformation.backend.eventlog.model.EventLogEntry
 import com.terraformation.backend.plantingmanagement.event.PlantingSeasonPersistentEvent
+import com.terraformation.backend.plantingmanagement.event.PlantingSeasonRelatedPersistentEvent
+import com.terraformation.backend.plantingmanagement.event.PlantingSeasonSpeciesTargetPersistentEvent
+import com.terraformation.backend.plantingmanagement.event.PlantingSeasonSpeciesTargetUpdatedEvent
 import com.terraformation.backend.plantingmanagement.event.PlantingSeasonUpdatedEvent
 import com.terraformation.backend.plantingmanagement.event.PlantingSeasonUpdatedEventValues
 import jakarta.inject.Named
@@ -21,6 +24,11 @@ class PlantingSeasonNotificationsService(
     private val dslContext: DSLContext,
     private val eventLogStore: EventLogStore,
 ) {
+  private val notificationEventClasses =
+      listOf(
+          PlantingSeasonPersistentEvent::class,
+          PlantingSeasonSpeciesTargetPersistentEvent::class,
+      )
 
   /**
    * Returns the undismissed events for every planting season in an organization, grouped by
@@ -29,7 +37,7 @@ class PlantingSeasonNotificationsService(
    */
   fun getNotifications(
       organizationId: OrganizationId
-  ): Map<PlantingSeasonId, List<EventLogEntry<PlantingSeasonPersistentEvent>>> {
+  ): Map<PlantingSeasonId, List<EventLogEntry<PlantingSeasonRelatedPersistentEvent>>> {
     val dismissedEventIds =
         fetchLastDismissedEventLogIdsByCondition(
             PLANTING_SEASONS.plantingSites.ORGANIZATION_ID.eq(organizationId)
@@ -42,7 +50,10 @@ class PlantingSeasonNotificationsService(
     }
 
     return eventLogStore
-        .fetchByIdsSince(dismissedEventIds, listOf(PlantingSeasonPersistentEvent::class))
+        .fetchByIdsSince(
+            dismissedEventIds,
+            notificationEventClasses,
+        )
         .groupBy { it.event.plantingSeasonId }
         .mapValues { (_, events) -> combineEvents(events) }
   }
@@ -53,7 +64,7 @@ class PlantingSeasonNotificationsService(
    */
   fun getNotifications(
       plantingSeasonId: PlantingSeasonId
-  ): List<EventLogEntry<PlantingSeasonPersistentEvent>> {
+  ): List<EventLogEntry<PlantingSeasonRelatedPersistentEvent>> {
     requirePermissions { readPlantingSeason(plantingSeasonId) }
 
     val dismissedEventIds =
@@ -62,31 +73,39 @@ class PlantingSeasonNotificationsService(
     return combineEvents(
         eventLogStore.fetchByIdsSince(
             dismissedEventIds,
-            listOf(PlantingSeasonPersistentEvent::class),
+            notificationEventClasses,
         )
     )
   }
 
   /**
-   * Collapses the update events for a planting season into a single event, so that the result
-   * contains at most one update notification. For every field, the combined event keeps the
-   * [changedFrom][PlantingSeasonUpdatedEvent.changedFrom] value from the earliest update that
-   * changed it and the [changedTo][PlantingSeasonUpdatedEvent.changedTo] value from the latest
-   * update that changed it.
-   *
-   * Updates that change the status to [PlantingSeasonStatus.Closed] are excluded from the combined
-   * event and remain as separate events in the result. Non-update events are also left untouched.
+   * Collapses the update events for a planting season into at most one update notification per kind
+   * of update. Non-update events are left untouched.
    *
    * [entries] is expected to be ordered by the time each event was logged, which is the order
    * returned by [EventLogStore.fetchByIdsSince].
    */
   private fun combineEvents(
-      entries: List<EventLogEntry<PlantingSeasonPersistentEvent>>
-  ): List<EventLogEntry<PlantingSeasonPersistentEvent>> {
+      entries: List<EventLogEntry<PlantingSeasonRelatedPersistentEvent>>
+  ): List<EventLogEntry<PlantingSeasonRelatedPersistentEvent>> {
+    return combineSpeciesTargetUpdates(combineSeasonUpdates(entries))
+  }
+
+  /**
+   * Collapses the [PlantingSeasonUpdatedEvent]s for a season into a single event. For every field,
+   * the combined event keeps the [changedFrom][PlantingSeasonUpdatedEvent.changedFrom] value from
+   * the earliest update that changed it and the [changedTo][PlantingSeasonUpdatedEvent.changedTo]
+   * value from the latest update that changed it.
+   *
+   * Updates that change the status to [PlantingSeasonStatus.Closed] are excluded from the combined
+   * event and remain as separate events in the result.
+   */
+  private fun combineSeasonUpdates(
+      entries: List<EventLogEntry<PlantingSeasonRelatedPersistentEvent>>
+  ): List<EventLogEntry<PlantingSeasonRelatedPersistentEvent>> {
     require(entries.mapTo(mutableSetOf()) { it.event.plantingSeasonId }.size <= 1) {
       "combineEvents must be called with entries for a single planting season"
     }
-
     val combinableUpdates = entries.filter {
       val event = it.event
       event is PlantingSeasonUpdatedEvent && event.changedTo.status != PlantingSeasonStatus.Closed
@@ -125,6 +144,53 @@ class PlantingSeasonNotificationsService(
         event.changedTo.status == PlantingSeasonStatus.Closed -> entry
         entry.id == lastUpdateEntry.id -> combinedEntry
         else -> null
+      }
+    }
+  }
+
+  /**
+   * Collapses the [PlantingSeasonSpeciesTargetUpdatedEvent]s for each species target into a single
+   * event, keeping the [changedFrom][PlantingSeasonSpeciesTargetUpdatedEvent.changedFrom] of the
+   * earliest update and the [changedTo][PlantingSeasonSpeciesTargetUpdatedEvent.changedTo] of the
+   * latest update. Only updates to the same species and substratum are combined; the combined event
+   * keeps that target's last update as a representative.
+   */
+  private fun combineSpeciesTargetUpdates(
+      entries: List<EventLogEntry<PlantingSeasonRelatedPersistentEvent>>
+  ): List<EventLogEntry<PlantingSeasonRelatedPersistentEvent>> {
+    val updatesByTarget =
+        entries
+            .filter { it.event is PlantingSeasonSpeciesTargetUpdatedEvent }
+            .groupBy {
+              val event = it.event as PlantingSeasonSpeciesTargetUpdatedEvent
+              event.speciesId to event.substratumId
+            }
+
+    val combinedByLastId =
+        mutableMapOf<EventLogId, EventLogEntry<PlantingSeasonRelatedPersistentEvent>>()
+    val combinedIds = mutableSetOf<EventLogId>()
+
+    updatesByTarget.values
+        .filter { it.size >= 2 }
+        .forEach { group ->
+          val updateEvents = group.map { it.event as PlantingSeasonSpeciesTargetUpdatedEvent }
+          val lastEntry = group.last()
+          combinedByLastId[lastEntry.id] =
+              lastEntry.copy(
+                  event = updateEvents.last().copy(changedFrom = updateEvents.first().changedFrom)
+              )
+          group.forEach { combinedIds += it.id }
+        }
+
+    if (combinedByLastId.isEmpty()) {
+      return entries
+    }
+
+    return entries.mapNotNull { entry ->
+      when {
+        entry.id in combinedByLastId -> combinedByLastId[entry.id]
+        entry.id in combinedIds -> null
+        else -> entry
       }
     }
   }

--- a/src/main/kotlin/com/terraformation/backend/plantingmanagement/event/PlantingSeasonPersistentEvent.kt
+++ b/src/main/kotlin/com/terraformation/backend/plantingmanagement/event/PlantingSeasonPersistentEvent.kt
@@ -7,15 +7,14 @@ import com.terraformation.backend.db.tracking.PlantingSiteId
 import com.terraformation.backend.eventlog.EntityCreatedPersistentEvent
 import com.terraformation.backend.eventlog.EntityDeletedPersistentEvent
 import com.terraformation.backend.eventlog.FieldsUpdatedPersistentEvent
-import com.terraformation.backend.eventlog.PersistentEvent
 import com.terraformation.backend.i18n.Messages
 import com.terraformation.backend.i18n.currentLocale
 import java.time.LocalDate
 
-sealed interface PlantingSeasonPersistentEvent : PersistentEvent {
-  val organizationId: OrganizationId
-  val plantingSeasonId: PlantingSeasonId
-  val plantingSiteId: PlantingSiteId
+sealed interface PlantingSeasonPersistentEvent : PlantingSeasonRelatedPersistentEvent {
+  override val organizationId: OrganizationId
+  override val plantingSeasonId: PlantingSeasonId
+  override val plantingSiteId: PlantingSiteId
 }
 
 data class PlantingSeasonCreatedEventV1(

--- a/src/main/kotlin/com/terraformation/backend/plantingmanagement/event/PlantingSeasonRelatedPersistentEvent.kt
+++ b/src/main/kotlin/com/terraformation/backend/plantingmanagement/event/PlantingSeasonRelatedPersistentEvent.kt
@@ -1,0 +1,17 @@
+package com.terraformation.backend.plantingmanagement.event
+
+import com.terraformation.backend.db.default_schema.OrganizationId
+import com.terraformation.backend.db.tracking.PlantingSeasonId
+import com.terraformation.backend.db.tracking.PlantingSiteId
+import com.terraformation.backend.eventlog.PersistentEvent
+
+/**
+ * Common supertype for events that are scoped to a planting season. This lets the notification
+ * machinery fetch and group the different kinds of planting season events together by
+ * [plantingSeasonId].
+ */
+interface PlantingSeasonRelatedPersistentEvent : PersistentEvent {
+  val organizationId: OrganizationId
+  val plantingSeasonId: PlantingSeasonId
+  val plantingSiteId: PlantingSiteId
+}

--- a/src/main/kotlin/com/terraformation/backend/plantingmanagement/event/PlantingSeasonSpeciesTargetPersistentEvent.kt
+++ b/src/main/kotlin/com/terraformation/backend/plantingmanagement/event/PlantingSeasonSpeciesTargetPersistentEvent.kt
@@ -9,14 +9,13 @@ import com.terraformation.backend.db.tracking.SubstratumId
 import com.terraformation.backend.eventlog.EntityCreatedPersistentEvent
 import com.terraformation.backend.eventlog.EntityDeletedPersistentEvent
 import com.terraformation.backend.eventlog.FieldsUpdatedPersistentEvent
-import com.terraformation.backend.eventlog.PersistentEvent
 import com.terraformation.backend.i18n.Messages
 import com.terraformation.backend.util.nullIfEquals
 
-sealed interface PlantingSeasonSpeciesTargetPersistentEvent : PersistentEvent {
-  val organizationId: OrganizationId
-  val plantingSeasonId: PlantingSeasonId
-  val plantingSiteId: PlantingSiteId
+sealed interface PlantingSeasonSpeciesTargetPersistentEvent : PlantingSeasonRelatedPersistentEvent {
+  override val organizationId: OrganizationId
+  override val plantingSeasonId: PlantingSeasonId
+  override val plantingSiteId: PlantingSiteId
   val speciesId: SpeciesId
   val stratumName: String
   val substratumHistoryId: SubstratumHistoryId

--- a/src/test/kotlin/com/terraformation/backend/plantingmanagement/db/PlantingSeasonNotificationsServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/plantingmanagement/db/PlantingSeasonNotificationsServiceTest.kt
@@ -8,14 +8,21 @@ import com.terraformation.backend.customer.model.TerrawareUser
 import com.terraformation.backend.db.DatabaseTest
 import com.terraformation.backend.db.default_schema.OrganizationId
 import com.terraformation.backend.db.default_schema.Role
+import com.terraformation.backend.db.default_schema.SpeciesId
 import com.terraformation.backend.db.tracking.PlantingSeasonId
 import com.terraformation.backend.db.tracking.PlantingSeasonStatus
 import com.terraformation.backend.db.tracking.PlantingSiteId
+import com.terraformation.backend.db.tracking.StratumId
+import com.terraformation.backend.db.tracking.SubstratumHistoryId
+import com.terraformation.backend.db.tracking.SubstratumId
 import com.terraformation.backend.eventlog.db.EventLogStore
 import com.terraformation.backend.eventlog.model.EventLogEntry
 import com.terraformation.backend.plantingmanagement.event.PlantingSeasonCreatedEvent
 import com.terraformation.backend.plantingmanagement.event.PlantingSeasonDeletedEvent
-import com.terraformation.backend.plantingmanagement.event.PlantingSeasonPersistentEvent
+import com.terraformation.backend.plantingmanagement.event.PlantingSeasonRelatedPersistentEvent
+import com.terraformation.backend.plantingmanagement.event.PlantingSeasonSpeciesTargetCreatedEvent
+import com.terraformation.backend.plantingmanagement.event.PlantingSeasonSpeciesTargetUpdatedEvent
+import com.terraformation.backend.plantingmanagement.event.PlantingSeasonSpeciesTargetUpdatedEventValues
 import com.terraformation.backend.plantingmanagement.event.PlantingSeasonUpdatedEvent
 import com.terraformation.backend.plantingmanagement.event.PlantingSeasonUpdatedEventValues
 import java.time.LocalDate
@@ -39,14 +46,22 @@ internal class PlantingSeasonNotificationsServiceTest : DatabaseTest(), RunsAsDa
 
   private lateinit var organizationId: OrganizationId
   private lateinit var plantingSiteId: PlantingSiteId
+  private lateinit var stratumId1: StratumId
+  private lateinit var substratumId1: SubstratumId
   private lateinit var plantingSeasonId: PlantingSeasonId
+  private lateinit var speciesId1: SpeciesId
+  private lateinit var speciesId2: SpeciesId
 
   @BeforeEach
   fun setUp() {
     organizationId = insertOrganization()
     insertOrganizationUser(role = Role.Manager)
     plantingSiteId = insertPlantingSite()
+    stratumId1 = insertStratum()
+    substratumId1 = insertSubstratum()
     plantingSeasonId = insertPlantingSeason()
+    speciesId1 = insertSpecies()
+    speciesId2 = insertSpecies()
   }
 
   @Nested
@@ -108,7 +123,7 @@ internal class PlantingSeasonNotificationsServiceTest : DatabaseTest(), RunsAsDa
       insertPlantingSeasonNotification(lastDismissedEventLogId = dismissed.id)
 
       assertEquals(
-          emptyList<EventLogEntry<PlantingSeasonPersistentEvent>>(),
+          emptyList<EventLogEntry<PlantingSeasonRelatedPersistentEvent>>(),
           service.getNotifications(plantingSeasonId),
       )
     }
@@ -182,7 +197,7 @@ internal class PlantingSeasonNotificationsServiceTest : DatabaseTest(), RunsAsDa
       val emptyOrganizationId = insertOrganization()
 
       assertEquals(
-          emptyMap<PlantingSeasonId, List<EventLogEntry<PlantingSeasonPersistentEvent>>>(),
+          emptyMap<PlantingSeasonId, List<EventLogEntry<PlantingSeasonRelatedPersistentEvent>>>(),
           service.getNotifications(emptyOrganizationId),
       )
     }
@@ -266,13 +281,145 @@ internal class PlantingSeasonNotificationsServiceTest : DatabaseTest(), RunsAsDa
     }
   }
 
+  @Nested
+  inner class CombineSpeciesTargetEvents {
+    @Test
+    fun `groups season and species target events together`() {
+      val seasonCreated = insertCreatedEvent()
+      val targetCreated = insertSpeciesTargetCreatedEvent()
+
+      assertEquals(listOf(seasonCreated, targetCreated), service.getNotifications(plantingSeasonId))
+    }
+
+    @Test
+    fun `combines updates to the same species and substratum keeping earliest changedFrom and latest changedTo`() {
+      insertSpeciesTargetUpdatedEvent(
+          speciesId = speciesId1,
+          changedFrom = PlantingSeasonSpeciesTargetUpdatedEventValues(quantity = 5),
+          changedTo = PlantingSeasonSpeciesTargetUpdatedEventValues(quantity = 7),
+      )
+      clock.instant = clock.instant.plusSeconds(1)
+      val second =
+          insertSpeciesTargetUpdatedEvent(
+              speciesId = speciesId1,
+              changedFrom = PlantingSeasonSpeciesTargetUpdatedEventValues(quantity = 7),
+              changedTo = PlantingSeasonSpeciesTargetUpdatedEventValues(quantity = 9),
+          )
+
+      val combined =
+          second.copy(
+              event =
+                  (second.event as PlantingSeasonSpeciesTargetUpdatedEvent).copy(
+                      changedFrom = PlantingSeasonSpeciesTargetUpdatedEventValues(quantity = 5)
+                  )
+          )
+
+      assertEquals(listOf(combined), service.getNotifications(plantingSeasonId))
+    }
+
+    @Test
+    fun `does not combine updates for different species`() {
+      val first =
+          insertSpeciesTargetUpdatedEvent(
+              speciesId = speciesId1,
+              changedFrom = PlantingSeasonSpeciesTargetUpdatedEventValues(quantity = 5),
+              changedTo = PlantingSeasonSpeciesTargetUpdatedEventValues(quantity = 7),
+          )
+      clock.instant = clock.instant.plusSeconds(1)
+      val second =
+          insertSpeciesTargetUpdatedEvent(
+              speciesId = speciesId2,
+              changedFrom = PlantingSeasonSpeciesTargetUpdatedEventValues(quantity = 0),
+              changedTo = PlantingSeasonSpeciesTargetUpdatedEventValues(quantity = 3),
+          )
+
+      assertEquals(listOf(first, second), service.getNotifications(plantingSeasonId))
+    }
+
+    @Test
+    fun `does not combine updates for different substrata`() {
+      val otherSubstratumId = insertSubstratum()
+      val first =
+          insertSpeciesTargetUpdatedEvent(
+              substratumId = substratumId1,
+              changedFrom = PlantingSeasonSpeciesTargetUpdatedEventValues(quantity = 5),
+              changedTo = PlantingSeasonSpeciesTargetUpdatedEventValues(quantity = 7),
+          )
+      clock.instant = clock.instant.plusSeconds(1)
+      val second =
+          insertSpeciesTargetUpdatedEvent(
+              substratumId = otherSubstratumId,
+              changedFrom = PlantingSeasonSpeciesTargetUpdatedEventValues(quantity = 1),
+              changedTo = PlantingSeasonSpeciesTargetUpdatedEventValues(quantity = 4),
+          )
+
+      assertEquals(listOf(first, second), service.getNotifications(plantingSeasonId))
+    }
+
+    @Test
+    fun `leaves a single species target update unchanged`() {
+      val update =
+          insertSpeciesTargetUpdatedEvent(
+              changedFrom = PlantingSeasonSpeciesTargetUpdatedEventValues(quantity = 5),
+              changedTo = PlantingSeasonSpeciesTargetUpdatedEventValues(quantity = 7),
+          )
+
+      assertEquals(listOf(update), service.getNotifications(plantingSeasonId))
+    }
+
+    @Test
+    fun `combines each event type independently within a season`() {
+      insertUpdatedEvent(
+          changedFrom = PlantingSeasonUpdatedEventValues(name = "A"),
+          changedTo = PlantingSeasonUpdatedEventValues(name = "B"),
+      )
+      insertSpeciesTargetUpdatedEvent(
+          speciesId = speciesId1,
+          changedFrom = PlantingSeasonSpeciesTargetUpdatedEventValues(quantity = 5),
+          changedTo = PlantingSeasonSpeciesTargetUpdatedEventValues(quantity = 7),
+      )
+      clock.instant = clock.instant.plusSeconds(1)
+      val seasonUpdate2 =
+          insertUpdatedEvent(
+              changedFrom = PlantingSeasonUpdatedEventValues(name = "B"),
+              changedTo = PlantingSeasonUpdatedEventValues(name = "C"),
+          )
+      val targetUpdate2 =
+          insertSpeciesTargetUpdatedEvent(
+              speciesId = speciesId1,
+              changedFrom = PlantingSeasonSpeciesTargetUpdatedEventValues(quantity = 7),
+              changedTo = PlantingSeasonSpeciesTargetUpdatedEventValues(quantity = 9),
+          )
+
+      val combinedSeason =
+          seasonUpdate2.copy(
+              event =
+                  (seasonUpdate2.event as PlantingSeasonUpdatedEvent).copy(
+                      changedFrom = PlantingSeasonUpdatedEventValues(name = "A")
+                  )
+          )
+      val combinedTarget =
+          targetUpdate2.copy(
+              event =
+                  (targetUpdate2.event as PlantingSeasonSpeciesTargetUpdatedEvent).copy(
+                      changedFrom = PlantingSeasonSpeciesTargetUpdatedEventValues(quantity = 5)
+                  )
+          )
+
+      assertEquals(
+          listOf(combinedSeason, combinedTarget),
+          service.getNotifications(plantingSeasonId),
+      )
+    }
+  }
+
   private fun insertUpdatedEvent(
       changedFrom: PlantingSeasonUpdatedEventValues = PlantingSeasonUpdatedEventValues(),
       changedTo: PlantingSeasonUpdatedEventValues = PlantingSeasonUpdatedEventValues(),
       plantingSeasonId: PlantingSeasonId = this.plantingSeasonId,
       plantingSiteId: PlantingSiteId = this.plantingSiteId,
       organizationId: OrganizationId = this.organizationId,
-  ): EventLogEntry<PlantingSeasonPersistentEvent> {
+  ): EventLogEntry<PlantingSeasonRelatedPersistentEvent> {
     val event =
         PlantingSeasonUpdatedEvent(
             changedFrom = changedFrom,
@@ -290,7 +437,7 @@ internal class PlantingSeasonNotificationsServiceTest : DatabaseTest(), RunsAsDa
       name: String = "Season",
       plantingSiteId: PlantingSiteId = this.plantingSiteId,
       organizationId: OrganizationId = this.organizationId,
-  ): EventLogEntry<PlantingSeasonPersistentEvent> {
+  ): EventLogEntry<PlantingSeasonRelatedPersistentEvent> {
     val event =
         PlantingSeasonCreatedEvent(
             endDate = LocalDate.EPOCH.plusDays(1),
@@ -309,12 +456,64 @@ internal class PlantingSeasonNotificationsServiceTest : DatabaseTest(), RunsAsDa
       plantingSeasonId: PlantingSeasonId = this.plantingSeasonId,
       plantingSiteId: PlantingSiteId = this.plantingSiteId,
       organizationId: OrganizationId = this.organizationId,
-  ): EventLogEntry<PlantingSeasonPersistentEvent> {
+  ): EventLogEntry<PlantingSeasonRelatedPersistentEvent> {
     val event =
         PlantingSeasonDeletedEvent(
             organizationId = organizationId,
             plantingSeasonId = plantingSeasonId,
             plantingSiteId = plantingSiteId,
+        )
+
+    return EventLogEntry(user.userId, clock.instant, event, eventLogStore.insertEvent(event))
+  }
+
+  private fun insertSpeciesTargetCreatedEvent(
+      speciesId: SpeciesId = speciesId1,
+      quantity: Int = 1,
+      substratumId: SubstratumId = substratumId1,
+      plantingSeasonId: PlantingSeasonId = this.plantingSeasonId,
+      plantingSiteId: PlantingSiteId = this.plantingSiteId,
+      organizationId: OrganizationId = this.organizationId,
+  ): EventLogEntry<PlantingSeasonRelatedPersistentEvent> {
+    val event =
+        PlantingSeasonSpeciesTargetCreatedEvent(
+            organizationId = organizationId,
+            plantingSeasonId = plantingSeasonId,
+            plantingSiteId = plantingSiteId,
+            quantity = quantity,
+            speciesId = speciesId,
+            stratumName = "Stratum",
+            substratumHistoryId = SubstratumHistoryId(substratumId.value),
+            substratumId = substratumId,
+            substratumName = "Substratum",
+        )
+
+    return EventLogEntry(user.userId, clock.instant, event, eventLogStore.insertEvent(event))
+  }
+
+  private fun insertSpeciesTargetUpdatedEvent(
+      speciesId: SpeciesId = speciesId1,
+      changedFrom: PlantingSeasonSpeciesTargetUpdatedEventValues =
+          PlantingSeasonSpeciesTargetUpdatedEventValues(),
+      changedTo: PlantingSeasonSpeciesTargetUpdatedEventValues =
+          PlantingSeasonSpeciesTargetUpdatedEventValues(),
+      substratumId: SubstratumId = substratumId1,
+      plantingSeasonId: PlantingSeasonId = this.plantingSeasonId,
+      plantingSiteId: PlantingSiteId = this.plantingSiteId,
+      organizationId: OrganizationId = this.organizationId,
+  ): EventLogEntry<PlantingSeasonRelatedPersistentEvent> {
+    val event =
+        PlantingSeasonSpeciesTargetUpdatedEvent(
+            changedFrom = changedFrom,
+            changedTo = changedTo,
+            organizationId = organizationId,
+            plantingSeasonId = plantingSeasonId,
+            plantingSiteId = plantingSiteId,
+            speciesId = speciesId,
+            stratumName = "Stratum",
+            substratumHistoryId = SubstratumHistoryId(substratumId.value),
+            substratumId = substratumId,
+            substratumName = "Substratum",
         )
 
     return EventLogEntry(user.userId, clock.instant, event, eventLogStore.insertEvent(event))

--- a/src/test/kotlin/com/terraformation/backend/plantingmanagement/db/PlantingSeasonNotificationsServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/plantingmanagement/db/PlantingSeasonNotificationsServiceTest.kt
@@ -71,7 +71,7 @@ internal class PlantingSeasonNotificationsServiceTest : DatabaseTest(), RunsAsDa
       val created = insertCreatedEvent()
       val deleted = insertDeletedEvent()
 
-      assertEquals(listOf(created, deleted), service.getNotifications(plantingSeasonId))
+      assertEquals(listOf(created.event, deleted.event), service.getNotifications(plantingSeasonId))
     }
 
     @Test
@@ -81,7 +81,7 @@ internal class PlantingSeasonNotificationsServiceTest : DatabaseTest(), RunsAsDa
       val newest = insertDeletedEvent()
       insertPlantingSeasonNotification(lastDismissedEventLogId = dismissed.id)
 
-      assertEquals(listOf(newer, newest), service.getNotifications(plantingSeasonId))
+      assertEquals(listOf(newer.event, newest.event), service.getNotifications(plantingSeasonId))
     }
 
     @Test
@@ -98,11 +98,8 @@ internal class PlantingSeasonNotificationsServiceTest : DatabaseTest(), RunsAsDa
           )
 
       val combined =
-          second.copy(
-              event =
-                  (second.event as PlantingSeasonUpdatedEvent).copy(
-                      changedFrom = PlantingSeasonUpdatedEventValues(name = "A")
-                  )
+          (second.event as PlantingSeasonUpdatedEvent).copy(
+              changedFrom = PlantingSeasonUpdatedEventValues(name = "A")
           )
 
       assertEquals(listOf(combined), service.getNotifications(plantingSeasonId))
@@ -114,7 +111,7 @@ internal class PlantingSeasonNotificationsServiceTest : DatabaseTest(), RunsAsDa
       val expected = insertCreatedEvent()
       insertCreatedEvent(plantingSeasonId = otherSeasonId)
 
-      assertEquals(listOf(expected), service.getNotifications(plantingSeasonId))
+      assertEquals(listOf(expected.event), service.getNotifications(plantingSeasonId))
     }
 
     @Test
@@ -123,7 +120,7 @@ internal class PlantingSeasonNotificationsServiceTest : DatabaseTest(), RunsAsDa
       insertPlantingSeasonNotification(lastDismissedEventLogId = dismissed.id)
 
       assertEquals(
-          emptyList<EventLogEntry<PlantingSeasonRelatedPersistentEvent>>(),
+          emptyList<PlantingSeasonRelatedPersistentEvent>(),
           service.getNotifications(plantingSeasonId),
       )
     }
@@ -146,8 +143,8 @@ internal class PlantingSeasonNotificationsServiceTest : DatabaseTest(), RunsAsDa
 
       assertEquals(
           mapOf(
-              plantingSeasonId to listOf(firstSeasonEvent),
-              otherSeasonId to listOf(otherSeasonEvent),
+              plantingSeasonId to listOf(firstSeasonEvent.event),
+              otherSeasonId to listOf(otherSeasonEvent.event),
           ),
           service.getNotifications(organizationId),
       )
@@ -166,8 +163,8 @@ internal class PlantingSeasonNotificationsServiceTest : DatabaseTest(), RunsAsDa
 
       assertEquals(
           mapOf(
-              plantingSeasonId to listOf(firstSeasonNewer),
-              otherSeasonId to listOf(otherSeasonEvent),
+              plantingSeasonId to listOf(firstSeasonNewer.event),
+              otherSeasonId to listOf(otherSeasonEvent.event),
           ),
           service.getNotifications(organizationId),
       )
@@ -187,7 +184,7 @@ internal class PlantingSeasonNotificationsServiceTest : DatabaseTest(), RunsAsDa
       )
 
       assertEquals(
-          mapOf(plantingSeasonId to listOf(expected)),
+          mapOf(plantingSeasonId to listOf(expected.event)),
           service.getNotifications(organizationId),
       )
     }
@@ -197,7 +194,7 @@ internal class PlantingSeasonNotificationsServiceTest : DatabaseTest(), RunsAsDa
       val emptyOrganizationId = insertOrganization()
 
       assertEquals(
-          emptyMap<PlantingSeasonId, List<EventLogEntry<PlantingSeasonRelatedPersistentEvent>>>(),
+          emptyMap<PlantingSeasonId, List<PlantingSeasonRelatedPersistentEvent>>(),
           service.getNotifications(emptyOrganizationId),
       )
     }
@@ -246,27 +243,27 @@ internal class PlantingSeasonNotificationsServiceTest : DatabaseTest(), RunsAsDa
           )
 
       val combined =
-          second.copy(
-              event =
-                  (second.event as PlantingSeasonUpdatedEvent).copy(
-                      changedFrom =
-                          PlantingSeasonUpdatedEventValues(
-                              endDate = firstEnd,
-                              name = "A",
-                              startDate = firstStart,
-                              status = PlantingSeasonStatus.Upcoming,
-                          ),
-                      changedTo =
-                          PlantingSeasonUpdatedEventValues(
-                              endDate = secondEnd,
-                              name = "B",
-                              startDate = secondStart,
-                              status = PlantingSeasonStatus.Active,
-                          ),
-                  )
+          (second.event as PlantingSeasonUpdatedEvent).copy(
+              changedFrom =
+                  PlantingSeasonUpdatedEventValues(
+                      endDate = firstEnd,
+                      name = "A",
+                      startDate = firstStart,
+                      status = PlantingSeasonStatus.Upcoming,
+                  ),
+              changedTo =
+                  PlantingSeasonUpdatedEventValues(
+                      endDate = secondEnd,
+                      name = "B",
+                      startDate = secondStart,
+                      status = PlantingSeasonStatus.Active,
+                  ),
           )
 
-      assertEquals(listOf(created, combined, third), service.getNotifications(plantingSeasonId))
+      assertEquals(
+          listOf(created.event, combined, third.event),
+          service.getNotifications(plantingSeasonId),
+      )
     }
 
     @Test
@@ -277,7 +274,7 @@ internal class PlantingSeasonNotificationsServiceTest : DatabaseTest(), RunsAsDa
               changedTo = PlantingSeasonUpdatedEventValues(name = "B"),
           )
 
-      assertEquals(listOf(update), service.getNotifications(plantingSeasonId))
+      assertEquals(listOf(update.event), service.getNotifications(plantingSeasonId))
     }
   }
 
@@ -288,7 +285,10 @@ internal class PlantingSeasonNotificationsServiceTest : DatabaseTest(), RunsAsDa
       val seasonCreated = insertCreatedEvent()
       val targetCreated = insertSpeciesTargetCreatedEvent()
 
-      assertEquals(listOf(seasonCreated, targetCreated), service.getNotifications(plantingSeasonId))
+      assertEquals(
+          listOf(seasonCreated.event, targetCreated.event),
+          service.getNotifications(plantingSeasonId),
+      )
     }
 
     @Test
@@ -307,11 +307,8 @@ internal class PlantingSeasonNotificationsServiceTest : DatabaseTest(), RunsAsDa
           )
 
       val combined =
-          second.copy(
-              event =
-                  (second.event as PlantingSeasonSpeciesTargetUpdatedEvent).copy(
-                      changedFrom = PlantingSeasonSpeciesTargetUpdatedEventValues(quantity = 5)
-                  )
+          (second.event as PlantingSeasonSpeciesTargetUpdatedEvent).copy(
+              changedFrom = PlantingSeasonSpeciesTargetUpdatedEventValues(quantity = 5)
           )
 
       assertEquals(listOf(combined), service.getNotifications(plantingSeasonId))
@@ -333,7 +330,7 @@ internal class PlantingSeasonNotificationsServiceTest : DatabaseTest(), RunsAsDa
               changedTo = PlantingSeasonSpeciesTargetUpdatedEventValues(quantity = 3),
           )
 
-      assertEquals(listOf(first, second), service.getNotifications(plantingSeasonId))
+      assertEquals(listOf(first.event, second.event), service.getNotifications(plantingSeasonId))
     }
 
     @Test
@@ -353,7 +350,7 @@ internal class PlantingSeasonNotificationsServiceTest : DatabaseTest(), RunsAsDa
               changedTo = PlantingSeasonSpeciesTargetUpdatedEventValues(quantity = 4),
           )
 
-      assertEquals(listOf(first, second), service.getNotifications(plantingSeasonId))
+      assertEquals(listOf(first.event, second.event), service.getNotifications(plantingSeasonId))
     }
 
     @Test
@@ -364,7 +361,7 @@ internal class PlantingSeasonNotificationsServiceTest : DatabaseTest(), RunsAsDa
               changedTo = PlantingSeasonSpeciesTargetUpdatedEventValues(quantity = 7),
           )
 
-      assertEquals(listOf(update), service.getNotifications(plantingSeasonId))
+      assertEquals(listOf(update.event), service.getNotifications(plantingSeasonId))
     }
 
     @Test
@@ -392,18 +389,12 @@ internal class PlantingSeasonNotificationsServiceTest : DatabaseTest(), RunsAsDa
           )
 
       val combinedSeason =
-          seasonUpdate2.copy(
-              event =
-                  (seasonUpdate2.event as PlantingSeasonUpdatedEvent).copy(
-                      changedFrom = PlantingSeasonUpdatedEventValues(name = "A")
-                  )
+          (seasonUpdate2.event as PlantingSeasonUpdatedEvent).copy(
+              changedFrom = PlantingSeasonUpdatedEventValues(name = "A")
           )
       val combinedTarget =
-          targetUpdate2.copy(
-              event =
-                  (targetUpdate2.event as PlantingSeasonSpeciesTargetUpdatedEvent).copy(
-                      changedFrom = PlantingSeasonSpeciesTargetUpdatedEventValues(quantity = 5)
-                  )
+          (targetUpdate2.event as PlantingSeasonSpeciesTargetUpdatedEvent).copy(
+              changedFrom = PlantingSeasonSpeciesTargetUpdatedEventValues(quantity = 5)
           )
 
       assertEquals(


### PR DESCRIPTION
Update `PlantingSeasonNotificationService` to also retrieve PlantingSeasonTarget events. Update Planting Season persistent events with a common interface - `PlantingSeasonRelatedPersistentEvent` (I don't love this name, open to ideas). Use a similar combining logic as `PlantingSeasonPersistentEvent`s, but keep it per species and substratum. The FE (or possibly the control) will eventually take this list and retrieve the set of unique species, discarding the quantities and substrata.

A new model type will be defined in the next PR, along the lines of this:

```kotlin
data class PlantingSeasonNotificationModel(
  val plantingSeasonId: PlantingSeasonId,
  val lastEventLogId: EventLogId,
  val eventsList: List<PlantingSeasonRelatedPersistentEvent>
)
```

Additionally, a later PR will rename some of these methods to separate planting management notifications from inventory management.

Co-authored-by: Claude Opus 4.8 [noreply@anthropic.com](mailto:noreply@anthropic.com)