### PR TITLE
Default test planting sites to have boundaries, history

### DIFF
--- a/src/test/kotlin/com/terraformation/backend/accelerator/ActivityMediaServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/ActivityMediaServiceTest.kt
@@ -375,7 +375,7 @@ internal class ActivityMediaServiceTest : DatabaseTest(), RunsAsDatabaseUser {
 
     @Test
     fun `throws exception if activity is an observation`() {
-      insertPlantingSite(x = 0, width = 10)
+      insertPlantingSite()
       insertStratum()
       insertSubstratum()
       insertMonitoringPlot()

--- a/src/test/kotlin/com/terraformation/backend/accelerator/ObservationActivityServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/ObservationActivityServiceTest.kt
@@ -141,7 +141,7 @@ class ObservationActivityServiceTest : DatabaseTest(), RunsAsDatabaseUser {
     organizationId = insertOrganization()
     insertOrganizationUser(role = Role.Manager)
     projectId = insertProject(phase = AcceleratorPhase.Phase2PlanAndScale)
-    plantingSiteId = insertPlantingSite(x = 0, width = 15, projectId = projectId)
+    plantingSiteId = insertPlantingSite(projectId = projectId)
 
     observationId = insertObservation(completedTime = Instant.EPOCH)
     insertStratum()

--- a/src/test/kotlin/com/terraformation/backend/accelerator/db/ActivityMediaStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/db/ActivityMediaStoreTest.kt
@@ -61,7 +61,7 @@ class ActivityMediaStoreTest : DatabaseTest(), RunsAsDatabaseUser {
 
     @Test
     fun `returns observation metadata for observation media files`() {
-      insertPlantingSite(x = 0, width = 11)
+      insertPlantingSite()
       insertStratum()
       insertSubstratum()
       insertMonitoringPlot(plotNumber = 123)

--- a/src/test/kotlin/com/terraformation/backend/accelerator/db/ActivityStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/db/ActivityStoreTest.kt
@@ -268,7 +268,7 @@ class ActivityStoreTest : DatabaseTest(), RunsAsDatabaseUser {
     @Test
     fun `includes activity media`() {
       insertOrganizationUser(role = Role.Admin)
-      insertPlantingSite(x = 0, width = 11)
+      insertPlantingSite()
       insertStratum()
       insertSubstratum()
       insertMonitoringPlot(plotNumber = 321)
@@ -874,7 +874,7 @@ class ActivityStoreTest : DatabaseTest(), RunsAsDatabaseUser {
               description = "Original description",
               projectId = projectId,
           )
-      insertPlantingSite(x = 0, width = 10)
+      insertPlantingSite()
       insertObservation()
       insertActivityObservation()
 

--- a/src/test/kotlin/com/terraformation/backend/db/DatabaseBackedTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/db/DatabaseBackedTest.kt
@@ -2472,7 +2472,7 @@ abstract class DatabaseBackedTest {
   fun insertPlantingSite(
       row: PlantingSitesRow = PlantingSitesRow(),
       areaHa: BigDecimal? = row.areaHa,
-      x: Number? = null,
+      x: Number? = 0,
       y: Number? = if (x != null) 0 else null,
       width: Number = 3,
       height: Number = 2,

--- a/src/test/kotlin/com/terraformation/backend/funder/PublishedActivityServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/funder/PublishedActivityServiceTest.kt
@@ -84,7 +84,7 @@ class PublishedActivityServiceTest : DatabaseTest(), RunsAsDatabaseUser {
 
     @BeforeEach
     fun setUp() {
-      insertPlantingSite(x = 0)
+      insertPlantingSite()
       insertStratum()
       insertSubstratum()
       insertMonitoringPlot()

--- a/src/test/kotlin/com/terraformation/backend/funder/db/PublishedActivityStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/funder/db/PublishedActivityStoreTest.kt
@@ -93,7 +93,7 @@ class PublishedActivityStoreTest : DatabaseTest(), RunsAsDatabaseUser {
       insertActivityMediaFile()
       insertPublishedActivityMediaFile()
 
-      insertPlantingSite(x = 0, width = 10)
+      insertPlantingSite()
       insertStratum()
       insertSubstratum()
       insertMonitoringPlot(plotNumber = 123, isAdHoc = true)
@@ -321,7 +321,7 @@ class PublishedActivityStoreTest : DatabaseTest(), RunsAsDatabaseUser {
       activitiesDao.update(
           activitiesDao.fetchOneById(activityId)!!.copy(activityTypeId = ActivityType.Monitoring)
       )
-      insertPlantingSite(x = 0, width = 10)
+      insertPlantingSite()
       insertStratum()
       insertSubstratum()
       val monitoringPlotId = insertMonitoringPlot()

--- a/src/test/kotlin/com/terraformation/backend/plantingmanagement/PlantingSeasonServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/plantingmanagement/PlantingSeasonServiceTest.kt
@@ -56,7 +56,7 @@ internal class PlantingSeasonServiceTest : DatabaseTest(), RunsAsDatabaseUser {
   @BeforeEach
   fun setUp() {
     insertOrganization()
-    plantingSiteId = insertPlantingSite(x = 0)
+    plantingSiteId = insertPlantingSite()
     insertOrganizationUser(role = Role.Manager)
     insertStratum()
     plantingSeasonId = insertPlantingSeason()

--- a/src/test/kotlin/com/terraformation/backend/plantingmanagement/db/PlantingSeasonAllocatedSpeciesStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/plantingmanagement/db/PlantingSeasonAllocatedSpeciesStoreTest.kt
@@ -33,7 +33,7 @@ internal class PlantingSeasonAllocatedSpeciesStoreTest : DatabaseTest(), RunsAsD
   fun setUp() {
     insertOrganization()
     insertOrganizationUser(role = Role.Manager)
-    insertPlantingSite(x = 0)
+    insertPlantingSite()
     plantingSeasonId = insertPlantingSeason()
     speciesId = insertSpecies()
   }

--- a/src/test/kotlin/com/terraformation/backend/plantingmanagement/db/PlantingSeasonSpeciesTargetsStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/plantingmanagement/db/PlantingSeasonSpeciesTargetsStoreTest.kt
@@ -49,7 +49,7 @@ internal class PlantingSeasonSpeciesTargetsStoreTest : DatabaseTest(), RunsAsDat
   @BeforeEach
   fun setUp() {
     organizationId = insertOrganization()
-    plantingSiteId = insertPlantingSite(x = 0)
+    plantingSiteId = insertPlantingSite()
     insertOrganizationUser(role = Role.Manager)
     insertStratum()
     plantingSeasonId = insertPlantingSeason()

--- a/src/test/kotlin/com/terraformation/backend/search/table/MediaFilesTableTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/search/table/MediaFilesTableTest.kt
@@ -38,7 +38,7 @@ internal class MediaFilesTableTest : DatabaseTest(), RunsAsUser {
 
   @Test
   fun `returns observation media files alongside organization media files`() {
-    insertPlantingSite(x = 0, width = 11)
+    insertPlantingSite()
     insertMonitoringPlot()
     insertObservation()
     insertObservationPlot()
@@ -68,7 +68,7 @@ internal class MediaFilesTableTest : DatabaseTest(), RunsAsUser {
 
   @Test
   fun `exposes observation-specific fields`() {
-    insertPlantingSite(x = 0, width = 11)
+    insertPlantingSite()
     insertMonitoringPlot()
     insertObservation()
     insertObservationPlot()
@@ -112,7 +112,7 @@ internal class MediaFilesTableTest : DatabaseTest(), RunsAsUser {
 
   @Test
   fun `exposes observation and monitoringPlot sublists for observation media`() {
-    insertPlantingSite(x = 0, width = 11)
+    insertPlantingSite()
     val monitoringPlotId = insertMonitoringPlot()
     val observationId = insertObservation()
     insertObservationPlot()
@@ -199,7 +199,7 @@ internal class MediaFilesTableTest : DatabaseTest(), RunsAsUser {
 
   @Test
   fun `user without org role sees no media files`() {
-    insertPlantingSite(x = 0, width = 11)
+    insertPlantingSite()
     insertMonitoringPlot()
     insertObservation()
     insertObservationPlot()

--- a/src/test/kotlin/com/terraformation/backend/species/SpeciesServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/species/SpeciesServiceTest.kt
@@ -131,7 +131,7 @@ internal class SpeciesServiceTest : DatabaseTest(), RunsAsUser {
   @Test
   fun `deleteSpecies throws exception if species is in use in observation`() {
     val speciesId = insertSpecies("species name")
-    insertPlantingSite(x = 0)
+    insertPlantingSite()
     insertStratum()
     insertSubstratum()
     insertMonitoringPlot()

--- a/src/test/kotlin/com/terraformation/backend/species/db/SpeciesStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/species/db/SpeciesStoreTest.kt
@@ -614,7 +614,7 @@ internal class SpeciesStoreTest : DatabaseTest(), RunsAsUser {
       insertSpecies(scientificName = "Unused species")
 
       insertFacility(type = FacilityType.Nursery)
-      insertPlantingSite(x = 0)
+      insertPlantingSite()
       insertStratum()
       val substratumId = insertSubstratum()
       insertMonitoringPlot()
@@ -831,7 +831,7 @@ internal class SpeciesStoreTest : DatabaseTest(), RunsAsUser {
         )
     store.createSpecies(NewSpeciesModel(organizationId = organizationId, scientificName = "unused"))
 
-    insertPlantingSite(x = 0)
+    insertPlantingSite()
     insertStratum()
     insertSubstratum()
     insertMonitoringPlot()

--- a/src/test/kotlin/com/terraformation/backend/splat/SplatServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/splat/SplatServiceTest.kt
@@ -89,7 +89,7 @@ class SplatServiceTest : DatabaseTest(), RunsAsDatabaseUser {
 
     organizationId = insertOrganization()
     insertOrganizationUser(role = Role.Admin)
-    insertPlantingSite(x = 0, width = 11, gridOrigin = point(1))
+    insertPlantingSite(gridOrigin = point(1))
     insertMonitoringPlot()
     observationId = insertObservation(state = ObservationState.InProgress)
     fileId = insertFile()

--- a/src/test/kotlin/com/terraformation/backend/tracking/ObservationServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/ObservationServiceTest.kt
@@ -225,7 +225,7 @@ class ObservationServiceTest : DatabaseTest(), RunsAsDatabaseUser {
 
     organizationId = insertOrganization()
     insertOrganizationUser(role = Role.Admin)
-    plantingSiteId = insertPlantingSite(x = 0, width = 11, gridOrigin = point(1))
+    plantingSiteId = insertPlantingSite(width = 11, gridOrigin = point(1))
   }
 
   @Nested
@@ -356,7 +356,7 @@ class ObservationServiceTest : DatabaseTest(), RunsAsDatabaseUser {
       // In stratum 2, the service should create two permanent plots, but neither of them should be
       // included in the observation since they all lie in an unrequested substratum.
 
-      plantingSiteId = insertPlantingSite(x = 0, width = 14, gridOrigin = point(1))
+      plantingSiteId = insertPlantingSite(width = 14, gridOrigin = point(1))
       insertFacility(type = FacilityType.Nursery)
       insertSpecies()
 
@@ -503,7 +503,7 @@ class ObservationServiceTest : DatabaseTest(), RunsAsDatabaseUser {
       // - Substrata that are not requested are not included in the observation, meaning we only
       //   include the plots in substrata 1 and 2.
 
-      plantingSiteId = insertPlantingSite(x = 0, width = 15, gridOrigin = point(1))
+      plantingSiteId = insertPlantingSite(width = 15, gridOrigin = point(1))
       insertFacility(type = FacilityType.Nursery)
       insertSpecies()
 
@@ -2449,7 +2449,7 @@ class ObservationServiceTest : DatabaseTest(), RunsAsDatabaseUser {
 
       // Observation in another org the user cannot manage — skipped even with a completed plot.
       val otherOrganizationId = insertOrganization()
-      val otherPlantingSiteId = insertPlantingSite(organizationId = otherOrganizationId, x = 0)
+      val otherPlantingSiteId = insertPlantingSite(organizationId = otherOrganizationId)
       insertObservation(
           plantingSiteId = otherPlantingSiteId,
           state = ObservationState.Completed,

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/DeliveryStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/DeliveryStoreTest.kt
@@ -38,7 +38,7 @@ internal class DeliveryStoreTest : DatabaseTest(), RunsAsUser {
     DeliveryStore(clock, deliveriesDao, dslContext, ParentStore(dslContext), plantingsDao)
   }
 
-  private val plantingSiteId by lazy { insertPlantingSite(x = 0) }
+  private val plantingSiteId by lazy { insertPlantingSite() }
   private val stratumId by lazy { insertStratum(plantingSiteId = plantingSiteId) }
   private val substratumId by lazy { insertSubstratum(stratumId = stratumId) }
   private val speciesId1 by lazy { insertSpecies() }

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/ObservationResultsStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/ObservationResultsStoreTest.kt
@@ -1230,7 +1230,7 @@ class ObservationResultsStoreTest : ObservationScenarioTest() {
     @Test
     fun `fetch observation summary with temp plots`() {
       val plantingSiteId =
-          insertPlantingSite(x = 0, areaHa = BigDecimal(2500), survivalRateIncludesTempPlots = true)
+          insertPlantingSite(areaHa = BigDecimal(2500), survivalRateIncludesTempPlots = true)
       every { user.canReadPlantingSite(plantingSiteId) } returns true
 
       runSummaryScenario(

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/ObservationScenarioTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/ObservationScenarioTest.kt
@@ -98,7 +98,7 @@ abstract class ObservationScenarioTest : DatabaseTest(), RunsAsUser {
   @BeforeEach
   fun initialSetUp() {
     organizationId = insertOrganization()
-    plantingSiteId = insertPlantingSite(x = 0, areaHa = BigDecimal(2500))
+    plantingSiteId = insertPlantingSite(areaHa = BigDecimal(2500))
 
     every { user.canReadObservation(any()) } returns true
     every { user.canUpdateObservation(any()) } returns true

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/ObservationTestHelper.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/ObservationTestHelper.kt
@@ -87,7 +87,6 @@ class ObservationTestHelper(
             height = height,
             timeZone = timeZone,
             width = width,
-            x = 0,
         )
     test.insertStratum(
         height = height,

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/TrackingStatsStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/TrackingStatsStoreTest.kt
@@ -53,24 +53,24 @@ class TrackingStatsStoreTest : DatabaseTest(), RunsAsDatabaseUser {
       //
       // (70 * 10 + 50 * 20 + 10 * 40) / (10 + 20 + 40) = 30
 
-      insertPlantingSite(projectId = projectId1, x = 0)
+      insertPlantingSite(projectId = projectId1)
       insertStratum()
       insertObservation(completedTime = Instant.ofEpochSecond(100))
       insertObservationStratumResult(survivalRate = 90, survivalRateArea = 5)
       insertObservation(completedTime = Instant.ofEpochSecond(200))
       insertObservationStratumResult(survivalRate = 70, survivalRateArea = 10)
 
-      insertPlantingSite(projectId = projectId1, x = 0)
+      insertPlantingSite(projectId = projectId1)
       insertStratum()
       insertObservation(completedTime = Instant.ofEpochSecond(300))
       insertObservationStratumResult(survivalRate = 50, survivalRateArea = 20)
 
-      insertPlantingSite(projectId = projectId2, x = 0)
+      insertPlantingSite(projectId = projectId2)
       insertStratum()
       insertObservation(completedTime = Instant.ofEpochSecond(400))
       insertObservationStratumResult(survivalRate = 10, survivalRateArea = 40)
 
-      insertPlantingSite(projectId = projectId2, x = 0)
+      insertPlantingSite(projectId = projectId2)
       insertStratum()
       insertObservation(completedTime = Instant.ofEpochSecond(500))
       insertObservationStratumResult(survivalRate = 30, survivalRateArea = 80)
@@ -79,7 +79,7 @@ class TrackingStatsStoreTest : DatabaseTest(), RunsAsDatabaseUser {
 
       // Other organization's site should be ignored
       insertOrganization()
-      insertPlantingSite(x = 0)
+      insertPlantingSite()
       insertStratum()
       insertObservation(completedTime = Instant.ofEpochSecond(600))
       insertObservationStratumResult(survivalRate = 30, survivalRateArea = 80)
@@ -91,7 +91,7 @@ class TrackingStatsStoreTest : DatabaseTest(), RunsAsDatabaseUser {
     @Test
     fun `returns null if no sites in scope have survival rates`() {
       val projectId = insertProject()
-      insertPlantingSite(projectId = projectId, x = 0)
+      insertPlantingSite(projectId = projectId)
       insertStratum()
       insertObservation(completedTime = Instant.ofEpochSecond(100))
       insertObservationStratumResult()

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/biomassStore/BaseBiomassStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/biomassStore/BaseBiomassStoreTest.kt
@@ -27,7 +27,7 @@ abstract class BaseBiomassStoreTest : DatabaseTest(), RunsAsUser {
   @BeforeEach
   fun setUp() {
     organizationId = insertOrganization()
-    plantingSiteId = insertPlantingSite(x = 0)
+    plantingSiteId = insertPlantingSite()
 
     every { user.canCreateObservation(any()) } returns true
     every { user.canManageObservation(any()) } returns true

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/observationStore/BaseObservationStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/observationStore/BaseObservationStoreTest.kt
@@ -50,7 +50,7 @@ abstract class BaseObservationStoreTest : DatabaseTest(), RunsAsUser {
   @BeforeEach
   fun setUp() {
     organizationId = insertOrganization()
-    plantingSiteId = insertPlantingSite(x = 0)
+    plantingSiteId = insertPlantingSite()
 
     every { user.canCreateObservation(any()) } returns true
     every { user.canManageObservation(any()) } returns true

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/observationStore/ObservationStoreSurvivalRateCalculationTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/observationStore/ObservationStoreSurvivalRateCalculationTest.kt
@@ -474,7 +474,7 @@ class ObservationStoreSurvivalRateCalculationTest : ObservationScenarioTest() {
 
   @Test
   fun `survival rate is recalculated correctly for a substratum that has only temp plots`() {
-    val plantingSiteId = insertPlantingSite(survivalRateIncludesTempPlots = true, x = 0, y = 0)
+    val plantingSiteId = insertPlantingSite(survivalRateIncludesTempPlots = true)
     val stratumId = insertStratum()
     val substratum1 = insertSubstratum()
     val observationId1 = insertObservation()
@@ -844,7 +844,7 @@ class ObservationStoreSurvivalRateCalculationTest : ObservationScenarioTest() {
   @Test
   fun `survival rate is calculated for a site including temp plot data`() {
     val newPlantingSiteId =
-        insertPlantingSite(x = 0, areaHa = BigDecimal(2500), survivalRateIncludesTempPlots = true)
+        insertPlantingSite(areaHa = BigDecimal(2500), survivalRateIncludesTempPlots = true)
 
     every { user.canReadPlantingSite(newPlantingSiteId) } returns true
 
@@ -1496,7 +1496,7 @@ class ObservationStoreSurvivalRateCalculationTest : ObservationScenarioTest() {
   @Test
   fun `survival rate with geometry change between observations, includes temp`() {
     val newPlantingSiteId =
-        insertPlantingSite(x = 0, areaHa = BigDecimal(2500), survivalRateIncludesTempPlots = true)
+        insertPlantingSite(areaHa = BigDecimal(2500), survivalRateIncludesTempPlots = true)
     every { user.canReadPlantingSite(newPlantingSiteId) } returns true
 
     fun updatePlantingSite() {

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/plantingSiteStore/PlantingSiteStoreDeleteTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/plantingSiteStore/PlantingSiteStoreDeleteTest.kt
@@ -26,7 +26,7 @@ internal class PlantingSiteStoreDeleteTest : BasePlantingSiteStoreTest() {
     fun `deletes detailed map data and observations`() {
       every { user.canDeletePlantingSite(any()) } returns true
 
-      val plantingSiteId = insertPlantingSite(x = 0)
+      val plantingSiteId = insertPlantingSite()
       insertStratum()
       insertSubstratum()
       insertMonitoringPlot()

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/plantingSiteStore/PlantingSiteStoreRecalculateAreasTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/plantingSiteStore/PlantingSiteStoreRecalculateAreasTest.kt
@@ -60,7 +60,7 @@ internal class PlantingSiteStoreRecalculateAreasTest : BasePlantingSiteStoreTest
 
   @Test
   fun `skips sites without a boundary`() {
-    val siteId = insertPlantingSite(areaHa = null)
+    val siteId = insertPlantingSite(x = null, areaHa = null)
 
     store.recalculatePlantingSiteAreas(successMessages::add, failureMessages::add)
 

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/plantingSiteStore/PlantingSiteStoreUpdateStratumTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/plantingSiteStore/PlantingSiteStoreUpdateStratumTest.kt
@@ -22,7 +22,7 @@ internal class PlantingSiteStoreUpdateStratumTest : BasePlantingSiteStoreTest() 
     fun `updates editable values`() {
       val createdTime = Instant.ofEpochSecond(1000)
       val createdBy = insertUser()
-      val plantingSiteId = insertPlantingSite(x = 0)
+      val plantingSiteId = insertPlantingSite()
 
       val initialRow =
           StrataRow(
@@ -94,7 +94,7 @@ internal class PlantingSiteStoreUpdateStratumTest : BasePlantingSiteStoreTest() 
 
     @Test
     fun `updates full names of substrata if stratum is renamed`() {
-      insertPlantingSite(x = 0)
+      insertPlantingSite()
       val stratumId1 = insertStratum(name = "initial 1")
       val substratumId1 = insertSubstratum(name = "sub 1")
       val substratumId2 = insertSubstratum(name = "sub 2")
@@ -115,7 +115,7 @@ internal class PlantingSiteStoreUpdateStratumTest : BasePlantingSiteStoreTest() 
 
     @Test
     fun `updates stratum name in current history entry`() {
-      insertPlantingSite(x = 0)
+      insertPlantingSite()
       val stratumId = insertStratum(name = "initial")
       insertSubstratum(name = "substratum")
 


### PR DESCRIPTION
We only create planting site history rows for sites that have boundaries, meaning
that in tests where we cared about having history IDs available, we had to
explicitly set a boundary in the `insertPlantingSite` call (usually by passing a
non-null value for the `x` parameter). In the actual system, we've been requiring
planting sites to have boundaries for quite a while now. Default the test data to
something more closely resembling live data by using a boundary by default.

The boundary can be disabled by specifying `x = null`, in cases where we want to
test handling of old planting sites from before we started requiring boundaries.