### PR TITLE
Tell agents not to run parallel Gradle commands

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,6 +9,8 @@
 - Run single test: `./gradlew test --tests "com.terraformation.backend.package.ClassName"`
 - Generate API docs: `./gradlew generateOpenApiDocs`
 
+Run ./gradlew commands one at a time, serially, rather than launching multiple of them in the background. Concurrent Gradle runs can cause inconsistent results and can trigger unnecessary recompilation.
+
 ## Code Style Guidelines
 
 - See the file docs/CONVENTIONS.md for coding conventions.


### PR DESCRIPTION
In a few cases, I've seen LLM coding tools do things like launch a `compileKotlin`
task and a `test` task in parallel using separate Gradle commands. This causes
unnecessary churn and the possibility of scrambled output because the test run
also implicitly compiles the code.

Try to discourage that behavior by telling agents to run one Gradle command at
a time.