### PR TITLE
SW-8427 Publish planting date request status events

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/nursery/db/BatchStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/nursery/db/BatchStore.kt
@@ -748,14 +748,6 @@ class BatchStore(
       withdrawalsDao.insert(withdrawalsRow)
       val withdrawalId = withdrawalsRow.id!!
 
-      if (withdrawal.scheduledPlantingDateRequestId != null) {
-        eventPublisher.publishEvent(
-            WithdrawalAssociatedWithPlantingDateRequestEvent(
-                withdrawal.scheduledPlantingDateRequestId
-            )
-        )
-      }
-
       val destinationBatchIds: Map<BatchId, BatchId> =
           createDestinationBatches(withdrawalId, withdrawal, readyByDate)
 
@@ -841,6 +833,14 @@ class BatchStore(
 
                 batchWithdrawalsRow
               }
+
+      if (withdrawal.scheduledPlantingDateRequestId != null) {
+        eventPublisher.publishEvent(
+            WithdrawalAssociatedWithPlantingDateRequestEvent(
+                withdrawal.scheduledPlantingDateRequestId
+            )
+        )
+      }
 
       withdrawalsRow.toModel(batchWithdrawalsRows)
     }

--- a/src/main/kotlin/com/terraformation/backend/plantingmanagement/db/PlantingDateRequestsStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/plantingmanagement/db/PlantingDateRequestsStore.kt
@@ -274,6 +274,7 @@ class PlantingDateRequestsStore(
                     substratumName = info.substratumName,
                 )
             )
+
         oldQuantity != null && newQuantity == null ->
             eventPublisher.publishEvent(
                 PlantingDateRequestSpeciesDeletedEvent(
@@ -288,6 +289,7 @@ class PlantingDateRequestsStore(
                     substratumName = info.substratumName,
                 )
             )
+
         oldQuantity != null && newQuantity != null && oldQuantity != newQuantity ->
             eventPublisher.publishEvent(
                 PlantingDateRequestSpeciesUpdatedEvent(
@@ -311,48 +313,82 @@ class PlantingDateRequestsStore(
   }
 
   private fun updateRequestStatus(scheduledPlantingDateId: ScheduledPlantingDateId) {
-    val requestedQuantities: Map<SpeciesId, BigDecimal> =
-        with(PLANTING_DATE_REQUEST_SPECIES) {
+    seasonHelper.withLockedScheduledPlantingDate(scheduledPlantingDateId) {
+      val requestedQuantities: Map<SpeciesId, BigDecimal> =
+          with(PLANTING_DATE_REQUEST_SPECIES) {
+            dslContext
+                .select(SPECIES_ID, DSL.sum(QUANTITY))
+                .from(PLANTING_DATE_REQUEST_SPECIES)
+                .where(SCHEDULED_PLANTING_DATE_ID.eq(scheduledPlantingDateId))
+                .groupBy(SPECIES_ID)
+                .associate { it[SPECIES_ID]!! to it[DSL.sum(QUANTITY)]!! }
+          }
+
+      val withdrawnQuantities: Map<SpeciesId, BigDecimal> =
           dslContext
-              .select(SPECIES_ID, DSL.sum(QUANTITY))
-              .from(PLANTING_DATE_REQUEST_SPECIES)
-              .where(SCHEDULED_PLANTING_DATE_ID.eq(scheduledPlantingDateId))
-              .groupBy(SPECIES_ID)
-              .associate { it[SPECIES_ID]!! to it[DSL.sum(QUANTITY)]!! }
-        }
+              .select(BATCHES.SPECIES_ID, DSL.sum(BATCH_WITHDRAWALS.READY_QUANTITY_WITHDRAWN))
+              .from(BATCH_WITHDRAWALS)
+              .join(BATCHES)
+              .on(BATCHES.ID.eq(BATCH_WITHDRAWALS.BATCH_ID))
+              .join(WITHDRAWALS)
+              .on(WITHDRAWALS.ID.eq(BATCH_WITHDRAWALS.WITHDRAWAL_ID))
+              .where(WITHDRAWALS.SCHEDULED_PLANTING_DATE_REQUEST_ID.eq(scheduledPlantingDateId))
+              .groupBy(BATCHES.SPECIES_ID)
+              .associate {
+                it[BATCHES.SPECIES_ID]!! to
+                    it[DSL.sum(BATCH_WITHDRAWALS.READY_QUANTITY_WITHDRAWN)]!!
+              }
 
-    val withdrawnQuantities: Map<SpeciesId, BigDecimal> =
-        dslContext
-            .select(BATCHES.SPECIES_ID, DSL.sum(BATCH_WITHDRAWALS.READY_QUANTITY_WITHDRAWN))
-            .from(BATCH_WITHDRAWALS)
-            .join(BATCHES)
-            .on(BATCHES.ID.eq(BATCH_WITHDRAWALS.BATCH_ID))
-            .join(WITHDRAWALS)
-            .on(WITHDRAWALS.ID.eq(BATCH_WITHDRAWALS.WITHDRAWAL_ID))
-            .where(WITHDRAWALS.SCHEDULED_PLANTING_DATE_REQUEST_ID.eq(scheduledPlantingDateId))
-            .groupBy(BATCHES.SPECIES_ID)
-            .associate {
-              it[BATCHES.SPECIES_ID]!! to it[DSL.sum(BATCH_WITHDRAWALS.READY_QUANTITY_WITHDRAWN)]!!
-            }
+      val oldStatus =
+          dslContext
+              .select(PLANTING_DATE_REQUESTS.STATUS_ID)
+              .from(PLANTING_DATE_REQUESTS)
+              .where(PLANTING_DATE_REQUESTS.SCHEDULED_PLANTING_DATE_ID.eq(scheduledPlantingDateId))
+              .fetchOne(PLANTING_DATE_REQUESTS.STATUS_ID)
 
-    val newStatus =
-        when {
-          requestedQuantities.isEmpty() -> PlantingDateRequestStatus.Pending
-          requestedQuantities.all { (speciesId, quantity) ->
-            (withdrawnQuantities[speciesId] ?: BigDecimal.ZERO) >= quantity
-          } -> PlantingDateRequestStatus.Fulfilled
-          requestedQuantities.keys.any {
-            (withdrawnQuantities[it] ?: BigDecimal.ZERO) > BigDecimal.ZERO
-          } -> PlantingDateRequestStatus.Partial
-          else -> PlantingDateRequestStatus.Pending
-        }
+      val newStatus =
+          when {
+            requestedQuantities.isEmpty() -> PlantingDateRequestStatus.Pending
+            requestedQuantities.all { (speciesId, quantity) ->
+              (withdrawnQuantities[speciesId] ?: BigDecimal.ZERO) >= quantity
+            } -> PlantingDateRequestStatus.Fulfilled
 
-    // This runs as an automated recompute triggered by a withdrawal event rather than a user
-    // edit, so modified_by and modified_time are intentionally left unchanged.
-    dslContext
-        .update(PLANTING_DATE_REQUESTS)
-        .set(PLANTING_DATE_REQUESTS.STATUS_ID, newStatus)
-        .where(PLANTING_DATE_REQUESTS.SCHEDULED_PLANTING_DATE_ID.eq(scheduledPlantingDateId))
-        .execute()
+            requestedQuantities.keys.any {
+              (withdrawnQuantities[it] ?: BigDecimal.ZERO) > BigDecimal.ZERO
+            } -> PlantingDateRequestStatus.Partial
+
+            else -> PlantingDateRequestStatus.Pending
+          }
+
+      // This runs as an automated recompute triggered by a withdrawal event rather than a user
+      // edit, so modified_by and modified_time are intentionally left unchanged.
+      dslContext
+          .update(PLANTING_DATE_REQUESTS)
+          .set(PLANTING_DATE_REQUESTS.STATUS_ID, newStatus)
+          .where(PLANTING_DATE_REQUESTS.SCHEDULED_PLANTING_DATE_ID.eq(scheduledPlantingDateId))
+          .execute()
+
+      if (oldStatus != newStatus) {
+        val plantingSeasonId =
+            dslContext
+                .select(SCHEDULED_PLANTING_DATES.PLANTING_SEASON_ID)
+                .from(SCHEDULED_PLANTING_DATES)
+                .where(SCHEDULED_PLANTING_DATES.ID.eq(scheduledPlantingDateId))
+                .fetchOne(SCHEDULED_PLANTING_DATES.PLANTING_SEASON_ID)!!
+        val (plantingSiteId, organizationId) =
+            seasonHelper.fetchPlantingSiteAndOrganization(plantingSeasonId)
+
+        eventPublisher.publishEvent(
+            PlantingDateRequestUpdatedEvent(
+                changedFrom = PlantingDateRequestUpdatedEventValues(status = oldStatus),
+                changedTo = PlantingDateRequestUpdatedEventValues(status = newStatus),
+                organizationId = organizationId,
+                plantingSeasonId = plantingSeasonId,
+                plantingSiteId = plantingSiteId,
+                scheduledPlantingDateId = scheduledPlantingDateId,
+            )
+        )
+      }
+    }
   }
 }

--- a/src/main/kotlin/com/terraformation/backend/plantingmanagement/db/SeasonHelper.kt
+++ b/src/main/kotlin/com/terraformation/backend/plantingmanagement/db/SeasonHelper.kt
@@ -5,10 +5,12 @@ import com.terraformation.backend.db.default_schema.OrganizationId
 import com.terraformation.backend.db.tracking.PlantingSeasonId
 import com.terraformation.backend.db.tracking.PlantingSeasonStatus
 import com.terraformation.backend.db.tracking.PlantingSiteId
+import com.terraformation.backend.db.tracking.ScheduledPlantingDateId
 import com.terraformation.backend.db.tracking.SubstratumHistoryId
 import com.terraformation.backend.db.tracking.SubstratumId
 import com.terraformation.backend.db.tracking.tables.references.PLANTING_SEASONS
 import com.terraformation.backend.db.tracking.tables.references.PLANTING_SITES
+import com.terraformation.backend.db.tracking.tables.references.SCHEDULED_PLANTING_DATES
 import com.terraformation.backend.db.tracking.tables.references.STRATA
 import com.terraformation.backend.db.tracking.tables.references.SUBSTRATA
 import com.terraformation.backend.db.tracking.tables.references.SUBSTRATUM_HISTORIES
@@ -89,6 +91,22 @@ class SeasonHelper(private val dslContext: DSLContext) {
           .where(PLANTING_SEASONS.ID.eq(plantingSeasonId))
           .forUpdate()
           .fetchOne() ?: throw PlantingSeasonNotFoundException(plantingSeasonId)
+
+      func()
+    }
+  }
+
+  fun <T> withLockedScheduledPlantingDate(
+      scheduledPlantingDateId: ScheduledPlantingDateId,
+      func: () -> T,
+  ): T {
+    return dslContext.transactionResult { _ ->
+      dslContext
+          .selectOne()
+          .from(SCHEDULED_PLANTING_DATES)
+          .where(SCHEDULED_PLANTING_DATES.ID.eq(scheduledPlantingDateId))
+          .forUpdate()
+          .fetchOne() ?: throw PlantingSeasonScheduledDateNotFoundException(scheduledPlantingDateId)
 
       func()
     }

--- a/src/test/kotlin/com/terraformation/backend/plantingmanagement/db/PlantingDateRequestsStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/plantingmanagement/db/PlantingDateRequestsStoreTest.kt
@@ -464,6 +464,21 @@ internal class PlantingDateRequestsStoreTest : DatabaseTest(), RunsAsDatabaseUse
       store.on(WithdrawalAssociatedWithPlantingDateRequestEvent(scheduledPlantingDateId))
 
       assertEquals(PlantingDateRequestStatus.Fulfilled, statusOf())
+
+      eventPublisher.assertEventPublished(
+          PlantingDateRequestUpdatedEvent(
+              changedFrom =
+                  PlantingDateRequestUpdatedEventValues(status = PlantingDateRequestStatus.Pending),
+              changedTo =
+                  PlantingDateRequestUpdatedEventValues(
+                      status = PlantingDateRequestStatus.Fulfilled
+                  ),
+              organizationId = organizationId,
+              plantingSeasonId = plantingSeasonId,
+              plantingSiteId = plantingSiteId,
+              scheduledPlantingDateId = scheduledPlantingDateId,
+          )
+      )
     }
 
     @Test
@@ -521,6 +536,15 @@ internal class PlantingDateRequestsStoreTest : DatabaseTest(), RunsAsDatabaseUse
       store.on(WithdrawalAssociatedWithPlantingDateRequestEvent(scheduledPlantingDateId))
 
       assertEquals(PlantingDateRequestStatus.Pending, statusOf())
+    }
+
+    @Test
+    fun `does not publish event when status is unchanged`() {
+      insertPlantingDateRequestSpecies(speciesId = speciesId, quantity = 5)
+
+      store.on(WithdrawalAssociatedWithPlantingDateRequestEvent(scheduledPlantingDateId))
+
+      eventPublisher.assertEventNotPublished<PlantingDateRequestUpdatedEvent>()
     }
 
     private fun statusOf(id: ScheduledPlantingDateId = scheduledPlantingDateId) =


### PR DESCRIPTION
When a withdrawal causes a planting date request's status to change, publish an
update event to record the change.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>