### PR TITLE
SW-8351 Implemented substratum observation dependencies

### DIFF
--- a/jooq/src/main/kotlin/com/terraformation/backend/jooq/Config.kt
+++ b/jooq/src/main/kotlin/com/terraformation/backend/jooq/Config.kt
@@ -548,7 +548,14 @@ val ID_WRAPPERS =
                     listOf("monitoring_plot_histories\\.id", ".*\\.monitoring_plot_history_id"),
                 ),
                 IdWrapper("MonitoringPlotId", listOf("monitoring_plots\\.id", ".*\\..*_plot_id")),
-                IdWrapper("ObservationId", listOf("observations\\.id", ".*\\.observation_id")),
+                IdWrapper(
+                    "ObservationId",
+                    listOf(
+                        "observations\\.id",
+                        ".*\\.observation_id",
+                        ".*\\.depends_on_observation_id",
+                    ),
+                ),
                 IdWrapper(
                     "ObservationTypeId",
                     listOf("observation_types\\.id", ".*\\.observation_type_id"),
@@ -587,6 +594,7 @@ val ID_WRAPPERS =
                     listOf(
                         "substratum_histories\\.id",
                         ".*\\.substratum_history_id",
+                        ".*\\.depends_on_substratum_history_id",
                     ),
                 ),
                 IdWrapper(

--- a/src/main/kotlin/com/terraformation/backend/tracking/db/ObservationStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/db/ObservationStore.kt
@@ -38,6 +38,7 @@ import com.terraformation.backend.db.tracking.tables.pojos.RecordedPlantsRow
 import com.terraformation.backend.db.tracking.tables.records.ObservationPlotConditionsRecord
 import com.terraformation.backend.db.tracking.tables.records.ObservedPlotSpeciesTotalsRecord
 import com.terraformation.backend.db.tracking.tables.records.RecordedPlantsRecord
+import com.terraformation.backend.db.tracking.tables.references.DEPENDENT_SUBSTRATUM_OBSERVATION
 import com.terraformation.backend.db.tracking.tables.references.MONITORING_PLOTS
 import com.terraformation.backend.db.tracking.tables.references.MONITORING_PLOT_HISTORIES
 import com.terraformation.backend.db.tracking.tables.references.OBSERVATIONS
@@ -111,6 +112,8 @@ import org.jooq.Condition
 import org.jooq.DSLContext
 import org.jooq.Field
 import org.jooq.Record
+import org.jooq.Record1
+import org.jooq.Select
 import org.jooq.impl.DSL
 import org.jooq.impl.SQLDataType
 import org.springframework.context.ApplicationEventPublisher
@@ -930,6 +933,20 @@ class ObservationStore(
           plantCountsBySpecies,
       )
 
+      observationPlotsDao.update(
+          observationPlotsRow.copy(
+              completedBy = currentUser().userId,
+              completedTime = clock.instant(),
+              notes = notes,
+              observedTime = observedTime,
+              statusId = ObservationPlotStatus.Completed,
+          )
+      )
+
+      if (!isAdHoc) {
+        recordSubstratumDependencies(observationId)
+      }
+
       updateObservationResults(
           observationId,
           plantingSite,
@@ -939,16 +956,6 @@ class ObservationStore(
           substratumHistoryId,
           monitoringPlotId,
           isAdHoc,
-      )
-
-      observationPlotsDao.update(
-          observationPlotsRow.copy(
-              completedBy = currentUser().userId,
-              completedTime = clock.instant(),
-              notes = notes,
-              observedTime = observedTime,
-              statusId = ObservationPlotStatus.Completed,
-          )
       )
 
       if (substratumId != null) {
@@ -1366,21 +1373,13 @@ class ObservationStore(
         //
         // So we want to update later observations that don't have newer results for the substratum
         // we're editing, that is, observations for which this observation's substratum-level totals
-        // would be used to calculate the stratum- and site-level totals.
+        // would be used to calculate the stratum- and site-level totals. Those are exactly the
+        // observations whose dependent_substratum_observation row for this substratum points back
+        // at
+        // the edited observation; matching on requested (rather than observed) substrata would miss
+        // later observations that requested the substratum but did not observe it.
 
-        val latestObservations = OBSERVATIONS.`as`("latest_observations")
-        val observationWithLatestResultsForSubstratum =
-            DSL.field(
-                DSL.select(latestObservations.ID)
-                    .from(latestObservations)
-                    .join(OBSERVATION_REQUESTED_SUBSTRATA)
-                    .on(latestObservations.ID.eq(OBSERVATION_REQUESTED_SUBSTRATA.OBSERVATION_ID))
-                    .where(latestObservations.COMPLETED_TIME.ge(observation.completedTime))
-                    .and(latestObservations.COMPLETED_TIME.le(OBSERVATIONS.COMPLETED_TIME))
-                    .and(OBSERVATION_REQUESTED_SUBSTRATA.SUBSTRATUM_ID.eq(substratumId))
-                    .orderBy(latestObservations.COMPLETED_TIME.desc(), latestObservations.ID.desc())
-                    .limit(1)
-            )
+        val dependentSsh = SUBSTRATUM_HISTORIES.`as`("edit_dependent_ssh")
         val stratumHistoryIdAtTimeOfObservation =
             DSL.field(
                 DSL.select(STRATUM_HISTORIES.ID)
@@ -1419,7 +1418,24 @@ class ObservationStore(
                 .from(OBSERVATIONS)
                 .where(OBSERVATIONS.PLANTING_SITE_ID.eq(observation.plantingSiteId))
                 .and(OBSERVATIONS.COMPLETED_TIME.gt(observation.completedTime))
-                .and(observationWithLatestResultsForSubstratum.eq(observationId))
+                .and(
+                    OBSERVATIONS.ID.`in`(
+                        DSL.select(DEPENDENT_SUBSTRATUM_OBSERVATION.OBSERVATION_ID)
+                            .from(DEPENDENT_SUBSTRATUM_OBSERVATION)
+                            .join(dependentSsh)
+                            .on(
+                                dependentSsh.ID.eq(
+                                    DEPENDENT_SUBSTRATUM_OBSERVATION.SUBSTRATUM_HISTORY_ID
+                                )
+                            )
+                            .where(
+                                DEPENDENT_SUBSTRATUM_OBSERVATION.DEPENDS_ON_OBSERVATION_ID.eq(
+                                    observationId
+                                )
+                            )
+                            .and(dependentSsh.SUBSTRATUM_ID.eq(substratumId))
+                    )
+                )
                 .and(OBSERVATIONS.OBSERVATION_TYPE_ID.eq(ObservationType.Monitoring))
                 .fetch()
 
@@ -1543,9 +1559,15 @@ class ObservationStore(
     if (hasCompletedPlots) {
       dslContext.transaction { _ ->
         log.info("Marking observation $observationId as abandoned")
+        // An abandoned observation is treated exactly like a completed one, except that its
+        // not-observed plots are ignored (see the survival-rate recalculation conditions) and a
+        // substratum whose plots were all left unobserved is rolled forward as if it had never been
+        // requested. So it runs the same recalculation sequence as completeObservation.
         abandonPlots(observationId)
         updateObservationState(observationId, ObservationState.Abandoned)
+        recordSubstratumDependencies(observationId)
         resetPlantPopulationSinceLastObservation(observation.plantingSiteId)
+        recalculateSurvivalRates(observationId, observation.plantingSiteId)
         recalculateSurvivalRateResults(observationId, observation.plantingSiteId)
       }
     } else {
@@ -1561,6 +1583,7 @@ class ObservationStore(
   ) {
     updateObservationState(observationId, ObservationState.Completed)
     if (!isAdHoc) {
+      recordSubstratumDependencies(observationId)
       // Ad-hoc observations do not reset unobserved populations
       resetPlantPopulationSinceLastObservation(plantingSiteId)
       recalculateSurvivalRates(observationId, plantingSiteId)
@@ -1568,6 +1591,105 @@ class ObservationStore(
     }
 
     eventPublisher.publishEvent(ObservationCompletedEvent(observationId))
+  }
+
+  private fun computeLatestObservationForSubstratumField(
+      observationId: ObservationId,
+      substratumIdField: Field<SubstratumId?>,
+  ): Select<Record1<ObservationId?>> {
+    val candidateObs = OBSERVATIONS.`as`("candidate_obs")
+    val op = OBSERVATION_PLOTS.`as`("dep_op")
+    val mph = MONITORING_PLOT_HISTORIES.`as`("dep_mph")
+
+    return DSL.select(candidateObs.ID)
+        .from(candidateObs)
+        .where(
+            DSL.exists(
+                DSL.selectOne()
+                    .from(op)
+                    .join(mph)
+                    .on(mph.ID.eq(op.MONITORING_PLOT_HISTORY_ID))
+                    .where(op.OBSERVATION_ID.eq(candidateObs.ID))
+                    .and(op.COMPLETED_TIME.isNotNull)
+                    .and(mph.SUBSTRATUM_ID.eq(substratumIdField))
+            )
+        )
+        .and(
+            DSL.or(
+                candidateObs.ID.eq(observationId),
+                candidateObs.COMPLETED_TIME.le(
+                    DSL.select(OBSERVATIONS.COMPLETED_TIME)
+                        .from(OBSERVATIONS)
+                        .where(OBSERVATIONS.ID.eq(observationId))
+                ),
+            )
+        )
+        .and(candidateObs.IS_AD_HOC.isFalse)
+        .orderBy(
+            // Prefer results from the same observation as the `observationId` if it exists.
+            candidateObs.ID.eq(observationId).desc(),
+            // Otherwise take the results from the next latest observation for that area.
+            candidateObs.COMPLETED_TIME.desc(),
+        )
+        .limit(1)
+  }
+
+  private fun recordSubstratumDependencies(observationId: ObservationId) {
+    val consumingSsh = SUBSTRATUM_HISTORIES.`as`("consuming_ssh")
+    val consumingSh = STRATUM_HISTORIES.`as`("consuming_sh")
+    val srcSsh = SUBSTRATUM_HISTORIES.`as`("src_ssh")
+    val srcSh = STRATUM_HISTORIES.`as`("src_sh")
+    val srcObs = OBSERVATIONS.`as`("src_obs")
+
+    val dependsOnObservationId =
+        DSL.field(
+            computeLatestObservationForSubstratumField(
+                observationId,
+                consumingSsh.SUBSTRATUM_ID,
+            )
+        )
+
+    val dependsOnSubstratumHistoryId =
+        DSL.field(
+            DSL.select(srcSsh.ID)
+                .from(srcObs)
+                .join(srcSh)
+                .on(srcSh.PLANTING_SITE_HISTORY_ID.eq(srcObs.PLANTING_SITE_HISTORY_ID))
+                .join(srcSsh)
+                .on(srcSsh.STRATUM_HISTORY_ID.eq(srcSh.ID))
+                .where(srcObs.ID.eq(dependsOnObservationId))
+                .and(srcSsh.SUBSTRATUM_ID.eq(consumingSsh.SUBSTRATUM_ID))
+        )
+
+    dslContext
+        .deleteFrom(DEPENDENT_SUBSTRATUM_OBSERVATION)
+        .where(DEPENDENT_SUBSTRATUM_OBSERVATION.OBSERVATION_ID.eq(observationId))
+        .execute()
+
+    dslContext
+        .insertInto(
+            DEPENDENT_SUBSTRATUM_OBSERVATION,
+            DEPENDENT_SUBSTRATUM_OBSERVATION.OBSERVATION_ID,
+            DEPENDENT_SUBSTRATUM_OBSERVATION.SUBSTRATUM_HISTORY_ID,
+            DEPENDENT_SUBSTRATUM_OBSERVATION.DEPENDS_ON_OBSERVATION_ID,
+            DEPENDENT_SUBSTRATUM_OBSERVATION.DEPENDS_ON_SUBSTRATUM_HISTORY_ID,
+        )
+        .select(
+            DSL.select(
+                    DSL.value(observationId, OBSERVATIONS.ID),
+                    consumingSsh.ID,
+                    dependsOnObservationId,
+                    dependsOnSubstratumHistoryId,
+                )
+                .from(OBSERVATIONS)
+                .join(consumingSh)
+                .on(consumingSh.PLANTING_SITE_HISTORY_ID.eq(OBSERVATIONS.PLANTING_SITE_HISTORY_ID))
+                .join(consumingSsh)
+                .on(consumingSsh.STRATUM_HISTORY_ID.eq(consumingSh.ID))
+                .where(OBSERVATIONS.ID.eq(observationId))
+                .and(dependsOnObservationId.isNotNull)
+        )
+        .execute()
   }
 
   /**
@@ -1605,6 +1727,10 @@ class ObservationStore(
             .fetch()
 
     dslContext.transaction { _ ->
+      if (!isAdHoc) {
+        recordSubstratumDependencies(observationId)
+      }
+
       completedPlots.forEach { record ->
         updateObservationResults(
             observationId,
@@ -1736,17 +1862,21 @@ class ObservationStore(
 
         with(OBSERVED_STRATUM_SPECIES_TOTALS) {
           val updateScope = ObservationSpeciesStratum(stratumHistoryId, stratumId)
+          // The live totals above roll each substratum forward from its latest observation, so the
+          // denominators must roll the same T0 densities forward to avoid inflating the rate.
           val survivalRatePermanentDenominator =
               getSurvivalRateDenominator(
                   updateScope,
                   PLOT_T0_DENSITIES.SPECIES_ID.eq(speciesKey.id),
                   DSL.value(observationId, OBSERVATIONS.ID.dataType),
+                  carryForward = true,
               )
           val survivalRateTempDenominator =
               getSurvivalRateTempDenominator(
                   updateScope,
                   STRATUM_T0_TEMP_DENSITIES.SPECIES_ID.eq(speciesKey.id),
                   DSL.value(observationId, OBSERVATIONS.ID.dataType),
+                  carryForward = true,
               )
           val survivalRateDenominator =
               DSL.coalesce(
@@ -1794,17 +1924,21 @@ class ObservationStore(
 
       with(OBSERVED_SITE_SPECIES_TOTALS) {
         val updateScope = ObservationSpeciesSite(plantingSiteId, plantingSiteHistoryId)
+        // Same as the stratum block: the site live totals roll substrata forward, so the
+        // denominators must too.
         val survivalRatePermanentDenominator =
             getSurvivalRateDenominator(
                 updateScope,
                 PLOT_T0_DENSITIES.SPECIES_ID.eq(speciesKey.id),
                 DSL.value(observationId, OBSERVATIONS.ID.dataType),
+                carryForward = true,
             )
         val survivalRateTempDenominator =
             getSurvivalRateTempDenominator(
                 updateScope,
                 STRATUM_T0_TEMP_DENSITIES.SPECIES_ID.eq(speciesKey.id),
                 DSL.value(observationId, OBSERVATIONS.ID.dataType),
+                carryForward = true,
             )
         val survivalRateDenominator =
             DSL.coalesce(
@@ -2057,17 +2191,23 @@ class ObservationStore(
   ) {
     val table = updateScope.observedTotalsTable
     val observationIdField = table.field("observation_id", OBSERVATIONS.ID.dataType)!!
+    // This scope's live total may roll a not-currently-observed substratum forward from a prior
+    // observation (stratum and site); when it does, the denominator must roll the same T0 densities
+    // forward or the rate is inflated.
+    val carryForward = updateScope.survivalRateDenominatorCarriesForward
     val survivalRatePermanentDenominator =
         getSurvivalRateDenominator(
             updateScope,
             DSL.trueCondition(),
             observationIdField,
+            carryForward,
         )
     val survivalRateTempDenominator =
         getSurvivalRateTempDenominator(
             updateScope,
             DSL.trueCondition(),
             observationIdField,
+            carryForward,
         )
     val survivalRateDenominator =
         DSL.coalesce(survivalRatePermanentDenominator, BigDecimal.ZERO)
@@ -2094,6 +2234,10 @@ class ObservationStore(
                     .from(OBSERVATION_PLOTS)
                     .where(updateScope.observationPlotsCondition(observationIdField))
                     .and(OBSERVATION_PLOTS.COMPLETED_TIME.isNull)
+                    // Not-observed plots (e.g. those left unfinished by an abandoned observation)
+                    // are
+                    // not pending; only genuinely incomplete plots block recalculation.
+                    .and(OBSERVATION_PLOTS.STATUS_ID.ne(ObservationPlotStatus.NotObserved))
             ),
         )
 
@@ -2180,17 +2324,23 @@ class ObservationStore(
   ) {
     val table = updateScope.observedTotalsTable
     val observationIdField = table.field("observation_id", OBSERVATIONS.ID.dataType)!!
+    // See the sibling overload: when the live total rolls a substratum forward, the denominator
+    // must
+    // roll the same T0 densities forward or the rate is inflated.
+    val carryForward = updateScope.survivalRateDenominatorCarriesForward
     val survivalRatePermanentDenominator =
         getSurvivalRateDenominator(
             updateScope,
             DSL.trueCondition(),
             DSL.value(observationId, OBSERVATIONS.ID.dataType),
+            carryForward,
         )
     val survivalRateTempDenominator =
         getSurvivalRateTempDenominator(
             updateScope,
             DSL.trueCondition(),
             DSL.value(observationId, OBSERVATIONS.ID.dataType),
+            carryForward,
         )
     val survivalRateDenominator =
         DSL.coalesce(survivalRatePermanentDenominator, BigDecimal.ZERO)
@@ -2220,6 +2370,10 @@ class ObservationStore(
                         )
                     )
                     .and(OBSERVATION_PLOTS.COMPLETED_TIME.isNull)
+                    // Not-observed plots (e.g. those left unfinished by an abandoned observation)
+                    // are
+                    // not pending; only genuinely incomplete plots block recalculation.
+                    .and(OBSERVATION_PLOTS.STATUS_ID.ne(ObservationPlotStatus.NotObserved))
             )
             .not()
 
@@ -2511,7 +2665,28 @@ class ObservationStore(
               .execute()
         }
 
+        // Other observations that rolled the source's substratum data forward; their dependency
+        // rows cascade away with the source, so capture them before the delete and recompute them
+        // afterward (they fall back to the next-latest source, which may now be the target that
+        // just absorbed the source's completed plots).
+        val dependentsOfSource =
+            dslContext
+                .selectDistinct(DEPENDENT_SUBSTRATUM_OBSERVATION.OBSERVATION_ID)
+                .from(DEPENDENT_SUBSTRATUM_OBSERVATION)
+                .where(
+                    DEPENDENT_SUBSTRATUM_OBSERVATION.DEPENDS_ON_OBSERVATION_ID.eq(
+                        sourceObservationId
+                    )
+                )
+                .and(DEPENDENT_SUBSTRATUM_OBSERVATION.OBSERVATION_ID.ne(sourceObservationId))
+                .fetch(DEPENDENT_SUBSTRATUM_OBSERVATION.OBSERVATION_ID.asNonNullable())
+
         dslContext.deleteFrom(OBSERVATIONS).where(OBSERVATIONS.ID.eq(sourceObservationId)).execute()
+
+        // The target absorbed the source's completed plots, so its set of observed substrata may
+        // have changed; recompute its dependencies and those of the source's former dependents.
+        recordSubstratumDependencies(targetObservationId)
+        dependentsOfSource.forEach { recordSubstratumDependencies(it) }
       }
     }
   }
@@ -2692,6 +2867,17 @@ class ObservationStore(
             .where(PLOT_T0_OBSERVATIONS.OBSERVATION_ID.eq(observationId))
             .fetch(PLOT_T0_OBSERVATIONS.MONITORING_PLOT_ID.asNonNullable())
 
+    // Other observations that roll this one's substratum data forward. Their dependency rows
+    // cascade-delete with this observation, so once it is gone they must recompute to fall back to
+    // the next-latest source (or drop the substratum if none remains).
+    val dependentObservationIds =
+        dslContext
+            .selectDistinct(DEPENDENT_SUBSTRATUM_OBSERVATION.OBSERVATION_ID)
+            .from(DEPENDENT_SUBSTRATUM_OBSERVATION)
+            .where(DEPENDENT_SUBSTRATUM_OBSERVATION.DEPENDS_ON_OBSERVATION_ID.eq(observationId))
+            .and(DEPENDENT_SUBSTRATUM_OBSERVATION.OBSERVATION_ID.ne(observationId))
+            .fetch(DEPENDENT_SUBSTRATUM_OBSERVATION.OBSERVATION_ID.asNonNullable())
+
     dslContext.transaction { _ ->
       if (t0PlotIds.isNotEmpty()) {
         dslContext
@@ -2701,6 +2887,8 @@ class ObservationStore(
       }
 
       dslContext.deleteFrom(OBSERVATIONS).where(OBSERVATIONS.ID.eq(observationId)).execute()
+
+      dependentObservationIds.forEach { recordSubstratumDependencies(it) }
     }
   }
 
@@ -3662,8 +3850,27 @@ class ObservationStore(
       updateScope: ObservationSpeciesScope<ID, HistoryId>,
       condition: Condition,
       observationIdField: Field<ObservationId?>,
+      carryForward: Boolean = false,
   ): Field<BigDecimal> {
     val opPerm = OBSERVATION_PLOTS.`as`("opPerm")
+    // When the live total rolls a substratum forward (stratum/site scopes), the denominator must
+    // attribute each plot's T0 to that substratum's roll-forward source observation, exactly as the
+    // live total does; otherwise it uses the requested-substrata mapping.
+    val plotObservationCondition =
+        if (carryForward) {
+          opPerm.IS_PERMANENT.isTrue.and(
+              opPerm.OBSERVATION_ID.eq(
+                  latestObservationForSubstratumField(
+                      observationIdField,
+                      opPerm.monitoringPlotHistories.SUBSTRATUM_ID,
+                  )
+              )
+          )
+        } else {
+          opPerm.OBSERVATION_ID.eq(
+              observationIdForPlot(PLOT_T0_DENSITIES.MONITORING_PLOT_ID, observationIdField, true)
+          )
+        }
     return DSL.field(
         DSL.select(DSL.sum(PLOT_T0_DENSITIES.PLOT_DENSITY).mul(DSL.inline(HECTARES_PER_PLOT)))
             .from(PLOT_T0_DENSITIES)
@@ -3678,15 +3885,7 @@ class ObservationStore(
                     updateScope.alternateCompletedCondition(PLOT_T0_DENSITIES.MONITORING_PLOT_ID),
                 )
             )
-            .and(
-                opPerm.OBSERVATION_ID.eq(
-                    observationIdForPlot(
-                        PLOT_T0_DENSITIES.MONITORING_PLOT_ID,
-                        observationIdField,
-                        true,
-                    )
-                )
-            )
+            .and(plotObservationCondition)
     )
   }
 
@@ -3694,9 +3893,25 @@ class ObservationStore(
       updateScope: ObservationSpeciesScope<ID, HistoryId>,
       condition: Condition,
       observationIdField: Field<ObservationId?>,
+      carryForward: Boolean = false,
   ): Field<BigDecimal> {
     val opTemp = OBSERVATION_PLOTS.`as`("opTemp")
     return with(STRATUM_T0_TEMP_DENSITIES) {
+      val plotObservationCondition =
+          if (carryForward) {
+            opTemp.IS_PERMANENT.isFalse.and(
+                opTemp.OBSERVATION_ID.eq(
+                    latestObservationForSubstratumField(
+                        observationIdField,
+                        opTemp.monitoringPlotHistories.SUBSTRATUM_ID,
+                    )
+                )
+            )
+          } else {
+            opTemp.OBSERVATION_ID.eq(
+                observationIdForPlot(opTemp.MONITORING_PLOT_ID, observationIdField, false)
+            )
+          }
       DSL.field(
           DSL.select(DSL.sum(STRATUM_DENSITY).mul(DSL.inline(HECTARES_PER_PLOT)))
               .from(STRATUM_T0_TEMP_DENSITIES)
@@ -3716,15 +3931,7 @@ class ObservationStore(
                       updateScope.alternateCompletedCondition(opTemp.MONITORING_PLOT_ID),
                   )
               )
-              .and(
-                  opTemp.OBSERVATION_ID.eq(
-                      observationIdForPlot(
-                          opTemp.MONITORING_PLOT_ID,
-                          observationIdField,
-                          false,
-                      )
-                  )
-              )
+              .and(plotObservationCondition)
       )
     }
   }

--- a/src/main/kotlin/com/terraformation/backend/tracking/db/ObservationStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/db/ObservationStore.kt
@@ -1370,51 +1370,11 @@ class ObservationStore(
         // Edits to an observation can affect stratum and site data for later observations, but only
         // if the edited observation hasn't been superseded by a newer observation of the same
         // substratum.
-        //
-        // So we want to update later observations that don't have newer results for the substratum
-        // we're editing, that is, observations for which this observation's substratum-level totals
-        // would be used to calculate the stratum- and site-level totals. Those are exactly the
-        // observations whose dependent_substratum_observation row for this substratum points back
-        // at
-        // the edited observation; matching on requested (rather than observed) substrata would miss
-        // later observations that requested the substratum but did not observe it.
 
         val dependentSsh = SUBSTRATUM_HISTORIES.`as`("edit_dependent_ssh")
-        val stratumHistoryIdAtTimeOfObservation =
-            DSL.field(
-                DSL.select(STRATUM_HISTORIES.ID)
-                    .from(STRATUM_HISTORIES)
-                    .join(SUBSTRATUM_HISTORIES)
-                    .on(STRATUM_HISTORIES.ID.eq(SUBSTRATUM_HISTORIES.STRATUM_HISTORY_ID))
-                    .where(
-                        STRATUM_HISTORIES.PLANTING_SITE_HISTORY_ID.eq(
-                            OBSERVATIONS.PLANTING_SITE_HISTORY_ID
-                        )
-                    )
-                    .and(SUBSTRATUM_HISTORIES.SUBSTRATUM_ID.eq(substratumId))
-            )
-        val stratumIdAtTimeOfObservation =
-            DSL.field(
-                DSL.select(STRATUM_HISTORIES.STRATUM_ID)
-                    .from(STRATUM_HISTORIES)
-                    .join(SUBSTRATUM_HISTORIES)
-                    .on(STRATUM_HISTORIES.ID.eq(SUBSTRATUM_HISTORIES.STRATUM_HISTORY_ID))
-                    .where(
-                        STRATUM_HISTORIES.PLANTING_SITE_HISTORY_ID.eq(
-                            OBSERVATIONS.PLANTING_SITE_HISTORY_ID
-                        )
-                    )
-                    .and(SUBSTRATUM_HISTORIES.SUBSTRATUM_ID.eq(substratumId))
-            )
-
         val laterObservationsDependentOnSubstratumDataFromThisObservation =
             dslContext
-                .select(
-                    OBSERVATIONS.ID.asNonNullable(),
-                    OBSERVATIONS.PLANTING_SITE_HISTORY_ID.asNonNullable(),
-                    stratumHistoryIdAtTimeOfObservation.asNonNullable(),
-                    stratumIdAtTimeOfObservation,
-                )
+                .select(OBSERVATIONS.ID.asNonNullable())
                 .from(OBSERVATIONS)
                 .where(OBSERVATIONS.PLANTING_SITE_ID.eq(observation.plantingSiteId))
                 .and(OBSERVATIONS.COMPLETED_TIME.gt(observation.completedTime))
@@ -1437,29 +1397,11 @@ class ObservationStore(
                     )
                 )
                 .and(OBSERVATIONS.OBSERVATION_TYPE_ID.eq(ObservationType.Monitoring))
-                .fetch()
+                .fetch(OBSERVATIONS.ID.asNonNullable())
 
-        laterObservationsDependentOnSubstratumDataFromThisObservation.forEach {
-            (
-                laterObservationId,
-                laterPlantingSiteHistoryId,
-                stratumHistoryIdInLaterObservation,
-                stratumIdInLaterObservation,
-            ) ->
-          updateSpeciesTotals(
-              observationId = laterObservationId,
-              plantingSite = plantingSitesRow,
-              plantingSiteHistoryId = laterPlantingSiteHistoryId,
-              stratumId = stratumIdInLaterObservation,
-              stratumHistoryId = stratumHistoryIdInLaterObservation,
-              substratumId = null,
-              substratumHistoryId = null,
-              monitoringPlotId = null,
-              monitoringPlotHistoryId = null,
-              isAdHoc = observation.isAdHoc,
-              isPermanent = isPermanent,
-              plantCountsBySpecies = plantCountAdjustments,
-          )
+        laterObservationsDependentOnSubstratumDataFromThisObservation.forEach { laterObservationId
+          ->
+          recalculateSurvivalRates(laterObservationId, observation.plantingSiteId)
           updateObservationResults(laterObservationId, observation.plantingSiteId)
           recalculateSurvivalRateResults(laterObservationId, observation.plantingSiteId)
         }
@@ -1559,10 +1501,6 @@ class ObservationStore(
     if (hasCompletedPlots) {
       dslContext.transaction { _ ->
         log.info("Marking observation $observationId as abandoned")
-        // An abandoned observation is treated exactly like a completed one, except that its
-        // not-observed plots are ignored (see the survival-rate recalculation conditions) and a
-        // substratum whose plots were all left unobserved is rolled forward as if it had never been
-        // requested. So it runs the same recalculation sequence as completeObservation.
         abandonPlots(observationId)
         updateObservationState(observationId, ObservationState.Abandoned)
         recordSubstratumDependencies(observationId)
@@ -2103,17 +2041,21 @@ class ObservationStore(
     val table = updateScope.observedTotalsTable
     val speciesIdField = table.field("species_id", SPECIES.ID.dataType)
     val observationIdField = table.field("observation_id", OBSERVATIONS.ID.dataType)!!
+
+    val carryForward = updateScope.survivalRateDenominatorCarriesForward
     val survivalRatePermanentDenominator =
         getSurvivalRateDenominator(
             updateScope,
             PLOT_T0_DENSITIES.SPECIES_ID.eq(speciesIdField),
             observationIdField,
+            carryForward,
         )
     val survivalRateTempDenominator =
         getSurvivalRateTempDenominator(
             updateScope,
             STRATUM_T0_TEMP_DENSITIES.SPECIES_ID.eq(speciesIdField),
             observationIdField,
+            carryForward,
         )
     val survivalRateDenominator =
         DSL.coalesce(survivalRatePermanentDenominator, BigDecimal.ZERO)

--- a/src/main/kotlin/com/terraformation/backend/tracking/db/Queries.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/db/Queries.kt
@@ -3,6 +3,7 @@ package com.terraformation.backend.tracking.db
 import com.terraformation.backend.db.tracking.MonitoringPlotId
 import com.terraformation.backend.db.tracking.ObservationId
 import com.terraformation.backend.db.tracking.SubstratumId
+import com.terraformation.backend.db.tracking.tables.references.DEPENDENT_SUBSTRATUM_OBSERVATION
 import com.terraformation.backend.db.tracking.tables.references.MONITORING_PLOT_HISTORIES
 import com.terraformation.backend.db.tracking.tables.references.OBSERVATIONS
 import com.terraformation.backend.db.tracking.tables.references.OBSERVATION_PLOTS
@@ -11,45 +12,29 @@ import com.terraformation.backend.db.tracking.tables.references.STRATUM_HISTORIE
 import com.terraformation.backend.db.tracking.tables.references.SUBSTRATUM_HISTORIES
 import org.jooq.Condition
 import org.jooq.Field
+import org.jooq.Record1
+import org.jooq.Select
 import org.jooq.impl.DSL
 
 /**
- * Retrieves the most recent observationId for a substratum, with a completed time less than or
- * equal to the given observationId's completed time.
+ * Retrieves the most recent observationId for a substratum, or null if the substratum was not
+ * observed in or before the requested observation
  *
  * The substratum in question is assumed to be OBSERVED_SUBSTRATUM_SPECIES_TOTALS.SUBSTRATUM_ID.
  */
 fun latestObservationForSubstratumField(
     observationIdField: Field<ObservationId?>,
     substratumIdField: Field<SubstratumId?>,
-) =
-    DSL.select(OBSERVATIONS.ID)
-        .from(OBSERVATIONS)
-        .join(OBSERVATION_REQUESTED_SUBSTRATA)
-        .on(OBSERVATIONS.ID.eq(OBSERVATION_REQUESTED_SUBSTRATA.OBSERVATION_ID))
-        .where(OBSERVATION_REQUESTED_SUBSTRATA.SUBSTRATUM_ID.eq(substratumIdField))
-        .and(
-            DSL.or(
-                // Always consider the reference observation itself, even while it is still in
-                // progress and so has no completed time to compare against yet.
-                OBSERVATIONS.ID.eq(observationIdField),
-                OBSERVATIONS.COMPLETED_TIME.le(
-                    DSL.select(OBSERVATIONS.COMPLETED_TIME)
-                        .from(OBSERVATIONS)
-                        .where(OBSERVATIONS.ID.eq(observationIdField))
-                ),
-            )
-        )
-        .and(OBSERVATIONS.IS_AD_HOC.isFalse)
-        .orderBy(
-            // Prefer results from the same observation as the `observationId` if it exists.
-            // True is considered greater than false, so sorting by an "=" expression in
-            // descending order means the matches come first.
-            OBSERVATIONS.ID.eq(observationIdField).desc(),
-            // Otherwise take the results from the next latest observation for that area.
-            OBSERVATIONS.COMPLETED_TIME.desc(),
-        )
-        .limit(1)
+): Select<Record1<ObservationId?>> {
+  val dependentSsh = SUBSTRATUM_HISTORIES.`as`("dependent_obs_ssh")
+  return DSL.select(DEPENDENT_SUBSTRATUM_OBSERVATION.DEPENDS_ON_OBSERVATION_ID)
+      .from(DEPENDENT_SUBSTRATUM_OBSERVATION)
+      .join(dependentSsh)
+      .on(dependentSsh.ID.eq(DEPENDENT_SUBSTRATUM_OBSERVATION.SUBSTRATUM_HISTORY_ID))
+      .where(DEPENDENT_SUBSTRATUM_OBSERVATION.OBSERVATION_ID.eq(observationIdField))
+      .and(dependentSsh.SUBSTRATUM_ID.eq(substratumIdField))
+      .limit(1)
+}
 
 /**
  * Returns an observationId if the given monitoring plot is used in the observation results from

--- a/src/main/kotlin/com/terraformation/backend/tracking/util/ObservationResultsScope.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/util/ObservationResultsScope.kt
@@ -12,6 +12,7 @@ import com.terraformation.backend.db.tracking.SubstratumHistoryId
 import com.terraformation.backend.db.tracking.SubstratumId
 import com.terraformation.backend.db.tracking.tables.ObservationPlotResults
 import com.terraformation.backend.db.tracking.tables.ObservationPlots
+import com.terraformation.backend.db.tracking.tables.references.DEPENDENT_SUBSTRATUM_OBSERVATION
 import com.terraformation.backend.db.tracking.tables.references.MONITORING_PLOTS
 import com.terraformation.backend.db.tracking.tables.references.MONITORING_PLOT_HISTORIES
 import com.terraformation.backend.db.tracking.tables.references.OBSERVATIONS
@@ -59,12 +60,16 @@ interface ObservationResultsScope<ID : Any, HistoryId : Any> :
   val latestLiveField: Field<Int>
 
   /**
-   * Condition that covers all result table rows that could be affected by a change to the scoped
-   * entity. For ID-based scopes this is the same as [observedTotalsCondition]. For plotId-based
-   * scopes it expands to include all observations for every substratum/stratum the plot has ever
-   * historically belonged to, ensuring that observations which reference the plot's data via
-   * [observationIdForPlot] are also updated.
+   * Whether this scope's survival-rate denominator must roll a substratum's data forward the same
+   * way [latestLiveField] does. True for the stratum and site scopes, whose live totals pull each
+   * substratum from its latest observation at or before the current one (so the denominator must
+   * pull the same T0 densities, or the rate is inflated). False for the plot and substratum scopes,
+   * which use only the current observation's data.
    */
+  val survivalRateDenominatorCarriesForward: Boolean
+    get() = false
+
+  /** Condition that covers all result table rows that could be affected downstream. */
   val survivalRateRecalculationCondition: Condition
 
   fun anyChildHasNullSurvivalRateCondition(observationIdField: Field<ObservationId?>): Condition
@@ -402,6 +407,8 @@ class ObservationResultsStratum(
           stratumHistorySelect
       )
 
+  override val survivalRateDenominatorCarriesForward = true
+
   override val latestLiveField =
       with(OBSERVATION_SUBSTRATUM_RESULTS) {
         DSL.field(
@@ -465,16 +472,45 @@ class ObservationResultsStratum(
   override val observedTotalsCondition =
       OBSERVATION_STRATUM_RESULTS.STRATUM_HISTORY_ID.`in`(stratumHistorySelect)
 
+  /**
+   * For the plotId case, scopes the recalc to exactly the stratum result rows whose data is rolled
+   * up from the edited plot's observations.
+   */
   override val survivalRateRecalculationCondition: Condition
     get() =
         if (plotId != null) {
-          OBSERVATION_STRATUM_RESULTS.STRATUM_HISTORY_ID.`in`(
-              DSL.selectDistinct(SUBSTRATUM_HISTORIES.STRATUM_HISTORY_ID)
-                  .from(MONITORING_PLOT_HISTORIES)
-                  .join(SUBSTRATUM_HISTORIES)
-                  .on(SUBSTRATUM_HISTORIES.ID.eq(MONITORING_PLOT_HISTORIES.SUBSTRATUM_HISTORY_ID))
-                  .where(MONITORING_PLOT_HISTORIES.MONITORING_PLOT_ID.eq(plotId))
-          )
+          DSL.row(
+                  OBSERVATION_STRATUM_RESULTS.OBSERVATION_ID,
+                  OBSERVATION_STRATUM_RESULTS.STRATUM_HISTORY_ID,
+              )
+              .`in`(
+                  DSL.select(
+                          DEPENDENT_SUBSTRATUM_OBSERVATION.OBSERVATION_ID,
+                          SUBSTRATUM_HISTORIES.STRATUM_HISTORY_ID,
+                      )
+                      .from(DEPENDENT_SUBSTRATUM_OBSERVATION)
+                      .join(SUBSTRATUM_HISTORIES)
+                      .on(
+                          SUBSTRATUM_HISTORIES.ID.eq(
+                              DEPENDENT_SUBSTRATUM_OBSERVATION.SUBSTRATUM_HISTORY_ID
+                          )
+                      )
+                      .where(
+                          DSL.row(
+                                  DEPENDENT_SUBSTRATUM_OBSERVATION.DEPENDS_ON_OBSERVATION_ID,
+                                  DEPENDENT_SUBSTRATUM_OBSERVATION.DEPENDS_ON_SUBSTRATUM_HISTORY_ID,
+                              )
+                              .`in`(
+                                  DSL.select(
+                                          OBSERVATION_PLOTS.OBSERVATION_ID,
+                                          OBSERVATION_PLOTS.monitoringPlotHistories
+                                              .SUBSTRATUM_HISTORY_ID,
+                                      )
+                                      .from(OBSERVATION_PLOTS)
+                                      .where(OBSERVATION_PLOTS.MONITORING_PLOT_ID.eq(plotId))
+                              )
+                      )
+              )
         } else {
           observedTotalsCondition
         }
@@ -632,6 +668,8 @@ class ObservationResultsSite(
   override val rollupSpeciesCondition = OBSERVED_SITE_SPECIES_TOTALS.PLANTING_SITE_ID.eq(siteSelect)
 
   override val plotResultsCondition = DSL.trueCondition()
+
+  override val survivalRateDenominatorCarriesForward = true
 
   override val latestLiveField =
       with(OBSERVATION_SUBSTRATUM_RESULTS) {

--- a/src/main/kotlin/com/terraformation/backend/tracking/util/ObservationResultsScope.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/util/ObservationResultsScope.kt
@@ -59,16 +59,6 @@ interface ObservationResultsScope<ID : Any, HistoryId : Any> :
 
   val latestLiveField: Field<Int>
 
-  /**
-   * Whether this scope's survival-rate denominator must roll a substratum's data forward the same
-   * way [latestLiveField] does. True for the stratum and site scopes, whose live totals pull each
-   * substratum from its latest observation at or before the current one (so the denominator must
-   * pull the same T0 densities, or the rate is inflated). False for the plot and substratum scopes,
-   * which use only the current observation's data.
-   */
-  val survivalRateDenominatorCarriesForward: Boolean
-    get() = false
-
   /** Condition that covers all result table rows that could be affected downstream. */
   val survivalRateRecalculationCondition: Condition
 

--- a/src/main/kotlin/com/terraformation/backend/tracking/util/ObservationSpeciesScope.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/util/ObservationSpeciesScope.kt
@@ -43,6 +43,16 @@ interface ObservationSpeciesScope<ID : Any, HistoryId : Any> {
   val observedTotalsScopeHistoryField: TableField<*, HistoryId?>
   val observedTotalsTable: Table<out Record>
 
+  /**
+   * Whether this scope's live totals roll a not-currently-observed substratum forward from a prior
+   * observation. True for the stratum and site scopes, whose totals sum each substratum at its
+   * latest observation; the survival-rate denominator must roll the same T0 densities forward or
+   * the rate is inflated. False for the plot and substratum scopes, which use only the current
+   * observation's data.
+   */
+  val survivalRateDenominatorCarriesForward: Boolean
+    get() = false
+
   fun alternateCompletedCondition(plotField: TableField<*, MonitoringPlotId?>): Condition
 
   fun tempStratumCondition(tempStratumTable: ObservationPlots): Condition
@@ -215,6 +225,8 @@ class ObservationSpeciesStratum(
 
   override val observedTotalsTable = OBSERVED_STRATUM_SPECIES_TOTALS
 
+  override val survivalRateDenominatorCarriesForward = true
+
   override fun alternateCompletedCondition(plotField: TableField<*, MonitoringPlotId?>) =
       if (plotId == null) DSL.falseCondition() else plotField.eq(plotId)
 
@@ -292,6 +304,8 @@ class ObservationSpeciesSite(
       OBSERVED_SITE_SPECIES_TOTALS.PLANTING_SITE_HISTORY_ID
 
   override val observedTotalsTable = OBSERVED_SITE_SPECIES_TOTALS
+
+  override val survivalRateDenominatorCarriesForward = true
 
   override fun alternateCompletedCondition(plotField: TableField<*, MonitoringPlotId?>) =
       if (plotId == null) DSL.falseCondition() else plotField.eq(plotId)

--- a/src/main/resources/db/migration/0500/V517__DependentSubstratumObservation.sql
+++ b/src/main/resources/db/migration/0500/V517__DependentSubstratumObservation.sql
@@ -1,0 +1,49 @@
+CREATE TABLE tracking.dependent_substratum_observation (
+    observation_id BIGINT NOT NULL REFERENCES tracking.observations ON DELETE CASCADE,
+    substratum_history_id BIGINT NOT NULL REFERENCES tracking.substratum_histories ON DELETE CASCADE,
+    depends_on_observation_id BIGINT NOT NULL REFERENCES tracking.observations ON DELETE CASCADE,
+    depends_on_substratum_history_id BIGINT NOT NULL REFERENCES tracking.substratum_histories ON DELETE CASCADE,
+
+    PRIMARY KEY (observation_id, substratum_history_id)
+);
+
+CREATE INDEX ON tracking.dependent_substratum_observation (depends_on_observation_id, depends_on_substratum_history_id);
+
+INSERT INTO tracking.dependent_substratum_observation
+    (observation_id, substratum_history_id, depends_on_observation_id, depends_on_substratum_history_id)
+SELECT consuming.id,
+       consuming_ssh.id,
+       src.depends_on_observation_id,
+       src_ssh.id
+FROM tracking.observations consuming
+JOIN tracking.stratum_histories consuming_sh
+    ON consuming_sh.planting_site_history_id = consuming.planting_site_history_id
+JOIN tracking.substratum_histories consuming_ssh
+    ON consuming_ssh.stratum_history_id = consuming_sh.id
+JOIN LATERAL (
+    SELECT o2.id AS depends_on_observation_id
+    FROM tracking.observations o2
+    WHERE o2.is_ad_hoc = FALSE
+      AND (o2.id = consuming.id OR o2.completed_time <= consuming.completed_time)
+      -- The substratum must have been actually observed (a completed plot), not merely requested.
+      AND EXISTS (
+          SELECT 1
+          FROM tracking.observation_plots op
+          JOIN tracking.monitoring_plot_histories mph
+              ON mph.id = op.monitoring_plot_history_id
+          WHERE op.observation_id = o2.id
+            AND op.completed_time IS NOT NULL
+            AND mph.substratum_id = consuming_ssh.substratum_id
+      )
+    ORDER BY (o2.id = consuming.id) DESC, o2.completed_time DESC
+    LIMIT 1
+) src ON TRUE
+JOIN tracking.observations src_obs
+    ON src_obs.id = src.depends_on_observation_id
+JOIN tracking.stratum_histories src_sh
+    ON src_sh.planting_site_history_id = src_obs.planting_site_history_id
+JOIN tracking.substratum_histories src_ssh
+    ON src_ssh.stratum_history_id = src_sh.id
+   AND src_ssh.substratum_id = consuming_ssh.substratum_id
+WHERE consuming.is_ad_hoc = FALSE
+  AND consuming.completed_time IS NOT NULL;

--- a/src/main/resources/db/migration/R__Comments.sql
+++ b/src/main/resources/db/migration/R__Comments.sql
@@ -431,6 +431,12 @@ COMMENT ON COLUMN tracking.deliveries.reassigned_by IS 'Which user recorded the 
 COMMENT ON COLUMN tracking.deliveries.reassigned_time IS 'When the reassignment was recorded. Null if this delivery has no reassignment.';
 COMMENT ON COLUMN tracking.deliveries.withdrawal_id IS 'Which nursery withdrawal the plants came from.';
 
+COMMENT ON TABLE tracking.dependent_substratum_observation IS 'For a completed observation and each substratum in its geometry snapshot, the prior (or same) observation whose substratum results should be rolled forward. A materialization of the "latest observation at or before this one that observed the substratum" relationship. A substratum observed in the observation itself is stored as a self-reference.';
+COMMENT ON COLUMN tracking.dependent_substratum_observation.observation_id IS 'The consuming observation whose rolled-up results use the depended-on data.';
+COMMENT ON COLUMN tracking.dependent_substratum_observation.substratum_history_id IS 'The substratum''s history in the consuming observation''s snapshot.';
+COMMENT ON COLUMN tracking.dependent_substratum_observation.depends_on_observation_id IS 'The observation whose substratum results are rolled forward; equals observation_id when the substratum was observed in the consuming observation.';
+COMMENT ON COLUMN tracking.dependent_substratum_observation.depends_on_substratum_history_id IS 'The substratum''s history in the depended-on observation''s snapshot.';
+
 COMMENT ON TABLE tracking.draft_planting_sites IS 'Details of planting sites that are in the process of being defined.';
 COMMENT ON COLUMN tracking.draft_planting_sites.data IS 'Client-defined state of the definition of the planting site. This may include a mix of map data and application state and is treated as opaque by the server.';
 COMMENT ON COLUMN tracking.draft_planting_sites.num_substrata is 'Number of substrata defined so far.';

--- a/src/test/kotlin/com/terraformation/backend/accelerator/db/ReportStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/db/ReportStoreTest.kt
@@ -5592,7 +5592,7 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
             insertHistory = false,
         )
     val substratum1oldHistory = insertSubstratumHistory(stratumHistoryId = site1stratumOldHistory)
-    insertSubstratumHistory()
+    val substratum1NewHistory = insertSubstratumHistory()
     val substratum1plot1 = insertMonitoringPlot(permanentIndex = 1, insertHistory = false)
     val substratum1plot1OldHist =
         insertMonitoringPlotHistory(
@@ -5634,7 +5634,7 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
             insertHistory = false,
         )
     val substratum2oldHistory = insertSubstratumHistory(stratumHistoryId = site1stratumOldHistory)
-    insertSubstratumHistory()
+    val substratum2NewHistory = insertSubstratumHistory()
     // this plot was in observation1 but was reassigned from observation2
     val reassignedPlot = insertMonitoringPlot(permanentIndex = 2)
     val reassignedPlotHist = inserted.monitoringPlotHistoryId
@@ -5710,6 +5710,7 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
             areaHa = BigDecimal(1000),
             plantingCompletedTime = null,
         )
+    val incompleteSubstratumHistory = inserted.substratumHistoryId
     // plot was in a different substratum previously
     val incompleteSubstratumPlot1 = insertMonitoringPlot(permanentIndex = 5, insertHistory = false)
     val incompleteSubstratumPlot1OldHist =
@@ -5735,7 +5736,7 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
             insertHistory = false,
         )
     val futureSubstratumOldHist = insertSubstratumHistory(stratumHistoryId = site1stratumOldHistory)
-    insertSubstratumHistory()
+    val futureSubstratumNewHistory = insertSubstratumHistory()
     val futureSubstratumPlot1 = insertMonitoringPlot(permanentIndex = 6, insertHistory = false)
     val futureSubstratumPlot1OldHist =
         insertMonitoringPlotHistory(
@@ -5765,6 +5766,7 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
             areaHa = BigDecimal(30),
             plantingCompletedTime = plantingCompletedDate2.atStartOfDay().toInstant(ZoneOffset.UTC),
         )
+    val site2Substratum1History = inserted.substratumHistoryId
     val substratum3plot1 = insertMonitoringPlot(permanentIndex = 1)
     val substratum3plot1Hist = inserted.monitoringPlotHistoryId
     insertPlotT0Density(
@@ -6218,6 +6220,34 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
     // Total plants: 50
     // Dead plants: 20
 
+    // observation2 observed substratumId2, incompleteSubstratum, and futureSubstratum
+    insertDependentSubstratumObservation(
+        observationId = site1observation2,
+        substratumHistoryId = substratum2NewHistory,
+    )
+    insertDependentSubstratumObservation(
+        observationId = site1observation2,
+        substratumHistoryId = incompleteSubstratumHistory,
+    )
+    insertDependentSubstratumObservation(
+        observationId = site1observation2,
+        substratumHistoryId = futureSubstratumNewHistory,
+    )
+
+    // observation2 did not observe substratumId1
+    insertDependentSubstratumObservation(
+        observationId = site1observation2,
+        substratumHistoryId = substratum1NewHistory,
+        dependsOnObservationId = site1OldObservationId,
+        dependsOnSubstratumHistoryId = substratum1oldHistory,
+    )
+
+    // Site 2 only has one observation
+    insertDependentSubstratumObservation(
+        observationId = site2ObservationId,
+        substratumHistoryId = site2Substratum1History,
+    )
+
     // Populate the rolled-up stratum and site SRs that the project-level area-weighted
     // calculation reads from. Site 1's stratum has substrata of areas 10+20+1000+3000=4030 ha;
     // site 2 has one substratum of area 30 ha. With both stratum SRs=50, the project SR is
@@ -6488,6 +6518,16 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
         plantingSiteId = plantingSite3,
         plantingSiteHistoryId = plantingSiteHistory3,
         permanentLive = 51,
+    )
+
+    // Each site only has one substratum and one observation. Site 3 is unobserved.
+    insertDependentSubstratumObservation(
+        observationId = site1ObservationId,
+        substratumHistoryId = site1SubstratumHistory,
+    )
+    insertDependentSubstratumObservation(
+        observationId = site2ObservationId,
+        substratumHistoryId = site2SubstratumHistory,
     )
 
     // Populate the rolled-up site/stratum SR values that the project-level area-weighted

--- a/src/test/kotlin/com/terraformation/backend/db/DatabaseBackedTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/db/DatabaseBackedTest.kt
@@ -455,6 +455,7 @@ import com.terraformation.backend.db.tracking.SubstratumId
 import com.terraformation.backend.db.tracking.TreeGrowthForm
 import com.terraformation.backend.db.tracking.keys.PLANTING_SITES_PKEY
 import com.terraformation.backend.db.tracking.tables.daos.DeliveriesDao
+import com.terraformation.backend.db.tracking.tables.daos.DependentSubstratumObservationDao
 import com.terraformation.backend.db.tracking.tables.daos.DraftPlantingSitesDao
 import com.terraformation.backend.db.tracking.tables.daos.MonitoringPlotHistoriesDao
 import com.terraformation.backend.db.tracking.tables.daos.MonitoringPlotOverlapsDao
@@ -501,6 +502,7 @@ import com.terraformation.backend.db.tracking.tables.daos.SubstrataDao
 import com.terraformation.backend.db.tracking.tables.daos.SubstratumHistoriesDao
 import com.terraformation.backend.db.tracking.tables.daos.SubstratumPopulationsDao
 import com.terraformation.backend.db.tracking.tables.pojos.DeliveriesRow
+import com.terraformation.backend.db.tracking.tables.pojos.DependentSubstratumObservationRow
 import com.terraformation.backend.db.tracking.tables.pojos.DraftPlantingSitesRow
 import com.terraformation.backend.db.tracking.tables.pojos.MonitoringPlotHistoriesRow
 import com.terraformation.backend.db.tracking.tables.pojos.MonitoringPlotOverlapsRow
@@ -713,6 +715,7 @@ abstract class DatabaseBackedTest {
   protected val deliverablesDao: DeliverablesDao by lazyDao()
   protected val deliverableVariablesDao: DeliverableVariablesDao by lazyDao()
   protected val deliveriesDao: DeliveriesDao by lazyDao()
+  protected val dependentSubstratumObservationDao: DependentSubstratumObservationDao by lazyDao()
   protected val deviceManagersDao: DeviceManagersDao by lazyDao()
   protected val devicesDao: DevicesDao by lazyDao()
   protected val deviceTemplatesDao: DeviceTemplatesDao by lazyDao()
@@ -3712,6 +3715,22 @@ abstract class DatabaseBackedTest {
   ) {
     observationRequestedSubstrataDao.insert(
         ObservationRequestedSubstrataRow(observationId, substratumId)
+    )
+  }
+
+  protected fun insertDependentSubstratumObservation(
+      observationId: ObservationId,
+      substratumHistoryId: SubstratumHistoryId,
+      dependsOnObservationId: ObservationId = observationId,
+      dependsOnSubstratumHistoryId: SubstratumHistoryId = substratumHistoryId,
+  ) {
+    dependentSubstratumObservationDao.insert(
+        DependentSubstratumObservationRow(
+            observationId = observationId,
+            substratumHistoryId = substratumHistoryId,
+            dependsOnObservationId = dependsOnObservationId,
+            dependsOnSubstratumHistoryId = dependsOnSubstratumHistoryId,
+        )
     )
   }
 

--- a/src/test/kotlin/com/terraformation/backend/db/SchemaDocsGenerator.kt
+++ b/src/test/kotlin/com/terraformation/backend/db/SchemaDocsGenerator.kt
@@ -403,6 +403,7 @@ class SchemaDocsGenerator : DatabaseTest() {
               mapOf(
                   "biomass_forest_types" to setOf(ALL, TRACKING),
                   "deliveries" to setOf(ALL, TRACKING),
+                  "dependent_substratum_observation" to setOf(ALL, TRACKING),
                   "draft_planting_sites" to setOf(ALL, TRACKING),
                   "mangrove_tides" to setOf(ALL, TRACKING),
                   "monitoring_plot_histories" to setOf(ALL, TRACKING),

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/ObservationScenarioTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/ObservationScenarioTest.kt
@@ -99,6 +99,7 @@ abstract class ObservationScenarioTest : DatabaseTest(), RunsAsUser {
 
     every { user.canReadObservation(any()) } returns true
     every { user.canUpdateObservation(any()) } returns true
+    every { user.canUpdateObservationQuantities(any()) } returns true
     every { user.canReadPlantingSite(plantingSiteId) } returns true
   }
 

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/observationStore/ObservationStoreMergeObservationDataTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/observationStore/ObservationStoreMergeObservationDataTest.kt
@@ -6,7 +6,9 @@ import com.terraformation.backend.db.tracking.ObservableCondition
 import com.terraformation.backend.db.tracking.ObservationId
 import com.terraformation.backend.db.tracking.RecordedPlantStatus
 import com.terraformation.backend.db.tracking.RecordedSpeciesCertainty
+import com.terraformation.backend.db.tracking.SubstratumId
 import com.terraformation.backend.db.tracking.tables.pojos.RecordedPlantsRow
+import com.terraformation.backend.db.tracking.tables.references.DEPENDENT_SUBSTRATUM_OBSERVATION
 import com.terraformation.backend.db.tracking.tables.references.OBSERVATIONS
 import com.terraformation.backend.db.tracking.tables.references.OBSERVATION_MEDIA_FILES
 import com.terraformation.backend.db.tracking.tables.references.OBSERVATION_PLOTS
@@ -23,6 +25,7 @@ import com.terraformation.backend.db.tracking.tables.references.OBSERVED_SUBSTRA
 import com.terraformation.backend.db.tracking.tables.references.PLOT_T0_DENSITIES
 import com.terraformation.backend.db.tracking.tables.references.PLOT_T0_OBSERVATIONS
 import com.terraformation.backend.db.tracking.tables.references.RECORDED_PLANTS
+import com.terraformation.backend.db.tracking.tables.references.SUBSTRATUM_HISTORIES
 import com.terraformation.backend.point
 import java.time.Instant
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -269,6 +272,98 @@ class ObservationStoreMergeObservationDataTest : BaseObservationStoreTest() {
     assertEquals(expectedTotals, helper.fetchAllTotals(), "Species totals after rebuild")
     assertEquals(expectedResults, helper.fetchAllResults(), "Observation results after rebuild")
   }
+
+  @Test
+  fun `merge folds the source's substratum into the target's dependencies`() {
+    val substratumA = inserted.substratumId
+    val substratumB = insertSubstratum()
+    val plotA = insertMonitoringPlot(substratumId = substratumA)
+    val plotB = insertMonitoringPlot(substratumId = substratumB)
+
+    // Each observation covers only part of the site: the target observes substratum A, the source
+    // observes substratum B.
+    clock.instant = Instant.ofEpochSecond(1)
+    val target = insertObservation()
+    completePlotWith(target, plotA, 1)
+
+    clock.instant = Instant.ofEpochSecond(2)
+    val source = insertObservation()
+    completePlotWith(source, plotB, 1)
+
+    store.mergeObservationData(source, target)
+
+    // The target absorbed the source's B plot, so it now self-references both substrata, and no
+    // dependency row points at the deleted source.
+    assertEquals(target, dependencySource(target, substratumA), "Target dependency for A")
+    assertEquals(target, dependencySource(target, substratumB), "Target dependency for B")
+    assertEquals(
+        emptyList<ObservationId?>(),
+        dslContext
+            .select(DEPENDENT_SUBSTRATUM_OBSERVATION.OBSERVATION_ID)
+            .from(DEPENDENT_SUBSTRATUM_OBSERVATION)
+            .where(DEPENDENT_SUBSTRATUM_OBSERVATION.DEPENDS_ON_OBSERVATION_ID.eq(source))
+            .fetch(DEPENDENT_SUBSTRATUM_OBSERVATION.OBSERVATION_ID),
+        "No dependency rows reference the deleted source",
+    )
+  }
+
+  @Test
+  fun `merge recomputes dependencies of observations that rolled the source forward`() {
+    val substratumA = inserted.substratumId
+    val substratumB = insertSubstratum()
+    val plotA = insertMonitoringPlot(substratumId = substratumA)
+    val plotB = insertMonitoringPlot(substratumId = substratumB)
+    val plotA2 = insertMonitoringPlot(substratumId = substratumA)
+
+    // Partial-site observations: target observes A, source observes B (the latest B data), and a
+    // later observation observes only A so it rolls B forward from the source.
+    clock.instant = Instant.ofEpochSecond(1)
+    val target = insertObservation()
+    completePlotWith(target, plotA, 1)
+
+    clock.instant = Instant.ofEpochSecond(2)
+    val source = insertObservation()
+    completePlotWith(source, plotB, 1)
+
+    clock.instant = Instant.ofEpochSecond(3)
+    val later = insertObservation()
+    completePlotWith(later, plotA2, 1)
+
+    assertEquals(
+        source,
+        dependencySource(later, substratumB),
+        "Later observation rolls B forward from the source before the merge",
+    )
+
+    store.mergeObservationData(source, target)
+
+    // The target absorbed B, so the later observation must now roll B forward from the target
+    // rather than from the deleted source (which would otherwise drop the substratum).
+    assertEquals(
+        target,
+        dependencySource(later, substratumB),
+        "Later observation rolls B forward from the target after the merge",
+    )
+    assertEquals(
+        later,
+        dependencySource(later, substratumA),
+        "Later observation still self-references A",
+    )
+  }
+
+  /** The observation whose substratum data [observationId] rolls forward for [substratumId]. */
+  private fun dependencySource(
+      observationId: ObservationId,
+      substratumId: SubstratumId,
+  ): ObservationId? =
+      dslContext
+          .select(DEPENDENT_SUBSTRATUM_OBSERVATION.DEPENDS_ON_OBSERVATION_ID)
+          .from(DEPENDENT_SUBSTRATUM_OBSERVATION)
+          .join(SUBSTRATUM_HISTORIES)
+          .on(SUBSTRATUM_HISTORIES.ID.eq(DEPENDENT_SUBSTRATUM_OBSERVATION.SUBSTRATUM_HISTORY_ID))
+          .where(DEPENDENT_SUBSTRATUM_OBSERVATION.OBSERVATION_ID.eq(observationId))
+          .and(SUBSTRATUM_HISTORIES.SUBSTRATUM_ID.eq(substratumId))
+          .fetchOne(DEPENDENT_SUBSTRATUM_OBSERVATION.DEPENDS_ON_OBSERVATION_ID)
 
   private fun livePlant(speciesId: SpeciesId = this.speciesId) =
       RecordedPlantsRow(

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/observationStore/ObservationStoreMergeObservationDataTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/observationStore/ObservationStoreMergeObservationDataTest.kt
@@ -6,8 +6,8 @@ import com.terraformation.backend.db.tracking.ObservableCondition
 import com.terraformation.backend.db.tracking.ObservationId
 import com.terraformation.backend.db.tracking.RecordedPlantStatus
 import com.terraformation.backend.db.tracking.RecordedSpeciesCertainty
-import com.terraformation.backend.db.tracking.SubstratumId
 import com.terraformation.backend.db.tracking.tables.pojos.RecordedPlantsRow
+import com.terraformation.backend.db.tracking.tables.records.DependentSubstratumObservationRecord
 import com.terraformation.backend.db.tracking.tables.references.DEPENDENT_SUBSTRATUM_OBSERVATION
 import com.terraformation.backend.db.tracking.tables.references.OBSERVATIONS
 import com.terraformation.backend.db.tracking.tables.references.OBSERVATION_MEDIA_FILES
@@ -25,7 +25,6 @@ import com.terraformation.backend.db.tracking.tables.references.OBSERVED_SUBSTRA
 import com.terraformation.backend.db.tracking.tables.references.PLOT_T0_DENSITIES
 import com.terraformation.backend.db.tracking.tables.references.PLOT_T0_OBSERVATIONS
 import com.terraformation.backend.db.tracking.tables.references.RECORDED_PLANTS
-import com.terraformation.backend.db.tracking.tables.references.SUBSTRATUM_HISTORIES
 import com.terraformation.backend.point
 import java.time.Instant
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -276,7 +275,9 @@ class ObservationStoreMergeObservationDataTest : BaseObservationStoreTest() {
   @Test
   fun `merge folds the source's substratum into the target's dependencies`() {
     val substratumA = inserted.substratumId
+    val substratumAHistory = inserted.substratumHistoryId
     val substratumB = insertSubstratum()
+    val substratumBHistory = inserted.substratumHistoryId
     val plotA = insertMonitoringPlot(substratumId = substratumA)
     val plotB = insertMonitoringPlot(substratumId = substratumB)
 
@@ -292,25 +293,37 @@ class ObservationStoreMergeObservationDataTest : BaseObservationStoreTest() {
 
     store.mergeObservationData(source, target)
 
-    // The target absorbed the source's B plot, so it now self-references both substrata, and no
-    // dependency row points at the deleted source.
-    assertEquals(target, dependencySource(target, substratumA), "Target dependency for A")
-    assertEquals(target, dependencySource(target, substratumB), "Target dependency for B")
-    assertEquals(
-        emptyList<ObservationId?>(),
-        dslContext
-            .select(DEPENDENT_SUBSTRATUM_OBSERVATION.OBSERVATION_ID)
-            .from(DEPENDENT_SUBSTRATUM_OBSERVATION)
-            .where(DEPENDENT_SUBSTRATUM_OBSERVATION.DEPENDS_ON_OBSERVATION_ID.eq(source))
-            .fetch(DEPENDENT_SUBSTRATUM_OBSERVATION.OBSERVATION_ID),
+    // The target absorbed the source's B plot, so it now self-references both substrata.
+    assertTableEquals(
+        listOf(
+            DependentSubstratumObservationRecord(
+                target,
+                substratumAHistory,
+                target,
+                substratumAHistory,
+            ),
+            DependentSubstratumObservationRecord(
+                target,
+                substratumBHistory,
+                target,
+                substratumBHistory,
+            ),
+        ),
+        "Target self-references both substrata after the merge",
+    )
+    assertTableEmpty(
+        DEPENDENT_SUBSTRATUM_OBSERVATION,
         "No dependency rows reference the deleted source",
+        where = DEPENDENT_SUBSTRATUM_OBSERVATION.DEPENDS_ON_OBSERVATION_ID.eq(source),
     )
   }
 
   @Test
   fun `merge recomputes dependencies of observations that rolled the source forward`() {
     val substratumA = inserted.substratumId
+    val substratumAHistory = inserted.substratumHistoryId
     val substratumB = insertSubstratum()
+    val substratumBHistory = inserted.substratumHistoryId
     val plotA = insertMonitoringPlot(substratumId = substratumA)
     val plotB = insertMonitoringPlot(substratumId = substratumB)
     val plotA2 = insertMonitoringPlot(substratumId = substratumA)
@@ -329,9 +342,42 @@ class ObservationStoreMergeObservationDataTest : BaseObservationStoreTest() {
     val later = insertObservation()
     completePlotWith(later, plotA2, 1)
 
-    assertEquals(
-        source,
-        dependencySource(later, substratumB),
+    // Before the merge, the later observation rolls B forward from the source. The source itself
+    // rolls A forward from the target (it never observed A), and every observation has a row for
+    // each substratum in its snapshot.
+    assertTableEquals(
+        listOf(
+            DependentSubstratumObservationRecord(
+                target,
+                substratumAHistory,
+                target,
+                substratumAHistory,
+            ),
+            DependentSubstratumObservationRecord(
+                source,
+                substratumAHistory,
+                target,
+                substratumAHistory,
+            ),
+            DependentSubstratumObservationRecord(
+                source,
+                substratumBHistory,
+                source,
+                substratumBHistory,
+            ),
+            DependentSubstratumObservationRecord(
+                later,
+                substratumAHistory,
+                later,
+                substratumAHistory,
+            ),
+            DependentSubstratumObservationRecord(
+                later,
+                substratumBHistory,
+                source,
+                substratumBHistory,
+            ),
+        ),
         "Later observation rolls B forward from the source before the merge",
     )
 
@@ -339,31 +385,36 @@ class ObservationStoreMergeObservationDataTest : BaseObservationStoreTest() {
 
     // The target absorbed B, so the later observation must now roll B forward from the target
     // rather than from the deleted source (which would otherwise drop the substratum).
-    assertEquals(
-        target,
-        dependencySource(later, substratumB),
+    assertTableEquals(
+        listOf(
+            DependentSubstratumObservationRecord(
+                target,
+                substratumAHistory,
+                target,
+                substratumAHistory,
+            ),
+            DependentSubstratumObservationRecord(
+                target,
+                substratumBHistory,
+                target,
+                substratumBHistory,
+            ),
+            DependentSubstratumObservationRecord(
+                later,
+                substratumAHistory,
+                later,
+                substratumAHistory,
+            ),
+            DependentSubstratumObservationRecord(
+                later,
+                substratumBHistory,
+                target,
+                substratumBHistory,
+            ),
+        ),
         "Later observation rolls B forward from the target after the merge",
     )
-    assertEquals(
-        later,
-        dependencySource(later, substratumA),
-        "Later observation still self-references A",
-    )
   }
-
-  /** The observation whose substratum data [observationId] rolls forward for [substratumId]. */
-  private fun dependencySource(
-      observationId: ObservationId,
-      substratumId: SubstratumId,
-  ): ObservationId? =
-      dslContext
-          .select(DEPENDENT_SUBSTRATUM_OBSERVATION.DEPENDS_ON_OBSERVATION_ID)
-          .from(DEPENDENT_SUBSTRATUM_OBSERVATION)
-          .join(SUBSTRATUM_HISTORIES)
-          .on(SUBSTRATUM_HISTORIES.ID.eq(DEPENDENT_SUBSTRATUM_OBSERVATION.SUBSTRATUM_HISTORY_ID))
-          .where(DEPENDENT_SUBSTRATUM_OBSERVATION.OBSERVATION_ID.eq(observationId))
-          .and(SUBSTRATUM_HISTORIES.SUBSTRATUM_ID.eq(substratumId))
-          .fetchOne(DEPENDENT_SUBSTRATUM_OBSERVATION.DEPENDS_ON_OBSERVATION_ID)
 
   private fun livePlant(speciesId: SpeciesId = this.speciesId) =
       RecordedPlantsRow(

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/observationStore/ObservationStoreSubstratumDependenciesTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/observationStore/ObservationStoreSubstratumDependenciesTest.kt
@@ -1,0 +1,340 @@
+package com.terraformation.backend.tracking.db.observationStore
+
+import com.terraformation.backend.db.tracking.RecordedPlantStatus
+import com.terraformation.backend.db.tracking.RecordedSpeciesCertainty
+import com.terraformation.backend.db.tracking.tables.pojos.RecordedPlantsRow
+import com.terraformation.backend.db.tracking.tables.records.DependentSubstratumObservationRecord
+import com.terraformation.backend.mockUser
+import com.terraformation.backend.point
+import com.terraformation.backend.tracking.db.ObservationScenarioTest
+import java.time.Instant
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class ObservationStoreSubstratumDependenciesTest : ObservationScenarioTest() {
+  override val user = mockUser()
+
+  private lateinit var recordedPlants: List<RecordedPlantsRow>
+
+  @BeforeEach
+  fun insertRecordedSpecies() {
+    val speciesId = insertSpecies()
+    recordedPlants =
+        listOf(
+            RecordedPlantsRow(
+                certaintyId = RecordedSpeciesCertainty.Known,
+                gpsCoordinates = point(1),
+                speciesId = speciesId,
+                statusId = RecordedPlantStatus.Live,
+            )
+        )
+  }
+
+  @Test
+  fun `records self-reference for an observed substratum`() {
+    insertStratum()
+    insertSubstratum()
+    val substratumHistoryId = inserted.substratumHistoryId
+    val plotId = insertMonitoringPlot(permanentIndex = 1)
+    val observationId = insertObservation()
+    insertObservationRequestedSubstratum()
+    insertObservationPlot(claimedBy = user.userId, isPermanent = true)
+
+    observationStore.completePlot(
+        observationId,
+        plotId,
+        emptySet(),
+        "Notes",
+        Instant.ofEpochSecond(1),
+        recordedPlants,
+    )
+
+    assertTableEquals(
+        DependentSubstratumObservationRecord(
+            observationId = observationId,
+            substratumHistoryId = substratumHistoryId,
+            dependsOnObservationId = observationId,
+            dependsOnSubstratumHistoryId = substratumHistoryId,
+        ),
+        "Observed substratum self-references this observation",
+    )
+  }
+
+  @Test
+  fun `records prior observation for a substratum not observed in the later observation`() {
+    insertStratum()
+    val substratumIdA = insertSubstratum()
+    val substratumHistoryIdA = inserted.substratumHistoryId
+    val plotIdA = insertMonitoringPlot(permanentIndex = 1, substratumId = substratumIdA)
+    val plotHistoryIdA = inserted.monitoringPlotHistoryId
+
+    val substratumIdB = insertSubstratum()
+    val substratumHistoryIdB = inserted.substratumHistoryId
+    val plotIdB = insertMonitoringPlot(permanentIndex = 2, substratumId = substratumIdB)
+    val plotHistoryIdB = inserted.monitoringPlotHistoryId
+
+    clock.instant = Instant.ofEpochSecond(1)
+    val observationId1 = insertObservation()
+    insertObservationRequestedSubstratum(substratumId = substratumIdA)
+    insertObservationRequestedSubstratum(substratumId = substratumIdB)
+    insertObservationPlot(
+        claimedBy = user.userId,
+        isPermanent = true,
+        monitoringPlotId = plotIdA,
+        monitoringPlotHistoryId = plotHistoryIdA,
+    )
+    insertObservationPlot(
+        claimedBy = user.userId,
+        isPermanent = true,
+        monitoringPlotId = plotIdB,
+        monitoringPlotHistoryId = plotHistoryIdB,
+    )
+
+    observationStore.completePlot(
+        observationId1,
+        plotIdA,
+        emptySet(),
+        "Notes",
+        clock.instant,
+        recordedPlants,
+    )
+    observationStore.completePlot(
+        observationId1,
+        plotIdB,
+        emptySet(),
+        "Notes",
+        clock.instant,
+        recordedPlants,
+    )
+
+    clock.instant = Instant.ofEpochSecond(2)
+    val observationId2 = insertObservation()
+    insertObservationRequestedSubstratum(substratumId = substratumIdA)
+    val plotIdA2 = insertMonitoringPlot(permanentIndex = 3, substratumId = substratumIdA)
+    val plotHistoryIdA2 = inserted.monitoringPlotHistoryId
+    insertObservationPlot(
+        claimedBy = user.userId,
+        isPermanent = true,
+        monitoringPlotId = plotIdA2,
+        monitoringPlotHistoryId = plotHistoryIdA2,
+    )
+
+    observationStore.completePlot(
+        observationId2,
+        plotIdA2,
+        emptySet(),
+        "Notes",
+        clock.instant,
+        recordedPlants,
+    )
+
+    assertTableEquals(
+        listOf(
+            // observationId1 observed both substrata -> self-references.
+            DependentSubstratumObservationRecord(
+                observationId = observationId1,
+                substratumHistoryId = substratumHistoryIdA,
+                dependsOnObservationId = observationId1,
+                dependsOnSubstratumHistoryId = substratumHistoryIdA,
+            ),
+            DependentSubstratumObservationRecord(
+                observationId = observationId1,
+                substratumHistoryId = substratumHistoryIdB,
+                dependsOnObservationId = observationId1,
+                dependsOnSubstratumHistoryId = substratumHistoryIdB,
+            ),
+            // observationId2 observed A -> self-reference; B was not observed -> points back to
+            // observationId1.
+            DependentSubstratumObservationRecord(
+                observationId = observationId2,
+                substratumHistoryId = substratumHistoryIdA,
+                dependsOnObservationId = observationId2,
+                dependsOnSubstratumHistoryId = substratumHistoryIdA,
+            ),
+            DependentSubstratumObservationRecord(
+                observationId = observationId2,
+                substratumHistoryId = substratumHistoryIdB,
+                dependsOnObservationId = observationId1,
+                dependsOnSubstratumHistoryId = substratumHistoryIdB,
+            ),
+        ),
+        "Later observation references prior observation for unobserved substratum",
+    )
+  }
+
+  @Test
+  fun `records prior observation for a requested but unobserved substratum`() {
+    insertStratum()
+    val substratumIdA = insertSubstratum()
+    val substratumHistoryIdA = inserted.substratumHistoryId
+    val plotIdA = insertMonitoringPlot(permanentIndex = 1, substratumId = substratumIdA)
+    val plotHistoryIdA = inserted.monitoringPlotHistoryId
+
+    val substratumIdB = insertSubstratum()
+    val substratumHistoryIdB = inserted.substratumHistoryId
+    val plotIdB = insertMonitoringPlot(permanentIndex = 2, substratumId = substratumIdB)
+    val plotHistoryIdB = inserted.monitoringPlotHistoryId
+
+    // observationId1 observes both substrata.
+    clock.instant = Instant.ofEpochSecond(1)
+    val observationId1 = insertObservation()
+    insertObservationRequestedSubstratum(substratumId = substratumIdA)
+    insertObservationRequestedSubstratum(substratumId = substratumIdB)
+    insertObservationPlot(
+        claimedBy = user.userId,
+        isPermanent = true,
+        monitoringPlotId = plotIdA,
+        monitoringPlotHistoryId = plotHistoryIdA,
+    )
+    insertObservationPlot(
+        claimedBy = user.userId,
+        isPermanent = true,
+        monitoringPlotId = plotIdB,
+        monitoringPlotHistoryId = plotHistoryIdB,
+    )
+
+    observationStore.completePlot(
+        observationId1,
+        plotIdA,
+        emptySet(),
+        "Notes",
+        clock.instant,
+        recordedPlants,
+    )
+    observationStore.completePlot(
+        observationId1,
+        plotIdB,
+        emptySet(),
+        "Notes",
+        clock.instant,
+        recordedPlants,
+    )
+
+    // observationId2 requests B but completes no plot in it (only A is observed), so B was
+    // requested yet never actually observed in this observation.
+    clock.instant = Instant.ofEpochSecond(2)
+    val observationId2 = insertObservation()
+    insertObservationRequestedSubstratum(substratumId = substratumIdA)
+    insertObservationRequestedSubstratum(substratumId = substratumIdB)
+    val plotIdA2 = insertMonitoringPlot(permanentIndex = 3, substratumId = substratumIdA)
+    val plotHistoryIdA2 = inserted.monitoringPlotHistoryId
+    insertObservationPlot(
+        claimedBy = user.userId,
+        isPermanent = true,
+        monitoringPlotId = plotIdA2,
+        monitoringPlotHistoryId = plotHistoryIdA2,
+    )
+
+    observationStore.completePlot(
+        observationId2,
+        plotIdA2,
+        emptySet(),
+        "Notes",
+        clock.instant,
+        recordedPlants,
+    )
+
+    assertTableEquals(
+        listOf(
+            DependentSubstratumObservationRecord(
+                observationId = observationId1,
+                substratumHistoryId = substratumHistoryIdA,
+                dependsOnObservationId = observationId1,
+                dependsOnSubstratumHistoryId = substratumHistoryIdA,
+            ),
+            DependentSubstratumObservationRecord(
+                observationId = observationId1,
+                substratumHistoryId = substratumHistoryIdB,
+                dependsOnObservationId = observationId1,
+                dependsOnSubstratumHistoryId = substratumHistoryIdB,
+            ),
+            DependentSubstratumObservationRecord(
+                observationId = observationId2,
+                substratumHistoryId = substratumHistoryIdA,
+                dependsOnObservationId = observationId2,
+                dependsOnSubstratumHistoryId = substratumHistoryIdA,
+            ),
+            // B was requested but not observed in observationId2, so it rolls forward to the prior
+            // observation that actually observed it rather than self-referencing.
+            DependentSubstratumObservationRecord(
+                observationId = observationId2,
+                substratumHistoryId = substratumHistoryIdB,
+                dependsOnObservationId = observationId1,
+                dependsOnSubstratumHistoryId = substratumHistoryIdB,
+            ),
+        ),
+        "Requested but unobserved substratum rolls forward instead of self-referencing",
+    )
+  }
+
+  @Test
+  fun `records dependencies for a site-wide observation with no requested substrata`() {
+    insertStratum()
+    insertSubstratum()
+    val substratumHistoryId = inserted.substratumHistoryId
+    val plotId = insertMonitoringPlot(permanentIndex = 1)
+    val observationId = insertObservation()
+    // No requested substrata: the observation covers the entire site.
+    insertObservationPlot(claimedBy = user.userId, isPermanent = true)
+
+    observationStore.completePlot(
+        observationId,
+        plotId,
+        emptySet(),
+        "Notes",
+        Instant.ofEpochSecond(1),
+        recordedPlants,
+    )
+
+    assertTableEquals(
+        DependentSubstratumObservationRecord(
+            observationId = observationId,
+            substratumHistoryId = substratumHistoryId,
+            dependsOnObservationId = observationId,
+            dependsOnSubstratumHistoryId = substratumHistoryId,
+        ),
+        "Site-wide observation self-references its observed substratum",
+    )
+  }
+
+  @Test
+  fun `records no row for a substratum never observed at or before the observation`() {
+    insertStratum()
+    val substratumIdA = insertSubstratum()
+    val substratumHistoryIdA = inserted.substratumHistoryId
+    val plotIdA = insertMonitoringPlot(permanentIndex = 1, substratumId = substratumIdA)
+    val plotHistoryIdA = inserted.monitoringPlotHistoryId
+
+    // Substratum B is present in the snapshot but never requested/observed.
+    val substratumIdB = insertSubstratum()
+    insertMonitoringPlot(permanentIndex = 2, substratumId = substratumIdB)
+
+    val observationId = insertObservation()
+    insertObservationRequestedSubstratum(substratumId = substratumIdA)
+    insertObservationPlot(
+        claimedBy = user.userId,
+        isPermanent = true,
+        monitoringPlotId = plotIdA,
+        monitoringPlotHistoryId = plotHistoryIdA,
+    )
+
+    observationStore.completePlot(
+        observationId,
+        plotIdA,
+        emptySet(),
+        "Notes",
+        Instant.ofEpochSecond(1),
+        recordedPlants,
+    )
+
+    assertTableEquals(
+        DependentSubstratumObservationRecord(
+            observationId = observationId,
+            substratumHistoryId = substratumHistoryIdA,
+            dependsOnObservationId = observationId,
+            dependsOnSubstratumHistoryId = substratumHistoryIdA,
+        ),
+        "Never-observed substratum has no dependency row",
+    )
+  }
+}

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/observationStore/ObservationStoreSurvivalRateCalculationTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/observationStore/ObservationStoreSurvivalRateCalculationTest.kt
@@ -11,6 +11,7 @@ import com.terraformation.backend.db.tracking.StratumId
 import com.terraformation.backend.db.tracking.SubstratumId
 import com.terraformation.backend.db.tracking.tables.pojos.RecordedPlantsRow
 import com.terraformation.backend.db.tracking.tables.references.MONITORING_PLOTS
+import com.terraformation.backend.db.tracking.tables.references.OBSERVATION_STRATUM_RESULTS
 import com.terraformation.backend.db.tracking.tables.references.PLANTING_SITES
 import com.terraformation.backend.db.tracking.tables.references.STRATUM_T0_TEMP_DENSITIES
 import com.terraformation.backend.mockUser
@@ -26,6 +27,8 @@ import kotlin.math.roundToInt
 import org.jooq.impl.DSL
 import org.jooq.impl.SQLDataType
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertAll
@@ -810,6 +813,108 @@ class ObservationStoreSurvivalRateCalculationTest : ObservationScenarioTest() {
             mapOf(plantingSiteId to rates2),
         )
     assertSurvivalRates(expected2, "Survival rates includes species not in observation 2")
+  }
+
+  @Test
+  fun `survival rate recalc skips observations that do not depend on the edited plot's data`() {
+    every { user.canUpdateObservationQuantities(any()) } returns true
+
+    val species1 = insertSpecies()
+    insertPlotT0Density(plotDensity = BigDecimal.valueOf(10).toPlantsPerHectare())
+    val plotQ = insertMonitoringPlot(permanentIndex = 2)
+    insertPlotT0Density(plotDensity = BigDecimal.valueOf(10).toPlantsPerHectare())
+
+    observationStore.completePlot(
+        observationId,
+        plotId,
+        emptySet(),
+        "Notes",
+        observedTime,
+        listOf(
+            RecordedPlantsRow(
+                certaintyId = RecordedSpeciesCertainty.Known,
+                gpsCoordinates = point(1),
+                speciesId = species1,
+                statusId = RecordedPlantStatus.Live,
+            )
+        ),
+    )
+
+    val observation2 = insertObservation()
+    insertObservationRequestedSubstratum()
+    insertObservationPlot(
+        monitoringPlotId = plotQ,
+        observationId = observation2,
+        claimedBy = user.userId,
+        isPermanent = true,
+    )
+    observationStore.completePlot(
+        observation2,
+        plotQ,
+        emptySet(),
+        "Notes",
+        observedTime.plusSeconds(10),
+        listOf(
+            RecordedPlantsRow(
+                certaintyId = RecordedSpeciesCertainty.Known,
+                gpsCoordinates = point(1),
+                speciesId = species1,
+                statusId = RecordedPlantStatus.Live,
+            )
+        ),
+    )
+
+    // Stamp a sentinel into observation 2's stratum survival rate after completion. A correct
+    // recalc scoped to dependents of observation 1 must leave this untouched.
+    val sentinel = 999
+    dslContext
+        .update(OBSERVATION_STRATUM_RESULTS)
+        .set(OBSERVATION_STRATUM_RESULTS.SURVIVAL_RATE, sentinel)
+        .where(OBSERVATION_STRATUM_RESULTS.OBSERVATION_ID.eq(observation2))
+        .and(OBSERVATION_STRATUM_RESULTS.STRATUM_ID.eq(stratumId))
+        .execute()
+
+    // Edit observation 1's species totals for plot P, then run the recalc that the edit path
+    // triggers via the MonitoringSpeciesTotalsEditedEvent listener.
+    observationStore.updateMonitoringSpecies(
+        observationId,
+        plotId,
+        RecordedSpeciesCertainty.Known,
+        species1,
+        null,
+    ) { model ->
+      model.copy(totalLive = model.totalLive + 1)
+    }
+    observationStore.recalculateSurvivalRates(plotId)
+
+    val obs1StratumRate =
+        observationStratumResultsDao
+            .fetchByObservationId(observationId)
+            .single { it.stratumId == stratumId }
+            .survivalRate
+    val obs2StratumRate =
+        observationStratumResultsDao
+            .fetchByObservationId(observation2)
+            .single { it.stratumId == stratumId }
+            .survivalRate
+
+    assertAll(
+        {
+          assertEquals(
+              100 * 2 / 10,
+              obs1StratumRate,
+              "Observation 1 stratum survival rate is recomputed from the edited totals",
+          )
+        },
+        {
+          assertEquals(
+              sentinel,
+              obs2StratumRate,
+              "Observation 2 stratum survival rate is untouched because it does not depend on " +
+                  "observation 1",
+          )
+        },
+    )
   }
 
   @Test
@@ -1711,6 +1816,211 @@ class ObservationStoreSurvivalRateCalculationTest : ObservationScenarioTest() {
     }
 
     return SurvivalRates(plotRates, substratumRates, stratumRates, siteRates)
+  }
+
+  /**
+   * End-to-end flow for how a substratum ends up requested-but-unobserved in practice: an
+   * observation that planned to cover it is abandoned before that substratum's plot is completed.
+   * The abandoned observation must still roll the substratum's last-observed data forward.
+   */
+  @Test
+  fun `abandoning an observation rolls its unobserved substrata forward into the rollups`() {
+    val speciesId = insertSpecies()
+    insertPlotT0Density(
+        monitoringPlotId = plotId,
+        speciesId = speciesId,
+        plotDensity = BigDecimal.valueOf(10).toPlantsPerHectare(),
+    )
+
+    val substratumB = insertSubstratum()
+    val plotB = insertMonitoringPlot(permanentIndex = 2, substratumId = substratumB)
+    insertPlotT0Density(
+        monitoringPlotId = plotB,
+        speciesId = speciesId,
+        plotDensity = BigDecimal.valueOf(20).toPlantsPerHectare(),
+    )
+
+    // observation 1 observes both A and B.
+    insertObservationRequestedSubstratum(observationId = observationId, substratumId = substratumB)
+    insertObservationPlot(
+        observationId = observationId,
+        monitoringPlotId = plotB,
+        claimedBy = user.userId,
+        isPermanent = true,
+    )
+    observationStore.completePlot(
+        observationId,
+        plotId,
+        emptySet(),
+        "Notes",
+        observedTime,
+        createPlantsRows(mapOf(speciesId to 8), RecordedPlantStatus.Live),
+    )
+    observationStore.completePlot(
+        observationId,
+        plotB,
+        emptySet(),
+        "Notes",
+        observedTime,
+        createPlantsRows(mapOf(speciesId to 16), RecordedPlantStatus.Live),
+    )
+
+    // observation 2 requests A and B and has plots in both, but only A's plot is completed before
+    // the observation is abandoned, leaving B requested-but-unobserved.
+    val observation2 = insertObservation()
+    insertObservationRequestedSubstratum(observationId = observation2, substratumId = substratumId)
+    insertObservationRequestedSubstratum(observationId = observation2, substratumId = substratumB)
+    insertObservationPlot(
+        observationId = observation2,
+        monitoringPlotId = plotId,
+        claimedBy = user.userId,
+        isPermanent = true,
+    )
+    insertObservationPlot(
+        observationId = observation2,
+        monitoringPlotId = plotB,
+        claimedBy = user.userId,
+        isPermanent = true,
+    )
+    observationStore.completePlot(
+        observation2,
+        plotId,
+        emptySet(),
+        "Notes",
+        observedTime.plusSeconds(10),
+        createPlantsRows(mapOf(speciesId to 9), RecordedPlantStatus.Live),
+    )
+
+    observationStore.abandonObservation(observation2)
+
+    // B was never observed in observation 2, so its dependency row rolls forward to observation 1.
+    val bDependency =
+        dependentSubstratumObservationDao.fetchByObservationId(observation2).single {
+          it.dependsOnObservationId != observation2
+        }
+    assertEquals(
+        observationId,
+        bDependency.dependsOnObservationId,
+        "B rolls forward to observation 1",
+    )
+
+    // An abandoned observation is treated like a completed one (its not-observed plot is ignored),
+    // so it rolls B forward into the stratum survival rate in both the numerator (live) and the
+    // denominator (T0): (A live 9 + B live 16) / (A T0 10 + B T0 20) = 25/30 ~= 83%.
+    val stratumResult =
+        observationStratumResultsDao.fetchByObservationId(observation2).single {
+          it.stratumId == stratumId
+        }
+    assertEquals(
+        83,
+        stratumResult.survivalRate,
+        "Abandoned observation rolls B's survival rate forward",
+    )
+    assertNotNull(stratumResult.plantDensity, "Abandoned observation rolls B's density forward")
+  }
+
+  /**
+   * Editing the data an abandoned observation rolls forward must update that abandoned
+   * observation's rollups. The edited observation is the latest one to actually observe the
+   * substratum, so the later abandoned observation depends on it.
+   */
+  @Test
+  fun `editing an observation propagates into a later abandoned observation that rolls it forward`() {
+    val speciesId = insertSpecies()
+    insertPlotT0Density(
+        monitoringPlotId = plotId,
+        speciesId = speciesId,
+        plotDensity = BigDecimal.valueOf(10).toPlantsPerHectare(),
+    )
+
+    val substratumB = insertSubstratum()
+    val plotB = insertMonitoringPlot(permanentIndex = 2, substratumId = substratumB)
+    insertPlotT0Density(
+        monitoringPlotId = plotB,
+        speciesId = speciesId,
+        plotDensity = BigDecimal.valueOf(20).toPlantsPerHectare(),
+    )
+
+    insertObservationRequestedSubstratum(observationId = observationId, substratumId = substratumB)
+    insertObservationPlot(
+        observationId = observationId,
+        monitoringPlotId = plotB,
+        claimedBy = user.userId,
+        isPermanent = true,
+    )
+    observationStore.completePlot(
+        observationId,
+        plotId,
+        emptySet(),
+        "Notes",
+        observedTime,
+        createPlantsRows(mapOf(speciesId to 8), RecordedPlantStatus.Live),
+    )
+    observationStore.completePlot(
+        observationId,
+        plotB,
+        emptySet(),
+        "Notes",
+        observedTime,
+        createPlantsRows(mapOf(speciesId to 16), RecordedPlantStatus.Live),
+    )
+
+    val observation2 = insertObservation()
+    insertObservationRequestedSubstratum(observationId = observation2, substratumId = substratumId)
+    insertObservationRequestedSubstratum(observationId = observation2, substratumId = substratumB)
+    insertObservationPlot(
+        observationId = observation2,
+        monitoringPlotId = plotId,
+        claimedBy = user.userId,
+        isPermanent = true,
+    )
+    insertObservationPlot(
+        observationId = observation2,
+        monitoringPlotId = plotB,
+        claimedBy = user.userId,
+        isPermanent = true,
+    )
+    // Complete observation 2 strictly after observation 1 (completion times are monotonic per
+    // site);
+    // the edit-propagation lookup only considers later observations.
+    clock.instant = Instant.ofEpochSecond(10)
+    observationStore.completePlot(
+        observation2,
+        plotId,
+        emptySet(),
+        "Notes",
+        observedTime.plusSeconds(10),
+        createPlantsRows(mapOf(speciesId to 9), RecordedPlantStatus.Live),
+    )
+    observationStore.abandonObservation(observation2)
+
+    fun observation2StratumRate() =
+        observationStratumResultsDao
+            .fetchByObservationId(observation2)
+            .single { it.stratumId == stratumId }
+            .survivalRate
+
+    val rateBeforeEdit = observation2StratumRate()
+
+    // Edit observation 1's B data (which the abandoned observation 2 rolls forward) down to zero
+    // live plants.
+    observationStore.updateMonitoringSpecies(
+        observationId,
+        plotB,
+        RecordedSpeciesCertainty.Known,
+        speciesId,
+        null,
+    ) { model ->
+      model.copy(totalLive = 0)
+    }
+
+    val rateAfterEdit = observation2StratumRate()
+
+    // The edit must flow into observation 2's rolled-up survival rate. Matching on requested
+    // (rather
+    // than observed) substrata would treat observation 2 as superseding B and leave this stale.
+    assertNotEquals(rateBeforeEdit, rateAfterEdit, "Abandoned observation rate after editing B")
+    assertEquals(true, rateAfterEdit!! < rateBeforeEdit!!, "Lower live count lowers the rate")
   }
 
   private fun createPlantsRows(

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/observationStore/ObservationStoreSurvivalRateCalculationTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/observationStore/ObservationStoreSurvivalRateCalculationTest.kt
@@ -29,7 +29,6 @@ import kotlin.math.roundToInt
 import org.jooq.impl.DSL
 import org.jooq.impl.SQLDataType
 import org.junit.jupiter.api.Assertions.assertEquals
-import org.junit.jupiter.api.Assertions.assertNotEquals
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -1820,11 +1819,6 @@ class ObservationStoreSurvivalRateCalculationTest : ObservationScenarioTest() {
     return SurvivalRates(plotRates, substratumRates, stratumRates, siteRates)
   }
 
-  /**
-   * End-to-end flow for how a substratum ends up requested-but-unobserved in practice: an
-   * observation that planned to cover it is abandoned before that substratum's plot is completed.
-   * The abandoned observation must still roll the substratum's last-observed data forward.
-   */
   @Test
   fun `abandoning an observation rolls its unobserved substrata forward into the rollups`() {
     val speciesId = insertSpecies()
@@ -2038,110 +2032,6 @@ class ObservationStoreSurvivalRateCalculationTest : ObservationScenarioTest() {
         message = "Stratum species totals for observation 2 after editing observation 1's B data",
         where = OBSERVED_STRATUM_SPECIES_TOTALS.OBSERVATION_ID.eq(observation2),
     )
-  }
-
-  /**
-   * Editing the data an abandoned observation rolls forward must update that abandoned
-   * observation's rollups. The edited observation is the latest one to actually observe the
-   * substratum, so the later abandoned observation depends on it.
-   */
-  @Test
-  fun `editing an observation propagates into a later abandoned observation that rolls it forward`() {
-    val speciesId = insertSpecies()
-    insertPlotT0Density(
-        monitoringPlotId = plotId,
-        speciesId = speciesId,
-        plotDensity = BigDecimal.valueOf(10).toPlantsPerHectare(),
-    )
-
-    val substratumB = insertSubstratum()
-    val plotB = insertMonitoringPlot(permanentIndex = 2, substratumId = substratumB)
-    insertPlotT0Density(
-        monitoringPlotId = plotB,
-        speciesId = speciesId,
-        plotDensity = BigDecimal.valueOf(20).toPlantsPerHectare(),
-    )
-
-    insertObservationRequestedSubstratum(observationId = observationId, substratumId = substratumB)
-    insertObservationPlot(
-        observationId = observationId,
-        monitoringPlotId = plotB,
-        claimedBy = user.userId,
-        isPermanent = true,
-    )
-    observationStore.completePlot(
-        observationId,
-        plotId,
-        emptySet(),
-        "Notes",
-        observedTime,
-        createPlantsRows(mapOf(speciesId to 8), RecordedPlantStatus.Live),
-    )
-    observationStore.completePlot(
-        observationId,
-        plotB,
-        emptySet(),
-        "Notes",
-        observedTime,
-        createPlantsRows(mapOf(speciesId to 16), RecordedPlantStatus.Live),
-    )
-
-    val observation2 = insertObservation()
-    insertObservationRequestedSubstratum(observationId = observation2, substratumId = substratumId)
-    insertObservationRequestedSubstratum(observationId = observation2, substratumId = substratumB)
-    insertObservationPlot(
-        observationId = observation2,
-        monitoringPlotId = plotId,
-        claimedBy = user.userId,
-        isPermanent = true,
-    )
-    insertObservationPlot(
-        observationId = observation2,
-        monitoringPlotId = plotB,
-        claimedBy = user.userId,
-        isPermanent = true,
-    )
-    // Complete observation 2 strictly after observation 1 (completion times are monotonic per
-    // site);
-    // the edit-propagation lookup only considers later observations.
-    clock.instant = Instant.ofEpochSecond(10)
-    observationStore.completePlot(
-        observation2,
-        plotId,
-        emptySet(),
-        "Notes",
-        observedTime.plusSeconds(10),
-        createPlantsRows(mapOf(speciesId to 9), RecordedPlantStatus.Live),
-    )
-    observationStore.abandonObservation(observation2)
-
-    fun observation2StratumRate() =
-        observationStratumResultsDao
-            .fetchByObservationId(observation2)
-            .single { it.stratumId == stratumId }
-            .survivalRate
-
-    val rateBeforeEdit = observation2StratumRate()
-
-    // Edit observation 1's B data (which the abandoned observation 2 rolls forward) down to zero
-    // live plants.
-    observationStore.updateMonitoringSpecies(
-        observationId,
-        plotB,
-        RecordedSpeciesCertainty.Known,
-        speciesId,
-        null,
-    ) { model ->
-      model.copy(totalLive = 0)
-    }
-
-    val rateAfterEdit = observation2StratumRate()
-
-    // The edit must flow into observation 2's rolled-up survival rate. Matching on requested
-    // (rather
-    // than observed) substrata would treat observation 2 as superseding B and leave this stale.
-    assertNotEquals(rateBeforeEdit, rateAfterEdit, "Abandoned observation rate after editing B")
-    assertEquals(true, rateAfterEdit!! < rateBeforeEdit!!, "Lower live count lowers the rate")
   }
 
   private fun createPlantsRows(

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/observationStore/ObservationStoreSurvivalRateCalculationTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/observationStore/ObservationStoreSurvivalRateCalculationTest.kt
@@ -10,8 +10,10 @@ import com.terraformation.backend.db.tracking.RecordedSpeciesCertainty
 import com.terraformation.backend.db.tracking.StratumId
 import com.terraformation.backend.db.tracking.SubstratumId
 import com.terraformation.backend.db.tracking.tables.pojos.RecordedPlantsRow
+import com.terraformation.backend.db.tracking.tables.records.ObservedStratumSpeciesTotalsRecord
 import com.terraformation.backend.db.tracking.tables.references.MONITORING_PLOTS
 import com.terraformation.backend.db.tracking.tables.references.OBSERVATION_STRATUM_RESULTS
+import com.terraformation.backend.db.tracking.tables.references.OBSERVED_STRATUM_SPECIES_TOTALS
 import com.terraformation.backend.db.tracking.tables.references.PLANTING_SITES
 import com.terraformation.backend.db.tracking.tables.references.STRATUM_T0_TEMP_DENSITIES
 import com.terraformation.backend.mockUser
@@ -1917,6 +1919,125 @@ class ObservationStoreSurvivalRateCalculationTest : ObservationScenarioTest() {
         "Abandoned observation rolls B's survival rate forward",
     )
     assertNotNull(stratumResult.plantDensity, "Abandoned observation rolls B's density forward")
+  }
+
+  @Test
+  fun `a full recalculation keeps a rolled-forward substratum's stratum survival rate consistent`() {
+    val speciesId = insertSpecies()
+    val stratumHistoryId = inserted.stratumHistoryId
+    insertPlotT0Density(
+        monitoringPlotId = plotId,
+        speciesId = speciesId,
+        plotDensity = BigDecimal.valueOf(10).toPlantsPerHectare(),
+    )
+
+    val substratumB = insertSubstratum()
+    val plotB = insertMonitoringPlot(permanentIndex = 2, substratumId = substratumB)
+    insertPlotT0Density(
+        monitoringPlotId = plotB,
+        speciesId = speciesId,
+        plotDensity = BigDecimal.valueOf(20).toPlantsPerHectare(),
+    )
+
+    // observation 1 observes both A and B.
+    insertObservationRequestedSubstratum(observationId = observationId, substratumId = substratumB)
+    insertObservationPlot(
+        observationId = observationId,
+        monitoringPlotId = plotB,
+        claimedBy = user.userId,
+        isPermanent = true,
+    )
+    observationStore.completePlot(
+        observationId,
+        plotId,
+        emptySet(),
+        "Notes",
+        observedTime,
+        createPlantsRows(mapOf(speciesId to 8), RecordedPlantStatus.Live),
+    )
+    observationStore.completePlot(
+        observationId,
+        plotB,
+        emptySet(),
+        "Notes",
+        observedTime,
+        createPlantsRows(mapOf(speciesId to 16), RecordedPlantStatus.Live),
+    )
+
+    // observation 2 observes only A and is abandoned
+    val observation2 = insertObservation()
+    insertObservationRequestedSubstratum(observationId = observation2, substratumId = substratumId)
+    insertObservationRequestedSubstratum(observationId = observation2, substratumId = substratumB)
+    insertObservationPlot(
+        observationId = observation2,
+        monitoringPlotId = plotId,
+        claimedBy = user.userId,
+        isPermanent = true,
+    )
+    insertObservationPlot(
+        observationId = observation2,
+        monitoringPlotId = plotB,
+        claimedBy = user.userId,
+        isPermanent = true,
+    )
+
+    clock.instant = Instant.ofEpochSecond(10)
+    observationStore.completePlot(
+        observation2,
+        plotId,
+        emptySet(),
+        "Notes",
+        observedTime.plusSeconds(10),
+        createPlantsRows(mapOf(speciesId to 9), RecordedPlantStatus.Live),
+    )
+
+    observationStore.abandonObservation(observation2)
+
+    assertTableEquals(
+        ObservedStratumSpeciesTotalsRecord(
+            observationId = observation2,
+            stratumId = stratumId,
+            stratumHistoryId = stratumHistoryId,
+            certaintyId = RecordedSpeciesCertainty.Known,
+            speciesId = speciesId,
+            speciesName = null,
+            totalLive = 9,
+            totalDead = 0,
+            totalExisting = 0,
+            permanentLive = 25,
+            survivalRate = 83,
+        ),
+        message = "Stratum species totals for observation 2 uses data from observation 1",
+        where = OBSERVED_STRATUM_SPECIES_TOTALS.OBSERVATION_ID.eq(observation2),
+    )
+
+    observationStore.updateMonitoringSpecies(
+        observationId,
+        plotB,
+        RecordedSpeciesCertainty.Known,
+        speciesId,
+        null,
+    ) { model ->
+      model.copy(totalLive = 6)
+    }
+
+    assertTableEquals(
+        ObservedStratumSpeciesTotalsRecord(
+            observationId = observation2,
+            stratumId = stratumId,
+            stratumHistoryId = stratumHistoryId,
+            certaintyId = RecordedSpeciesCertainty.Known,
+            speciesId = speciesId,
+            speciesName = null,
+            totalLive = 9,
+            totalDead = 0,
+            totalExisting = 0,
+            permanentLive = 15,
+            survivalRate = 50,
+        ),
+        message = "Stratum species totals for observation 2 after editing observation 1's B data",
+        where = OBSERVED_STRATUM_SPECIES_TOTALS.OBSERVATION_ID.eq(observation2),
+    )
   }
 
   /**


### PR DESCRIPTION
Added a dependent_substratum_observation table that tracks, for every (observation_id, substratum_history_id) pair, which (depends_on_observation_id, depends_on_substratum_history_id) pair should the observation use to perform rolling up for survival rates and planting density calculations

Co-Authored-By: Claude Opus 4.8 (1M context) [noreply@anthropic.com](mailto:noreply@anthropic.com)