### PR TITLE
SW-8420 Add model and endpoint for fetching planting season notifications

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/plantingmanagement/Models.kt
+++ b/src/main/kotlin/com/terraformation/backend/plantingmanagement/Models.kt
@@ -67,23 +67,23 @@ data class ExistingPlantingSeasonScheduledDateModel(
 )
 
 enum class PlantingSeasonNotificationType {
-  PLANTING_SEASON_CLOSED,
-  PLANTING_SEASON_PAST_END_DATE,
-  SPECIES_TARGETS_ADDED,
-  SPECIES_TARGETS_UPDATED,
-  ALLOCATION_QUANTITIES_UPDATED,
-  SEASON_WITHDRAWAL_RECORDED,
+  PlantingSeasonClosed,
+  PlantingSeasonPastEndDate,
+  SpeciesTargetsAdded,
+  SpeciesTargetsUpdated,
+  AllocationQuantitiesUpdated,
+  SeasonWithdrawalRecorded,
 }
 
-data class PlantingSeasonNotificationAlertModel(
+data class PlantingSeasonNotificationModel(
     val type: PlantingSeasonNotificationType,
     val speciesScientificNames: Set<String>? = null,
 )
 
-data class PlantingSeasonNotificationModel(
+data class PlantingSeasonNotificationGroupModel(
     val plantingSeasonId: PlantingSeasonId,
     val plantingSeasonName: String,
     val plantingSiteName: String,
     val lastEventLogId: EventLogId,
-    val events: List<PlantingSeasonNotificationAlertModel>,
+    val notifications: List<PlantingSeasonNotificationModel>,
 )

--- a/src/main/kotlin/com/terraformation/backend/plantingmanagement/Models.kt
+++ b/src/main/kotlin/com/terraformation/backend/plantingmanagement/Models.kt
@@ -1,5 +1,6 @@
 package com.terraformation.backend.plantingmanagement
 
+import com.terraformation.backend.db.default_schema.EventLogId
 import com.terraformation.backend.db.default_schema.SpeciesId
 import com.terraformation.backend.db.tracking.PlantingSeasonId
 import com.terraformation.backend.db.tracking.PlantingSeasonStatus
@@ -63,4 +64,26 @@ data class ExistingPlantingSeasonScheduledDateModel(
     val plantingSeasonId: PlantingSeasonId,
     val scheduledPlantingDateId: ScheduledPlantingDateId,
     val species: List<ExistingPlantingSeasonScheduledDateSpecies> = emptyList(),
+)
+
+enum class PlantingSeasonNotificationType {
+  PLANTING_SEASON_CLOSED,
+  PLANTING_SEASON_PAST_END_DATE,
+  SPECIES_TARGETS_ADDED,
+  SPECIES_TARGETS_UPDATED,
+  ALLOCATION_QUANTITIES_UPDATED,
+  SEASON_WITHDRAWAL_RECORDED,
+}
+
+data class PlantingSeasonNotificationAlertModel(
+    val type: PlantingSeasonNotificationType,
+    val speciesScientificNames: Set<String>? = null,
+)
+
+data class PlantingSeasonNotificationModel(
+    val plantingSeasonId: PlantingSeasonId,
+    val plantingSeasonName: String,
+    val plantingSiteName: String,
+    val lastEventLogId: EventLogId,
+    val events: List<PlantingSeasonNotificationAlertModel>,
 )

--- a/src/main/kotlin/com/terraformation/backend/plantingmanagement/api/PlantingSeasonNotificationsController.kt
+++ b/src/main/kotlin/com/terraformation/backend/plantingmanagement/api/PlantingSeasonNotificationsController.kt
@@ -7,8 +7,9 @@ import com.terraformation.backend.db.default_schema.EventLogId
 import com.terraformation.backend.db.default_schema.OrganizationId
 import com.terraformation.backend.db.tracking.PlantingSeasonId
 import com.terraformation.backend.i18n.Messages
-import com.terraformation.backend.plantingmanagement.PlantingSeasonNotificationAlertModel
+import com.terraformation.backend.plantingmanagement.PlantingSeasonNotificationGroupModel
 import com.terraformation.backend.plantingmanagement.PlantingSeasonNotificationModel
+import com.terraformation.backend.plantingmanagement.PlantingSeasonNotificationType
 import com.terraformation.backend.plantingmanagement.db.PlantingSeasonNotificationsService
 import io.swagger.v3.oas.annotations.Operation
 import org.springframework.web.bind.annotation.GetMapping
@@ -37,7 +38,7 @@ class PlantingSeasonNotificationsController(
           PlantingSeasonNotificationCategory.InventoryPlanning ->
               plantingSeasonNotificationsService
                   .getInventoryPlanningNotifications(organizationId)
-                  .map { PlantingSeasonNotificationPayload(it) }
+                  .map { PlantingSeasonNotificationGroupPayload(it) }
           PlantingSeasonNotificationCategory.PlantingSeasonPlanning -> emptyList()
         }
 
@@ -51,35 +52,35 @@ enum class PlantingSeasonNotificationCategory {
 }
 
 data class GetPlantingSeasonNotificationsResponsePayload(
-    val notifications: List<PlantingSeasonNotificationPayload>
+    val notifications: List<PlantingSeasonNotificationGroupPayload>
 ) : SuccessResponsePayload
 
-data class PlantingSeasonNotificationAlertPayload(
-    val type: com.terraformation.backend.plantingmanagement.PlantingSeasonNotificationType,
+data class PlantingSeasonNotificationPayload(
+    val type: PlantingSeasonNotificationType,
     val speciesScientificNames: Set<String>? = null,
 ) {
   constructor(
-      model: PlantingSeasonNotificationAlertModel
+      model: PlantingSeasonNotificationModel
   ) : this(
       type = model.type,
       speciesScientificNames = model.speciesScientificNames,
   )
 }
 
-data class PlantingSeasonNotificationPayload(
+data class PlantingSeasonNotificationGroupPayload(
     val plantingSeasonId: PlantingSeasonId,
     val plantingSeasonName: String,
     val plantingSiteName: String,
     val lastEventLogId: EventLogId,
-    val events: List<PlantingSeasonNotificationAlertPayload>,
+    val notifications: List<PlantingSeasonNotificationPayload>,
 ) {
   constructor(
-      model: PlantingSeasonNotificationModel
+      model: PlantingSeasonNotificationGroupModel
   ) : this(
       plantingSeasonId = model.plantingSeasonId,
       plantingSeasonName = model.plantingSeasonName,
       plantingSiteName = model.plantingSiteName,
       lastEventLogId = model.lastEventLogId,
-      events = model.events.map { PlantingSeasonNotificationAlertPayload(it) },
+      notifications = model.notifications.map { PlantingSeasonNotificationPayload(it) },
   )
 }

--- a/src/main/kotlin/com/terraformation/backend/plantingmanagement/api/PlantingSeasonNotificationsController.kt
+++ b/src/main/kotlin/com/terraformation/backend/plantingmanagement/api/PlantingSeasonNotificationsController.kt
@@ -29,22 +29,23 @@ class PlantingSeasonNotificationsController(
   @GetMapping("/notifications")
   fun getPlantingSeasonNotifications(
       @RequestParam("organizationId") organizationId: OrganizationId,
-      @RequestParam("notificationType") notificationType: PlantingSeasonNotificationType,
+      @RequestParam("notificationCategory")
+      notificationCategory: PlantingSeasonNotificationCategory,
   ): GetPlantingSeasonNotificationsResponsePayload {
     val notifications =
-        when (notificationType) {
-          PlantingSeasonNotificationType.InventoryPlanning ->
+        when (notificationCategory) {
+          PlantingSeasonNotificationCategory.InventoryPlanning ->
               plantingSeasonNotificationsService
                   .getInventoryPlanningNotifications(organizationId)
                   .map { PlantingSeasonNotificationPayload(it) }
-          PlantingSeasonNotificationType.PlantingSeasonPlanning -> emptyList()
+          PlantingSeasonNotificationCategory.PlantingSeasonPlanning -> emptyList()
         }
 
     return GetPlantingSeasonNotificationsResponsePayload(notifications)
   }
 }
 
-enum class PlantingSeasonNotificationType {
+enum class PlantingSeasonNotificationCategory {
   InventoryPlanning,
   PlantingSeasonPlanning,
 }

--- a/src/main/kotlin/com/terraformation/backend/plantingmanagement/api/PlantingSeasonNotificationsController.kt
+++ b/src/main/kotlin/com/terraformation/backend/plantingmanagement/api/PlantingSeasonNotificationsController.kt
@@ -1,0 +1,86 @@
+package com.terraformation.backend.plantingmanagement.api
+
+import com.terraformation.backend.api.ApiResponse200
+import com.terraformation.backend.api.SuccessResponsePayload
+import com.terraformation.backend.api.TrackingEndpoint
+import com.terraformation.backend.db.default_schema.EventLogId
+import com.terraformation.backend.db.default_schema.OrganizationId
+import com.terraformation.backend.db.tracking.PlantingSeasonId
+import com.terraformation.backend.i18n.Messages
+import com.terraformation.backend.plantingmanagement.PlantingSeasonNotificationAlertModel
+import com.terraformation.backend.plantingmanagement.PlantingSeasonNotificationModel
+import com.terraformation.backend.plantingmanagement.db.PlantingSeasonNotificationsService
+import io.swagger.v3.oas.annotations.Operation
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+
+@TrackingEndpoint
+@RequestMapping("/api/v1/planting-seasons")
+@RestController
+class PlantingSeasonNotificationsController(
+    private val plantingSeasonNotificationsService: PlantingSeasonNotificationsService,
+    private val messages: Messages,
+) {
+
+  @ApiResponse200
+  @Operation(summary = "Lists all notifications for an organization")
+  @GetMapping("/notifications")
+  fun getPlantingSeasonNotifications(
+      @RequestParam("organizationId") organizationId: OrganizationId,
+      @RequestParam("notificationType") notificationType: PlantingSeasonNotificationType,
+  ): GetPlantingSeasonNotificationsResponsePayload {
+    val notifications =
+        when (notificationType) {
+          PlantingSeasonNotificationType.InventoryPlanning ->
+              plantingSeasonNotificationsService
+                  .getInventoryPlanningNotifications(organizationId)
+                  .map {
+                    PlantingSeasonNotificationPayload(it)
+                  }
+          PlantingSeasonNotificationType.PlantingSeasonPlanning -> emptyList()
+        }
+
+    return GetPlantingSeasonNotificationsResponsePayload(notifications)
+  }
+}
+
+enum class PlantingSeasonNotificationType {
+  InventoryPlanning,
+  PlantingSeasonPlanning,
+}
+
+data class GetPlantingSeasonNotificationsResponsePayload(
+    val notifications: List<PlantingSeasonNotificationPayload>
+) : SuccessResponsePayload
+
+data class PlantingSeasonNotificationAlertPayload(
+    val type: com.terraformation.backend.plantingmanagement.PlantingSeasonNotificationType,
+    val speciesScientificNames: Set<String>? = null,
+) {
+  constructor(
+      model: PlantingSeasonNotificationAlertModel
+  ) : this(
+      type = model.type,
+      speciesScientificNames = model.speciesScientificNames,
+  )
+}
+
+data class PlantingSeasonNotificationPayload(
+    val plantingSeasonId: PlantingSeasonId,
+    val plantingSeasonName: String,
+    val plantingSiteName: String,
+    val lastEventLogId: EventLogId,
+    val events: List<PlantingSeasonNotificationAlertPayload>,
+) {
+  constructor(
+      model: PlantingSeasonNotificationModel
+  ) : this(
+      plantingSeasonId = model.plantingSeasonId,
+      plantingSeasonName = model.plantingSeasonName,
+      plantingSiteName = model.plantingSiteName,
+      lastEventLogId = model.lastEventLogId,
+      events = model.events.map { PlantingSeasonNotificationAlertPayload(it) },
+  )
+}

--- a/src/main/kotlin/com/terraformation/backend/plantingmanagement/api/PlantingSeasonNotificationsController.kt
+++ b/src/main/kotlin/com/terraformation/backend/plantingmanagement/api/PlantingSeasonNotificationsController.kt
@@ -36,9 +36,7 @@ class PlantingSeasonNotificationsController(
           PlantingSeasonNotificationType.InventoryPlanning ->
               plantingSeasonNotificationsService
                   .getInventoryPlanningNotifications(organizationId)
-                  .map {
-                    PlantingSeasonNotificationPayload(it)
-                  }
+                  .map { PlantingSeasonNotificationPayload(it) }
           PlantingSeasonNotificationType.PlantingSeasonPlanning -> emptyList()
         }
 

--- a/src/main/kotlin/com/terraformation/backend/plantingmanagement/db/PlantingSeasonNotificationsService.kt
+++ b/src/main/kotlin/com/terraformation/backend/plantingmanagement/db/PlantingSeasonNotificationsService.kt
@@ -11,7 +11,7 @@ import com.terraformation.backend.db.tracking.tables.references.PLANTING_SEASONS
 import com.terraformation.backend.db.tracking.tables.references.PLANTING_SEASON_NOTIFICATIONS
 import com.terraformation.backend.eventlog.db.EventLogStore
 import com.terraformation.backend.eventlog.model.EventLogEntry
-import com.terraformation.backend.plantingmanagement.PlantingSeasonNotificationAlertModel
+import com.terraformation.backend.plantingmanagement.PlantingSeasonNotificationGroupModel
 import com.terraformation.backend.plantingmanagement.PlantingSeasonNotificationModel
 import com.terraformation.backend.plantingmanagement.PlantingSeasonNotificationType
 import com.terraformation.backend.plantingmanagement.event.PlantingSeasonPersistentEvent
@@ -43,7 +43,7 @@ class PlantingSeasonNotificationsService(
    */
   fun getInventoryPlanningNotifications(
       organizationId: OrganizationId
-  ): List<PlantingSeasonNotificationModel> {
+  ): List<PlantingSeasonNotificationGroupModel> {
     val seasonInfoById =
         fetchSeasonInfoByCondition(
             PLANTING_SEASONS.plantingSites.ORGANIZATION_ID.eq(organizationId)
@@ -83,7 +83,7 @@ class PlantingSeasonNotificationsService(
    */
   fun getInventoryPlanningNotifications(
       plantingSeasonId: PlantingSeasonId
-  ): PlantingSeasonNotificationModel? {
+  ): PlantingSeasonNotificationGroupModel? {
     requirePermissions { readPlantingSeason(plantingSeasonId) }
 
     val seasonInfoById = fetchSeasonInfoByCondition(PLANTING_SEASONS.ID.eq(plantingSeasonId))
@@ -111,29 +111,29 @@ class PlantingSeasonNotificationsService(
       entries: List<EventLogEntry<PlantingSeasonRelatedPersistentEvent>>,
       seasonInfo: SeasonInfo,
       scientificNamesBySpeciesId: Map<SpeciesId, String>,
-  ): PlantingSeasonNotificationModel =
-      PlantingSeasonNotificationModel(
+  ): PlantingSeasonNotificationGroupModel =
+      PlantingSeasonNotificationGroupModel(
           plantingSeasonId = plantingSeasonId,
           plantingSeasonName = seasonInfo.plantingSeasonName,
           plantingSiteName = seasonInfo.plantingSiteName,
           lastEventLogId = entries.maxOf { it.id },
-          events = combineEvents(entries.map { it.event }, scientificNamesBySpeciesId),
+          notifications = combineEvents(entries.map { it.event }, scientificNamesBySpeciesId),
       )
 
   /**
-   * Collapses the events for a single planting season into at most one notification alert per
+   * Collapses the events for a single planting season into at most one notification per
    * [PlantingSeasonNotificationType]. Events that do not map to a notification type are dropped.
-   * For a species target alert, the scientific names of every species referenced by the combined
-   * events are gathered into [PlantingSeasonNotificationAlertModel.speciesScientificNames].
+   * For a species target notification, the scientific names of every species referenced by the
+   * combined events are gathered into [PlantingSeasonNotificationModel.speciesScientificNames].
    *
    * [events] is expected to be ordered by the time each event was logged, which is the order
-   * returned by [EventLogStore.fetchByIdsSince]; alerts are returned in the order their types first
-   * appear.
+   * returned by [EventLogStore.fetchByIdsSince]; notications are returned in the order their types
+   * first appear.
    */
   private fun combineEvents(
       events: List<PlantingSeasonRelatedPersistentEvent>,
       scientificNamesBySpeciesId: Map<SpeciesId, String>,
-  ): List<PlantingSeasonNotificationAlertModel> {
+  ): List<PlantingSeasonNotificationModel> {
     require(events.mapTo(mutableSetOf()) { it.plantingSeasonId }.size <= 1) {
       "combineEvents must be called with events for a single planting season"
     }
@@ -149,7 +149,7 @@ class PlantingSeasonNotificationsService(
     }
 
     return speciesNamesByType.map { (type, speciesNames) ->
-      PlantingSeasonNotificationAlertModel(
+      PlantingSeasonNotificationModel(
           type = type,
           speciesScientificNames = speciesNames.ifEmpty { null },
       )
@@ -160,14 +160,14 @@ class PlantingSeasonNotificationsService(
     get() =
         when (this) {
           is PlantingSeasonSpeciesTargetCreatedEvent ->
-              PlantingSeasonNotificationType.SPECIES_TARGETS_ADDED
+              PlantingSeasonNotificationType.SpeciesTargetsAdded
           is PlantingSeasonSpeciesTargetUpdatedEvent ->
-              PlantingSeasonNotificationType.SPECIES_TARGETS_UPDATED
+              PlantingSeasonNotificationType.SpeciesTargetsUpdated
           is PlantingSeasonUpdatedEvent ->
               if (changedTo.status == PlantingSeasonStatus.Closed) {
-                PlantingSeasonNotificationType.PLANTING_SEASON_CLOSED
+                PlantingSeasonNotificationType.PlantingSeasonClosed
               } else if (changedTo.status == PlantingSeasonStatus.PastEndDate) {
-                PlantingSeasonNotificationType.PLANTING_SEASON_PAST_END_DATE
+                PlantingSeasonNotificationType.PlantingSeasonPastEndDate
               } else {
                 null
               }

--- a/src/main/kotlin/com/terraformation/backend/plantingmanagement/db/PlantingSeasonNotificationsService.kt
+++ b/src/main/kotlin/com/terraformation/backend/plantingmanagement/db/PlantingSeasonNotificationsService.kt
@@ -3,17 +3,23 @@ package com.terraformation.backend.plantingmanagement.db
 import com.terraformation.backend.customer.model.requirePermissions
 import com.terraformation.backend.db.default_schema.EventLogId
 import com.terraformation.backend.db.default_schema.OrganizationId
+import com.terraformation.backend.db.default_schema.SpeciesId
+import com.terraformation.backend.db.default_schema.tables.references.SPECIES
 import com.terraformation.backend.db.tracking.PlantingSeasonId
 import com.terraformation.backend.db.tracking.PlantingSeasonStatus
 import com.terraformation.backend.db.tracking.tables.references.PLANTING_SEASONS
 import com.terraformation.backend.db.tracking.tables.references.PLANTING_SEASON_NOTIFICATIONS
 import com.terraformation.backend.eventlog.db.EventLogStore
+import com.terraformation.backend.eventlog.model.EventLogEntry
+import com.terraformation.backend.plantingmanagement.PlantingSeasonNotificationAlertModel
+import com.terraformation.backend.plantingmanagement.PlantingSeasonNotificationModel
+import com.terraformation.backend.plantingmanagement.PlantingSeasonNotificationType
 import com.terraformation.backend.plantingmanagement.event.PlantingSeasonPersistentEvent
 import com.terraformation.backend.plantingmanagement.event.PlantingSeasonRelatedPersistentEvent
+import com.terraformation.backend.plantingmanagement.event.PlantingSeasonSpeciesTargetCreatedEvent
 import com.terraformation.backend.plantingmanagement.event.PlantingSeasonSpeciesTargetPersistentEvent
 import com.terraformation.backend.plantingmanagement.event.PlantingSeasonSpeciesTargetUpdatedEvent
 import com.terraformation.backend.plantingmanagement.event.PlantingSeasonUpdatedEvent
-import com.terraformation.backend.plantingmanagement.event.PlantingSeasonUpdatedEventValues
 import jakarta.inject.Named
 import kotlin.reflect.KClass
 import org.jooq.Condition
@@ -31,169 +37,175 @@ class PlantingSeasonNotificationsService(
       )
 
   /**
-   * Returns the undismissed events for every planting season in an organization, grouped by
-   * planting season. A season that has never dismissed a notification has all of its events
-   * returned; a season with no undismissed events is absent from the result.
+   * Returns the undismissed notifications for every planting season in an organization. A season
+   * that has never dismissed a notification has all of its events returned; a season with no
+   * undismissed events is absent from the result.
    */
-  fun getNotifications(
+  fun getInventoryPlanningNotifications(
       organizationId: OrganizationId
-  ): Map<PlantingSeasonId, List<PlantingSeasonRelatedPersistentEvent>> {
-    val dismissedEventIds =
-        fetchLastDismissedEventLogIdsByCondition(
+  ): List<PlantingSeasonNotificationModel> {
+    val seasonInfoById =
+        fetchSeasonInfoByCondition(
             PLANTING_SEASONS.plantingSites.ORGANIZATION_ID.eq(organizationId)
         )
 
-    requirePermissions { dismissedEventIds.keys.forEach { readPlantingSeason(it) } }
+    requirePermissions { seasonInfoById.keys.forEach { readPlantingSeason(it) } }
 
-    if (dismissedEventIds.isEmpty()) {
-      return emptyMap()
+    if (seasonInfoById.isEmpty()) {
+      return emptyList()
     }
 
-    return eventLogStore
-        .fetchByIdsSince(
-            dismissedEventIds,
-            notificationEventClasses,
-        )
-        .map { it.event }
-        .groupBy { it.plantingSeasonId }
-        .mapValues { (_, events) -> combineEvents(events) }
+    val entriesBySeason =
+        eventLogStore
+            .fetchByIdsSince(
+                seasonInfoById.mapValues { it.value.lastDismissedEventLogId },
+                notificationEventClasses,
+            )
+            .groupBy { it.event.plantingSeasonId }
+
+    val scientificNamesBySpeciesId =
+        fetchScientificNamesBySpeciesId(speciesIdsOf(entriesBySeason.values.flatten()))
+
+    return entriesBySeason.map { (plantingSeasonId, entries) ->
+      buildNotificationModel(
+          plantingSeasonId,
+          entries,
+          seasonInfoById.getValue(plantingSeasonId),
+          scientificNamesBySpeciesId,
+      )
+    }
   }
 
   /**
-   * Returns the undismissed events for a single planting season, ordered by the time they were
-   * logged. If the season has never dismissed a notification, all of its events are returned.
+   * Returns the undismissed notification for a single planting season, or null if the season has no
+   * undismissed events. If the season has never dismissed a notification, all of its events are
+   * returned.
    */
-  fun getNotifications(
+  fun getInventoryPlanningNotifications(
       plantingSeasonId: PlantingSeasonId
-  ): List<PlantingSeasonRelatedPersistentEvent> {
+  ): PlantingSeasonNotificationModel? {
     requirePermissions { readPlantingSeason(plantingSeasonId) }
 
-    val dismissedEventIds =
-        fetchLastDismissedEventLogIdsByCondition(PLANTING_SEASONS.ID.eq(plantingSeasonId))
+    val seasonInfoById = fetchSeasonInfoByCondition(PLANTING_SEASONS.ID.eq(plantingSeasonId))
 
-    return combineEvents(
-        eventLogStore
-            .fetchByIdsSince(
-                dismissedEventIds,
-                notificationEventClasses,
-            )
-            .map { it.event }
+    val entries =
+        eventLogStore.fetchByIdsSince(
+            seasonInfoById.mapValues { it.value.lastDismissedEventLogId },
+            notificationEventClasses,
+        )
+
+    if (entries.isEmpty()) {
+      return null
+    }
+
+    return buildNotificationModel(
+        plantingSeasonId,
+        entries,
+        seasonInfoById.getValue(plantingSeasonId),
+        fetchScientificNamesBySpeciesId(speciesIdsOf(entries)),
     )
   }
 
+  private fun buildNotificationModel(
+      plantingSeasonId: PlantingSeasonId,
+      entries: List<EventLogEntry<PlantingSeasonRelatedPersistentEvent>>,
+      seasonInfo: SeasonInfo,
+      scientificNamesBySpeciesId: Map<SpeciesId, String>,
+  ): PlantingSeasonNotificationModel =
+      PlantingSeasonNotificationModel(
+          plantingSeasonId = plantingSeasonId,
+          plantingSeasonName = seasonInfo.plantingSeasonName,
+          plantingSiteName = seasonInfo.plantingSiteName,
+          lastEventLogId = entries.maxOf { it.id },
+          events = combineEvents(entries.map { it.event }, scientificNamesBySpeciesId),
+      )
+
   /**
-   * Collapses the update events for a planting season into at most one update notification per kind
-   * of update. Non-update events are left untouched.
+   * Collapses the events for a single planting season into at most one notification alert per
+   * [PlantingSeasonNotificationType]. Events that do not map to a notification type are dropped.
+   * For a species target alert, the scientific names of every species referenced by the combined
+   * events are gathered into [PlantingSeasonNotificationAlertModel.speciesScientificNames].
    *
    * [events] is expected to be ordered by the time each event was logged, which is the order
-   * returned by [EventLogStore.fetchByIdsSince].
+   * returned by [EventLogStore.fetchByIdsSince]; alerts are returned in the order their types first
+   * appear.
    */
   private fun combineEvents(
-      events: List<PlantingSeasonRelatedPersistentEvent>
-  ): List<PlantingSeasonRelatedPersistentEvent> {
+      events: List<PlantingSeasonRelatedPersistentEvent>,
+      scientificNamesBySpeciesId: Map<SpeciesId, String>,
+  ): List<PlantingSeasonNotificationAlertModel> {
     require(events.mapTo(mutableSetOf()) { it.plantingSeasonId }.size <= 1) {
       "combineEvents must be called with events for a single planting season"
     }
 
-    return combineSpeciesTargetUpdates(combineSeasonUpdates(events))
-  }
+    val speciesNamesByType = linkedMapOf<PlantingSeasonNotificationType, MutableSet<String>>()
 
-  /**
-   * Collapses the [PlantingSeasonUpdatedEvent]s for a season into a single event. For every field,
-   * the combined event keeps the [changedFrom][PlantingSeasonUpdatedEvent.changedFrom] value from
-   * the earliest update that changed it and the [changedTo][PlantingSeasonUpdatedEvent.changedTo]
-   * value from the latest update that changed it.
-   *
-   * Updates that change the status to [PlantingSeasonStatus.Closed] are excluded from the combined
-   * event and remain as separate events in the result.
-   */
-  private fun combineSeasonUpdates(
-      events: List<PlantingSeasonRelatedPersistentEvent>
-  ): List<PlantingSeasonRelatedPersistentEvent> {
-    val combinableUpdates =
-        events.filterIsInstance<PlantingSeasonUpdatedEvent>().filter {
-          it.changedTo.status != PlantingSeasonStatus.Closed
-        }
-
-    if (combinableUpdates.size < 2) {
-      return events
-    }
-
-    val combinedFrom =
-        PlantingSeasonUpdatedEventValues(
-            endDate = combinableUpdates.firstNotNullOfOrNull { it.changedFrom.endDate },
-            name = combinableUpdates.firstNotNullOfOrNull { it.changedFrom.name },
-            startDate = combinableUpdates.firstNotNullOfOrNull { it.changedFrom.startDate },
-            status = combinableUpdates.firstNotNullOfOrNull { it.changedFrom.status },
-        )
-    val combinedTo =
-        PlantingSeasonUpdatedEventValues(
-            endDate = combinableUpdates.lastNotNullOfOrNull { it.changedTo.endDate },
-            name = combinableUpdates.lastNotNullOfOrNull { it.changedTo.name },
-            startDate = combinableUpdates.lastNotNullOfOrNull { it.changedTo.startDate },
-            status = combinableUpdates.lastNotNullOfOrNull { it.changedTo.status },
-        )
-
-    val lastCombinable = combinableUpdates.last()
-
-    return events.mapNotNull { event ->
-      when {
-        event !is PlantingSeasonUpdatedEvent -> event
-        event.changedTo.status == PlantingSeasonStatus.Closed -> event
-        event === lastCombinable -> event.copy(changedFrom = combinedFrom, changedTo = combinedTo)
-        else -> null
+    events.forEach { event ->
+      val type = event.notificationType ?: return@forEach
+      val speciesNames = speciesNamesByType.getOrPut(type) { mutableSetOf() }
+      if (event is PlantingSeasonSpeciesTargetPersistentEvent) {
+        scientificNamesBySpeciesId[event.speciesId]?.let { speciesNames.add(it) }
       }
     }
+
+    return speciesNamesByType.map { (type, speciesNames) ->
+      PlantingSeasonNotificationAlertModel(
+          type = type,
+          speciesScientificNames = speciesNames.ifEmpty { null },
+      )
+    }
   }
 
-  /**
-   * Collapses the [PlantingSeasonSpeciesTargetUpdatedEvent]s for each species target into a single
-   * event, keeping the [changedFrom][PlantingSeasonSpeciesTargetUpdatedEvent.changedFrom] of the
-   * earliest update and the [changedTo][PlantingSeasonSpeciesTargetUpdatedEvent.changedTo] of the
-   * latest update. Only updates to the same species and substratum are combined; the combined event
-   * keeps that target's last update as a representative.
-   */
-  private fun combineSpeciesTargetUpdates(
-      events: List<PlantingSeasonRelatedPersistentEvent>
-  ): List<PlantingSeasonRelatedPersistentEvent> {
-    val updatesByTarget =
-        events
-            .filterIsInstance<PlantingSeasonSpeciesTargetUpdatedEvent>()
-            .groupBy { it.speciesId to it.substratumId }
-            .filterValues { it.size >= 2 }
-
-    if (updatesByTarget.isEmpty()) {
-      return events
-    }
-
-    return events.mapNotNull { event ->
-      if (event !is PlantingSeasonSpeciesTargetUpdatedEvent) {
-        event
-      } else {
-        val group = updatesByTarget[event.speciesId to event.substratumId]
-        when {
-          group == null -> event
-          event === group.last() -> group.last().copy(changedFrom = group.first().changedFrom)
+  private val PlantingSeasonRelatedPersistentEvent.notificationType: PlantingSeasonNotificationType?
+    get() =
+        when (this) {
+          is PlantingSeasonSpeciesTargetCreatedEvent ->
+              PlantingSeasonNotificationType.SPECIES_TARGETS_ADDED
+          is PlantingSeasonSpeciesTargetUpdatedEvent ->
+              PlantingSeasonNotificationType.SPECIES_TARGETS_UPDATED
+          is PlantingSeasonUpdatedEvent ->
+              if (changedTo.status == PlantingSeasonStatus.Closed) {
+                PlantingSeasonNotificationType.PLANTING_SEASON_CLOSED
+              } else if (changedTo.status == PlantingSeasonStatus.PastEndDate) {
+                PlantingSeasonNotificationType.PLANTING_SEASON_PAST_END_DATE
+              } else {
+                null
+              }
           else -> null
         }
-      }
+
+  private fun speciesIdsOf(
+      entries: List<EventLogEntry<PlantingSeasonRelatedPersistentEvent>>
+  ): Set<SpeciesId> =
+      entries
+          .map { it.event }
+          .filterIsInstance<PlantingSeasonSpeciesTargetPersistentEvent>()
+          .mapTo(mutableSetOf()) { it.speciesId }
+
+  private fun fetchScientificNamesBySpeciesId(speciesIds: Set<SpeciesId>): Map<SpeciesId, String> {
+    if (speciesIds.isEmpty()) {
+      return emptyMap()
     }
+
+    return dslContext
+        .select(SPECIES.ID, SPECIES.SCIENTIFIC_NAME)
+        .from(SPECIES)
+        .where(SPECIES.ID.`in`(speciesIds))
+        .associate { it[SPECIES.ID]!! to it[SPECIES.SCIENTIFIC_NAME]!! }
   }
 
-  private fun <T, R> List<T>.lastNotNullOfOrNull(transform: (T) -> R?): R? =
-      asReversed().firstNotNullOfOrNull(transform)
-
   /**
-   * Returns the dismissal watermark for every planting season matching [condition]. Every matching
-   * season is included; the value is null for seasons that have never dismissed a notification,
-   * which means all of their events should be treated as undismissed.
+   * Returns the dismissal watermark and display names for every planting season matching
+   * [condition]. Every matching season is included; [SeasonInfo.lastDismissedEventLogId] is null
+   * for seasons that have never dismissed a notification, which means all of their events should be
+   * treated as undismissed.
    */
-  private fun fetchLastDismissedEventLogIdsByCondition(
-      condition: Condition
-  ): Map<PlantingSeasonId, EventLogId?> =
+  private fun fetchSeasonInfoByCondition(condition: Condition): Map<PlantingSeasonId, SeasonInfo> =
       dslContext
           .select(
               PLANTING_SEASONS.ID,
+              PLANTING_SEASONS.NAME,
+              PLANTING_SEASONS.plantingSites.NAME,
               PLANTING_SEASON_NOTIFICATIONS.LAST_DISMISSED_EVENT_LOG_ID,
           )
           .from(PLANTING_SEASONS)
@@ -202,6 +214,17 @@ class PlantingSeasonNotificationsService(
           .where(condition)
           .associate { record ->
             record[PLANTING_SEASONS.ID]!! to
-                record[PLANTING_SEASON_NOTIFICATIONS.LAST_DISMISSED_EVENT_LOG_ID]
+                SeasonInfo(
+                    lastDismissedEventLogId =
+                        record[PLANTING_SEASON_NOTIFICATIONS.LAST_DISMISSED_EVENT_LOG_ID],
+                    plantingSeasonName = record[PLANTING_SEASONS.NAME]!!,
+                    plantingSiteName = record[PLANTING_SEASONS.plantingSites.NAME]!!,
+                )
           }
+
+  private data class SeasonInfo(
+      val lastDismissedEventLogId: EventLogId?,
+      val plantingSeasonName: String,
+      val plantingSiteName: String,
+  )
 }

--- a/src/test/kotlin/com/terraformation/backend/plantingmanagement/db/PlantingSeasonNotificationsServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/plantingmanagement/db/PlantingSeasonNotificationsServiceTest.kt
@@ -6,6 +6,7 @@ import com.terraformation.backend.RunsAsDatabaseUser
 import com.terraformation.backend.TestClock
 import com.terraformation.backend.customer.model.TerrawareUser
 import com.terraformation.backend.db.DatabaseTest
+import com.terraformation.backend.db.default_schema.EventLogId
 import com.terraformation.backend.db.default_schema.OrganizationId
 import com.terraformation.backend.db.default_schema.Role
 import com.terraformation.backend.db.default_schema.SpeciesId
@@ -17,8 +18,10 @@ import com.terraformation.backend.db.tracking.SubstratumHistoryId
 import com.terraformation.backend.db.tracking.SubstratumId
 import com.terraformation.backend.eventlog.db.EventLogStore
 import com.terraformation.backend.eventlog.model.EventLogEntry
+import com.terraformation.backend.plantingmanagement.PlantingSeasonNotificationAlertModel
+import com.terraformation.backend.plantingmanagement.PlantingSeasonNotificationModel
+import com.terraformation.backend.plantingmanagement.PlantingSeasonNotificationType
 import com.terraformation.backend.plantingmanagement.event.PlantingSeasonCreatedEvent
-import com.terraformation.backend.plantingmanagement.event.PlantingSeasonDeletedEvent
 import com.terraformation.backend.plantingmanagement.event.PlantingSeasonRelatedPersistentEvent
 import com.terraformation.backend.plantingmanagement.event.PlantingSeasonSpeciesTargetCreatedEvent
 import com.terraformation.backend.plantingmanagement.event.PlantingSeasonSpeciesTargetUpdatedEvent
@@ -27,6 +30,7 @@ import com.terraformation.backend.plantingmanagement.event.PlantingSeasonUpdated
 import com.terraformation.backend.plantingmanagement.event.PlantingSeasonUpdatedEventValues
 import java.time.LocalDate
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
@@ -44,6 +48,11 @@ internal class PlantingSeasonNotificationsServiceTest : DatabaseTest(), RunsAsDa
     PlantingSeasonNotificationsService(dslContext, eventLogStore)
   }
 
+  private val plantingSiteName = "Test Site"
+  private val plantingSeasonName = "Test Season"
+  private val speciesName1 = "Species A"
+  private val speciesName2 = "Species B"
+
   private lateinit var organizationId: OrganizationId
   private lateinit var plantingSiteId: PlantingSiteId
   private lateinit var stratumId1: StratumId
@@ -56,106 +65,152 @@ internal class PlantingSeasonNotificationsServiceTest : DatabaseTest(), RunsAsDa
   fun setUp() {
     organizationId = insertOrganization()
     insertOrganizationUser(role = Role.Manager)
-    plantingSiteId = insertPlantingSite()
+    plantingSiteId = insertPlantingSite(name = plantingSiteName)
     stratumId1 = insertStratum()
     substratumId1 = insertSubstratum()
-    plantingSeasonId = insertPlantingSeason()
-    speciesId1 = insertSpecies()
-    speciesId2 = insertSpecies()
+    plantingSeasonId = insertPlantingSeason(name = plantingSeasonName)
+    speciesId1 = insertSpecies(scientificName = speciesName1)
+    speciesId2 = insertSpecies(scientificName = speciesName2)
   }
 
-  @Nested
-  inner class GetNotificationsByPlantingSeason {
-    @Test
-    fun `returns all events when the season has never dismissed a notification`() {
-      val created = insertCreatedEvent()
-      val deleted = insertDeletedEvent()
+  private fun model(
+      lastEventLogId: EventLogId,
+      events: List<PlantingSeasonNotificationAlertModel>,
+      plantingSeasonId: PlantingSeasonId = this.plantingSeasonId,
+      plantingSeasonName: String = this.plantingSeasonName,
+      plantingSiteName: String = this.plantingSiteName,
+  ) =
+      PlantingSeasonNotificationModel(
+          plantingSeasonId = plantingSeasonId,
+          plantingSeasonName = plantingSeasonName,
+          plantingSiteName = plantingSiteName,
+          lastEventLogId = lastEventLogId,
+          events = events,
+      )
 
-      assertEquals(listOf(created.event, deleted.event), service.getNotifications(plantingSeasonId))
+  private fun added(vararg speciesNames: String) =
+      PlantingSeasonNotificationAlertModel(
+          PlantingSeasonNotificationType.SPECIES_TARGETS_ADDED,
+          speciesNames.toSet(),
+      )
+
+  private fun updated(vararg speciesNames: String) =
+      PlantingSeasonNotificationAlertModel(
+          PlantingSeasonNotificationType.SPECIES_TARGETS_UPDATED,
+          speciesNames.toSet(),
+      )
+
+  private val pastEndDate =
+      PlantingSeasonNotificationAlertModel(
+          PlantingSeasonNotificationType.PLANTING_SEASON_PAST_END_DATE
+      )
+
+  private val closed =
+      PlantingSeasonNotificationAlertModel(PlantingSeasonNotificationType.PLANTING_SEASON_CLOSED)
+
+  @Nested
+  inner class GetInventoryPlanningNotificationsByPlantingSeason {
+    @Test
+    fun `returns all alerts when the season has never dismissed a notification`() {
+      insertSpeciesTargetCreatedEvent(speciesId = speciesId1)
+      clock.instant = clock.instant.plusSeconds(1)
+      val updatedEvent = insertSpeciesTargetUpdatedEvent(speciesId = speciesId1)
+
+      assertEquals(
+          model(updatedEvent.id, listOf(added(speciesName1), updated(speciesName1))),
+          service.getInventoryPlanningNotifications(plantingSeasonId),
+      )
     }
 
     @Test
-    fun `returns only events logged after the dismissal watermark`() {
-      val dismissed = insertCreatedEvent()
-      val newer = insertCreatedEvent(name = "Newer")
-      val newest = insertDeletedEvent()
+    fun `returns only alerts for events logged after the dismissal watermark`() {
+      val dismissed = insertSpeciesTargetCreatedEvent(speciesId = speciesId1)
+      clock.instant = clock.instant.plusSeconds(1)
+      val newer = insertSpeciesTargetUpdatedEvent(speciesId = speciesId1)
       insertPlantingSeasonNotification(lastDismissedEventLogId = dismissed.id)
 
-      assertEquals(listOf(newer.event, newest.event), service.getNotifications(plantingSeasonId))
-    }
-
-    @Test
-    fun `returns a single combined update event per season`() {
-      insertUpdatedEvent(
-          changedFrom = PlantingSeasonUpdatedEventValues(name = "A"),
-          changedTo = PlantingSeasonUpdatedEventValues(name = "B"),
+      assertEquals(
+          model(newer.id, listOf(updated(speciesName1))),
+          service.getInventoryPlanningNotifications(plantingSeasonId),
       )
-      clock.instant = clock.instant.plusSeconds(1)
-      val second =
-          insertUpdatedEvent(
-              changedFrom = PlantingSeasonUpdatedEventValues(name = "B"),
-              changedTo = PlantingSeasonUpdatedEventValues(name = "C"),
-          )
-
-      val combined =
-          (second.event as PlantingSeasonUpdatedEvent).copy(
-              changedFrom = PlantingSeasonUpdatedEventValues(name = "A")
-          )
-
-      assertEquals(listOf(combined), service.getNotifications(plantingSeasonId))
     }
 
     @Test
     fun `excludes events for other planting seasons`() {
-      val otherSeasonId = insertPlantingSeason()
-      val expected = insertCreatedEvent()
-      insertCreatedEvent(plantingSeasonId = otherSeasonId)
+      val otherSeasonId = insertPlantingSeason(name = "Other Season")
+      val expected = insertSpeciesTargetCreatedEvent(speciesId = speciesId1)
+      insertSpeciesTargetCreatedEvent(speciesId = speciesId1, plantingSeasonId = otherSeasonId)
 
-      assertEquals(listOf(expected.event), service.getNotifications(plantingSeasonId))
+      assertEquals(
+          model(expected.id, listOf(added(speciesName1))),
+          service.getInventoryPlanningNotifications(plantingSeasonId),
+      )
     }
 
     @Test
-    fun `returns empty list when there are no undismissed events`() {
-      val dismissed = insertCreatedEvent()
-      insertPlantingSeasonNotification(lastDismissedEventLogId = dismissed.id)
+    fun `ignores events that do not map to a notification type`() {
+      insertCreatedEvent()
+      clock.instant = clock.instant.plusSeconds(1)
+      val target = insertSpeciesTargetCreatedEvent(speciesId = speciesId1)
 
       assertEquals(
-          emptyList<PlantingSeasonRelatedPersistentEvent>(),
-          service.getNotifications(plantingSeasonId),
+          model(target.id, listOf(added(speciesName1))),
+          service.getInventoryPlanningNotifications(plantingSeasonId),
       )
+    }
+
+    @Test
+    fun `returns null when there are no undismissed events`() {
+      val dismissed = insertSpeciesTargetCreatedEvent(speciesId = speciesId1)
+      insertPlantingSeasonNotification(lastDismissedEventLogId = dismissed.id)
+
+      assertNull(service.getInventoryPlanningNotifications(plantingSeasonId))
     }
 
     @Test
     fun `throws exception when user has no permission to read the planting season`() {
       deleteOrganizationUser()
 
-      assertThrows<PlantingSeasonNotFoundException> { service.getNotifications(plantingSeasonId) }
+      assertThrows<PlantingSeasonNotFoundException> {
+        service.getInventoryPlanningNotifications(plantingSeasonId)
+      }
     }
   }
 
   @Nested
-  inner class GetNotificationsByOrganization {
+  inner class GetInventoryPlanningNotificationsByOrganization {
     @Test
-    fun `groups undismissed events by planting season`() {
-      val otherSeasonId = insertPlantingSeason()
-      val firstSeasonEvent = insertCreatedEvent()
-      val otherSeasonEvent = insertCreatedEvent(plantingSeasonId = otherSeasonId)
+    fun `groups alerts by planting season`() {
+      val otherSeasonId = insertPlantingSeason(name = "Other Season")
+      val firstSeasonEvent = insertSpeciesTargetCreatedEvent(speciesId = speciesId1)
+      val otherSeasonEvent =
+          insertSpeciesTargetCreatedEvent(speciesId = speciesId1, plantingSeasonId = otherSeasonId)
 
       assertEquals(
           mapOf(
-              plantingSeasonId to listOf(firstSeasonEvent.event),
-              otherSeasonId to listOf(otherSeasonEvent.event),
+              plantingSeasonId to model(firstSeasonEvent.id, listOf(added(speciesName1))),
+              otherSeasonId to
+                  model(
+                      otherSeasonEvent.id,
+                      listOf(added(speciesName1)),
+                      plantingSeasonId = otherSeasonId,
+                      plantingSeasonName = "Other Season",
+                  ),
           ),
-          service.getNotifications(organizationId),
+          service.getInventoryPlanningNotifications(organizationId).associateBy {
+            it.plantingSeasonId
+          },
       )
     }
 
     @Test
     fun `applies each season's dismissal watermark independently`() {
-      val otherSeasonId = insertPlantingSeason()
-      val dismissed = insertCreatedEvent()
-      val firstSeasonNewer = insertCreatedEvent(name = "Newer")
-      val otherSeasonEvent = insertCreatedEvent(plantingSeasonId = otherSeasonId)
+      val otherSeasonId = insertPlantingSeason(name = "Other Season")
+      val dismissed = insertSpeciesTargetCreatedEvent(speciesId = speciesId1)
+      clock.instant = clock.instant.plusSeconds(1)
+      val firstSeasonNewer = insertSpeciesTargetUpdatedEvent(speciesId = speciesId1)
+      val otherSeasonEvent =
+          insertSpeciesTargetCreatedEvent(speciesId = speciesId1, plantingSeasonId = otherSeasonId)
       insertPlantingSeasonNotification(
           plantingSeasonId = plantingSeasonId,
           lastDismissedEventLogId = dismissed.id,
@@ -163,39 +218,50 @@ internal class PlantingSeasonNotificationsServiceTest : DatabaseTest(), RunsAsDa
 
       assertEquals(
           mapOf(
-              plantingSeasonId to listOf(firstSeasonNewer.event),
-              otherSeasonId to listOf(otherSeasonEvent.event),
+              plantingSeasonId to model(firstSeasonNewer.id, listOf(updated(speciesName1))),
+              otherSeasonId to
+                  model(
+                      otherSeasonEvent.id,
+                      listOf(added(speciesName1)),
+                      plantingSeasonId = otherSeasonId,
+                      plantingSeasonName = "Other Season",
+                  ),
           ),
-          service.getNotifications(organizationId),
+          service.getInventoryPlanningNotifications(organizationId).associateBy {
+            it.plantingSeasonId
+          },
       )
     }
 
     @Test
     fun `excludes events from other organizations`() {
-      val expected = insertCreatedEvent()
+      val expected = insertSpeciesTargetCreatedEvent(speciesId = speciesId1)
 
       val otherOrganizationId = insertOrganization()
       val otherSiteId = insertPlantingSite(organizationId = otherOrganizationId)
       val otherSeasonId = insertPlantingSeason(plantingSiteId = otherSiteId)
-      insertCreatedEvent(
+      insertSpeciesTargetCreatedEvent(
+          speciesId = speciesId1,
           organizationId = otherOrganizationId,
           plantingSiteId = otherSiteId,
           plantingSeasonId = otherSeasonId,
       )
 
       assertEquals(
-          mapOf(plantingSeasonId to listOf(expected.event)),
-          service.getNotifications(organizationId),
+          mapOf(plantingSeasonId to model(expected.id, listOf(added(speciesName1)))),
+          service.getInventoryPlanningNotifications(organizationId).associateBy {
+            it.plantingSeasonId
+          },
       )
     }
 
     @Test
-    fun `returns empty map when the organization has no planting seasons`() {
+    fun `returns empty list when the organization has no planting seasons`() {
       val emptyOrganizationId = insertOrganization()
 
       assertEquals(
-          emptyMap<PlantingSeasonId, List<PlantingSeasonRelatedPersistentEvent>>(),
-          service.getNotifications(emptyOrganizationId),
+          emptyList<PlantingSeasonNotificationModel>(),
+          service.getInventoryPlanningNotifications(emptyOrganizationId),
       )
     }
 
@@ -203,203 +269,88 @@ internal class PlantingSeasonNotificationsServiceTest : DatabaseTest(), RunsAsDa
     fun `throws exception when user lacks permission for a season in the organization`() {
       deleteOrganizationUser()
 
-      assertThrows<PlantingSeasonNotFoundException> { service.getNotifications(organizationId) }
+      assertThrows<PlantingSeasonNotFoundException> {
+        service.getInventoryPlanningNotifications(organizationId)
+      }
     }
   }
 
   @Nested
   inner class CombineEvents {
     @Test
-    fun `merges correctly and keeps non-update events`() {
-      val firstStart = LocalDate.of(2024, 1, 1)
-      val secondStart = LocalDate.of(2024, 2, 1)
-      val firstEnd = LocalDate.of(2024, 6, 1)
-      val secondEnd = LocalDate.of(2024, 7, 1)
+    fun `collapses events of the same type across species into a single alert`() {
+      insertSpeciesTargetUpdatedEvent(speciesId = speciesId1)
+      insertSpeciesTargetUpdatedEvent(speciesId = speciesId2)
 
-      val created = insertCreatedEvent()
-      insertUpdatedEvent(
-          changedFrom = PlantingSeasonUpdatedEventValues(name = "A", startDate = firstStart),
-          changedTo = PlantingSeasonUpdatedEventValues(name = "B", startDate = secondStart),
+      val notification = service.getInventoryPlanningNotifications(plantingSeasonId)
+
+      assertEquals(
+          listOf(updated(speciesName1, speciesName2)),
+          notification?.events,
       )
+    }
+
+    @Test
+    fun `keeps species even if the changes are reverted`() {
+      insertSpeciesTargetUpdatedEvent(
+          speciesId = speciesId1,
+          changedFrom = PlantingSeasonSpeciesTargetUpdatedEventValues(quantity = 5),
+          changedTo = PlantingSeasonSpeciesTargetUpdatedEventValues(quantity = 10),
+      )
+      insertSpeciesTargetUpdatedEvent(speciesId = speciesId2)
+      insertSpeciesTargetUpdatedEvent(
+          speciesId = speciesId1,
+          changedFrom = PlantingSeasonSpeciesTargetUpdatedEventValues(quantity = 10),
+          changedTo = PlantingSeasonSpeciesTargetUpdatedEventValues(quantity = 5),
+      )
+
+      val notification = service.getInventoryPlanningNotifications(plantingSeasonId)
+
+      assertEquals(
+          listOf(updated(speciesName1, speciesName2)),
+          notification?.events,
+      )
+    }
+
+    @Test
+    fun `keeps a separate alert per notification type in first-seen order`() {
+      insertSpeciesTargetCreatedEvent(speciesId = speciesId1)
       clock.instant = clock.instant.plusSeconds(1)
-      val second =
-          insertUpdatedEvent(
-              changedFrom =
-                  PlantingSeasonUpdatedEventValues(
-                      endDate = firstEnd,
-                      status = PlantingSeasonStatus.Upcoming,
-                  ),
-              changedTo =
-                  PlantingSeasonUpdatedEventValues(
-                      endDate = secondEnd,
-                      status = PlantingSeasonStatus.Active,
-                  ),
-          )
+      insertSpeciesTargetUpdatedEvent(speciesId = speciesId1)
       clock.instant = clock.instant.plusSeconds(1)
-      val third =
+      val close =
           insertUpdatedEvent(
               changedFrom = PlantingSeasonUpdatedEventValues(status = PlantingSeasonStatus.Active),
               changedTo = PlantingSeasonUpdatedEventValues(status = PlantingSeasonStatus.Closed),
           )
 
-      val combined =
-          (second.event as PlantingSeasonUpdatedEvent).copy(
-              changedFrom =
-                  PlantingSeasonUpdatedEventValues(
-                      endDate = firstEnd,
-                      name = "A",
-                      startDate = firstStart,
-                      status = PlantingSeasonStatus.Upcoming,
-                  ),
-              changedTo =
-                  PlantingSeasonUpdatedEventValues(
-                      endDate = secondEnd,
-                      name = "B",
-                      startDate = secondStart,
-                      status = PlantingSeasonStatus.Active,
-                  ),
-          )
-
       assertEquals(
-          listOf(created.event, combined, third.event),
-          service.getNotifications(plantingSeasonId),
+          model(close.id, listOf(added(speciesName1), updated(speciesName1), closed)),
+          service.getInventoryPlanningNotifications(plantingSeasonId),
       )
     }
 
     @Test
-    fun `leaves a single update event unchanged`() {
-      val update =
-          insertUpdatedEvent(
-              changedFrom = PlantingSeasonUpdatedEventValues(name = "A"),
-              changedTo = PlantingSeasonUpdatedEventValues(name = "B"),
-          )
-
-      assertEquals(listOf(update.event), service.getNotifications(plantingSeasonId))
-    }
-  }
-
-  @Nested
-  inner class CombineSpeciesTargetEvents {
-    @Test
-    fun `groups season and species target events together`() {
-      val seasonCreated = insertCreatedEvent()
-      val targetCreated = insertSpeciesTargetCreatedEvent()
-
-      assertEquals(
-          listOf(seasonCreated.event, targetCreated.event),
-          service.getNotifications(plantingSeasonId),
-      )
-    }
-
-    @Test
-    fun `combines updates to the same species and substratum keeping earliest changedFrom and latest changedTo`() {
-      insertSpeciesTargetUpdatedEvent(
-          speciesId = speciesId1,
-          changedFrom = PlantingSeasonSpeciesTargetUpdatedEventValues(quantity = 5),
-          changedTo = PlantingSeasonSpeciesTargetUpdatedEventValues(quantity = 7),
-      )
-      clock.instant = clock.instant.plusSeconds(1)
-      val second =
-          insertSpeciesTargetUpdatedEvent(
-              speciesId = speciesId1,
-              changedFrom = PlantingSeasonSpeciesTargetUpdatedEventValues(quantity = 7),
-              changedTo = PlantingSeasonSpeciesTargetUpdatedEventValues(quantity = 9),
-          )
-
-      val combined =
-          (second.event as PlantingSeasonSpeciesTargetUpdatedEvent).copy(
-              changedFrom = PlantingSeasonSpeciesTargetUpdatedEventValues(quantity = 5)
-          )
-
-      assertEquals(listOf(combined), service.getNotifications(plantingSeasonId))
-    }
-
-    @Test
-    fun `does not combine updates for different species`() {
-      val first =
-          insertSpeciesTargetUpdatedEvent(
-              speciesId = speciesId1,
-              changedFrom = PlantingSeasonSpeciesTargetUpdatedEventValues(quantity = 5),
-              changedTo = PlantingSeasonSpeciesTargetUpdatedEventValues(quantity = 7),
-          )
-      clock.instant = clock.instant.plusSeconds(1)
-      val second =
-          insertSpeciesTargetUpdatedEvent(
-              speciesId = speciesId2,
-              changedFrom = PlantingSeasonSpeciesTargetUpdatedEventValues(quantity = 0),
-              changedTo = PlantingSeasonSpeciesTargetUpdatedEventValues(quantity = 3),
-          )
-
-      assertEquals(listOf(first.event, second.event), service.getNotifications(plantingSeasonId))
-    }
-
-    @Test
-    fun `does not combine updates for different substrata`() {
-      val otherSubstratumId = insertSubstratum()
-      val first =
-          insertSpeciesTargetUpdatedEvent(
-              substratumId = substratumId1,
-              changedFrom = PlantingSeasonSpeciesTargetUpdatedEventValues(quantity = 5),
-              changedTo = PlantingSeasonSpeciesTargetUpdatedEventValues(quantity = 7),
-          )
-      clock.instant = clock.instant.plusSeconds(1)
-      val second =
-          insertSpeciesTargetUpdatedEvent(
-              substratumId = otherSubstratumId,
-              changedFrom = PlantingSeasonSpeciesTargetUpdatedEventValues(quantity = 1),
-              changedTo = PlantingSeasonSpeciesTargetUpdatedEventValues(quantity = 4),
-          )
-
-      assertEquals(listOf(first.event, second.event), service.getNotifications(plantingSeasonId))
-    }
-
-    @Test
-    fun `leaves a single species target update unchanged`() {
-      val update =
-          insertSpeciesTargetUpdatedEvent(
-              changedFrom = PlantingSeasonSpeciesTargetUpdatedEventValues(quantity = 5),
-              changedTo = PlantingSeasonSpeciesTargetUpdatedEventValues(quantity = 7),
-          )
-
-      assertEquals(listOf(update.event), service.getNotifications(plantingSeasonId))
-    }
-
-    @Test
-    fun `combines each event type independently within a season`() {
+    fun `maps status change alerts correctly`() {
       insertUpdatedEvent(
           changedFrom = PlantingSeasonUpdatedEventValues(name = "A"),
           changedTo = PlantingSeasonUpdatedEventValues(name = "B"),
       )
-      insertSpeciesTargetUpdatedEvent(
-          speciesId = speciesId1,
-          changedFrom = PlantingSeasonSpeciesTargetUpdatedEventValues(quantity = 5),
-          changedTo = PlantingSeasonSpeciesTargetUpdatedEventValues(quantity = 7),
-      )
       clock.instant = clock.instant.plusSeconds(1)
-      val seasonUpdate2 =
+      insertUpdatedEvent(
+          changedFrom = PlantingSeasonUpdatedEventValues(status = PlantingSeasonStatus.Active),
+          changedTo = PlantingSeasonUpdatedEventValues(status = PlantingSeasonStatus.PastEndDate),
+      )
+      val closedEvent =
           insertUpdatedEvent(
-              changedFrom = PlantingSeasonUpdatedEventValues(name = "B"),
-              changedTo = PlantingSeasonUpdatedEventValues(name = "C"),
-          )
-      val targetUpdate2 =
-          insertSpeciesTargetUpdatedEvent(
-              speciesId = speciesId1,
-              changedFrom = PlantingSeasonSpeciesTargetUpdatedEventValues(quantity = 7),
-              changedTo = PlantingSeasonSpeciesTargetUpdatedEventValues(quantity = 9),
-          )
-
-      val combinedSeason =
-          (seasonUpdate2.event as PlantingSeasonUpdatedEvent).copy(
-              changedFrom = PlantingSeasonUpdatedEventValues(name = "A")
-          )
-      val combinedTarget =
-          (targetUpdate2.event as PlantingSeasonSpeciesTargetUpdatedEvent).copy(
-              changedFrom = PlantingSeasonSpeciesTargetUpdatedEventValues(quantity = 5)
+              changedFrom =
+                  PlantingSeasonUpdatedEventValues(status = PlantingSeasonStatus.PastEndDate),
+              changedTo = PlantingSeasonUpdatedEventValues(status = PlantingSeasonStatus.Closed),
           )
 
       assertEquals(
-          listOf(combinedSeason, combinedTarget),
-          service.getNotifications(plantingSeasonId),
+          model(closedEvent.id, listOf(pastEndDate, closed)),
+          service.getInventoryPlanningNotifications(plantingSeasonId),
       )
     }
   }
@@ -443,21 +394,6 @@ internal class PlantingSeasonNotificationsServiceTest : DatabaseTest(), RunsAsDa
     return EventLogEntry(user.userId, clock.instant, event, eventLogStore.insertEvent(event))
   }
 
-  private fun insertDeletedEvent(
-      plantingSeasonId: PlantingSeasonId = this.plantingSeasonId,
-      plantingSiteId: PlantingSiteId = this.plantingSiteId,
-      organizationId: OrganizationId = this.organizationId,
-  ): EventLogEntry<PlantingSeasonRelatedPersistentEvent> {
-    val event =
-        PlantingSeasonDeletedEvent(
-            organizationId = organizationId,
-            plantingSeasonId = plantingSeasonId,
-            plantingSiteId = plantingSiteId,
-        )
-
-    return EventLogEntry(user.userId, clock.instant, event, eventLogStore.insertEvent(event))
-  }
-
   private fun insertSpeciesTargetCreatedEvent(
       speciesId: SpeciesId = speciesId1,
       quantity: Int = 1,
@@ -485,9 +421,9 @@ internal class PlantingSeasonNotificationsServiceTest : DatabaseTest(), RunsAsDa
   private fun insertSpeciesTargetUpdatedEvent(
       speciesId: SpeciesId = speciesId1,
       changedFrom: PlantingSeasonSpeciesTargetUpdatedEventValues =
-          PlantingSeasonSpeciesTargetUpdatedEventValues(),
+          PlantingSeasonSpeciesTargetUpdatedEventValues(quantity = 5),
       changedTo: PlantingSeasonSpeciesTargetUpdatedEventValues =
-          PlantingSeasonSpeciesTargetUpdatedEventValues(),
+          PlantingSeasonSpeciesTargetUpdatedEventValues(quantity = 7),
       substratumId: SubstratumId = substratumId1,
       plantingSeasonId: PlantingSeasonId = this.plantingSeasonId,
       plantingSiteId: PlantingSiteId = this.plantingSiteId,

--- a/src/test/kotlin/com/terraformation/backend/plantingmanagement/db/PlantingSeasonNotificationsServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/plantingmanagement/db/PlantingSeasonNotificationsServiceTest.kt
@@ -18,7 +18,7 @@ import com.terraformation.backend.db.tracking.SubstratumHistoryId
 import com.terraformation.backend.db.tracking.SubstratumId
 import com.terraformation.backend.eventlog.db.EventLogStore
 import com.terraformation.backend.eventlog.model.EventLogEntry
-import com.terraformation.backend.plantingmanagement.PlantingSeasonNotificationAlertModel
+import com.terraformation.backend.plantingmanagement.PlantingSeasonNotificationGroupModel
 import com.terraformation.backend.plantingmanagement.PlantingSeasonNotificationModel
 import com.terraformation.backend.plantingmanagement.PlantingSeasonNotificationType
 import com.terraformation.backend.plantingmanagement.event.PlantingSeasonCreatedEvent
@@ -75,43 +75,41 @@ internal class PlantingSeasonNotificationsServiceTest : DatabaseTest(), RunsAsDa
 
   private fun model(
       lastEventLogId: EventLogId,
-      events: List<PlantingSeasonNotificationAlertModel>,
+      events: List<PlantingSeasonNotificationModel>,
       plantingSeasonId: PlantingSeasonId = this.plantingSeasonId,
       plantingSeasonName: String = this.plantingSeasonName,
       plantingSiteName: String = this.plantingSiteName,
   ) =
-      PlantingSeasonNotificationModel(
+      PlantingSeasonNotificationGroupModel(
           plantingSeasonId = plantingSeasonId,
           plantingSeasonName = plantingSeasonName,
           plantingSiteName = plantingSiteName,
           lastEventLogId = lastEventLogId,
-          events = events,
+          notifications = events,
       )
 
   private fun added(vararg speciesNames: String) =
-      PlantingSeasonNotificationAlertModel(
-          PlantingSeasonNotificationType.SPECIES_TARGETS_ADDED,
+      PlantingSeasonNotificationModel(
+          PlantingSeasonNotificationType.SpeciesTargetsAdded,
           speciesNames.toSet(),
       )
 
   private fun updated(vararg speciesNames: String) =
-      PlantingSeasonNotificationAlertModel(
-          PlantingSeasonNotificationType.SPECIES_TARGETS_UPDATED,
+      PlantingSeasonNotificationModel(
+          PlantingSeasonNotificationType.SpeciesTargetsUpdated,
           speciesNames.toSet(),
       )
 
   private val pastEndDate =
-      PlantingSeasonNotificationAlertModel(
-          PlantingSeasonNotificationType.PLANTING_SEASON_PAST_END_DATE
-      )
+      PlantingSeasonNotificationModel(PlantingSeasonNotificationType.PlantingSeasonPastEndDate)
 
   private val closed =
-      PlantingSeasonNotificationAlertModel(PlantingSeasonNotificationType.PLANTING_SEASON_CLOSED)
+      PlantingSeasonNotificationModel(PlantingSeasonNotificationType.PlantingSeasonClosed)
 
   @Nested
   inner class GetInventoryPlanningNotificationsByPlantingSeason {
     @Test
-    fun `returns all alerts when the season has never dismissed a notification`() {
+    fun `returns all notifications when the season has never dismissed a notification`() {
       insertSpeciesTargetCreatedEvent(speciesId = speciesId1)
       clock.instant = clock.instant.plusSeconds(1)
       val updatedEvent = insertSpeciesTargetUpdatedEvent(speciesId = speciesId1)
@@ -123,7 +121,7 @@ internal class PlantingSeasonNotificationsServiceTest : DatabaseTest(), RunsAsDa
     }
 
     @Test
-    fun `returns only alerts for events logged after the dismissal watermark`() {
+    fun `returns only notifications for events logged after the dismissal watermark`() {
       val dismissed = insertSpeciesTargetCreatedEvent(speciesId = speciesId1)
       clock.instant = clock.instant.plusSeconds(1)
       val newer = insertSpeciesTargetUpdatedEvent(speciesId = speciesId1)
@@ -180,7 +178,7 @@ internal class PlantingSeasonNotificationsServiceTest : DatabaseTest(), RunsAsDa
   @Nested
   inner class GetInventoryPlanningNotificationsByOrganization {
     @Test
-    fun `groups alerts by planting season`() {
+    fun `groups notifications by planting season`() {
       val otherSeasonId = insertPlantingSeason(name = "Other Season")
       val firstSeasonEvent = insertSpeciesTargetCreatedEvent(speciesId = speciesId1)
       val otherSeasonEvent =
@@ -260,7 +258,7 @@ internal class PlantingSeasonNotificationsServiceTest : DatabaseTest(), RunsAsDa
       val emptyOrganizationId = insertOrganization()
 
       assertEquals(
-          emptyList<PlantingSeasonNotificationModel>(),
+          emptyList<PlantingSeasonNotificationGroupModel>(),
           service.getInventoryPlanningNotifications(emptyOrganizationId),
       )
     }
@@ -278,7 +276,7 @@ internal class PlantingSeasonNotificationsServiceTest : DatabaseTest(), RunsAsDa
   @Nested
   inner class CombineEvents {
     @Test
-    fun `collapses events of the same type across species into a single alert`() {
+    fun `collapses events of the same type across species into a single notification`() {
       insertSpeciesTargetUpdatedEvent(speciesId = speciesId1)
       insertSpeciesTargetUpdatedEvent(speciesId = speciesId2)
 
@@ -286,7 +284,7 @@ internal class PlantingSeasonNotificationsServiceTest : DatabaseTest(), RunsAsDa
 
       assertEquals(
           listOf(updated(speciesName1, speciesName2)),
-          notification?.events,
+          notification?.notifications,
       )
     }
 
@@ -308,12 +306,12 @@ internal class PlantingSeasonNotificationsServiceTest : DatabaseTest(), RunsAsDa
 
       assertEquals(
           listOf(updated(speciesName1, speciesName2)),
-          notification?.events,
+          notification?.notifications,
       )
     }
 
     @Test
-    fun `keeps a separate alert per notification type in first-seen order`() {
+    fun `keeps a separate notification per notification type in first-seen order`() {
       insertSpeciesTargetCreatedEvent(speciesId = speciesId1)
       clock.instant = clock.instant.plusSeconds(1)
       insertSpeciesTargetUpdatedEvent(speciesId = speciesId1)
@@ -331,7 +329,7 @@ internal class PlantingSeasonNotificationsServiceTest : DatabaseTest(), RunsAsDa
     }
 
     @Test
-    fun `maps status change alerts correctly`() {
+    fun `maps status change notifications correctly`() {
       insertUpdatedEvent(
           changedFrom = PlantingSeasonUpdatedEventValues(name = "A"),
           changedTo = PlantingSeasonUpdatedEventValues(name = "B"),


### PR DESCRIPTION
Update the service to return a model instead of a list of events per season. Add a new enum to distinguish the various notification type (some are as-of-yet unused). Add an endpoint that fetches the notifications based on the category requested (`PlantingSeasonPlanning` will be completed later).