### PR TITLE
Add allocatedQuantity to scheduled planting date payload

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/plantingmanagement/Models.kt
+++ b/src/main/kotlin/com/terraformation/backend/plantingmanagement/Models.kt
@@ -51,9 +51,16 @@ data class PlantingSeasonScheduledDateModel(
   }
 }
 
+data class ExistingPlantingSeasonScheduledDateSpecies(
+    val allocatedQuantity: Int,
+    val quantity: Int,
+    val speciesId: SpeciesId,
+    val substratumId: SubstratumId,
+)
+
 data class ExistingPlantingSeasonScheduledDateModel(
     val date: LocalDate,
     val plantingSeasonId: PlantingSeasonId,
     val scheduledPlantingDateId: ScheduledPlantingDateId,
-    val species: List<PlantingSeasonScheduledDateSpecies> = emptyList(),
+    val species: List<ExistingPlantingSeasonScheduledDateSpecies> = emptyList(),
 )

--- a/src/main/kotlin/com/terraformation/backend/plantingmanagement/api/PlantingSeasonScheduledDatesController.kt
+++ b/src/main/kotlin/com/terraformation/backend/plantingmanagement/api/PlantingSeasonScheduledDatesController.kt
@@ -149,10 +149,17 @@ data class ListScheduledDatesResponsePayload(val scheduledDates: List<ScheduledD
 data class GetScheduledDateResponsePayload(val scheduledDate: ScheduledDatePayload) :
     SuccessResponsePayload
 
+data class ScheduledPlantingDateSpeciesResponsePayload(
+    val allocatedQuantity: Int,
+    val quantity: Int,
+    val speciesId: SpeciesId,
+    val substratumId: SubstratumId,
+)
+
 data class ScheduledDatePayload(
     val date: LocalDate,
     val scheduledPlantingDateId: ScheduledPlantingDateId,
-    val species: List<ScheduledPlantingDateSpeciesPayload>,
+    val species: List<ScheduledPlantingDateSpeciesResponsePayload>,
 ) {
   constructor(
       model: ExistingPlantingSeasonScheduledDateModel
@@ -161,7 +168,8 @@ data class ScheduledDatePayload(
       scheduledPlantingDateId = model.scheduledPlantingDateId,
       species =
           model.species.map {
-            ScheduledPlantingDateSpeciesPayload(
+            ScheduledPlantingDateSpeciesResponsePayload(
+                allocatedQuantity = it.allocatedQuantity,
                 quantity = it.quantity,
                 speciesId = it.speciesId,
                 substratumId = it.substratumId,

--- a/src/main/kotlin/com/terraformation/backend/plantingmanagement/db/PlantingSeasonScheduledDatesStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/plantingmanagement/db/PlantingSeasonScheduledDatesStore.kt
@@ -7,11 +7,12 @@ import com.terraformation.backend.db.tracking.PlantingSeasonId
 import com.terraformation.backend.db.tracking.ScheduledPlantingDateId
 import com.terraformation.backend.db.tracking.SubstratumId
 import com.terraformation.backend.db.tracking.tables.references.PLANTING_SEASONS
+import com.terraformation.backend.db.tracking.tables.references.PLANTING_SEASON_ALLOCATED_SPECIES
 import com.terraformation.backend.db.tracking.tables.references.SCHEDULED_PLANTING_DATES
 import com.terraformation.backend.db.tracking.tables.references.SCHEDULED_PLANTING_DATE_SPECIES
 import com.terraformation.backend.plantingmanagement.ExistingPlantingSeasonScheduledDateModel
+import com.terraformation.backend.plantingmanagement.ExistingPlantingSeasonScheduledDateSpecies
 import com.terraformation.backend.plantingmanagement.PlantingSeasonScheduledDateModel
-import com.terraformation.backend.plantingmanagement.PlantingSeasonScheduledDateSpecies
 import com.terraformation.backend.plantingmanagement.event.PlantingSeasonScheduledDateCreatedEvent
 import com.terraformation.backend.plantingmanagement.event.PlantingSeasonScheduledDateDeletedEvent
 import com.terraformation.backend.plantingmanagement.event.PlantingSeasonScheduledDateSpeciesCreatedEvent
@@ -398,17 +399,30 @@ class PlantingSeasonScheduledDatesStore(
     val speciesMultiset =
         with(SCHEDULED_PLANTING_DATE_SPECIES) {
           DSL.multiset(
-                  DSL.select(SPECIES_ID, SUBSTRATUM_ID, QUANTITY)
+                  DSL.select(
+                          SPECIES_ID,
+                          SUBSTRATUM_ID,
+                          QUANTITY,
+                          PLANTING_SEASON_ALLOCATED_SPECIES.QUANTITY,
+                      )
                       .from(SCHEDULED_PLANTING_DATE_SPECIES)
+                      .leftJoin(PLANTING_SEASON_ALLOCATED_SPECIES)
+                      .on(
+                          PLANTING_SEASON_ALLOCATED_SPECIES.PLANTING_SEASON_ID.eq(
+                                  scheduledPlantingDates.PLANTING_SEASON_ID
+                              )
+                              .and(PLANTING_SEASON_ALLOCATED_SPECIES.SPECIES_ID.eq(SPECIES_ID))
+                      )
                       .where(SCHEDULED_PLANTING_DATE_ID.eq(SCHEDULED_PLANTING_DATES.ID))
                       .orderBy(SPECIES_ID, SUBSTRATUM_ID)
               )
               .convertFrom { result ->
                 result.map { record ->
-                  PlantingSeasonScheduledDateSpecies(
+                  ExistingPlantingSeasonScheduledDateSpecies(
+                      allocatedQuantity = record[PLANTING_SEASON_ALLOCATED_SPECIES.QUANTITY] ?: 0,
+                      quantity = record[QUANTITY]!!,
                       speciesId = record[SPECIES_ID]!!,
                       substratumId = record[SUBSTRATUM_ID]!!,
-                      quantity = record[QUANTITY]!!,
                   )
                 }
               }

--- a/src/test/kotlin/com/terraformation/backend/plantingmanagement/PlantingSeasonScheduledDateModelTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/plantingmanagement/PlantingSeasonScheduledDateModelTest.kt
@@ -36,4 +36,31 @@ class PlantingSeasonScheduledDateModelTest {
       )
     }
   }
+
+  @Test
+  fun `throws IllegalArgumentException when a species is listed twice for the same substratum`() {
+    val plantingSeasonId = PlantingSeasonId(1)
+    val speciesId = SpeciesId(2)
+    val substratumId = SubstratumId(3)
+
+    assertThrows<IllegalArgumentException> {
+      PlantingSeasonScheduledDateModel(
+          plantingSeasonId = plantingSeasonId,
+          date = LocalDate.EPOCH,
+          species =
+              listOf(
+                  PlantingSeasonScheduledDateSpecies(
+                      quantity = 5,
+                      speciesId = speciesId,
+                      substratumId = substratumId,
+                  ),
+                  PlantingSeasonScheduledDateSpecies(
+                      quantity = 10,
+                      speciesId = speciesId,
+                      substratumId = substratumId,
+                  ),
+              ),
+      )
+    }
+  }
 }

--- a/src/test/kotlin/com/terraformation/backend/plantingmanagement/db/PlantingSeasonScheduledDatesStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/plantingmanagement/db/PlantingSeasonScheduledDatesStoreTest.kt
@@ -19,6 +19,7 @@ import com.terraformation.backend.db.tracking.tables.records.ScheduledPlantingDa
 import com.terraformation.backend.db.tracking.tables.references.SCHEDULED_PLANTING_DATES
 import com.terraformation.backend.db.tracking.tables.references.SCHEDULED_PLANTING_DATE_SPECIES
 import com.terraformation.backend.plantingmanagement.ExistingPlantingSeasonScheduledDateModel
+import com.terraformation.backend.plantingmanagement.ExistingPlantingSeasonScheduledDateSpecies
 import com.terraformation.backend.plantingmanagement.PlantingSeasonScheduledDateModel
 import com.terraformation.backend.plantingmanagement.PlantingSeasonScheduledDateSpecies
 import com.terraformation.backend.plantingmanagement.event.PlantingSeasonScheduledDateCreatedEvent
@@ -119,7 +120,8 @@ internal class PlantingSeasonScheduledDatesStoreTest : DatabaseTest(), RunsAsDat
                   scheduledPlantingDateId = scheduledDate2,
                   species =
                       listOf(
-                          PlantingSeasonScheduledDateSpecies(
+                          ExistingPlantingSeasonScheduledDateSpecies(
+                              allocatedQuantity = 0,
                               quantity = 20,
                               speciesId = speciesId2,
                               substratumId = substratumId,
@@ -132,7 +134,8 @@ internal class PlantingSeasonScheduledDatesStoreTest : DatabaseTest(), RunsAsDat
                   scheduledPlantingDateId = scheduledDate1,
                   species =
                       listOf(
-                          PlantingSeasonScheduledDateSpecies(
+                          ExistingPlantingSeasonScheduledDateSpecies(
+                              allocatedQuantity = 0,
                               quantity = 10,
                               speciesId = speciesId,
                               substratumId = substratumId,
@@ -189,12 +192,14 @@ internal class PlantingSeasonScheduledDatesStoreTest : DatabaseTest(), RunsAsDat
               scheduledPlantingDateId = scheduledDate,
               species =
                   listOf(
-                      PlantingSeasonScheduledDateSpecies(
+                      ExistingPlantingSeasonScheduledDateSpecies(
+                          allocatedQuantity = 0,
                           quantity = 10,
                           speciesId = speciesId,
                           substratumId = substratumId,
                       ),
-                      PlantingSeasonScheduledDateSpecies(
+                      ExistingPlantingSeasonScheduledDateSpecies(
+                          allocatedQuantity = 0,
                           quantity = 20,
                           speciesId = speciesId2,
                           substratumId = substratumId,
@@ -203,6 +208,89 @@ internal class PlantingSeasonScheduledDatesStoreTest : DatabaseTest(), RunsAsDat
           ),
           result,
           "returns correct scheduled date",
+      )
+    }
+
+    @Test
+    fun `populates allocatedQuantity from the planting season allocation for each species`() {
+      val speciesId2 = insertSpecies()
+      val substratumId2 = insertSubstratum()
+      val scheduledDate = insertPlantingSeasonScheduledDate(date = LocalDate.EPOCH)
+      insertScheduledPlantingDateSpecies(
+          scheduledPlantingDateId = scheduledDate,
+          speciesId = speciesId,
+          substratumId = substratumId,
+          quantity = 10,
+      )
+      insertScheduledPlantingDateSpecies(
+          scheduledPlantingDateId = scheduledDate,
+          speciesId = speciesId,
+          substratumId = substratumId2,
+          quantity = 20,
+      )
+      insertScheduledPlantingDateSpecies(
+          scheduledPlantingDateId = scheduledDate,
+          speciesId = speciesId2,
+          substratumId = substratumId,
+          quantity = 30,
+      )
+
+      // The allocation is per (season, species), so both substrata of speciesId share it.
+      // speciesId2
+      // has no allocation, so its allocatedQuantity is 0.
+      insertPlantingSeasonAllocatedSpecies(speciesId = speciesId, quantity = 100)
+
+      val result = store.fetch(plantingSeasonId, scheduledDate)
+
+      assertEquals(
+          listOf(
+              ExistingPlantingSeasonScheduledDateSpecies(
+                  allocatedQuantity = 100,
+                  quantity = 10,
+                  speciesId = speciesId,
+                  substratumId = substratumId,
+              ),
+              ExistingPlantingSeasonScheduledDateSpecies(
+                  allocatedQuantity = 100,
+                  quantity = 20,
+                  speciesId = speciesId,
+                  substratumId = substratumId2,
+              ),
+              ExistingPlantingSeasonScheduledDateSpecies(
+                  allocatedQuantity = 0,
+                  quantity = 30,
+                  speciesId = speciesId2,
+                  substratumId = substratumId,
+              ),
+          ),
+          result.species,
+          "Allocated quantity per species",
+      )
+    }
+
+    @Test
+    fun `does not include allocations from other planting seasons`() {
+      val scheduledDate = insertPlantingSeasonScheduledDate(date = LocalDate.EPOCH)
+      insertScheduledPlantingDateSpecies(
+          scheduledPlantingDateId = scheduledDate,
+          speciesId = speciesId,
+          substratumId = substratumId,
+          quantity = 10,
+      )
+
+      val otherSeasonId = insertPlantingSeason()
+      insertPlantingSeasonAllocatedSpecies(
+          plantingSeasonId = otherSeasonId,
+          speciesId = speciesId,
+          quantity = 100,
+      )
+
+      val result = store.fetch(plantingSeasonId, scheduledDate)
+
+      assertEquals(
+          0,
+          result.species.single().allocatedQuantity,
+          "Allocation from another season is excluded",
       )
     }
 


### PR DESCRIPTION
Allocations were not complete when Scheduled Planting Dates were worked. Now that they are complete, include the `allocatedQuantity` for that season's species in the species payloa for a scheduled planting date. 

Also add a missing unit test for the `PlantingSeasonScheduledDateMode`. 