### PR TITLE
SW-8489 Use consistent coverage minimum for plots

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/tracking/model/UnusedSquareFinder.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/model/UnusedSquareFinder.kt
@@ -125,7 +125,7 @@ class UnusedSquareFinder(
    * covered.
    */
   private fun coveredByStratum(polygon: Geometry): Boolean {
-    return polygon.nearlyCoveredBy(stratumGeometry, 99.9)
+    return polygon.nearlyCoveredBy(stratumGeometry)
   }
 
   /**

--- a/src/main/kotlin/com/terraformation/backend/util/Extensions.kt
+++ b/src/main/kotlin/com/terraformation/backend/util/Extensions.kt
@@ -266,9 +266,9 @@ fun Geometry.coveragePercent(other: Geometry): Double {
  * in that it allows a small margin of error to account for floating-point inaccuracy.
  *
  * @param minCoveragePercent Minimum percentage of this geometry's area that needs to be covered by
- *   the other geometry. Default is 99.99%.
+ *   the other geometry. Default is 99.9%.
  */
-fun Geometry.nearlyCoveredBy(other: Geometry, minCoveragePercent: Double = 99.99): Boolean {
+fun Geometry.nearlyCoveredBy(other: Geometry, minCoveragePercent: Double = 99.9): Boolean {
   return coveredBy(other) || coveragePercent(other) >= minCoveragePercent
 }
 


### PR DESCRIPTION
The code that places monitoring plots in planting sites requires that the plots be
99.9% covered by the site boundary. This is to allow for cases where a plot lies
just on the edge of a region and coordinate inaccuracy causes it to look like part
of it is just barely outside the region.

Unfortunately, the code that decides whether or not monitoring plots need to be
replaced after map edits was requiring 99.99% coverage. So a monitoring plot that
was, say, 99.95% covered could be created on the original version of a site map,
then rejected as invalid after a map edit even if it remained 99.95% covered.

Fix it by using 99.9% as the coverage minimum in both places.