### PR TITLE
Speed up SearchServiceNestedFieldsTest

### DIFF
--- a/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceNestedFieldsTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceNestedFieldsTest.kt
@@ -1211,14 +1211,12 @@ internal class SearchServiceNestedFieldsTest : SearchServiceTest() {
           val prefix = SearchFieldPrefix(fullyQualifiedField.searchTable)
           val field = prefix.resolve(fieldName.substringAfterLast('.'))
           val sortFields = listOf(SearchSortField(field))
-          assertDoesNotThrow("Sort by $fieldName") {
-            searchService.search(
-                prefix,
-                listOf(field),
-                mapOf(rootPrefix to NoConditionNode()),
-                sortFields,
-            )
-          }
+          searchService.search(
+              prefix,
+              listOf(field),
+              mapOf(rootPrefix to NoConditionNode()),
+              sortFields,
+          )
         }
       }
     }

--- a/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceNestedFieldsTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceNestedFieldsTest.kt
@@ -16,6 +16,7 @@ import com.terraformation.backend.search.SearchFieldPrefix
 import com.terraformation.backend.search.SearchFilterType
 import com.terraformation.backend.search.SearchResults
 import com.terraformation.backend.search.SearchSortField
+import com.terraformation.backend.search.field.AliasField
 import java.time.LocalDate
 import java.time.ZoneId
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -1186,23 +1187,39 @@ internal class SearchServiceNestedFieldsTest : SearchServiceTest() {
 
   @Test
   fun `all fields are valid sort keys`() {
-    val prefix = SearchFieldPrefix(tables.organizations)
+    val rootPrefix = SearchFieldPrefix(tables.organizations)
 
-    val expected = listOf(mapOf("id" to "$organizationId"))
-    val searchFields = listOf(prefix.resolve("id"))
+    tables.organizations.getAllFieldNames().forEach { fieldName ->
+      val fullyQualifiedField = rootPrefix.resolve(fieldName)
 
-    prefix.searchTable.getAllFieldNames().forEach { fieldName ->
-      val field = prefix.resolve(fieldName)
-      val sortFields = listOf(SearchSortField(field))
       assertDoesNotThrow("Sort by $fieldName") {
-        val result =
+        if (fullyQualifiedField.searchField is AliasField) {
+          // An alias points to its target's search table, which doesn't know how to resolve the
+          // alias's name if (as is usually true) its name differs from the name of the target
+          // field.
+          val sortFields = listOf(SearchSortField(fullyQualifiedField))
+          searchService.search(
+              rootPrefix,
+              listOf(fullyQualifiedField),
+              mapOf(rootPrefix to NoConditionNode()),
+              sortFields,
+          )
+        } else {
+          // Query and sort by the field directly on its search table rather than in the form of
+          // nested sublists from the root prefix; sublists cause the search code to generate
+          // SQL with lots of nested subqueries, which slows the test down.
+          val prefix = SearchFieldPrefix(fullyQualifiedField.searchTable)
+          val field = prefix.resolve(fieldName.substringAfterLast('.'))
+          val sortFields = listOf(SearchSortField(field))
+          assertDoesNotThrow("Sort by $fieldName") {
             searchService.search(
                 prefix,
-                searchFields,
-                mapOf(prefix to NoConditionNode()),
+                listOf(field),
+                mapOf(rootPrefix to NoConditionNode()),
                 sortFields,
             )
-        assertEquals(expected, result.results, "Sort by $fieldName")
+          }
+        }
       }
     }
   }


### PR DESCRIPTION
The "all fields are valid sort keys" test was referencing fields using nested
sublists that, for some tables, could be close to a dozen nesting levels deep.
The generated SQL worked, but the nesting slowed the queries down, and this
test covers hundreds of search fields.

Change the test so that if a field isn't an alias for another field, the
search query uses the field's table as its prefix. The generated SQL becomes
much simpler and runs more quickly.

Alias fields continue to use the old nested-sublists style, but there aren't
many of them.

On my laptop, execution time for the test method goes from 12.5 to 3.3
seconds.