### PR TITLE
SW-8427 Publish allocated species create/update events

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/plantingmanagement/db/PlantingSeasonAllocatedSpeciesStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/plantingmanagement/db/PlantingSeasonAllocatedSpeciesStore.kt
@@ -6,16 +6,21 @@ import com.terraformation.backend.db.default_schema.SpeciesId
 import com.terraformation.backend.db.tracking.PlantingSeasonId
 import com.terraformation.backend.db.tracking.tables.references.PLANTING_SEASON_ALLOCATED_SPECIES
 import com.terraformation.backend.db.tracking.tables.references.PLANTING_SEASON_SPECIES_TARGETS
+import com.terraformation.backend.plantingmanagement.event.PlantingSeasonAllocatedSpeciesCreatedEvent
+import com.terraformation.backend.plantingmanagement.event.PlantingSeasonAllocatedSpeciesUpdatedEvent
+import com.terraformation.backend.plantingmanagement.event.PlantingSeasonAllocatedSpeciesUpdatedEventValues
 import com.terraformation.backend.plantingmanagement.event.PlantingSeasonSpeciesTargetDeletedEvent
 import jakarta.inject.Named
 import java.time.InstantSource
 import org.jooq.DSLContext
+import org.springframework.context.ApplicationEventPublisher
 import org.springframework.context.event.EventListener
 
 @Named
 class PlantingSeasonAllocatedSpeciesStore(
     private val clock: InstantSource,
     private val dslContext: DSLContext,
+    private val eventPublisher: ApplicationEventPublisher,
     private val seasonHelper: SeasonHelper,
 ) {
   fun upsert(plantingSeasonId: PlantingSeasonId, speciesId: SpeciesId, quantity: Int) {
@@ -26,23 +31,66 @@ class PlantingSeasonAllocatedSpeciesStore(
 
     val userId = currentUser().userId
     val now = clock.instant()
+    val (plantingSiteId, organizationId) =
+        seasonHelper.fetchPlantingSiteAndOrganization(plantingSeasonId)
 
-    with(PLANTING_SEASON_ALLOCATED_SPECIES) {
-      dslContext
-          .insertInto(PLANTING_SEASON_ALLOCATED_SPECIES)
-          .set(PLANTING_SEASON_ID, plantingSeasonId)
-          .set(SPECIES_ID, speciesId)
-          .set(QUANTITY, quantity)
-          .set(CREATED_BY, userId)
-          .set(CREATED_TIME, now)
-          .set(MODIFIED_BY, userId)
-          .set(MODIFIED_TIME, now)
-          .onConflict(PLANTING_SEASON_ID, SPECIES_ID)
-          .doUpdate()
-          .set(QUANTITY, quantity)
-          .set(MODIFIED_BY, userId)
-          .set(MODIFIED_TIME, now)
-          .execute()
+    seasonHelper.withLockedPlantingSeason(plantingSeasonId) {
+      val existingQuantity =
+          with(PLANTING_SEASON_ALLOCATED_SPECIES) {
+            dslContext
+                .select(QUANTITY)
+                .from(PLANTING_SEASON_ALLOCATED_SPECIES)
+                .where(PLANTING_SEASON_ID.eq(plantingSeasonId))
+                .and(SPECIES_ID.eq(speciesId))
+                .fetchOne(QUANTITY)
+          }
+
+      with(PLANTING_SEASON_ALLOCATED_SPECIES) {
+        dslContext
+            .insertInto(PLANTING_SEASON_ALLOCATED_SPECIES)
+            .set(PLANTING_SEASON_ID, plantingSeasonId)
+            .set(SPECIES_ID, speciesId)
+            .set(QUANTITY, quantity)
+            .set(CREATED_BY, userId)
+            .set(CREATED_TIME, now)
+            .set(MODIFIED_BY, userId)
+            .set(MODIFIED_TIME, now)
+            .onConflict(PLANTING_SEASON_ID, SPECIES_ID)
+            .doUpdate()
+            .set(QUANTITY, quantity)
+            .set(MODIFIED_BY, userId)
+            .set(MODIFIED_TIME, now)
+            .execute()
+      }
+
+      when {
+        existingQuantity == null ->
+            eventPublisher.publishEvent(
+                PlantingSeasonAllocatedSpeciesCreatedEvent(
+                    organizationId = organizationId,
+                    plantingSeasonId = plantingSeasonId,
+                    plantingSiteId = plantingSiteId,
+                    quantity = quantity,
+                    speciesId = speciesId,
+                )
+            )
+
+        existingQuantity != quantity ->
+            eventPublisher.publishEvent(
+                PlantingSeasonAllocatedSpeciesUpdatedEvent(
+                    changedFrom =
+                        PlantingSeasonAllocatedSpeciesUpdatedEventValues(
+                            quantity = existingQuantity
+                        ),
+                    changedTo =
+                        PlantingSeasonAllocatedSpeciesUpdatedEventValues(quantity = quantity),
+                    organizationId = organizationId,
+                    plantingSeasonId = plantingSeasonId,
+                    plantingSiteId = plantingSiteId,
+                    speciesId = speciesId,
+                )
+            )
+      }
     }
   }
 

--- a/src/main/resources/db/migration/0500/V505__PlantingSeasonAllocatedSpeciesCreatedEvents.sql
+++ b/src/main/resources/db/migration/0500/V505__PlantingSeasonAllocatedSpeciesCreatedEvents.sql
@@ -1,0 +1,17 @@
+INSERT INTO event_log (created_by, created_time, event_class, payload)
+SELECT
+    alloc.created_by,
+    alloc.created_time,
+    'com.terraformation.backend.plantingmanagement.event.PlantingSeasonAllocatedSpeciesCreatedEventV1',
+    json_object(
+        '_historical' VALUE true,
+        'organizationId' VALUE sites.organization_id,
+        'plantingSeasonId' VALUE seasons.id,
+        'plantingSiteId' VALUE sites.id,
+        'quantity' VALUE alloc.quantity,
+        'speciesId' VALUE alloc.species_id
+        ABSENT ON NULL
+    )::JSONB
+FROM tracking.planting_season_allocated_species alloc
+JOIN tracking.planting_seasons seasons ON alloc.planting_season_id = seasons.id
+JOIN tracking.planting_sites sites ON seasons.planting_site_id = sites.id;

--- a/src/test/kotlin/com/terraformation/backend/plantingmanagement/db/PlantingSeasonAllocatedSpeciesStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/plantingmanagement/db/PlantingSeasonAllocatedSpeciesStoreTest.kt
@@ -2,6 +2,7 @@ package com.terraformation.backend.plantingmanagement.db
 
 import com.terraformation.backend.RunsAsDatabaseUser
 import com.terraformation.backend.TestClock
+import com.terraformation.backend.TestEventPublisher
 import com.terraformation.backend.customer.model.TerrawareUser
 import com.terraformation.backend.db.DatabaseTest
 import com.terraformation.backend.db.default_schema.Role
@@ -10,6 +11,9 @@ import com.terraformation.backend.db.tracking.PlantingSeasonId
 import com.terraformation.backend.db.tracking.PlantingSeasonStatus
 import com.terraformation.backend.db.tracking.tables.records.PlantingSeasonAllocatedSpeciesRecord
 import com.terraformation.backend.db.tracking.tables.references.PLANTING_SEASON_ALLOCATED_SPECIES
+import com.terraformation.backend.plantingmanagement.event.PlantingSeasonAllocatedSpeciesCreatedEvent
+import com.terraformation.backend.plantingmanagement.event.PlantingSeasonAllocatedSpeciesUpdatedEvent
+import com.terraformation.backend.plantingmanagement.event.PlantingSeasonAllocatedSpeciesUpdatedEventValues
 import com.terraformation.backend.plantingmanagement.event.PlantingSeasonSpeciesTargetDeletedEvent
 import java.time.Instant
 import org.junit.jupiter.api.BeforeEach
@@ -22,8 +26,9 @@ internal class PlantingSeasonAllocatedSpeciesStoreTest : DatabaseTest(), RunsAsD
   override lateinit var user: TerrawareUser
 
   private val clock = TestClock()
+  private val eventPublisher = TestEventPublisher()
   private val store: PlantingSeasonAllocatedSpeciesStore by lazy {
-    PlantingSeasonAllocatedSpeciesStore(clock, dslContext, SeasonHelper(dslContext))
+    PlantingSeasonAllocatedSpeciesStore(clock, dslContext, eventPublisher, SeasonHelper(dslContext))
   }
 
   private lateinit var plantingSeasonId: PlantingSeasonId
@@ -41,7 +46,7 @@ internal class PlantingSeasonAllocatedSpeciesStoreTest : DatabaseTest(), RunsAsD
   @Nested
   inner class Upsert {
     @Test
-    fun `inserts a new species allocation row`() {
+    fun `inserts a new species allocation row and publishes event`() {
       store.upsert(plantingSeasonId, speciesId, 5)
 
       assertTableEquals(
@@ -55,10 +60,20 @@ internal class PlantingSeasonAllocatedSpeciesStoreTest : DatabaseTest(), RunsAsD
               modifiedTime = clock.instant,
           ),
       )
+
+      eventPublisher.assertEventPublished(
+          PlantingSeasonAllocatedSpeciesCreatedEvent(
+              organizationId = inserted.organizationId,
+              plantingSeasonId = plantingSeasonId,
+              plantingSiteId = inserted.plantingSiteId,
+              quantity = 5,
+              speciesId = speciesId,
+          )
+      )
     }
 
     @Test
-    fun `updates quantity when row already exists`() {
+    fun `updates quantity and publishes event when row already exists`() {
       store.upsert(plantingSeasonId, speciesId, quantity = 5)
       clock.instant = Instant.ofEpochSecond(100)
       store.upsert(plantingSeasonId, speciesId, quantity = 20)
@@ -74,6 +89,25 @@ internal class PlantingSeasonAllocatedSpeciesStoreTest : DatabaseTest(), RunsAsD
               modifiedTime = clock.instant,
           )
       )
+
+      eventPublisher.assertEventPublished(
+          PlantingSeasonAllocatedSpeciesUpdatedEvent(
+              changedFrom = PlantingSeasonAllocatedSpeciesUpdatedEventValues(quantity = 5),
+              changedTo = PlantingSeasonAllocatedSpeciesUpdatedEventValues(quantity = 20),
+              organizationId = inserted.organizationId,
+              plantingSeasonId = plantingSeasonId,
+              plantingSiteId = inserted.plantingSiteId,
+              speciesId = speciesId,
+          )
+      )
+    }
+
+    @Test
+    fun `does not publish an event when the quantity is unchanged`() {
+      store.upsert(plantingSeasonId, speciesId, quantity = 5)
+      store.upsert(plantingSeasonId, speciesId, quantity = 5)
+
+      eventPublisher.assertEventNotPublished<PlantingSeasonAllocatedSpeciesUpdatedEvent>()
     }
 
     @Test


### PR DESCRIPTION
Publish persistent events when planting season allocated species are upserted.
Backfill creation events for existing allocated species.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>