### PR TITLE
SW-8434 Delete observation from admin UI

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/admin/AdminObservationsController.kt
+++ b/src/main/kotlin/com/terraformation/backend/admin/AdminObservationsController.kt
@@ -1,0 +1,47 @@
+package com.terraformation.backend.admin
+
+import com.terraformation.backend.api.RequireGlobalRole
+import com.terraformation.backend.db.default_schema.GlobalRole
+import com.terraformation.backend.db.tracking.ObservationId
+import com.terraformation.backend.log.perClassLogger
+import com.terraformation.backend.tracking.ObservationService
+import org.springframework.stereotype.Controller
+import org.springframework.validation.annotation.Validated
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.servlet.mvc.support.RedirectAttributes
+
+@Controller
+@RequestMapping("/admin")
+@RequireGlobalRole([GlobalRole.SuperAdmin])
+@Validated
+class AdminObservationsController(
+    private val observationService: ObservationService,
+) {
+  private val log = perClassLogger()
+
+  @GetMapping("/observations")
+  fun getAdminObservationsHome(): String {
+    return "/admin/observations"
+  }
+
+  @PostMapping("/deleteObservation")
+  fun adminDeleteObservation(
+      @RequestParam observationId: ObservationId,
+      redirectAttributes: RedirectAttributes,
+  ): String {
+    try {
+      observationService.deleteObservation(observationId)
+      redirectAttributes.successMessage = "Deleted observation $observationId."
+    } catch (e: Exception) {
+      log.error("Failed to delete observation $observationId", e)
+      redirectAttributes.failureMessage = "Failed to delete observation: $e"
+    }
+
+    return redirectToObservationsHome()
+  }
+
+  private fun redirectToObservationsHome() = "redirect:/admin/observations"
+}

--- a/src/main/kotlin/com/terraformation/backend/tracking/ObservationService.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/ObservationService.kt
@@ -809,6 +809,20 @@ class ObservationService(
     return observationLocker.withLockedObservation(observationId) { _ -> func() }
   }
 
+  fun deleteObservation(observationId: ObservationId) {
+    requirePermissions { manageObservation(observationId) }
+
+    systemUser.run {
+      val observation = observationStore.fetchObservationById(observationId)
+
+      deleteMediaWhere(OBSERVATION_MEDIA_FILES.OBSERVATION_ID.eq(observationId))
+
+      observationStore.deleteObservation(observationId)
+
+      observationStore.recalculateSurvivalRates(observation.plantingSiteId)
+    }
+  }
+
   @EventListener
   fun on(event: PlantingSiteDeletionStartedEvent) {
     deleteMediaWhere(

--- a/src/main/kotlin/com/terraformation/backend/tracking/db/ObservationStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/db/ObservationStore.kt
@@ -58,6 +58,7 @@ import com.terraformation.backend.db.tracking.tables.references.PLANTING_SITE_HI
 import com.terraformation.backend.db.tracking.tables.references.PLANTING_SITE_POPULATIONS
 import com.terraformation.backend.db.tracking.tables.references.PLANTING_SITE_SURVIVAL_RATE_CALCULATIONS
 import com.terraformation.backend.db.tracking.tables.references.PLOT_T0_DENSITIES
+import com.terraformation.backend.db.tracking.tables.references.PLOT_T0_OBSERVATIONS
 import com.terraformation.backend.db.tracking.tables.references.RECORDED_PLANTS
 import com.terraformation.backend.db.tracking.tables.references.STRATA
 import com.terraformation.backend.db.tracking.tables.references.STRATUM_HISTORIES
@@ -2366,12 +2367,21 @@ class ObservationStore(
     }
   }
 
-  private fun deleteObservation(observationId: ObservationId) {
+  fun deleteObservation(observationId: ObservationId) {
+    val t0PlotIds =
+        dslContext
+            .select(PLOT_T0_OBSERVATIONS.MONITORING_PLOT_ID)
+            .from(PLOT_T0_OBSERVATIONS)
+            .where(PLOT_T0_OBSERVATIONS.OBSERVATION_ID.eq(observationId))
+            .fetch(PLOT_T0_OBSERVATIONS.MONITORING_PLOT_ID.asNonNullable())
+
     dslContext.transaction { _ ->
-      dslContext
-          .deleteFrom(OBSERVATION_PLOTS)
-          .where(OBSERVATION_PLOTS.OBSERVATION_ID.eq(observationId))
-          .execute()
+      if (t0PlotIds.isNotEmpty()) {
+        dslContext
+            .deleteFrom(PLOT_T0_DENSITIES)
+            .where(PLOT_T0_DENSITIES.MONITORING_PLOT_ID.`in`(t0PlotIds))
+            .execute()
+      }
 
       dslContext.deleteFrom(OBSERVATIONS).where(OBSERVATIONS.ID.eq(observationId)).execute()
     }

--- a/src/main/resources/templates/admin/index.html
+++ b/src/main/resources/templates/admin/index.html
@@ -202,6 +202,10 @@
     </p>
 
     <p>
+        <a href="/admin/observations">Manage Observations</a>
+    </p>
+
+    <p>
         <a href="/admin/simplifyPlantingSites">Manage Planting Sites Simplification</a>
     </p>
 </details>

--- a/src/main/resources/templates/admin/observations.html
+++ b/src/main/resources/templates/admin/observations.html
@@ -1,0 +1,30 @@
+<!DOCTYPE HTML>
+<html xmlns:th="http://www.thymeleaf.org">
+<head th:replace="~{/admin/header :: head}"/>
+<body>
+
+<span th:replace="~{/admin/header :: top}"/>
+
+<p>
+    <a href="/admin/">Home</a>
+</p>
+
+<h2>Manage Observations</h2>
+
+<h3>Delete Observation</h3>
+
+<p>
+    Completely delete an observation and all its data. This may affect aggregate statistics
+    such as survival rate in later observations.
+</p>
+
+<form method="POST" action="/admin/deleteObservation">
+    <label>
+        Observation ID
+        <input type="text" name="observationId" required/>
+    </label>
+    <input type="submit" value="Delete Observation"/>
+</form>
+
+</body>
+</html>

--- a/src/test/kotlin/com/terraformation/backend/tracking/ObservationServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/ObservationServiceTest.kt
@@ -118,6 +118,7 @@ import io.mockk.confirmVerified
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.spyk
+import io.mockk.verify
 import io.mockk.verifyOrder
 import java.math.BigDecimal
 import java.time.Instant
@@ -161,18 +162,20 @@ class ObservationServiceTest : DatabaseTest(), RunsAsDatabaseUser {
   private val jobScheduler: JobScheduler = mockk()
   private val systemUser: SystemUser by lazy { SystemUser(usersDao) }
   private val observationStore: ObservationStore by lazy {
-    ObservationStore(
-        clock,
-        dslContext,
-        eventPublisher,
-        jobScheduler,
-        observationLocker,
-        observationsDao,
-        observationPlotConditionsDao,
-        observationPlotsDao,
-        observationRequestedSubstrataDao,
-        parentStore,
-        systemUser,
+    spyk(
+        ObservationStore(
+            clock,
+            dslContext,
+            eventPublisher,
+            jobScheduler,
+            observationLocker,
+            observationsDao,
+            observationPlotConditionsDao,
+            observationPlotsDao,
+            observationRequestedSubstrataDao,
+            parentStore,
+            systemUser,
+        )
     )
   }
   private val plantingSiteStore: PlantingSiteStore by lazy {
@@ -1163,6 +1166,60 @@ class ObservationServiceTest : DatabaseTest(), RunsAsDatabaseUser {
             "Observation media table should only have file from other observation",
         )
       }
+    }
+  }
+
+  @Nested
+  inner class DeleteObservation {
+    private lateinit var observationId: ObservationId
+    private lateinit var plotId: MonitoringPlotId
+
+    @BeforeEach
+    fun setUp() {
+      insertUserGlobalRole(role = GlobalRole.SuperAdmin)
+      insertStratum()
+      insertSubstratum()
+      plotId = insertMonitoringPlot()
+      observationId = insertObservation()
+      insertObservationPlot(
+          observationId = observationId,
+          monitoringPlotId = plotId,
+          statusId = ObservationPlotStatus.Completed,
+      )
+    }
+
+    @Test
+    fun `deletes the observation, its media, and recalculates survival rates`() {
+      val fileId = insertFile()
+      insertObservationMediaFile(
+          fileId = fileId,
+          observationId = observationId,
+          monitoringPlotId = plotId,
+          isOriginal = true,
+      )
+
+      service.deleteObservation(observationId)
+
+      assertTableEmpty(OBSERVATIONS)
+      assertTableEmpty(OBSERVATION_MEDIA_FILES)
+
+      eventPublisher.assertEventPublished(FileReferenceDeletedEvent(fileId))
+      eventPublisher.assertEventPublished(
+          ObservationMediaFileDeletedEvent(
+              fileId,
+              plotId,
+              observationId,
+              organizationId,
+              plantingSiteId,
+          )
+      )
+
+      verify { observationStore.recalculateSurvivalRates(plantingSiteId) }
+    }
+
+    @Test
+    fun `throws exception when the observation does not exist`() {
+      assertThrows<ObservationNotFoundException> { service.deleteObservation(ObservationId(-1)) }
     }
   }
 

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/observationStore/ObservationStoreDeleteObservationTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/observationStore/ObservationStoreDeleteObservationTest.kt
@@ -1,0 +1,63 @@
+package com.terraformation.backend.tracking.db.observationStore
+
+import com.terraformation.backend.db.tracking.ObservationPlotStatus
+import com.terraformation.backend.db.tracking.tables.references.OBSERVATIONS
+import com.terraformation.backend.db.tracking.tables.references.OBSERVATION_PLOTS
+import com.terraformation.backend.db.tracking.tables.references.PLOT_T0_DENSITIES
+import com.terraformation.backend.db.tracking.tables.references.RECORDED_PLANTS
+import org.junit.jupiter.api.Test
+
+class ObservationStoreDeleteObservationTest : BaseObservationStoreTest() {
+  @Test
+  fun `deletes the observation and its cascaded data`() {
+    insertStratum()
+    insertSubstratum()
+    val plotId = insertMonitoringPlot()
+    val speciesId = insertSpecies()
+    val observationId = insertObservation()
+    insertObservationPlot(
+        observationId = observationId,
+        monitoringPlotId = plotId,
+        statusId = ObservationPlotStatus.Completed,
+    )
+    insertRecordedPlant(
+        observationId = observationId,
+        monitoringPlotId = plotId,
+        speciesId = speciesId,
+    )
+
+    store.deleteObservation(observationId)
+
+    assertTableEmpty(OBSERVATIONS)
+    assertTableEmpty(OBSERVATION_PLOTS)
+    assertTableEmpty(RECORDED_PLANTS)
+  }
+
+  @Test
+  fun `clears plot t0 density only for plots whose t0 was the deleted observation`() {
+    insertSpecies()
+    insertStratum()
+    insertSubstratum()
+    val t0PlotId = insertMonitoringPlot()
+    val otherPlotId = insertMonitoringPlot()
+    val observationId1 = insertObservation()
+    val observationId2 = insertObservation()
+
+    insertObservationPlot(observationId = observationId1, monitoringPlotId = t0PlotId)
+    insertObservationPlot(observationId = observationId1, monitoringPlotId = otherPlotId)
+    insertObservationPlot(observationId = observationId2, monitoringPlotId = t0PlotId)
+    insertObservationPlot(observationId = observationId2, monitoringPlotId = otherPlotId)
+
+    insertPlotT0Density(monitoringPlotId = otherPlotId)
+    insertPlotT0Observation(monitoringPlotId = otherPlotId, observationId = observationId2)
+
+    val expectedDensities = dslContext.fetch(PLOT_T0_DENSITIES)
+
+    insertPlotT0Density(monitoringPlotId = t0PlotId)
+    insertPlotT0Observation(monitoringPlotId = t0PlotId, observationId = observationId1)
+
+    store.deleteObservation(observationId1)
+
+    assertTableEquals(expectedDensities)
+  }
+}


### PR DESCRIPTION
Add a new observation management page to the admin UI, with the first feature
being the ability to completely delete an observation.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>