### PR TITLE
Allow super-admins to manage all observations

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/customer/model/IndividualUser.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/IndividualUser.kt
@@ -322,9 +322,7 @@ data class IndividualUser(
 
   override fun canManageNotifications() = false
 
-  override fun canManageObservation(observationId: ObservationId) =
-      isSuperAdmin() &&
-          parentStore.getPlantingSiteId(observationId)?.let { canUpdatePlantingSite(it) } == true
+  override fun canManageObservation(observationId: ObservationId) = isSuperAdmin()
 
   override fun canManageProjectReportConfigs() = isAcceleratorAdmin()
 

--- a/src/main/kotlin/com/terraformation/backend/customer/model/IndividualUser.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/IndividualUser.kt
@@ -676,7 +676,7 @@ data class IndividualUser(
       canListNotifications(organizationId)
 
   override fun canUpdateObservation(observationId: ObservationId) =
-      isMember(parentStore.getOrganizationId(observationId))
+      isSuperAdmin() || isMember(parentStore.getOrganizationId(observationId))
 
   override fun canUpdateObservationQuantities(observationId: ObservationId) =
       isManagerOrHigher(parentStore.getOrganizationId(observationId))

--- a/src/test/kotlin/com/terraformation/backend/tracking/ObservationServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/ObservationServiceTest.kt
@@ -2447,17 +2447,6 @@ class ObservationServiceTest : DatabaseTest(), RunsAsDatabaseUser {
       // Upcoming observation with no plots — skipped.
       insertObservation(plantingSiteId = plantingSiteId, state = ObservationState.Upcoming)
 
-      // Observation in another org the user cannot manage — skipped even with a completed plot.
-      val otherOrganizationId = insertOrganization()
-      val otherPlantingSiteId = insertPlantingSite(organizationId = otherOrganizationId)
-      insertObservation(
-          plantingSiteId = otherPlantingSiteId,
-          state = ObservationState.Completed,
-          completedTime = Instant.ofEpochSecond(50),
-      )
-      insertMonitoringPlot()
-      insertObservationPlot(completedTime = Instant.ofEpochSecond(50))
-
       val spyStore = spyk(observationStore)
       every { spyStore.populateObservationResults(any()) } answers { /* tracked via verify */ }
 


### PR DESCRIPTION
There's no point requiring a super-admin to also be an admin in the organization
in order to do maintenance operations on observations; relax the permission to
only check for super-admin status.

All the calls to this permission check in the application code are either in
the admin UI or from application code that runs as the system user.