### PR TITLE
SW-8434 Delete incomplete plots in admin UI

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/admin/AdminObservationsController.kt
+++ b/src/main/kotlin/com/terraformation/backend/admin/AdminObservationsController.kt
@@ -55,8 +55,8 @@ class AdminObservationsController(
       redirectAttributes.successMessage =
           "Deleted incomplete plots from observation $observationId."
     } catch (e: Exception) {
-      log.error("Failed to delete observation $observationId", e)
-      redirectAttributes.failureMessage = "Failed to delete observation: $e"
+      log.error("Failed to delete incomplete plots from observation $observationId", e)
+      redirectAttributes.failureMessage = "Failed to delete incomplete plots from observation: $e"
     }
 
     return redirectToObservationsHome()

--- a/src/main/kotlin/com/terraformation/backend/admin/AdminObservationsController.kt
+++ b/src/main/kotlin/com/terraformation/backend/admin/AdminObservationsController.kt
@@ -5,6 +5,7 @@ import com.terraformation.backend.db.default_schema.GlobalRole
 import com.terraformation.backend.db.tracking.ObservationId
 import com.terraformation.backend.log.perClassLogger
 import com.terraformation.backend.tracking.ObservationService
+import com.terraformation.backend.tracking.db.ObservationStore
 import org.springframework.stereotype.Controller
 import org.springframework.validation.annotation.Validated
 import org.springframework.web.bind.annotation.GetMapping
@@ -19,6 +20,7 @@ import org.springframework.web.servlet.mvc.support.RedirectAttributes
 @Validated
 class AdminObservationsController(
     private val observationService: ObservationService,
+    private val observationStore: ObservationStore,
 ) {
   private val log = perClassLogger()
 
@@ -35,6 +37,23 @@ class AdminObservationsController(
     try {
       observationService.deleteObservation(observationId)
       redirectAttributes.successMessage = "Deleted observation $observationId."
+    } catch (e: Exception) {
+      log.error("Failed to delete observation $observationId", e)
+      redirectAttributes.failureMessage = "Failed to delete observation: $e"
+    }
+
+    return redirectToObservationsHome()
+  }
+
+  @PostMapping("/deleteIncompletePlots")
+  fun adminDeleteIncompletePlots(
+      @RequestParam observationId: ObservationId,
+      redirectAttributes: RedirectAttributes,
+  ): String {
+    try {
+      observationStore.deleteIncompletePlots(observationId)
+      redirectAttributes.successMessage =
+          "Deleted incomplete plots from observation $observationId."
     } catch (e: Exception) {
       log.error("Failed to delete observation $observationId", e)
       redirectAttributes.failureMessage = "Failed to delete observation: $e"

--- a/src/main/kotlin/com/terraformation/backend/tracking/db/ObservationStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/db/ObservationStore.kt
@@ -2387,6 +2387,28 @@ class ObservationStore(
     }
   }
 
+  fun deleteIncompletePlots(observationId: ObservationId) {
+    requirePermissions { manageObservation(observationId) }
+
+    val currentState =
+        dslContext.fetchValue(OBSERVATIONS.STATE_ID, OBSERVATIONS.ID.eq(observationId))
+            ?: throw ObservationNotFoundException(observationId)
+
+    if (currentState != ObservationState.Abandoned) {
+      throw IllegalStateException(
+          "Observation state is $currentState; can only delete plots from abandoned observations"
+      )
+    }
+
+    with(OBSERVATION_PLOTS) {
+      dslContext
+          .deleteFrom(OBSERVATION_PLOTS)
+          .where(OBSERVATION_ID.eq(observationId))
+          .and(STATUS_ID.ne(ObservationPlotStatus.Completed))
+          .execute()
+    }
+  }
+
   private fun resetPlantPopulationSinceLastObservation(plantingSiteId: PlantingSiteId) {
     dslContext
         .update(PLANTING_SITE_POPULATIONS)

--- a/src/main/resources/templates/admin/observations.html
+++ b/src/main/resources/templates/admin/observations.html
@@ -26,5 +26,21 @@
     <input type="submit" value="Delete Observation"/>
 </form>
 
+<h3>Remove Incomplete Plots from Abandoned Observation</h3>
+
+<p>
+    Remove all the plots in an abandoned observation that weren't completed, so they don't clutter
+    up the user's view of the observation. The observation will continue to be marked as abandoned
+    even though all its plots will be completed.
+</p>
+
+<form method="POST" action="/admin/deleteIncompletePlots">
+    <label>
+        Observation ID
+        <input type="text" name="observationId" required/>
+    </label>
+    <input type="submit" value="Remove Incomplete Plots"/>
+</form>
+
 </body>
 </html>

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/observationStore/ObservationStoreDeleteIncompletePlotsTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/observationStore/ObservationStoreDeleteIncompletePlotsTest.kt
@@ -1,0 +1,65 @@
+package com.terraformation.backend.tracking.db.observationStore
+
+import com.terraformation.backend.db.default_schema.GlobalRole
+import com.terraformation.backend.db.tracking.ObservationPlotStatus
+import com.terraformation.backend.db.tracking.ObservationState
+import com.terraformation.backend.db.tracking.tables.references.OBSERVATION_PLOTS
+import io.mockk.every
+import java.time.Instant
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.springframework.security.access.AccessDeniedException
+
+class ObservationStoreDeleteIncompletePlotsTest : BaseObservationStoreTest() {
+  @Test
+  fun `deletes incomplete plots from the observation`() {
+    insertUserGlobalRole(role = GlobalRole.SuperAdmin)
+    insertStratum()
+    insertSubstratum()
+
+    // A completed plot; it shouldn't be removed.
+    insertMonitoringPlot()
+    val observationId =
+        insertObservation(completedTime = Instant.EPOCH, state = ObservationState.Abandoned)
+    insertObservationPlot(completedBy = user.userId)
+
+    val observationPlotsWithOnlyCompletedPlot = dslContext.fetch(OBSERVATION_PLOTS)
+
+    // Claimed, not-observed, and unclaimed plots should be removed.
+    insertMonitoringPlot()
+    insertObservationPlot(claimedBy = user.userId)
+    insertMonitoringPlot()
+    insertObservationPlot(statusId = ObservationPlotStatus.NotObserved)
+    insertMonitoringPlot()
+    insertObservationPlot()
+
+    store.deleteIncompletePlots(observationId)
+
+    assertTableEquals(observationPlotsWithOnlyCompletedPlot)
+  }
+
+  @Test
+  fun `throws exception if observation is not abandoned`() {
+    insertUserGlobalRole(role = GlobalRole.SuperAdmin)
+    insertStratum()
+    insertSubstratum()
+    insertMonitoringPlot()
+    val observationId = insertObservation()
+    insertObservationPlot()
+
+    assertThrows<IllegalStateException> { store.deleteIncompletePlots(observationId) }
+  }
+
+  @Test
+  fun `throws exception if no permission to manage observation`() {
+    insertStratum()
+    insertSubstratum()
+    insertMonitoringPlot()
+    val observationId = insertObservation()
+    insertObservationPlot()
+
+    every { user.canManageObservation(observationId) } returns false
+
+    assertThrows<AccessDeniedException> { store.deleteIncompletePlots(observationId) }
+  }
+}


### PR DESCRIPTION
For abandoned observations, we want to be able to get rid of the plots that
were never completed, both so they don't clutter up the observation results and
as a preparation step for merging the observation's results into another
observation (an upcoming piece of functionality).

A plot that wasn't completed, by definition, can't have any observation data
or media files, so deleting it from an observation doesn't require any additional
cleanup.