### PR TITLE
SW-8434 Add method to recalculate species totals

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/tracking/db/ObservationStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/db/ObservationStore.kt
@@ -2369,13 +2369,14 @@ class ObservationStore(
 
   private fun fetchRecordedPlantCountsBySpecies(
       observationId: ObservationId,
-      monitoringPlotId: MonitoringPlotId,
-  ): Map<RecordedSpeciesKey, Map<RecordedPlantStatus, Int>> {
+      monitoringPlotIds: Collection<MonitoringPlotId>,
+  ): Map<MonitoringPlotId, Map<RecordedSpeciesKey, Map<RecordedPlantStatus, Int>>> {
     val countField = DSL.count()
     return with(RECORDED_PLANTS) {
       dslContext
           .select(
               CERTAINTY_ID,
+              MONITORING_PLOT_ID,
               SPECIES_ID,
               SPECIES_NAME,
               STATUS_ID,
@@ -2383,19 +2384,28 @@ class ObservationStore(
           )
           .from(RECORDED_PLANTS)
           .where(OBSERVATION_ID.eq(observationId))
-          .and(MONITORING_PLOT_ID.eq(monitoringPlotId))
-          .groupBy(CERTAINTY_ID, SPECIES_ID, SPECIES_NAME, STATUS_ID)
-          .fetchGroups(
-              { record ->
-                RecordedSpeciesKey(
-                    record[CERTAINTY_ID]!!,
-                    record[SPECIES_ID],
-                    record[SPECIES_NAME],
-                )
-              },
-              { record -> record[STATUS_ID]!! to record[countField] },
-          )
-          .mapValues { (_, statusCounts) -> statusCounts.toMap() }
+          .and(MONITORING_PLOT_ID.`in`(monitoringPlotIds))
+          .groupBy(MONITORING_PLOT_ID, CERTAINTY_ID, SPECIES_ID, SPECIES_NAME, STATUS_ID)
+          .fetchGroups(MONITORING_PLOT_ID.asNonNullable())
+          .map { (monitoringPlotId, resultForPlot) ->
+            val resultsForStatus =
+                resultForPlot
+                    .groupBy { record ->
+                      RecordedSpeciesKey(
+                          record[CERTAINTY_ID]!!,
+                          record[SPECIES_ID],
+                          record[SPECIES_NAME],
+                      )
+                    }
+                    .map { (speciesKey, result) ->
+                      speciesKey to
+                          result.associate { record -> record[STATUS_ID]!! to record[countField] }
+                    }
+                    .toMap()
+
+            monitoringPlotId to resultsForStatus
+          }
+          .toMap()
     }
   }
 
@@ -2474,6 +2484,12 @@ class ObservationStore(
                 .fetch()
           }
 
+      val allPlantCounts =
+          fetchRecordedPlantCountsBySpecies(
+              observationId,
+              completedPlots.map { it[OBSERVATION_PLOTS.MONITORING_PLOT_ID]!! },
+          )
+
       completedPlots.forEach { record ->
         val monitoringPlotId = record[OBSERVATION_PLOTS.MONITORING_PLOT_ID]!!
         val monitoringPlotHistoryId = record[OBSERVATION_PLOTS.MONITORING_PLOT_HISTORY_ID]!!
@@ -2488,7 +2504,7 @@ class ObservationStore(
                 OBSERVATION_PLOTS.monitoringPlotHistories.substratumHistories.stratumHistories
                     .STRATUM_ID]
 
-        val plantCounts = fetchRecordedPlantCountsBySpecies(observationId, monitoringPlotId)
+        val plantCounts = allPlantCounts[monitoringPlotId] ?: emptyMap()
 
         updateSpeciesTotals(
             observationId,

--- a/src/main/kotlin/com/terraformation/backend/tracking/db/ObservationStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/db/ObservationStore.kt
@@ -2500,7 +2500,7 @@ class ObservationStore(
             substratumHistoryId,
             monitoringPlotId,
             monitoringPlotHistoryId,
-            isAdHoc = false,
+            observation.isAdHoc,
             isPermanent,
             plantCounts,
         )
@@ -2513,7 +2513,7 @@ class ObservationStore(
             substratumId,
             substratumHistoryId,
             monitoringPlotId,
-            isAdHoc = false,
+            observation.isAdHoc,
         )
       }
     }

--- a/src/main/kotlin/com/terraformation/backend/tracking/db/ObservationStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/db/ObservationStore.kt
@@ -2367,6 +2367,158 @@ class ObservationStore(
     }
   }
 
+  private fun fetchRecordedPlantCountsBySpecies(
+      observationId: ObservationId,
+      monitoringPlotId: MonitoringPlotId,
+  ): Map<RecordedSpeciesKey, Map<RecordedPlantStatus, Int>> {
+    val countField = DSL.count()
+    return with(RECORDED_PLANTS) {
+      dslContext
+          .select(
+              CERTAINTY_ID,
+              SPECIES_ID,
+              SPECIES_NAME,
+              STATUS_ID,
+              countField,
+          )
+          .from(RECORDED_PLANTS)
+          .where(OBSERVATION_ID.eq(observationId))
+          .and(MONITORING_PLOT_ID.eq(monitoringPlotId))
+          .groupBy(CERTAINTY_ID, SPECIES_ID, SPECIES_NAME, STATUS_ID)
+          .fetchGroups(
+              { record ->
+                RecordedSpeciesKey(
+                    record[CERTAINTY_ID]!!,
+                    record[SPECIES_ID],
+                    record[SPECIES_NAME],
+                )
+              },
+              { record -> record[STATUS_ID]!! to record[countField] },
+          )
+          .mapValues { (_, statusCounts) -> statusCounts.toMap() }
+    }
+  }
+
+  /**
+   * Rebuilds the observed species totals and observation results for an observation based on the
+   * observation's recorded plants. Does not recalculate survival rates; call
+   * [recalculateSurvivalRates] for that.
+   */
+  fun recalculateObservationTotals(observationId: ObservationId) {
+    requirePermissions { manageObservation(observationId) }
+
+    val observation = fetchObservationById(observationId)
+    val plantingSiteId = observation.plantingSiteId
+    val plantingSiteHistoryId =
+        observation.plantingSiteHistoryId
+            ?: throw IllegalStateException(
+                "Observation $observationId has no planting site history"
+            )
+    val plantingSite =
+        dslContext
+            .select()
+            .from(PLANTING_SITES)
+            .where(PLANTING_SITES.ID.eq(plantingSiteId))
+            .fetchOneInto(PlantingSitesRow::class.java)
+            ?: throw PlantingSiteNotFoundException(plantingSiteId)
+
+    observationLocker.withLockedObservation(observationId) {
+      dslContext
+          .deleteFrom(OBSERVED_PLOT_SPECIES_TOTALS)
+          .where(OBSERVED_PLOT_SPECIES_TOTALS.OBSERVATION_ID.eq(observationId))
+          .execute()
+      dslContext
+          .deleteFrom(OBSERVED_SUBSTRATUM_SPECIES_TOTALS)
+          .where(OBSERVED_SUBSTRATUM_SPECIES_TOTALS.OBSERVATION_ID.eq(observationId))
+          .execute()
+      dslContext
+          .deleteFrom(OBSERVED_STRATUM_SPECIES_TOTALS)
+          .where(OBSERVED_STRATUM_SPECIES_TOTALS.OBSERVATION_ID.eq(observationId))
+          .execute()
+      dslContext
+          .deleteFrom(OBSERVED_SITE_SPECIES_TOTALS)
+          .where(OBSERVED_SITE_SPECIES_TOTALS.OBSERVATION_ID.eq(observationId))
+          .execute()
+      dslContext
+          .deleteFrom(OBSERVATION_PLOT_RESULTS)
+          .where(OBSERVATION_PLOT_RESULTS.OBSERVATION_ID.eq(observationId))
+          .execute()
+      dslContext
+          .deleteFrom(OBSERVATION_SUBSTRATUM_RESULTS)
+          .where(OBSERVATION_SUBSTRATUM_RESULTS.OBSERVATION_ID.eq(observationId))
+          .execute()
+      dslContext
+          .deleteFrom(OBSERVATION_STRATUM_RESULTS)
+          .where(OBSERVATION_STRATUM_RESULTS.OBSERVATION_ID.eq(observationId))
+          .execute()
+      dslContext
+          .deleteFrom(OBSERVATION_SITE_RESULTS)
+          .where(OBSERVATION_SITE_RESULTS.OBSERVATION_ID.eq(observationId))
+          .execute()
+
+      val completedPlots =
+          with(OBSERVATION_PLOTS) {
+            dslContext
+                .select(
+                    MONITORING_PLOT_ID,
+                    MONITORING_PLOT_HISTORY_ID,
+                    IS_PERMANENT,
+                    monitoringPlotHistories.SUBSTRATUM_ID,
+                    monitoringPlotHistories.SUBSTRATUM_HISTORY_ID,
+                    monitoringPlotHistories.substratumHistories.STRATUM_HISTORY_ID,
+                    monitoringPlotHistories.substratumHistories.stratumHistories.STRATUM_ID,
+                )
+                .from(OBSERVATION_PLOTS)
+                .where(OBSERVATION_ID.eq(observationId))
+                .and(STATUS_ID.eq(ObservationPlotStatus.Completed))
+                .fetch()
+          }
+
+      completedPlots.forEach { record ->
+        val monitoringPlotId = record[OBSERVATION_PLOTS.MONITORING_PLOT_ID]!!
+        val monitoringPlotHistoryId = record[OBSERVATION_PLOTS.MONITORING_PLOT_HISTORY_ID]!!
+        val isPermanent = record[OBSERVATION_PLOTS.IS_PERMANENT]!!
+        val substratumId = record[OBSERVATION_PLOTS.monitoringPlotHistories.SUBSTRATUM_ID]
+        val substratumHistoryId =
+            record[OBSERVATION_PLOTS.monitoringPlotHistories.SUBSTRATUM_HISTORY_ID]
+        val stratumHistoryId =
+            record[OBSERVATION_PLOTS.monitoringPlotHistories.substratumHistories.STRATUM_HISTORY_ID]
+        val stratumId =
+            record[
+                OBSERVATION_PLOTS.monitoringPlotHistories.substratumHistories.stratumHistories
+                    .STRATUM_ID]
+
+        val plantCounts = fetchRecordedPlantCountsBySpecies(observationId, monitoringPlotId)
+
+        updateSpeciesTotals(
+            observationId,
+            plantingSite,
+            plantingSiteHistoryId,
+            stratumId,
+            stratumHistoryId,
+            substratumId,
+            substratumHistoryId,
+            monitoringPlotId,
+            monitoringPlotHistoryId,
+            isAdHoc = false,
+            isPermanent,
+            plantCounts,
+        )
+
+        updateObservationResults(
+            observationId,
+            plantingSite,
+            stratumId,
+            stratumHistoryId,
+            substratumId,
+            substratumHistoryId,
+            monitoringPlotId,
+            isAdHoc = false,
+        )
+      }
+    }
+  }
+
   fun deleteObservation(observationId: ObservationId) {
     val t0PlotIds =
         dslContext

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/ObservationTestHelper.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/ObservationTestHelper.kt
@@ -8,10 +8,18 @@ import com.terraformation.backend.db.default_schema.UserId
 import com.terraformation.backend.db.tracking.MonitoringPlotId
 import com.terraformation.backend.db.tracking.PlantingSiteId
 import com.terraformation.backend.db.tracking.StratumId
+import com.terraformation.backend.db.tracking.tables.pojos.ObservationPlotResultsRow
+import com.terraformation.backend.db.tracking.tables.pojos.ObservationSiteResultsRow
+import com.terraformation.backend.db.tracking.tables.pojos.ObservationStratumResultsRow
+import com.terraformation.backend.db.tracking.tables.pojos.ObservationSubstratumResultsRow
 import com.terraformation.backend.db.tracking.tables.pojos.ObservedPlotSpeciesTotalsRow
 import com.terraformation.backend.db.tracking.tables.pojos.ObservedSiteSpeciesTotalsRow
 import com.terraformation.backend.db.tracking.tables.pojos.ObservedStratumSpeciesTotalsRow
 import com.terraformation.backend.db.tracking.tables.pojos.ObservedSubstratumSpeciesTotalsRow
+import com.terraformation.backend.db.tracking.tables.references.OBSERVATION_PLOT_RESULTS
+import com.terraformation.backend.db.tracking.tables.references.OBSERVATION_SITE_RESULTS
+import com.terraformation.backend.db.tracking.tables.references.OBSERVATION_STRATUM_RESULTS
+import com.terraformation.backend.db.tracking.tables.references.OBSERVATION_SUBSTRATUM_RESULTS
 import com.terraformation.backend.db.tracking.tables.references.OBSERVED_PLOT_SPECIES_TOTALS
 import com.terraformation.backend.db.tracking.tables.references.OBSERVED_SITE_SPECIES_TOTALS
 import com.terraformation.backend.db.tracking.tables.references.OBSERVED_STRATUM_SPECIES_TOTALS
@@ -61,6 +69,26 @@ class ObservationTestHelper(
             dslContext
                 .selectFrom(OBSERVED_SITE_SPECIES_TOTALS)
                 .fetchInto(ObservedSiteSpeciesTotalsRow::class.java))
+        .toSet()
+  }
+
+  /**
+   * Returns all the observation results rows (plot, substratum, stratum, site) in the database,
+   * suitable for round-trip checks of the results tables.
+   */
+  fun fetchAllResults(): Set<Any> {
+    return (dslContext
+            .selectFrom(OBSERVATION_PLOT_RESULTS)
+            .fetchInto(ObservationPlotResultsRow::class.java) +
+            dslContext
+                .selectFrom(OBSERVATION_SUBSTRATUM_RESULTS)
+                .fetchInto(ObservationSubstratumResultsRow::class.java) +
+            dslContext
+                .selectFrom(OBSERVATION_STRATUM_RESULTS)
+                .fetchInto(ObservationStratumResultsRow::class.java) +
+            dslContext
+                .selectFrom(OBSERVATION_SITE_RESULTS)
+                .fetchInto(ObservationSiteResultsRow::class.java))
         .toSet()
   }
 

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/observationStore/ObservationStoreMergeObservationDataTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/observationStore/ObservationStoreMergeObservationDataTest.kt
@@ -1,0 +1,107 @@
+package com.terraformation.backend.tracking.db.observationStore
+
+import com.terraformation.backend.db.default_schema.SpeciesId
+import com.terraformation.backend.db.tracking.RecordedPlantStatus
+import com.terraformation.backend.db.tracking.RecordedSpeciesCertainty
+import com.terraformation.backend.db.tracking.tables.pojos.RecordedPlantsRow
+import com.terraformation.backend.db.tracking.tables.references.OBSERVATION_PLOT_RESULTS
+import com.terraformation.backend.db.tracking.tables.references.OBSERVATION_SITE_RESULTS
+import com.terraformation.backend.db.tracking.tables.references.OBSERVATION_STRATUM_RESULTS
+import com.terraformation.backend.db.tracking.tables.references.OBSERVATION_SUBSTRATUM_RESULTS
+import com.terraformation.backend.db.tracking.tables.references.OBSERVED_PLOT_SPECIES_TOTALS
+import com.terraformation.backend.db.tracking.tables.references.OBSERVED_SITE_SPECIES_TOTALS
+import com.terraformation.backend.db.tracking.tables.references.OBSERVED_STRATUM_SPECIES_TOTALS
+import com.terraformation.backend.db.tracking.tables.references.OBSERVED_SUBSTRATUM_SPECIES_TOTALS
+import com.terraformation.backend.point
+import java.time.Instant
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class ObservationStoreMergeObservationDataTest : BaseObservationStoreTest() {
+  private lateinit var speciesId: SpeciesId
+
+  @BeforeEach
+  fun setUpSite() {
+    helper.insertPlantedSite(numPermanentPlots = 2)
+    speciesId = inserted.speciesId
+  }
+
+  @Test
+  fun `recalculateObservationTotals reproduces the totals from scratch`() {
+    val plotId = insertMonitoringPlot()
+    val observationId = insertObservation()
+
+    insertObservationPlot(
+        observationId = observationId,
+        monitoringPlotId = plotId,
+        claimedBy = user.userId,
+        claimedTime = Instant.EPOCH,
+    )
+    store.completePlot(
+        observationId,
+        plotId,
+        emptySet(),
+        null,
+        Instant.EPOCH,
+        listOf(livePlant(), deadPlant()),
+    )
+
+    val expectedTotals = helper.fetchAllTotals()
+    val expectedResults = helper.fetchAllResults()
+
+    dslContext
+        .update(OBSERVED_SITE_SPECIES_TOTALS)
+        .set(OBSERVED_SITE_SPECIES_TOTALS.TOTAL_LIVE, 9999)
+        .execute()
+    dslContext
+        .update(OBSERVED_STRATUM_SPECIES_TOTALS)
+        .set(OBSERVED_STRATUM_SPECIES_TOTALS.TOTAL_LIVE, 8888)
+        .execute()
+    dslContext
+        .update(OBSERVED_SUBSTRATUM_SPECIES_TOTALS)
+        .set(OBSERVED_SUBSTRATUM_SPECIES_TOTALS.TOTAL_LIVE, 7777)
+        .execute()
+    dslContext
+        .update(OBSERVED_PLOT_SPECIES_TOTALS)
+        .set(OBSERVED_PLOT_SPECIES_TOTALS.TOTAL_LIVE, 6666)
+        .execute()
+    dslContext
+        .update(OBSERVATION_SITE_RESULTS)
+        .set(OBSERVATION_SITE_RESULTS.TOTAL_LIVE, 9898)
+        .execute()
+    dslContext
+        .update(OBSERVATION_STRATUM_RESULTS)
+        .set(OBSERVATION_STRATUM_RESULTS.TOTAL_LIVE, 8787)
+        .execute()
+    dslContext
+        .update(OBSERVATION_SUBSTRATUM_RESULTS)
+        .set(OBSERVATION_SUBSTRATUM_RESULTS.TOTAL_LIVE, 7676)
+        .execute()
+    dslContext
+        .update(OBSERVATION_PLOT_RESULTS)
+        .set(OBSERVATION_PLOT_RESULTS.TOTAL_LIVE, 6565)
+        .execute()
+
+    store.recalculateObservationTotals(observationId)
+
+    assertEquals(expectedTotals, helper.fetchAllTotals(), "Species totals after rebuild")
+    assertEquals(expectedResults, helper.fetchAllResults(), "Observation results after rebuild")
+  }
+
+  private fun livePlant() =
+      RecordedPlantsRow(
+          certaintyId = RecordedSpeciesCertainty.Known,
+          gpsCoordinates = point(1),
+          speciesId = speciesId,
+          statusId = RecordedPlantStatus.Live,
+      )
+
+  private fun deadPlant() =
+      RecordedPlantsRow(
+          certaintyId = RecordedSpeciesCertainty.Known,
+          gpsCoordinates = point(1),
+          speciesId = speciesId,
+          statusId = RecordedPlantStatus.Dead,
+      )
+}

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/observationStore/ObservationStoreMergeObservationDataTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/observationStore/ObservationStoreMergeObservationDataTest.kt
@@ -29,22 +29,29 @@ class ObservationStoreMergeObservationDataTest : BaseObservationStoreTest() {
 
   @Test
   fun `recalculateObservationTotals reproduces the totals from scratch`() {
-    val plotId = insertMonitoringPlot()
     val observationId = insertObservation()
+    val plotId1 = insertMonitoringPlot()
+    insertObservationPlot(claimedBy = user.userId)
+    val plotId2 = insertMonitoringPlot()
+    insertObservationPlot(claimedBy = user.userId)
+    val speciesId2 = insertSpecies()
 
-    insertObservationPlot(
-        observationId = observationId,
-        monitoringPlotId = plotId,
-        claimedBy = user.userId,
-        claimedTime = Instant.EPOCH,
-    )
     store.completePlot(
         observationId,
-        plotId,
+        plotId1,
         emptySet(),
         null,
         Instant.EPOCH,
         listOf(livePlant(), deadPlant()),
+    )
+
+    store.completePlot(
+        observationId,
+        plotId2,
+        emptySet(),
+        null,
+        Instant.EPOCH,
+        listOf(livePlant(speciesId), livePlant(speciesId2), livePlant(speciesId2)),
     )
 
     val expectedTotals = helper.fetchAllTotals()
@@ -89,7 +96,7 @@ class ObservationStoreMergeObservationDataTest : BaseObservationStoreTest() {
     assertEquals(expectedResults, helper.fetchAllResults(), "Observation results after rebuild")
   }
 
-  private fun livePlant() =
+  private fun livePlant(speciesId: SpeciesId = this.speciesId) =
       RecordedPlantsRow(
           certaintyId = RecordedSpeciesCertainty.Known,
           gpsCoordinates = point(1),
@@ -97,7 +104,7 @@ class ObservationStoreMergeObservationDataTest : BaseObservationStoreTest() {
           statusId = RecordedPlantStatus.Live,
       )
 
-  private fun deadPlant() =
+  private fun deadPlant(speciesId: SpeciesId = this.speciesId) =
       RecordedPlantsRow(
           certaintyId = RecordedSpeciesCertainty.Known,
           gpsCoordinates = point(1),


### PR DESCRIPTION
Add an ObservationStore method to recalculate all the observed species totals
values from the recorded plants data. It's not used yet, but will be one of the
steps in the "merge observations" operation.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>