### PR TITLE
SW-8434 Merge observations in admin UI

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/admin/AdminObservationsController.kt
+++ b/src/main/kotlin/com/terraformation/backend/admin/AdminObservationsController.kt
@@ -62,5 +62,24 @@ class AdminObservationsController(
     return redirectToObservationsHome()
   }
 
+  @PostMapping("/mergeObservations")
+  fun adminMergeObservations(
+      @RequestParam sourceObservationId: ObservationId,
+      @RequestParam targetObservationId: ObservationId,
+      redirectAttributes: RedirectAttributes,
+  ): String {
+    try {
+      observationService.mergeObservations(sourceObservationId, targetObservationId)
+      redirectAttributes.successMessage =
+          "Merged observation $sourceObservationId into $targetObservationId."
+    } catch (e: Exception) {
+      log.error("Failed to merge observation $sourceObservationId into $targetObservationId", e)
+      redirectAttributes.failureMessage =
+          "Failed to merge observation $sourceObservationId into $targetObservationId: $e"
+    }
+
+    return redirectToObservationsHome()
+  }
+
   private fun redirectToObservationsHome() = "redirect:/admin/observations"
 }

--- a/src/main/kotlin/com/terraformation/backend/tracking/ObservationService.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/ObservationService.kt
@@ -40,6 +40,7 @@ import com.terraformation.backend.tracking.db.InvalidObservationStartDateExcepti
 import com.terraformation.backend.tracking.db.ObservationAlreadyStartedException
 import com.terraformation.backend.tracking.db.ObservationHasNoSubstrataException
 import com.terraformation.backend.tracking.db.ObservationLocker
+import com.terraformation.backend.tracking.db.ObservationMergeNotAllowedException
 import com.terraformation.backend.tracking.db.ObservationNotFoundException
 import com.terraformation.backend.tracking.db.ObservationPlotNotFoundException
 import com.terraformation.backend.tracking.db.ObservationRescheduleStateException
@@ -820,6 +821,59 @@ class ObservationService(
       observationStore.deleteObservation(observationId)
 
       observationStore.recalculateSurvivalRates(observation.plantingSiteId)
+    }
+  }
+
+  fun mergeObservations(sourceObservationId: ObservationId, targetObservationId: ObservationId) {
+    requirePermissions {
+      manageObservation(sourceObservationId)
+      manageObservation(targetObservationId)
+    }
+
+    if (sourceObservationId == targetObservationId) {
+      throw ObservationMergeNotAllowedException("Cannot merge an observation into itself")
+    }
+
+    val source = observationStore.fetchObservationById(sourceObservationId)
+    val target = observationStore.fetchObservationById(targetObservationId)
+
+    if (source.plantingSiteId != target.plantingSiteId) {
+      throw ObservationMergeNotAllowedException("Observations belong to different planting sites")
+    }
+    if (source.isAdHoc || target.isAdHoc) {
+      throw ObservationMergeNotAllowedException("Cannot merge ad-hoc observations")
+    }
+    if (
+        source.observationType != ObservationType.Monitoring ||
+            target.observationType != ObservationType.Monitoring
+    ) {
+      throw ObservationMergeNotAllowedException("Can only merge monitoring observations")
+    }
+    if (source.plantingSiteHistoryId == null || target.plantingSiteHistoryId == null) {
+      throw ObservationMergeNotAllowedException(
+          "Cannot merge observations that have not been started"
+      )
+    }
+
+    systemUser.run {
+      // Delete the target's media for any plot that an incoming completed source plot overwrites.
+      deleteMediaWhere(
+          OBSERVATION_MEDIA_FILES.OBSERVATION_ID.eq(targetObservationId)
+              .and(
+                  OBSERVATION_MEDIA_FILES.MONITORING_PLOT_ID.`in`(
+                      DSL.select(OBSERVATION_PLOTS.MONITORING_PLOT_ID)
+                          .from(OBSERVATION_PLOTS)
+                          .where(OBSERVATION_PLOTS.OBSERVATION_ID.eq(sourceObservationId))
+                          .and(OBSERVATION_PLOTS.STATUS_ID.eq(ObservationPlotStatus.Completed))
+                  )
+              )
+      )
+
+      dslContext.transaction { _ ->
+        observationStore.mergeObservationData(sourceObservationId, targetObservationId)
+        observationStore.recalculateObservationTotals(targetObservationId)
+        observationStore.recalculateSurvivalRates(source.plantingSiteId)
+      }
     }
   }
 

--- a/src/main/kotlin/com/terraformation/backend/tracking/db/Exceptions.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/db/Exceptions.kt
@@ -68,6 +68,8 @@ class ObservationAlreadyStartedException(val observationId: ObservationId) :
 class ObservationHasNoSubstrataException(val observationId: ObservationId) :
     MismatchedStateException("No substrata were requested for observation $observationId")
 
+class ObservationMergeNotAllowedException(message: String) : MismatchedStateException(message)
+
 class ObservationNotFoundException(val observationId: ObservationId) :
     EntityNotFoundException("Observation $observationId not found")
 

--- a/src/main/kotlin/com/terraformation/backend/tracking/db/ObservationStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/db/ObservationStore.kt
@@ -2376,7 +2376,7 @@ class ObservationStore(
    * Moves the raw per-plot data of completed plots from the source observation to the target
    * observation, repoints/drops t0 baselines, and deletes the source observation. Does NOT delete
    * media (the caller handles colliding target media) and does NOT rebuild derived aggregates (call
-   * [recalculateObservationTotals] afterward).
+   * [recalculateObservationTotals] and [recalculateSurvivalRates] afterward).
    */
   fun mergeObservationData(
       sourceObservationId: ObservationId,

--- a/src/main/kotlin/com/terraformation/backend/tracking/db/ObservationStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/db/ObservationStore.kt
@@ -41,6 +41,7 @@ import com.terraformation.backend.db.tracking.tables.records.RecordedPlantsRecor
 import com.terraformation.backend.db.tracking.tables.references.MONITORING_PLOTS
 import com.terraformation.backend.db.tracking.tables.references.MONITORING_PLOT_HISTORIES
 import com.terraformation.backend.db.tracking.tables.references.OBSERVATIONS
+import com.terraformation.backend.db.tracking.tables.references.OBSERVATION_MEDIA_FILES
 import com.terraformation.backend.db.tracking.tables.references.OBSERVATION_PLOTS
 import com.terraformation.backend.db.tracking.tables.references.OBSERVATION_PLOT_CONDITIONS
 import com.terraformation.backend.db.tracking.tables.references.OBSERVATION_PLOT_RESULTS
@@ -2363,6 +2364,154 @@ class ObservationStore(
             "Planting Site $plantingSiteId survival rate calculation in-progress. Additional calculation requested."
         )
         setSurvivalRateAdditionalCalculationRequested(plantingSiteId, true)
+      }
+    }
+  }
+
+  /**
+   * Merges the observation data from a source observation to a target.
+   *
+   * You probably want `ObservationService.mergeObservations` instead of this.
+   *
+   * Moves the raw per-plot data of completed plots from the source observation to the target
+   * observation, repoints/drops t0 baselines, and deletes the source observation. Does NOT delete
+   * media (the caller handles colliding target media) and does NOT rebuild derived aggregates (call
+   * [recalculateObservationTotals] afterward).
+   */
+  fun mergeObservationData(
+      sourceObservationId: ObservationId,
+      targetObservationId: ObservationId,
+  ) {
+    requirePermissions {
+      manageObservation(sourceObservationId)
+      manageObservation(targetObservationId)
+    }
+
+    // Lock both observations in ID order to avoid deadlocks.
+    val idsToLock = listOf(sourceObservationId, targetObservationId).sorted()
+
+    observationLocker.withLockedObservation(idsToLock[0]) {
+      observationLocker.withLockedObservation(idsToLock[1]) {
+        val completedInSource =
+            dslContext
+                .select(OBSERVATION_PLOTS.MONITORING_PLOT_ID)
+                .from(OBSERVATION_PLOTS)
+                .where(OBSERVATION_PLOTS.OBSERVATION_ID.eq(sourceObservationId))
+                .and(OBSERVATION_PLOTS.STATUS_ID.eq(ObservationPlotStatus.Completed))
+                .fetchSet(OBSERVATION_PLOTS.MONITORING_PLOT_ID.asNonNullable())
+
+        if (completedInSource.isNotEmpty()) {
+          val collidingPlots =
+              dslContext
+                  .select(OBSERVATION_PLOTS.MONITORING_PLOT_ID)
+                  .from(OBSERVATION_PLOTS)
+                  .where(OBSERVATION_PLOTS.OBSERVATION_ID.eq(targetObservationId))
+                  .and(OBSERVATION_PLOTS.MONITORING_PLOT_ID.`in`(completedInSource))
+                  .fetchSet(OBSERVATION_PLOTS.MONITORING_PLOT_ID.asNonNullable())
+
+          if (collidingPlots.isNotEmpty()) {
+            val t0DropPlots =
+                dslContext
+                    .select(PLOT_T0_OBSERVATIONS.MONITORING_PLOT_ID)
+                    .from(PLOT_T0_OBSERVATIONS)
+                    .where(PLOT_T0_OBSERVATIONS.MONITORING_PLOT_ID.`in`(collidingPlots))
+                    .and(PLOT_T0_OBSERVATIONS.OBSERVATION_ID.eq(targetObservationId))
+                    .fetchSet(PLOT_T0_OBSERVATIONS.MONITORING_PLOT_ID.asNonNullable())
+
+            dslContext
+                .deleteFrom(OBSERVATION_PLOTS)
+                .where(OBSERVATION_PLOTS.OBSERVATION_ID.eq(targetObservationId))
+                .and(OBSERVATION_PLOTS.MONITORING_PLOT_ID.`in`(collidingPlots))
+                .execute()
+
+            if (t0DropPlots.isNotEmpty()) {
+              dslContext
+                  .deleteFrom(PLOT_T0_DENSITIES)
+                  .where(PLOT_T0_DENSITIES.MONITORING_PLOT_ID.`in`(t0DropPlots))
+                  .execute()
+            }
+          }
+
+          // Copy the source's completed observation_plots rows into the target so the composite FKs
+          // of the child tables are satisfied when we reparent them.
+          with(OBSERVATION_PLOTS) {
+            dslContext
+                .insertInto(
+                    OBSERVATION_PLOTS,
+                    OBSERVATION_ID,
+                    MONITORING_PLOT_ID,
+                    CLAIMED_BY,
+                    CLAIMED_TIME,
+                    COMPLETED_BY,
+                    COMPLETED_TIME,
+                    CREATED_BY,
+                    CREATED_TIME,
+                    IS_PERMANENT,
+                    MODIFIED_BY,
+                    MODIFIED_TIME,
+                    OBSERVED_TIME,
+                    NOTES,
+                    STATUS_ID,
+                    MONITORING_PLOT_HISTORY_ID,
+                )
+                .select(
+                    DSL.select(
+                            DSL.value(targetObservationId, OBSERVATION_ID.dataType),
+                            MONITORING_PLOT_ID,
+                            CLAIMED_BY,
+                            CLAIMED_TIME,
+                            COMPLETED_BY,
+                            COMPLETED_TIME,
+                            CREATED_BY,
+                            CREATED_TIME,
+                            IS_PERMANENT,
+                            MODIFIED_BY,
+                            MODIFIED_TIME,
+                            OBSERVED_TIME,
+                            NOTES,
+                            STATUS_ID,
+                            MONITORING_PLOT_HISTORY_ID,
+                        )
+                        .from(OBSERVATION_PLOTS)
+                        .where(OBSERVATION_ID.eq(sourceObservationId))
+                        .and(STATUS_ID.eq(ObservationPlotStatus.Completed))
+                )
+                .execute()
+          }
+
+          dslContext
+              .update(RECORDED_PLANTS)
+              .set(RECORDED_PLANTS.OBSERVATION_ID, targetObservationId)
+              .where(RECORDED_PLANTS.OBSERVATION_ID.eq(sourceObservationId))
+              .and(RECORDED_PLANTS.MONITORING_PLOT_ID.`in`(completedInSource))
+              .execute()
+          dslContext
+              .update(OBSERVATION_PLOT_CONDITIONS)
+              .set(OBSERVATION_PLOT_CONDITIONS.OBSERVATION_ID, targetObservationId)
+              .where(OBSERVATION_PLOT_CONDITIONS.OBSERVATION_ID.eq(sourceObservationId))
+              .and(OBSERVATION_PLOT_CONDITIONS.MONITORING_PLOT_ID.`in`(completedInSource))
+              .execute()
+          dslContext
+              .update(OBSERVED_PLOT_COORDINATES)
+              .set(OBSERVED_PLOT_COORDINATES.OBSERVATION_ID, targetObservationId)
+              .where(OBSERVED_PLOT_COORDINATES.OBSERVATION_ID.eq(sourceObservationId))
+              .and(OBSERVED_PLOT_COORDINATES.MONITORING_PLOT_ID.`in`(completedInSource))
+              .execute()
+          dslContext
+              .update(OBSERVATION_MEDIA_FILES)
+              .set(OBSERVATION_MEDIA_FILES.OBSERVATION_ID, targetObservationId)
+              .where(OBSERVATION_MEDIA_FILES.OBSERVATION_ID.eq(sourceObservationId))
+              .and(OBSERVATION_MEDIA_FILES.MONITORING_PLOT_ID.`in`(completedInSource))
+              .execute()
+          dslContext
+              .update(PLOT_T0_OBSERVATIONS)
+              .set(PLOT_T0_OBSERVATIONS.OBSERVATION_ID, targetObservationId)
+              .where(PLOT_T0_OBSERVATIONS.OBSERVATION_ID.eq(sourceObservationId))
+              .and(PLOT_T0_OBSERVATIONS.MONITORING_PLOT_ID.`in`(completedInSource))
+              .execute()
+        }
+
+        dslContext.deleteFrom(OBSERVATIONS).where(OBSERVATIONS.ID.eq(sourceObservationId)).execute()
       }
     }
   }

--- a/src/main/resources/db/migration/0500/V507__ObservationPlotsFK.sql
+++ b/src/main/resources/db/migration/0500/V507__ObservationPlotsFK.sql
@@ -1,0 +1,13 @@
+ALTER TABLE tracking.observation_plot_conditions
+    ADD FOREIGN KEY (observation_id, monitoring_plot_id)
+        REFERENCES tracking.observation_plots (observation_id, monitoring_plot_id)
+        ON DELETE CASCADE;
+
+-- Existing observed_plot_coordinates FK doesn't have ON DELETE CASCADE
+ALTER TABLE tracking.observed_plot_coordinates
+    ADD FOREIGN KEY (observation_id, monitoring_plot_id)
+        REFERENCES tracking.observation_plots (observation_id, monitoring_plot_id)
+        ON DELETE CASCADE;
+
+ALTER TABLE tracking.observed_plot_coordinates
+    DROP CONSTRAINT observed_plot_coordinates_observation_id_monitoring_plot_i_fkey;

--- a/src/main/resources/templates/admin/observations.html
+++ b/src/main/resources/templates/admin/observations.html
@@ -42,5 +42,26 @@
     <input type="submit" value="Remove Incomplete Plots"/>
 </form>
 
+<h3>Merge Observations</h3>
+
+<p>
+    Move all the data from a source observation to a target observation, deleting the source
+    observation. If the same plot was completed in both observations, the data for that plot from
+    the target observation is deleted (that is, the merge overwrites any existing data). This will
+    affect aggregated statistics for the target observation and possibly for later observations.
+</p>
+
+<form method="POST" action="/admin/mergeObservations">
+    <label>
+        Source observation ID
+        <input type="text" name="sourceObservationId" required/>
+    </label>
+    <label>
+        Target observation ID
+        <input type="text" name="targetObservationId" required/>
+    </label>
+    <input type="submit" value="Merge Observations"/>
+</form>
+
 </body>
 </html>

--- a/src/test/kotlin/com/terraformation/backend/tracking/ObservationServiceMergeObservationsTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/ObservationServiceMergeObservationsTest.kt
@@ -1,0 +1,330 @@
+package com.terraformation.backend.tracking
+
+import com.terraformation.backend.RunsAsDatabaseUser
+import com.terraformation.backend.TestClock
+import com.terraformation.backend.TestEventPublisher
+import com.terraformation.backend.TestSingletons
+import com.terraformation.backend.customer.db.ParentStore
+import com.terraformation.backend.customer.model.SystemUser
+import com.terraformation.backend.customer.model.TerrawareUser
+import com.terraformation.backend.db.DatabaseTest
+import com.terraformation.backend.db.IdentifierGenerator
+import com.terraformation.backend.db.default_schema.GlobalRole
+import com.terraformation.backend.db.default_schema.Role
+import com.terraformation.backend.db.default_schema.SpeciesId
+import com.terraformation.backend.db.tracking.MonitoringPlotId
+import com.terraformation.backend.db.tracking.ObservationId
+import com.terraformation.backend.db.tracking.ObservationState
+import com.terraformation.backend.db.tracking.ObservationType
+import com.terraformation.backend.db.tracking.RecordedPlantStatus
+import com.terraformation.backend.db.tracking.RecordedSpeciesCertainty
+import com.terraformation.backend.db.tracking.tables.pojos.RecordedPlantsRow
+import com.terraformation.backend.db.tracking.tables.references.OBSERVATIONS
+import com.terraformation.backend.db.tracking.tables.references.OBSERVATION_MEDIA_FILES
+import com.terraformation.backend.db.tracking.tables.references.OBSERVATION_PLOTS
+import com.terraformation.backend.db.tracking.tables.references.OBSERVED_SITE_SPECIES_TOTALS
+import com.terraformation.backend.file.FileService
+import com.terraformation.backend.file.InMemoryFileStore
+import com.terraformation.backend.file.event.FileReferenceDeletedEvent
+import com.terraformation.backend.point
+import com.terraformation.backend.tracking.db.BiomassStore
+import com.terraformation.backend.tracking.db.ObservationLocker
+import com.terraformation.backend.tracking.db.ObservationMergeNotAllowedException
+import com.terraformation.backend.tracking.db.ObservationStore
+import com.terraformation.backend.tracking.db.ObservationTestHelper
+import com.terraformation.backend.tracking.db.PlantingSiteNotificationStore
+import com.terraformation.backend.tracking.db.PlantingSiteStore
+import com.terraformation.backend.tracking.event.ObservationMediaFileDeletedEvent
+import com.terraformation.backend.util.GeometrySimplifier
+import com.terraformation.backend.util.toPlantsPerHectare
+import io.mockk.every
+import io.mockk.mockk
+import java.math.BigDecimal
+import java.time.Instant
+import kotlin.math.roundToInt
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertNotNull
+import org.junit.jupiter.api.assertThrows
+
+class ObservationServiceMergeObservationsTest : DatabaseTest(), RunsAsDatabaseUser {
+  override lateinit var user: TerrawareUser
+
+  private val clock = TestClock()
+  private val eventPublisher = TestEventPublisher()
+  private val geometrySimplifier: GeometrySimplifier = mockk()
+  private val observationLocker: ObservationLocker by lazy { ObservationLocker(dslContext) }
+  private val parentStore: ParentStore by lazy { ParentStore(dslContext) }
+  private val fileService: FileService by lazy {
+    FileService(dslContext, clock, eventPublisher, filesDao, InMemoryFileStore())
+  }
+  private val systemUser: SystemUser by lazy { SystemUser(usersDao) }
+  private val observationStore: ObservationStore by lazy {
+    ObservationStore(
+        clock,
+        dslContext,
+        eventPublisher,
+        mockk(),
+        observationLocker,
+        observationsDao,
+        observationPlotConditionsDao,
+        observationPlotsDao,
+        observationRequestedSubstrataDao,
+        parentStore,
+        systemUser,
+    )
+  }
+  private val plantingSiteStore: PlantingSiteStore by lazy {
+    PlantingSiteStore(
+        clock,
+        TestSingletons.countryDetector,
+        dslContext,
+        TestEventPublisher(),
+        geometrySimplifier,
+        IdentifierGenerator(clock, dslContext),
+        monitoringPlotsDao,
+        parentStore,
+        plantingSitesDao,
+        eventPublisher,
+        strataDao,
+        substrataDao,
+    )
+  }
+
+  private val service: ObservationService by lazy {
+    ObservationService(
+        BiomassStore(dslContext, eventPublisher, observationLocker, parentStore),
+        clock,
+        dslContext,
+        eventPublisher,
+        fileService,
+        monitoringPlotsDao,
+        mockk(),
+        observationMediaFilesDao,
+        observationLocker,
+        observationStore,
+        PlantingSiteNotificationStore(clock, dslContext),
+        plantingSiteStore,
+        parentStore,
+        eventPublisher,
+        systemUser,
+        mockk(),
+    )
+  }
+
+  private val helper: ObservationTestHelper by lazy {
+    ObservationTestHelper(this, observationStore, user.userId)
+  }
+
+  @BeforeEach
+  fun setUp() {
+    every { geometrySimplifier.simplify(any(), any()) } answers { firstArg() }
+
+    insertOrganization()
+    insertOrganizationUser(role = Role.Admin)
+    insertUserGlobalRole(role = GlobalRole.SuperAdmin)
+  }
+
+  @Test
+  fun `combines disjoint plot totals into the target site totals`() {
+    helper.insertPlantedSite(numPermanentPlots = 2)
+    val speciesId = inserted.speciesId
+    val plotA = insertMonitoringPlot()
+    val plotB = insertMonitoringPlot()
+    val sourceObservationId = insertObservation()
+    insertObservationRequestedSubstratum()
+    val targetObservationId = insertObservation()
+    insertObservationRequestedSubstratum()
+
+    completePermanentPlot(sourceObservationId, plotA, speciesId, 1)
+    completePermanentPlot(targetObservationId, plotB, speciesId, 1)
+
+    service.mergeObservations(sourceObservationId, targetObservationId)
+
+    assertTableEmpty(OBSERVATIONS, where = OBSERVATIONS.ID.eq(sourceObservationId))
+    assertEquals(
+        setOf(plotA, plotB),
+        dslContext
+            .select(OBSERVATION_PLOTS.MONITORING_PLOT_ID)
+            .from(OBSERVATION_PLOTS)
+            .where(OBSERVATION_PLOTS.OBSERVATION_ID.eq(targetObservationId))
+            .fetchSet(OBSERVATION_PLOTS.MONITORING_PLOT_ID),
+        "Target observation plots",
+    )
+    assertEquals(
+        2,
+        dslContext.fetchValue(
+            OBSERVED_SITE_SPECIES_TOTALS.TOTAL_LIVE,
+            OBSERVED_SITE_SPECIES_TOTALS.OBSERVATION_ID.eq(targetObservationId)
+                .and(OBSERVED_SITE_SPECIES_TOTALS.SPECIES_ID.eq(speciesId)),
+        ),
+        "Site total live count in target observation",
+    )
+  }
+
+  @Test
+  fun `conflicting plot overwrites target media and deletes the old target files`() {
+    val plantingSiteId = helper.insertPlantedSite(numPermanentPlots = 2)
+    val speciesId = inserted.speciesId
+    val plotId = insertMonitoringPlot()
+    val sourceObservationId = insertObservation()
+    insertObservationRequestedSubstratum()
+    val targetObservationId = insertObservation()
+    insertObservationRequestedSubstratum()
+
+    completePermanentPlot(targetObservationId, plotId, speciesId, 1)
+    completePermanentPlot(sourceObservationId, plotId, speciesId, 2)
+
+    val targetFileId = insertFile()
+    insertObservationMediaFile(fileId = targetFileId, observationId = targetObservationId)
+    val sourceFileId = insertFile()
+    insertObservationMediaFile(fileId = sourceFileId, observationId = sourceObservationId)
+
+    service.mergeObservations(sourceObservationId, targetObservationId)
+
+    assertEquals(
+        listOf(sourceFileId),
+        dslContext
+            .select(OBSERVATION_MEDIA_FILES.FILE_ID)
+            .from(OBSERVATION_MEDIA_FILES)
+            .where(OBSERVATION_MEDIA_FILES.OBSERVATION_ID.eq(targetObservationId))
+            .fetch(OBSERVATION_MEDIA_FILES.FILE_ID),
+        "Target media files after merge",
+    )
+    eventPublisher.assertEventPublished(FileReferenceDeletedEvent(targetFileId))
+    eventPublisher.assertEventPublished(
+        ObservationMediaFileDeletedEvent(
+            targetFileId,
+            plotId,
+            targetObservationId,
+            inserted.organizationId,
+            plantingSiteId,
+        )
+    )
+  }
+
+  @Test
+  fun `recalculates survival rate for the target observation`() {
+    helper.insertPlantedSite(numPermanentPlots = 2)
+    val speciesId = inserted.speciesId
+    val plotId = insertMonitoringPlot()
+    val sourceObservationId = insertObservation()
+    insertObservationRequestedSubstratum()
+    val targetObservationId = insertObservation()
+    insertObservationRequestedSubstratum()
+
+    // The plot's t0 baseline density was 11 plants/ha; the source observation recorded one live
+    // plant in the permanent plot. After the merge the plot moves to the target, so the survival
+    // rate should be recalculated for the target as 100 * 1 / 11.
+    completePermanentPlot(sourceObservationId, plotId, speciesId, 1)
+    insertPlotT0Density(
+        monitoringPlotId = plotId,
+        speciesId = speciesId,
+        plotDensity = BigDecimal.valueOf(11).toPlantsPerHectare(),
+    )
+
+    service.mergeObservations(sourceObservationId, targetObservationId)
+
+    assertEquals(
+        (100.0 / 11).roundToInt(),
+        dslContext.fetchValue(
+            OBSERVED_SITE_SPECIES_TOTALS.SURVIVAL_RATE,
+            OBSERVED_SITE_SPECIES_TOTALS.OBSERVATION_ID.eq(targetObservationId)
+                .and(OBSERVED_SITE_SPECIES_TOTALS.SPECIES_ID.eq(speciesId)),
+        ),
+        "Target site survival rate after merge",
+    )
+  }
+
+  @Test
+  fun `cannot merge an observation into itself`() {
+    val plantingSiteId = insertPlantingSite()
+    val observationId = insertObservation(plantingSiteId = plantingSiteId)
+    assertThrows<ObservationMergeNotAllowedException> {
+      service.mergeObservations(observationId, observationId)
+    }
+  }
+
+  @Test
+  fun `cannot merge observations from different planting sites`() {
+    insertPlantingSite()
+    val source = insertObservation()
+    insertPlantingSite()
+    val target = insertObservation()
+
+    assertThrows<ObservationMergeNotAllowedException> { service.mergeObservations(source, target) }
+  }
+
+  @Test
+  fun `cannot merge ad-hoc observations`() {
+    insertPlantingSite()
+    val source = insertObservation(isAdHoc = true)
+    val target = insertObservation(isAdHoc = true)
+    assertThrows<ObservationMergeNotAllowedException> { service.mergeObservations(source, target) }
+  }
+
+  @Test
+  fun `cannot merge biomass observations`() {
+    insertPlantingSite()
+    val source = insertObservation(observationType = ObservationType.BiomassMeasurements)
+    val target = insertObservation(observationType = ObservationType.BiomassMeasurements)
+
+    assertThrows<ObservationMergeNotAllowedException> { service.mergeObservations(source, target) }
+  }
+
+  @Test
+  fun `cannot merge upcoming observations`() {
+    helper.insertPlantedSite(numPermanentPlots = 2)
+    val speciesId = inserted.speciesId
+    val plotId = insertMonitoringPlot()
+    val sourceObservationId = insertObservation()
+    insertObservationRequestedSubstratum()
+    completePermanentPlot(sourceObservationId, plotId, speciesId, 1)
+
+    val targetObservationId = insertObservation(state = ObservationState.Upcoming)
+
+    assertThrows<ObservationMergeNotAllowedException> {
+      service.mergeObservations(sourceObservationId, targetObservationId)
+    }
+
+    assertNotNull(
+        observationsDao.fetchOneById(sourceObservationId),
+        "Source observation should not be deleted",
+    )
+  }
+
+  /**
+   * Adds [plotId] to [observationId] as a permanent completed plot with [liveCount] live plants.
+   */
+  private fun completePermanentPlot(
+      observationId: ObservationId,
+      plotId: MonitoringPlotId,
+      speciesId: SpeciesId,
+      liveCount: Int,
+  ) {
+    insertObservationPlot(
+        observationId = observationId,
+        monitoringPlotId = plotId,
+        claimedBy = user.userId,
+        claimedTime = Instant.EPOCH,
+        isPermanent = true,
+    )
+    observationStore.completePlot(
+        observationId = observationId,
+        monitoringPlotId = plotId,
+        conditions = emptySet(),
+        notes = null,
+        observedTime = Instant.EPOCH,
+        plants =
+            List(liveCount) {
+              RecordedPlantsRow(
+                  certaintyId = RecordedSpeciesCertainty.Known,
+                  gpsCoordinates = point(1),
+                  speciesId = speciesId,
+                  statusId = RecordedPlantStatus.Live,
+              )
+            },
+    )
+  }
+}

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/observationStore/ObservationStoreMergeObservationDataTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/observationStore/ObservationStoreMergeObservationDataTest.kt
@@ -1,17 +1,28 @@
 package com.terraformation.backend.tracking.db.observationStore
 
 import com.terraformation.backend.db.default_schema.SpeciesId
+import com.terraformation.backend.db.tracking.MonitoringPlotId
+import com.terraformation.backend.db.tracking.ObservableCondition
+import com.terraformation.backend.db.tracking.ObservationId
 import com.terraformation.backend.db.tracking.RecordedPlantStatus
 import com.terraformation.backend.db.tracking.RecordedSpeciesCertainty
 import com.terraformation.backend.db.tracking.tables.pojos.RecordedPlantsRow
+import com.terraformation.backend.db.tracking.tables.references.OBSERVATIONS
+import com.terraformation.backend.db.tracking.tables.references.OBSERVATION_MEDIA_FILES
+import com.terraformation.backend.db.tracking.tables.references.OBSERVATION_PLOTS
+import com.terraformation.backend.db.tracking.tables.references.OBSERVATION_PLOT_CONDITIONS
 import com.terraformation.backend.db.tracking.tables.references.OBSERVATION_PLOT_RESULTS
 import com.terraformation.backend.db.tracking.tables.references.OBSERVATION_SITE_RESULTS
 import com.terraformation.backend.db.tracking.tables.references.OBSERVATION_STRATUM_RESULTS
 import com.terraformation.backend.db.tracking.tables.references.OBSERVATION_SUBSTRATUM_RESULTS
+import com.terraformation.backend.db.tracking.tables.references.OBSERVED_PLOT_COORDINATES
 import com.terraformation.backend.db.tracking.tables.references.OBSERVED_PLOT_SPECIES_TOTALS
 import com.terraformation.backend.db.tracking.tables.references.OBSERVED_SITE_SPECIES_TOTALS
 import com.terraformation.backend.db.tracking.tables.references.OBSERVED_STRATUM_SPECIES_TOTALS
 import com.terraformation.backend.db.tracking.tables.references.OBSERVED_SUBSTRATUM_SPECIES_TOTALS
+import com.terraformation.backend.db.tracking.tables.references.PLOT_T0_DENSITIES
+import com.terraformation.backend.db.tracking.tables.references.PLOT_T0_OBSERVATIONS
+import com.terraformation.backend.db.tracking.tables.references.RECORDED_PLANTS
 import com.terraformation.backend.point
 import java.time.Instant
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -25,6 +36,169 @@ class ObservationStoreMergeObservationDataTest : BaseObservationStoreTest() {
   fun setUpSite() {
     helper.insertPlantedSite(numPermanentPlots = 2)
     speciesId = inserted.speciesId
+  }
+
+  @Test
+  fun `moves completed source plot data into the target and deletes the source`() {
+    val plotA = insertMonitoringPlot()
+    val plotB = insertMonitoringPlot()
+    val sourceObservationId = insertObservation()
+    val targetObservationId = insertObservation()
+
+    completePlotWith(sourceObservationId, plotA, 1)
+    completePlotWith(targetObservationId, plotB, 1)
+
+    store.mergeObservationData(sourceObservationId, targetObservationId)
+
+    assertEquals(
+        setOf(plotA, plotB),
+        dslContext
+            .select(OBSERVATION_PLOTS.MONITORING_PLOT_ID)
+            .from(OBSERVATION_PLOTS)
+            .where(OBSERVATION_PLOTS.OBSERVATION_ID.eq(targetObservationId))
+            .fetchSet(OBSERVATION_PLOTS.MONITORING_PLOT_ID),
+        "Target observation plots",
+    )
+    assertTableEmpty(OBSERVATIONS, where = OBSERVATIONS.ID.eq(sourceObservationId))
+    assertTableEmpty(
+        OBSERVATION_PLOTS,
+        where = OBSERVATION_PLOTS.OBSERVATION_ID.eq(sourceObservationId),
+    )
+    assertTableEmpty(
+        RECORDED_PLANTS,
+        where = RECORDED_PLANTS.OBSERVATION_ID.eq(sourceObservationId),
+    )
+  }
+
+  @Test
+  fun `conflict plot overwrites target data and drops t0 when target was the t0 observation`() {
+    val plotId = insertMonitoringPlot()
+    val sourceObservationId = insertObservation()
+    val targetObservationId = insertObservation()
+
+    completePlotWith(sourceObservationId, plotId, 2)
+    val expectedRecordedPlants =
+        dslContext.fetch(RECORDED_PLANTS).onEach { it.observationId = targetObservationId }
+    completePlotWith(targetObservationId, plotId, 1)
+
+    insertPlotT0Density(monitoringPlotId = plotId)
+    insertPlotT0Observation(monitoringPlotId = plotId, observationId = targetObservationId)
+
+    store.mergeObservationData(sourceObservationId, targetObservationId)
+
+    assertTableEmpty(PLOT_T0_OBSERVATIONS)
+    assertTableEmpty(PLOT_T0_DENSITIES)
+    assertTableEquals(expectedRecordedPlants)
+  }
+
+  @Test
+  fun `repoints t0 to the target when the source was the t0 observation`() {
+    val plotId = insertMonitoringPlot()
+    val sourceObservationId = insertObservation()
+    val targetObservationId = insertObservation()
+
+    completePlotWith(sourceObservationId, plotId, 1)
+
+    insertPlotT0Density()
+    insertPlotT0Observation(observationId = sourceObservationId)
+
+    // T0 density for plot shouldn't be changed by the merge, but T0 observation should.
+    val expectedT0Density = dslContext.fetchSingle(PLOT_T0_DENSITIES)
+    val expectedT0Observations =
+        dslContext.fetchSingle(PLOT_T0_OBSERVATIONS).apply { observationId = targetObservationId }
+
+    store.mergeObservationData(sourceObservationId, targetObservationId)
+
+    assertTableEquals(expectedT0Observations)
+    assertTableEquals(expectedT0Density)
+  }
+
+  @Test
+  fun `leaves t0 untouched when a third observation is the t0 observation`() {
+    val plotId = insertMonitoringPlot()
+    val t0ObservationId = insertObservation()
+    val sourceObservationId = insertObservation()
+    val targetObservationId = insertObservation()
+
+    completePlotWith(t0ObservationId, plotId, 1)
+    completePlotWith(targetObservationId, plotId, 1)
+    completePlotWith(sourceObservationId, plotId, 1)
+
+    insertPlotT0Density()
+    insertPlotT0Observation(observationId = t0ObservationId)
+
+    val expectedT0Densities = dslContext.fetch(PLOT_T0_DENSITIES)
+    val expectedT0Observations = dslContext.fetch(PLOT_T0_OBSERVATIONS)
+
+    store.mergeObservationData(sourceObservationId, targetObservationId)
+
+    assertTableEquals(expectedT0Densities)
+    assertTableEquals(expectedT0Observations)
+  }
+
+  @Test
+  fun `reparents source child data to the target`() {
+    val plotId = insertMonitoringPlot()
+    val sourceObservationId = insertObservation()
+    val targetObservationId = insertObservation()
+    insertObservationPlot(observationId = sourceObservationId, claimedBy = user.userId)
+
+    store.completePlot(
+        sourceObservationId,
+        plotId,
+        setOf(ObservableCondition.AnimalDamage),
+        null,
+        Instant.EPOCH,
+        listOf(livePlant()),
+    )
+
+    insertFile()
+    insertObservationMediaFile(observationId = sourceObservationId)
+    insertObservedCoordinates(observationId = sourceObservationId)
+
+    val expectedObservationMediaFiles =
+        dslContext.fetchSingle(OBSERVATION_MEDIA_FILES).apply {
+          observationId = targetObservationId
+        }
+    val expectedPlotConditions =
+        dslContext.fetchSingle(OBSERVATION_PLOT_CONDITIONS).apply {
+          observationId = targetObservationId
+        }
+    val expectedPlotCoordinates =
+        dslContext.fetchSingle(OBSERVED_PLOT_COORDINATES).apply {
+          observationId = targetObservationId
+        }
+
+    store.mergeObservationData(sourceObservationId, targetObservationId)
+
+    assertTableEquals(expectedObservationMediaFiles)
+    assertTableEquals(expectedPlotConditions)
+    assertTableEquals(expectedPlotCoordinates)
+  }
+
+  @Test
+  fun `excludes incomplete source plots from the move and drops them with the source`() {
+    val completedPlot = insertMonitoringPlot()
+    val incompletePlot = insertMonitoringPlot()
+    val incompletePlotHistoryId = inserted.monitoringPlotHistoryId
+    val sourceObservationId = insertObservation()
+    val targetObservationId = insertObservation()
+
+    completePlotWith(sourceObservationId, completedPlot, 1)
+
+    val expectedObservationPlots =
+        dslContext.fetchSingle(OBSERVATION_PLOTS).apply { observationId = targetObservationId }
+
+    insertObservationPlot(
+        observationId = sourceObservationId,
+        monitoringPlotId = incompletePlot,
+        monitoringPlotHistoryId = incompletePlotHistoryId,
+    )
+
+    store.mergeObservationData(sourceObservationId, targetObservationId)
+
+    assertTableEquals(expectedObservationPlots)
+    assertTableEmpty(OBSERVATIONS, where = OBSERVATIONS.ID.eq(sourceObservationId))
   }
 
   @Test
@@ -111,4 +285,28 @@ class ObservationStoreMergeObservationDataTest : BaseObservationStoreTest() {
           speciesId = speciesId,
           statusId = RecordedPlantStatus.Dead,
       )
+
+  /**
+   * Adds [plotId] to [observationId] as a claimed plot and completes it with [plantCount] plants.
+   */
+  private fun completePlotWith(
+      observationId: ObservationId,
+      plotId: MonitoringPlotId,
+      plantCount: Int,
+  ) {
+    insertObservationPlot(
+        observationId = observationId,
+        monitoringPlotId = plotId,
+        claimedBy = user.userId,
+        claimedTime = Instant.EPOCH,
+    )
+    store.completePlot(
+        observationId,
+        plotId,
+        emptySet(),
+        null,
+        Instant.EPOCH,
+        List(plantCount) { livePlant() },
+    )
+  }
 }


### PR DESCRIPTION
Add an admin UI control to merge one observation into another one.

Merging moves all the results from the source observation into the target one.
If the target observation already had results for a given plot, that plot's data
is replaced by the data from the source observation (that is, the merge uses
"overwrite on conflict" semantics).

Aggregate data such as observation results and species totals are recalculated
from the raw recorded-plants data.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>