### PR TITLE
Added number of completed plots in latest observation in a substratum

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/tracking/api/PlantingSitesController.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/api/PlantingSitesController.kt
@@ -312,6 +312,7 @@ data class SubstratumResponsePayload(
     val id: SubstratumId,
     val latestObservationCompletedTime: Instant?,
     val latestObservationId: ObservationId?,
+    val latestObservationNumPlots: Int?,
     val monitoringPlots: List<MonitoringPlotPayload>,
     val name: String,
     @Schema(description = "When any monitoring plot in the substratum was most recently observed.")
@@ -329,6 +330,7 @@ data class SubstratumResponsePayload(
       id = model.id,
       latestObservationCompletedTime = model.latestObservationCompletedTime,
       latestObservationId = model.latestObservationId,
+      latestObservationNumPlots = model.latestObservationNumPlots,
       monitoringPlots = model.monitoringPlots.map { MonitoringPlotPayload(it) },
       name = model.name,
       observedTime = model.observedTime,

--- a/src/main/kotlin/com/terraformation/backend/tracking/db/PlantingSiteStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/db/PlantingSiteStore.kt
@@ -2226,6 +2226,14 @@ class PlantingSiteStore(
     val latestObservationCompletedTimeField =
         latestObservationField(OBSERVATIONS.COMPLETED_TIME, observationPlotCondition)
     val latestObservationIdField = latestObservationField(OBSERVATIONS.ID, observationPlotCondition)
+    val latestObservationNumPlots =
+        DSL.field(
+            DSL.selectCount()
+                .from(OBSERVATION_PLOTS)
+                .where(observationPlotCondition)
+                .and(OBSERVATION_PLOTS.OBSERVATION_ID.eq(latestObservationIdField))
+                .and(OBSERVATION_PLOTS.STATUS_ID.eq(ObservationPlotStatus.Completed))
+        )
 
     return DSL.multiset(
             DSL.select(
@@ -2235,6 +2243,7 @@ class PlantingSiteStore(
                     SUBSTRATA.ID,
                     latestObservationCompletedTimeField,
                     latestObservationIdField,
+                    latestObservationNumPlots,
                     monitoringPlotsField,
                     SUBSTRATA.NAME,
                     SUBSTRATA.OBSERVED_TIME,
@@ -2253,13 +2262,16 @@ class PlantingSiteStore(
         )
         .convertFrom { result ->
           result.map { record: Record ->
+            val latestObservationId = record[latestObservationIdField]
             ExistingSubstratumModel(
                 areaHa = record[SUBSTRATA.AREA_HA]!!,
                 boundary = record[boundaryField]!! as MultiPolygon,
                 fullName = record[SUBSTRATA.FULL_NAME]!!,
                 id = record[SUBSTRATA.ID]!!,
                 latestObservationCompletedTime = record[latestObservationCompletedTimeField],
-                latestObservationId = record[latestObservationIdField],
+                latestObservationId = latestObservationId,
+                latestObservationNumPlots =
+                    latestObservationId?.let { record[latestObservationNumPlots] },
                 monitoringPlots = monitoringPlotsField?.let { record[it] } ?: emptyList(),
                 name = record[SUBSTRATA.NAME]!!,
                 observedTime = record[SUBSTRATA.OBSERVED_TIME],

--- a/src/main/kotlin/com/terraformation/backend/tracking/model/SubstratumModel.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/model/SubstratumModel.kt
@@ -20,6 +20,10 @@ data class SubstratumModel<SSID : SubstratumId?>(
     val latestObservationCompletedTime: Instant? = null,
     /** The ID of the latest observation, if the substratum has completed observations */
     val latestObservationId: ObservationId? = null,
+    /**
+     * The number of plots in the latest observation, if the substratum has completed observations
+     */
+    val latestObservationNumPlots: Int? = null,
     val monitoringPlots: List<MonitoringPlotModel> = emptyList(),
     val name: String,
     val observedTime: Instant? = null,

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/plantingSiteStore/PlantingSiteStoreFetchSiteTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/plantingSiteStore/PlantingSiteStoreFetchSiteTest.kt
@@ -2,6 +2,7 @@ package com.terraformation.backend.tracking.db.plantingSiteStore
 
 import com.terraformation.backend.assertGeometryEquals
 import com.terraformation.backend.db.StableId
+import com.terraformation.backend.db.tracking.ObservationPlotStatus
 import com.terraformation.backend.multiPolygon
 import com.terraformation.backend.point
 import com.terraformation.backend.polygon
@@ -323,8 +324,14 @@ internal class PlantingSiteStoreFetchSiteTest : BasePlantingSiteStoreTest() {
           monitoringPlotId = monitoringPlotId2,
           monitoringPlotHistoryId = plotHistoryIds[monitoringPlotId2]!!,
       )
+      // Claimed but not completed in the latest observation; must not be counted.
+      insertObservationPlot(
+          monitoringPlotId = monitoringPlotId121,
+          monitoringPlotHistoryId = plotHistoryIds[monitoringPlotId121]!!,
+          statusId = ObservationPlotStatus.Claimed,
+      )
 
-      /* (x) - for latest (o) for observed but not the latest.
+      /* (x) - for latest (o) for observed but not the latest, (c) claimed but not completed.
 
         Observations         | 1 | 2 |
         ---------------------|---|---|
@@ -334,7 +341,7 @@ internal class PlantingSiteStoreFetchSiteTest : BasePlantingSiteStoreTest() {
         | - - - Plot 1-1-1   | x |   |
         | - - - Plot 1-1-2   |   |   |
         | - - Substratum 1-2 | o | x |
-        | - - - Plot 1-2-1   | x |   |
+        | - - - Plot 1-2-1   | x | c |
         | - - - Plot 1-2-2   | o | x |
         | - Stratum 2        |   | x |
         | - - Substratum 1-2 |   | x |
@@ -371,6 +378,7 @@ internal class PlantingSiteStoreFetchSiteTest : BasePlantingSiteStoreTest() {
                                       id = substratumId11,
                                       latestObservationCompletedTime = Instant.ofEpochSecond(1000),
                                       latestObservationId = observationId1,
+                                      latestObservationNumPlots = 1,
                                       fullName = "S1-1",
                                       name = "1",
                                       plantingCompletedTime = null,
@@ -403,6 +411,7 @@ internal class PlantingSiteStoreFetchSiteTest : BasePlantingSiteStoreTest() {
                                       id = substratumId12,
                                       latestObservationCompletedTime = Instant.ofEpochSecond(2000),
                                       latestObservationId = observationId2,
+                                      latestObservationNumPlots = 1,
                                       fullName = "S1-2",
                                       name = "2",
                                       plantingCompletedTime = null,
@@ -449,6 +458,7 @@ internal class PlantingSiteStoreFetchSiteTest : BasePlantingSiteStoreTest() {
                                       id = substratumId2,
                                       latestObservationCompletedTime = Instant.ofEpochSecond(2000),
                                       latestObservationId = observationId2,
+                                      latestObservationNumPlots = 1,
                                       fullName = "S2-1",
                                       name = "1",
                                       plantingCompletedTime = null,


### PR DESCRIPTION
One of the ways we use the summaries endpoint is to sum up the observed area. Expose number of plots via a subquery instead so the clients do not have to rely on the summaries endpoint to count plots in latest observation per substratum.