### PR TITLE
SW-8420 Add endpoint for specific season's notifications

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/plantingmanagement/api/PlantingSeasonNotificationsController.kt
+++ b/src/main/kotlin/com/terraformation/backend/plantingmanagement/api/PlantingSeasonNotificationsController.kt
@@ -13,6 +13,7 @@ import com.terraformation.backend.plantingmanagement.PlantingSeasonNotificationT
 import com.terraformation.backend.plantingmanagement.db.PlantingSeasonNotificationsService
 import io.swagger.v3.oas.annotations.Operation
 import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
@@ -27,8 +28,8 @@ class PlantingSeasonNotificationsController(
 
   @ApiResponse200
   @Operation(summary = "Lists all notifications for an organization")
-  @GetMapping("/notifications")
-  fun getPlantingSeasonNotifications(
+  @GetMapping("/organization-notifications")
+  fun getPlantingSeasonOrganizationNotifications(
       @RequestParam("organizationId") organizationId: OrganizationId,
       @RequestParam("notificationCategory")
       notificationCategory: PlantingSeasonNotificationCategory,
@@ -41,6 +42,30 @@ class PlantingSeasonNotificationsController(
                   .map { PlantingSeasonNotificationGroupPayload(it) }
           PlantingSeasonNotificationCategory.PlantingSeasonPlanning -> emptyList()
         }
+
+    return GetPlantingSeasonNotificationsResponsePayload(notifications)
+  }
+
+  @ApiResponse200
+  @Operation(summary = "Lists all notifications for a planting season")
+  @GetMapping("/{plantingSeasonId}/notifications")
+  fun getPlantingSeasonNotifications(
+      @PathVariable plantingSeasonId: PlantingSeasonId,
+      @RequestParam("notificationCategory")
+      notificationCategory: PlantingSeasonNotificationCategory,
+  ): GetPlantingSeasonNotificationsResponsePayload {
+    val notificationModel =
+        when (notificationCategory) {
+          PlantingSeasonNotificationCategory.InventoryPlanning ->
+              plantingSeasonNotificationsService.getInventoryPlanningNotifications(plantingSeasonId)
+          PlantingSeasonNotificationCategory.PlantingSeasonPlanning ->
+              plantingSeasonNotificationsService.getPlantingSeasonPlanningNotifications(
+                  plantingSeasonId
+              )
+        }
+
+    val notifications =
+        notificationModel?.let { listOf(PlantingSeasonNotificationGroupPayload(it)) } ?: emptyList()
 
     return GetPlantingSeasonNotificationsResponsePayload(notifications)
   }

--- a/src/main/kotlin/com/terraformation/backend/plantingmanagement/db/PlantingSeasonNotificationsService.kt
+++ b/src/main/kotlin/com/terraformation/backend/plantingmanagement/db/PlantingSeasonNotificationsService.kt
@@ -14,6 +14,7 @@ import com.terraformation.backend.eventlog.model.EventLogEntry
 import com.terraformation.backend.plantingmanagement.PlantingSeasonNotificationGroupModel
 import com.terraformation.backend.plantingmanagement.PlantingSeasonNotificationModel
 import com.terraformation.backend.plantingmanagement.PlantingSeasonNotificationType
+import com.terraformation.backend.plantingmanagement.event.PlantingSeasonAllocatedSpeciesPersistentEvent
 import com.terraformation.backend.plantingmanagement.event.PlantingSeasonPersistentEvent
 import com.terraformation.backend.plantingmanagement.event.PlantingSeasonRelatedPersistentEvent
 import com.terraformation.backend.plantingmanagement.event.PlantingSeasonSpeciesTargetCreatedEvent
@@ -30,10 +31,17 @@ class PlantingSeasonNotificationsService(
     private val dslContext: DSLContext,
     private val eventLogStore: EventLogStore,
 ) {
-  private val notificationEventClasses: List<KClass<out PlantingSeasonRelatedPersistentEvent>> =
+  private val inventoryPlanningNotificationEventClasses:
+      List<KClass<out PlantingSeasonRelatedPersistentEvent>> =
       listOf(
           PlantingSeasonPersistentEvent::class,
           PlantingSeasonSpeciesTargetPersistentEvent::class,
+      )
+
+  private val plantingSeasonPlanningNotificationEventClasses:
+      List<KClass<out PlantingSeasonRelatedPersistentEvent>> =
+      listOf(
+          PlantingSeasonAllocatedSpeciesPersistentEvent::class,
       )
 
   /**
@@ -59,7 +67,7 @@ class PlantingSeasonNotificationsService(
         eventLogStore
             .fetchByIdsSince(
                 seasonInfoById.mapValues { it.value.lastDismissedEventLogId },
-                notificationEventClasses,
+                inventoryPlanningNotificationEventClasses,
             )
             .groupBy { it.event.plantingSeasonId }
 
@@ -83,6 +91,23 @@ class PlantingSeasonNotificationsService(
    */
   fun getInventoryPlanningNotifications(
       plantingSeasonId: PlantingSeasonId
+  ): PlantingSeasonNotificationGroupModel? =
+      getPlantingSeasonNotifications(
+          plantingSeasonId,
+          inventoryPlanningNotificationEventClasses,
+      )
+
+  fun getPlantingSeasonPlanningNotifications(
+      plantingSeasonId: PlantingSeasonId
+  ): PlantingSeasonNotificationGroupModel? =
+      getPlantingSeasonNotifications(
+          plantingSeasonId,
+          plantingSeasonPlanningNotificationEventClasses,
+      )
+
+  private fun getPlantingSeasonNotifications(
+      plantingSeasonId: PlantingSeasonId,
+      requestedClasses: List<KClass<out PlantingSeasonRelatedPersistentEvent>>,
   ): PlantingSeasonNotificationGroupModel? {
     requirePermissions { readPlantingSeason(plantingSeasonId) }
 
@@ -91,7 +116,7 @@ class PlantingSeasonNotificationsService(
     val entries =
         eventLogStore.fetchByIdsSince(
             seasonInfoById.mapValues { it.value.lastDismissedEventLogId },
-            notificationEventClasses,
+            requestedClasses,
         )
 
     if (entries.isEmpty()) {
@@ -171,6 +196,8 @@ class PlantingSeasonNotificationsService(
               } else {
                 null
               }
+          is PlantingSeasonAllocatedSpeciesPersistentEvent ->
+              PlantingSeasonNotificationType.AllocationQuantitiesUpdated
           else -> null
         }
 

--- a/src/main/kotlin/com/terraformation/backend/plantingmanagement/event/PlantingSeasonAllocatedSpeciesPersistentEvent.kt
+++ b/src/main/kotlin/com/terraformation/backend/plantingmanagement/event/PlantingSeasonAllocatedSpeciesPersistentEvent.kt
@@ -7,14 +7,14 @@ import com.terraformation.backend.db.tracking.PlantingSiteId
 import com.terraformation.backend.eventlog.EntityCreatedPersistentEvent
 import com.terraformation.backend.eventlog.EntityDeletedPersistentEvent
 import com.terraformation.backend.eventlog.FieldsUpdatedPersistentEvent
-import com.terraformation.backend.eventlog.PersistentEvent
 import com.terraformation.backend.i18n.Messages
 import com.terraformation.backend.util.nullIfEquals
 
-sealed interface PlantingSeasonAllocatedSpeciesPersistentEvent : PersistentEvent {
-  val organizationId: OrganizationId
-  val plantingSeasonId: PlantingSeasonId
-  val plantingSiteId: PlantingSiteId
+sealed interface PlantingSeasonAllocatedSpeciesPersistentEvent :
+    PlantingSeasonRelatedPersistentEvent {
+  override val organizationId: OrganizationId
+  override val plantingSeasonId: PlantingSeasonId
+  override val plantingSiteId: PlantingSiteId
   val speciesId: SpeciesId
 }
 

--- a/src/test/kotlin/com/terraformation/backend/plantingmanagement/db/PlantingSeasonNotificationsServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/plantingmanagement/db/PlantingSeasonNotificationsServiceTest.kt
@@ -21,6 +21,10 @@ import com.terraformation.backend.eventlog.model.EventLogEntry
 import com.terraformation.backend.plantingmanagement.PlantingSeasonNotificationGroupModel
 import com.terraformation.backend.plantingmanagement.PlantingSeasonNotificationModel
 import com.terraformation.backend.plantingmanagement.PlantingSeasonNotificationType
+import com.terraformation.backend.plantingmanagement.event.PlantingSeasonAllocatedSpeciesCreatedEvent
+import com.terraformation.backend.plantingmanagement.event.PlantingSeasonAllocatedSpeciesPersistentEvent
+import com.terraformation.backend.plantingmanagement.event.PlantingSeasonAllocatedSpeciesUpdatedEvent
+import com.terraformation.backend.plantingmanagement.event.PlantingSeasonAllocatedSpeciesUpdatedEventValues
 import com.terraformation.backend.plantingmanagement.event.PlantingSeasonCreatedEvent
 import com.terraformation.backend.plantingmanagement.event.PlantingSeasonRelatedPersistentEvent
 import com.terraformation.backend.plantingmanagement.event.PlantingSeasonSpeciesTargetCreatedEvent
@@ -88,13 +92,13 @@ internal class PlantingSeasonNotificationsServiceTest : DatabaseTest(), RunsAsDa
           notifications = events,
       )
 
-  private fun added(vararg speciesNames: String) =
+  private fun targetAdded(vararg speciesNames: String) =
       PlantingSeasonNotificationModel(
           PlantingSeasonNotificationType.SpeciesTargetsAdded,
           speciesNames.toSet(),
       )
 
-  private fun updated(vararg speciesNames: String) =
+  private fun targetUpdated(vararg speciesNames: String) =
       PlantingSeasonNotificationModel(
           PlantingSeasonNotificationType.SpeciesTargetsUpdated,
           speciesNames.toSet(),
@@ -115,7 +119,7 @@ internal class PlantingSeasonNotificationsServiceTest : DatabaseTest(), RunsAsDa
       val updatedEvent = insertSpeciesTargetUpdatedEvent(speciesId = speciesId1)
 
       assertEquals(
-          model(updatedEvent.id, listOf(added(speciesName1), updated(speciesName1))),
+          model(updatedEvent.id, listOf(targetAdded(speciesName1), targetUpdated(speciesName1))),
           service.getInventoryPlanningNotifications(plantingSeasonId),
       )
     }
@@ -128,7 +132,7 @@ internal class PlantingSeasonNotificationsServiceTest : DatabaseTest(), RunsAsDa
       insertPlantingSeasonNotification(lastDismissedEventLogId = dismissed.id)
 
       assertEquals(
-          model(newer.id, listOf(updated(speciesName1))),
+          model(newer.id, listOf(targetUpdated(speciesName1))),
           service.getInventoryPlanningNotifications(plantingSeasonId),
       )
     }
@@ -140,7 +144,7 @@ internal class PlantingSeasonNotificationsServiceTest : DatabaseTest(), RunsAsDa
       insertSpeciesTargetCreatedEvent(speciesId = speciesId1, plantingSeasonId = otherSeasonId)
 
       assertEquals(
-          model(expected.id, listOf(added(speciesName1))),
+          model(expected.id, listOf(targetAdded(speciesName1))),
           service.getInventoryPlanningNotifications(plantingSeasonId),
       )
     }
@@ -152,7 +156,7 @@ internal class PlantingSeasonNotificationsServiceTest : DatabaseTest(), RunsAsDa
       val target = insertSpeciesTargetCreatedEvent(speciesId = speciesId1)
 
       assertEquals(
-          model(target.id, listOf(added(speciesName1))),
+          model(target.id, listOf(targetAdded(speciesName1))),
           service.getInventoryPlanningNotifications(plantingSeasonId),
       )
     }
@@ -176,6 +180,122 @@ internal class PlantingSeasonNotificationsServiceTest : DatabaseTest(), RunsAsDa
   }
 
   @Nested
+  inner class GetPlantingSeasonPlanningNotificationsByPlantingSeason {
+    @Test
+    fun `returns all notifications when the season has never dismissed a notification`() {
+      insertSpeciesAllocatedCreatedEvent(speciesId = speciesId1)
+      clock.instant = clock.instant.plusSeconds(1)
+      val updatedEvent = insertSpeciesAllocatedCreatedEvent(speciesId = speciesId2, quantity = 2)
+
+      assertEquals(
+          model(
+              updatedEvent.id,
+              listOf(
+                  PlantingSeasonNotificationModel(
+                      PlantingSeasonNotificationType.AllocationQuantitiesUpdated
+                  )
+              ),
+          ),
+          service.getPlantingSeasonPlanningNotifications(plantingSeasonId),
+      )
+    }
+
+    @Test
+    fun `returns only notifications for events logged after the dismissal watermark`() {
+      val dismissed = insertSpeciesAllocatedCreatedEvent(speciesId = speciesId1)
+      clock.instant = clock.instant.plusSeconds(1)
+      val newer = insertSpeciesAllocatedCreatedEvent(speciesId = speciesId2, quantity = 2)
+      insertPlantingSeasonNotification(lastDismissedEventLogId = dismissed.id)
+
+      assertEquals(
+          model(
+              newer.id,
+              listOf(
+                  PlantingSeasonNotificationModel(
+                      PlantingSeasonNotificationType.AllocationQuantitiesUpdated
+                  )
+              ),
+          ),
+          service.getPlantingSeasonPlanningNotifications(plantingSeasonId),
+      )
+    }
+
+    @Test
+    fun `excludes events for other planting seasons`() {
+      val otherSeasonId = insertPlantingSeason(name = "Other Season")
+      val expected = insertSpeciesAllocatedCreatedEvent(speciesId = speciesId1)
+      insertSpeciesAllocatedCreatedEvent(speciesId = speciesId1, plantingSeasonId = otherSeasonId)
+
+      assertEquals(
+          model(
+              expected.id,
+              listOf(
+                  PlantingSeasonNotificationModel(
+                      PlantingSeasonNotificationType.AllocationQuantitiesUpdated
+                  )
+              ),
+          ),
+          service.getPlantingSeasonPlanningNotifications(plantingSeasonId),
+      )
+    }
+
+    @Test
+    fun `ignores events that do not map to a notification type`() {
+      insertCreatedEvent() // should be ignored
+      clock.instant = clock.instant.plusSeconds(1)
+      val target = insertSpeciesAllocatedCreatedEvent(speciesId = speciesId1)
+
+      assertEquals(
+          model(
+              target.id,
+              listOf(
+                  PlantingSeasonNotificationModel(
+                      PlantingSeasonNotificationType.AllocationQuantitiesUpdated
+                  )
+              ),
+          ),
+          service.getPlantingSeasonPlanningNotifications(plantingSeasonId),
+      )
+    }
+
+    @Test
+    fun `combines events of the same type`() {
+      insertSpeciesAllocatedCreatedEvent(speciesId = speciesId1)
+      clock.instant = clock.instant.plusSeconds(1)
+      val latest = insertSpeciesAllocatedUpdatedEvent(speciesId = speciesId1)
+
+      assertEquals(
+          model(
+              latest.id,
+              listOf(
+                  PlantingSeasonNotificationModel(
+                      PlantingSeasonNotificationType.AllocationQuantitiesUpdated
+                  )
+              ),
+          ),
+          service.getPlantingSeasonPlanningNotifications(plantingSeasonId),
+      )
+    }
+
+    @Test
+    fun `returns null when there are no undismissed events`() {
+      val dismissed = insertSpeciesAllocatedCreatedEvent(speciesId = speciesId1)
+      insertPlantingSeasonNotification(lastDismissedEventLogId = dismissed.id)
+
+      assertNull(service.getPlantingSeasonPlanningNotifications(plantingSeasonId))
+    }
+
+    @Test
+    fun `throws exception when user has no permission to read the planting season`() {
+      deleteOrganizationUser()
+
+      assertThrows<PlantingSeasonNotFoundException> {
+        service.getPlantingSeasonPlanningNotifications(plantingSeasonId)
+      }
+    }
+  }
+
+  @Nested
   inner class GetInventoryPlanningNotificationsByOrganization {
     @Test
     fun `groups notifications by planting season`() {
@@ -186,11 +306,11 @@ internal class PlantingSeasonNotificationsServiceTest : DatabaseTest(), RunsAsDa
 
       assertEquals(
           mapOf(
-              plantingSeasonId to model(firstSeasonEvent.id, listOf(added(speciesName1))),
+              plantingSeasonId to model(firstSeasonEvent.id, listOf(targetAdded(speciesName1))),
               otherSeasonId to
                   model(
                       otherSeasonEvent.id,
-                      listOf(added(speciesName1)),
+                      listOf(targetAdded(speciesName1)),
                       plantingSeasonId = otherSeasonId,
                       plantingSeasonName = "Other Season",
                   ),
@@ -216,11 +336,11 @@ internal class PlantingSeasonNotificationsServiceTest : DatabaseTest(), RunsAsDa
 
       assertEquals(
           mapOf(
-              plantingSeasonId to model(firstSeasonNewer.id, listOf(updated(speciesName1))),
+              plantingSeasonId to model(firstSeasonNewer.id, listOf(targetUpdated(speciesName1))),
               otherSeasonId to
                   model(
                       otherSeasonEvent.id,
-                      listOf(added(speciesName1)),
+                      listOf(targetAdded(speciesName1)),
                       plantingSeasonId = otherSeasonId,
                       plantingSeasonName = "Other Season",
                   ),
@@ -246,7 +366,7 @@ internal class PlantingSeasonNotificationsServiceTest : DatabaseTest(), RunsAsDa
       )
 
       assertEquals(
-          mapOf(plantingSeasonId to model(expected.id, listOf(added(speciesName1)))),
+          mapOf(plantingSeasonId to model(expected.id, listOf(targetAdded(speciesName1)))),
           service.getInventoryPlanningNotifications(organizationId).associateBy {
             it.plantingSeasonId
           },
@@ -283,7 +403,7 @@ internal class PlantingSeasonNotificationsServiceTest : DatabaseTest(), RunsAsDa
       val notification = service.getInventoryPlanningNotifications(plantingSeasonId)
 
       assertEquals(
-          listOf(updated(speciesName1, speciesName2)),
+          listOf(targetUpdated(speciesName1, speciesName2)),
           notification?.notifications,
       )
     }
@@ -305,7 +425,7 @@ internal class PlantingSeasonNotificationsServiceTest : DatabaseTest(), RunsAsDa
       val notification = service.getInventoryPlanningNotifications(plantingSeasonId)
 
       assertEquals(
-          listOf(updated(speciesName1, speciesName2)),
+          listOf(targetUpdated(speciesName1, speciesName2)),
           notification?.notifications,
       )
     }
@@ -323,7 +443,7 @@ internal class PlantingSeasonNotificationsServiceTest : DatabaseTest(), RunsAsDa
           )
 
       assertEquals(
-          model(close.id, listOf(added(speciesName1), updated(speciesName1), closed)),
+          model(close.id, listOf(targetAdded(speciesName1), targetUpdated(speciesName1), closed)),
           service.getInventoryPlanningNotifications(plantingSeasonId),
       )
     }
@@ -356,9 +476,9 @@ internal class PlantingSeasonNotificationsServiceTest : DatabaseTest(), RunsAsDa
   private fun insertUpdatedEvent(
       changedFrom: PlantingSeasonUpdatedEventValues = PlantingSeasonUpdatedEventValues(),
       changedTo: PlantingSeasonUpdatedEventValues = PlantingSeasonUpdatedEventValues(),
+      organizationId: OrganizationId = this.organizationId,
       plantingSeasonId: PlantingSeasonId = this.plantingSeasonId,
       plantingSiteId: PlantingSiteId = this.plantingSiteId,
-      organizationId: OrganizationId = this.organizationId,
   ): EventLogEntry<PlantingSeasonRelatedPersistentEvent> {
     val event =
         PlantingSeasonUpdatedEvent(
@@ -373,10 +493,10 @@ internal class PlantingSeasonNotificationsServiceTest : DatabaseTest(), RunsAsDa
   }
 
   private fun insertCreatedEvent(
-      plantingSeasonId: PlantingSeasonId = this.plantingSeasonId,
       name: String = "Season",
-      plantingSiteId: PlantingSiteId = this.plantingSiteId,
       organizationId: OrganizationId = this.organizationId,
+      plantingSeasonId: PlantingSeasonId = this.plantingSeasonId,
+      plantingSiteId: PlantingSiteId = this.plantingSiteId,
   ): EventLogEntry<PlantingSeasonRelatedPersistentEvent> {
     val event =
         PlantingSeasonCreatedEvent(
@@ -393,12 +513,12 @@ internal class PlantingSeasonNotificationsServiceTest : DatabaseTest(), RunsAsDa
   }
 
   private fun insertSpeciesTargetCreatedEvent(
-      speciesId: SpeciesId = speciesId1,
-      quantity: Int = 1,
-      substratumId: SubstratumId = substratumId1,
+      organizationId: OrganizationId = this.organizationId,
       plantingSeasonId: PlantingSeasonId = this.plantingSeasonId,
       plantingSiteId: PlantingSiteId = this.plantingSiteId,
-      organizationId: OrganizationId = this.organizationId,
+      quantity: Int = 1,
+      speciesId: SpeciesId = speciesId1,
+      substratumId: SubstratumId = substratumId1,
   ): EventLogEntry<PlantingSeasonRelatedPersistentEvent> {
     val event =
         PlantingSeasonSpeciesTargetCreatedEvent(
@@ -417,15 +537,15 @@ internal class PlantingSeasonNotificationsServiceTest : DatabaseTest(), RunsAsDa
   }
 
   private fun insertSpeciesTargetUpdatedEvent(
-      speciesId: SpeciesId = speciesId1,
       changedFrom: PlantingSeasonSpeciesTargetUpdatedEventValues =
           PlantingSeasonSpeciesTargetUpdatedEventValues(quantity = 5),
       changedTo: PlantingSeasonSpeciesTargetUpdatedEventValues =
           PlantingSeasonSpeciesTargetUpdatedEventValues(quantity = 7),
-      substratumId: SubstratumId = substratumId1,
+      organizationId: OrganizationId = this.organizationId,
       plantingSeasonId: PlantingSeasonId = this.plantingSeasonId,
       plantingSiteId: PlantingSiteId = this.plantingSiteId,
-      organizationId: OrganizationId = this.organizationId,
+      speciesId: SpeciesId = speciesId1,
+      substratumId: SubstratumId = substratumId1,
   ): EventLogEntry<PlantingSeasonRelatedPersistentEvent> {
     val event =
         PlantingSeasonSpeciesTargetUpdatedEvent(
@@ -439,6 +559,48 @@ internal class PlantingSeasonNotificationsServiceTest : DatabaseTest(), RunsAsDa
             substratumHistoryId = SubstratumHistoryId(substratumId.value),
             substratumId = substratumId,
             substratumName = "Substratum",
+        )
+
+    return EventLogEntry(user.userId, clock.instant, event, eventLogStore.insertEvent(event))
+  }
+
+  private fun insertSpeciesAllocatedCreatedEvent(
+      organizationId: OrganizationId = this.organizationId,
+      plantingSeasonId: PlantingSeasonId = this.plantingSeasonId,
+      plantingSiteId: PlantingSiteId = this.plantingSiteId,
+      quantity: Int = 1,
+      speciesId: SpeciesId = speciesId1,
+  ): EventLogEntry<PlantingSeasonAllocatedSpeciesPersistentEvent> {
+    val event =
+        PlantingSeasonAllocatedSpeciesCreatedEvent(
+            organizationId = organizationId,
+            plantingSeasonId = plantingSeasonId,
+            plantingSiteId = plantingSiteId,
+            quantity = quantity,
+            speciesId = speciesId,
+        )
+
+    return EventLogEntry(user.userId, clock.instant, event, eventLogStore.insertEvent(event))
+  }
+
+  private fun insertSpeciesAllocatedUpdatedEvent(
+      changedFrom: PlantingSeasonAllocatedSpeciesUpdatedEventValues =
+          PlantingSeasonAllocatedSpeciesUpdatedEventValues(quantity = 5),
+      changedTo: PlantingSeasonAllocatedSpeciesUpdatedEventValues =
+          PlantingSeasonAllocatedSpeciesUpdatedEventValues(quantity = 7),
+      organizationId: OrganizationId = this.organizationId,
+      plantingSeasonId: PlantingSeasonId = this.plantingSeasonId,
+      plantingSiteId: PlantingSiteId = this.plantingSiteId,
+      speciesId: SpeciesId = speciesId1,
+  ): EventLogEntry<PlantingSeasonAllocatedSpeciesPersistentEvent> {
+    val event =
+        PlantingSeasonAllocatedSpeciesUpdatedEvent(
+            changedFrom = changedFrom,
+            changedTo = changedTo,
+            organizationId = organizationId,
+            plantingSeasonId = plantingSeasonId,
+            plantingSiteId = plantingSiteId,
+            speciesId = speciesId,
         )
 
     return EventLogEntry(user.userId, clock.instant, event, eventLogStore.insertEvent(event))


### PR DESCRIPTION
Add an endpoint for a specific season's notifications.

Add a new service method to get planting season planning notifications, and include allocations updated events.

This endpoint will also get one or two more event types in separate PRs.