### PR TITLE
SW-8420 Add endpoint for single season's notifications

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/plantingmanagement/Models.kt
+++ b/src/main/kotlin/com/terraformation/backend/plantingmanagement/Models.kt
@@ -75,6 +75,25 @@ enum class PlantingSeasonNotificationType {
   SeasonWithdrawalRecorded,
 }
 
+enum class PlantingSeasonNotificationCategory {
+  InventoryPlanning,
+  PlantingSeasonPlanning;
+
+  val notificationTypes: Set<PlantingSeasonNotificationType>
+    get() =
+        when (this) {
+          InventoryPlanning ->
+              setOf(
+                  PlantingSeasonNotificationType.PlantingSeasonClosed,
+                  PlantingSeasonNotificationType.PlantingSeasonPastEndDate,
+                  PlantingSeasonNotificationType.SpeciesTargetsAdded,
+                  PlantingSeasonNotificationType.SpeciesTargetsUpdated,
+              )
+          PlantingSeasonPlanning ->
+              setOf(PlantingSeasonNotificationType.AllocationQuantitiesUpdated)
+        }
+}
+
 data class PlantingSeasonNotificationModel(
     val type: PlantingSeasonNotificationType,
     val speciesScientificNames: Set<String>? = null,

--- a/src/main/kotlin/com/terraformation/backend/plantingmanagement/api/PlantingSeasonNotificationsController.kt
+++ b/src/main/kotlin/com/terraformation/backend/plantingmanagement/api/PlantingSeasonNotificationsController.kt
@@ -7,6 +7,7 @@ import com.terraformation.backend.db.default_schema.EventLogId
 import com.terraformation.backend.db.default_schema.OrganizationId
 import com.terraformation.backend.db.tracking.PlantingSeasonId
 import com.terraformation.backend.i18n.Messages
+import com.terraformation.backend.plantingmanagement.PlantingSeasonNotificationCategory
 import com.terraformation.backend.plantingmanagement.PlantingSeasonNotificationGroupModel
 import com.terraformation.backend.plantingmanagement.PlantingSeasonNotificationModel
 import com.terraformation.backend.plantingmanagement.PlantingSeasonNotificationType
@@ -26,29 +27,29 @@ class PlantingSeasonNotificationsController(
 ) {
 
   @ApiResponse200
-  @Operation(summary = "Lists all notifications for an organization")
+  @Operation(
+      summary = "Lists all planting season notifications",
+      description =
+          "If plantingSeasonId is specified, only returns notifications for that specific Planting Season.",
+  )
   @GetMapping("/notifications")
   fun getPlantingSeasonNotifications(
-      @RequestParam("organizationId") organizationId: OrganizationId,
+      @RequestParam("organizationId") organizationId: OrganizationId?,
+      @RequestParam("plantingSeasonId") plantingSeasonId: PlantingSeasonId?,
       @RequestParam("notificationCategory")
       notificationCategory: PlantingSeasonNotificationCategory,
   ): GetPlantingSeasonNotificationsResponsePayload {
     val notifications =
-        when (notificationCategory) {
-          PlantingSeasonNotificationCategory.InventoryPlanning ->
-              plantingSeasonNotificationsService
-                  .getInventoryPlanningNotifications(organizationId)
-                  .map { PlantingSeasonNotificationGroupPayload(it) }
-          PlantingSeasonNotificationCategory.PlantingSeasonPlanning -> emptyList()
-        }
+        plantingSeasonNotificationsService
+            .getNotifications(
+                organizationId,
+                plantingSeasonId,
+                notificationCategory.notificationTypes,
+            )
+            .map { PlantingSeasonNotificationGroupPayload(it) }
 
     return GetPlantingSeasonNotificationsResponsePayload(notifications)
   }
-}
-
-enum class PlantingSeasonNotificationCategory {
-  InventoryPlanning,
-  PlantingSeasonPlanning,
 }
 
 data class GetPlantingSeasonNotificationsResponsePayload(

--- a/src/main/kotlin/com/terraformation/backend/plantingmanagement/api/PlantingSeasonNotificationsController.kt
+++ b/src/main/kotlin/com/terraformation/backend/plantingmanagement/api/PlantingSeasonNotificationsController.kt
@@ -40,15 +40,25 @@ class PlantingSeasonNotificationsController(
       notificationCategory: PlantingSeasonNotificationCategory,
   ): GetPlantingSeasonNotificationsResponsePayload {
     val notifications =
-        plantingSeasonNotificationsService
-            .getNotifications(
-                organizationId,
-                plantingSeasonId,
-                notificationCategory.notificationTypes,
-            )
-            .map { PlantingSeasonNotificationGroupPayload(it) }
+        if (plantingSeasonId != null) {
+          plantingSeasonNotificationsService.getNotifications(
+              plantingSeasonId,
+              notificationCategory.notificationTypes,
+          )
+        } else if (organizationId != null) {
+          plantingSeasonNotificationsService.getNotifications(
+              organizationId,
+              notificationCategory.notificationTypes,
+          )
+        } else {
+          throw IllegalArgumentException(
+              "Either organizationId or plantingSeasonId must be specified."
+          )
+        }
 
-    return GetPlantingSeasonNotificationsResponsePayload(notifications)
+    return GetPlantingSeasonNotificationsResponsePayload(
+        notifications.map { PlantingSeasonNotificationGroupPayload(it) }
+    )
   }
 }
 

--- a/src/main/kotlin/com/terraformation/backend/plantingmanagement/db/PlantingSeasonNotificationsService.kt
+++ b/src/main/kotlin/com/terraformation/backend/plantingmanagement/db/PlantingSeasonNotificationsService.kt
@@ -14,6 +14,7 @@ import com.terraformation.backend.eventlog.model.EventLogEntry
 import com.terraformation.backend.plantingmanagement.PlantingSeasonNotificationGroupModel
 import com.terraformation.backend.plantingmanagement.PlantingSeasonNotificationModel
 import com.terraformation.backend.plantingmanagement.PlantingSeasonNotificationType
+import com.terraformation.backend.plantingmanagement.event.PlantingSeasonAllocatedSpeciesPersistentEvent
 import com.terraformation.backend.plantingmanagement.event.PlantingSeasonPersistentEvent
 import com.terraformation.backend.plantingmanagement.event.PlantingSeasonRelatedPersistentEvent
 import com.terraformation.backend.plantingmanagement.event.PlantingSeasonSpeciesTargetCreatedEvent
@@ -30,24 +31,51 @@ class PlantingSeasonNotificationsService(
     private val dslContext: DSLContext,
     private val eventLogStore: EventLogStore,
 ) {
-  private val notificationEventClasses: List<KClass<out PlantingSeasonRelatedPersistentEvent>> =
-      listOf(
-          PlantingSeasonPersistentEvent::class,
-          PlantingSeasonSpeciesTargetPersistentEvent::class,
+  private val eventClassesByNotificationType:
+      Map<PlantingSeasonNotificationType, KClass<out PlantingSeasonRelatedPersistentEvent>> =
+      mapOf(
+          PlantingSeasonNotificationType.PlantingSeasonClosed to
+              PlantingSeasonPersistentEvent::class,
+          PlantingSeasonNotificationType.PlantingSeasonPastEndDate to
+              PlantingSeasonPersistentEvent::class,
+          PlantingSeasonNotificationType.SpeciesTargetsAdded to
+              PlantingSeasonSpeciesTargetPersistentEvent::class,
+          PlantingSeasonNotificationType.SpeciesTargetsUpdated to
+              PlantingSeasonSpeciesTargetPersistentEvent::class,
+          PlantingSeasonNotificationType.AllocationQuantitiesUpdated to
+              PlantingSeasonAllocatedSpeciesPersistentEvent::class,
       )
 
   /**
-   * Returns the undismissed notifications for every planting season in an organization. A season
-   * that has never dismissed a notification has all of its events returned; a season with no
-   * undismissed events is absent from the result.
+   * Returns the undismissed notifications of the requested [types], grouped by planting season.
+   *
+   * If [plantingSeasonId] is non-null, only that season is considered; otherwise every planting
+   * season in [organizationId] is considered. At least one of the two must be non-null, and
+   * [plantingSeasonId] takes precedence when both are supplied.
+   *
+   * A season that has never dismissed a notification has all of its events returned; a season with
+   * no undismissed events of the requested types is absent from the result.
    */
-  fun getInventoryPlanningNotifications(
-      organizationId: OrganizationId
+  fun getNotifications(
+      organizationId: OrganizationId?,
+      plantingSeasonId: PlantingSeasonId?,
+      types: Collection<PlantingSeasonNotificationType>,
   ): List<PlantingSeasonNotificationGroupModel> {
-    val seasonInfoById =
-        fetchSeasonInfoByCondition(
-            PLANTING_SEASONS.plantingSites.ORGANIZATION_ID.eq(organizationId)
-        )
+    require(organizationId != null || plantingSeasonId != null) {
+      "Either organizationId or plantingSeasonId must be specified."
+    }
+
+    val requestedTypes = types.toSet()
+    val eventClasses = eventClassesToFetch(requestedTypes)
+    if (eventClasses.isEmpty()) {
+      return emptyList()
+    }
+
+    val condition =
+        if (plantingSeasonId != null) PLANTING_SEASONS.ID.eq(plantingSeasonId)
+        else PLANTING_SEASONS.plantingSites.ORGANIZATION_ID.eq(organizationId)
+
+    val seasonInfoById = fetchSeasonInfoByCondition(condition)
 
     requirePermissions { seasonInfoById.keys.forEach { readPlantingSeason(it) } }
 
@@ -59,72 +87,57 @@ class PlantingSeasonNotificationsService(
         eventLogStore
             .fetchByIdsSince(
                 seasonInfoById.mapValues { it.value.lastDismissedEventLogId },
-                notificationEventClasses,
+                eventClasses,
             )
             .groupBy { it.event.plantingSeasonId }
 
     val scientificNamesBySpeciesId =
         fetchScientificNamesBySpeciesId(speciesIdsOf(entriesBySeason.values.flatten()))
 
-    return entriesBySeason.map { (plantingSeasonId, entries) ->
+    return entriesBySeason.mapNotNull { (plantingSeasonId, entries) ->
       buildNotificationModel(
           plantingSeasonId,
           entries,
           seasonInfoById.getValue(plantingSeasonId),
           scientificNamesBySpeciesId,
+          requestedTypes,
       )
     }
   }
 
-  /**
-   * Returns the undismissed notification for a single planting season, or null if the season has no
-   * undismissed events. If the season has never dismissed a notification, all of its events are
-   * returned.
-   */
-  fun getInventoryPlanningNotifications(
-      plantingSeasonId: PlantingSeasonId
-  ): PlantingSeasonNotificationGroupModel? {
-    requirePermissions { readPlantingSeason(plantingSeasonId) }
-
-    val seasonInfoById = fetchSeasonInfoByCondition(PLANTING_SEASONS.ID.eq(plantingSeasonId))
-
-    val entries =
-        eventLogStore.fetchByIdsSince(
-            seasonInfoById.mapValues { it.value.lastDismissedEventLogId },
-            notificationEventClasses,
-        )
-
-    if (entries.isEmpty()) {
-      return null
-    }
-
-    return buildNotificationModel(
-        plantingSeasonId,
-        entries,
-        seasonInfoById.getValue(plantingSeasonId),
-        fetchScientificNamesBySpeciesId(speciesIdsOf(entries)),
-    )
-  }
+  private fun eventClassesToFetch(
+      types: Set<PlantingSeasonNotificationType>
+  ): List<KClass<out PlantingSeasonRelatedPersistentEvent>> =
+      types.mapNotNull { eventClassesByNotificationType[it] }.distinct()
 
   private fun buildNotificationModel(
       plantingSeasonId: PlantingSeasonId,
       entries: List<EventLogEntry<PlantingSeasonRelatedPersistentEvent>>,
       seasonInfo: SeasonInfo,
       scientificNamesBySpeciesId: Map<SpeciesId, String>,
-  ): PlantingSeasonNotificationGroupModel =
-      PlantingSeasonNotificationGroupModel(
-          plantingSeasonId = plantingSeasonId,
-          plantingSeasonName = seasonInfo.plantingSeasonName,
-          plantingSiteName = seasonInfo.plantingSiteName,
-          lastEventLogId = entries.maxOf { it.id },
-          notifications = combineEvents(entries.map { it.event }, scientificNamesBySpeciesId),
-      )
+      requestedTypes: Set<PlantingSeasonNotificationType>,
+  ): PlantingSeasonNotificationGroupModel? {
+    val notifications =
+        combineEvents(entries.map { it.event }, scientificNamesBySpeciesId, requestedTypes)
+    if (notifications.isEmpty()) {
+      return null
+    }
+
+    return PlantingSeasonNotificationGroupModel(
+        plantingSeasonId = plantingSeasonId,
+        plantingSeasonName = seasonInfo.plantingSeasonName,
+        plantingSiteName = seasonInfo.plantingSiteName,
+        lastEventLogId = entries.maxOf { it.id },
+        notifications = notifications,
+    )
+  }
 
   /**
    * Collapses the events for a single planting season into at most one notification per
-   * [PlantingSeasonNotificationType]. Events that do not map to a notification type are dropped.
-   * For a species target notification, the scientific names of every species referenced by the
-   * combined events are gathered into [PlantingSeasonNotificationModel.speciesScientificNames].
+   * [PlantingSeasonNotificationType]. Events that do not map to a notification type, or whose type
+   * is not in [requestedTypes], are dropped. For a species target notification, the scientific
+   * names of every species referenced by the combined events are gathered into
+   * [PlantingSeasonNotificationModel.speciesScientificNames].
    *
    * [events] is expected to be ordered by the time each event was logged, which is the order
    * returned by [EventLogStore.fetchByIdsSince]; notications are returned in the order their types
@@ -133,6 +146,7 @@ class PlantingSeasonNotificationsService(
   private fun combineEvents(
       events: List<PlantingSeasonRelatedPersistentEvent>,
       scientificNamesBySpeciesId: Map<SpeciesId, String>,
+      requestedTypes: Set<PlantingSeasonNotificationType>,
   ): List<PlantingSeasonNotificationModel> {
     require(events.mapTo(mutableSetOf()) { it.plantingSeasonId }.size <= 1) {
       "combineEvents must be called with events for a single planting season"
@@ -142,6 +156,7 @@ class PlantingSeasonNotificationsService(
 
     events.forEach { event ->
       val type = event.notificationType ?: return@forEach
+      if (type !in requestedTypes) return@forEach
       val speciesNames = speciesNamesByType.getOrPut(type) { mutableSetOf() }
       if (event is PlantingSeasonSpeciesTargetPersistentEvent) {
         scientificNamesBySpeciesId[event.speciesId]?.let { speciesNames.add(it) }
@@ -171,6 +186,8 @@ class PlantingSeasonNotificationsService(
               } else {
                 null
               }
+          is PlantingSeasonAllocatedSpeciesPersistentEvent ->
+              PlantingSeasonNotificationType.AllocationQuantitiesUpdated
           else -> null
         }
 

--- a/src/main/kotlin/com/terraformation/backend/plantingmanagement/db/PlantingSeasonNotificationsService.kt
+++ b/src/main/kotlin/com/terraformation/backend/plantingmanagement/db/PlantingSeasonNotificationsService.kt
@@ -47,33 +47,43 @@ class PlantingSeasonNotificationsService(
       )
 
   /**
-   * Returns the undismissed notifications of the requested [types], grouped by planting season.
-   *
-   * If [plantingSeasonId] is non-null, only that season is considered; otherwise every planting
-   * season in [organizationId] is considered. At least one of the two must be non-null, and
-   * [plantingSeasonId] takes precedence when both are supplied.
+   * Returns the undismissed notifications of the requested [types] for every planting season in
+   * [organizationId], grouped by planting season.
    *
    * A season that has never dismissed a notification has all of its events returned; a season with
    * no undismissed events of the requested types is absent from the result.
    */
   fun getNotifications(
-      organizationId: OrganizationId?,
-      plantingSeasonId: PlantingSeasonId?,
+      organizationId: OrganizationId,
+      types: Collection<PlantingSeasonNotificationType>,
+  ): List<PlantingSeasonNotificationGroupModel> =
+      getNotifications(
+          PLANTING_SEASONS.plantingSites.ORGANIZATION_ID.eq(organizationId),
+          types,
+      )
+
+  /**
+   * Returns the undismissed notifications of the requested [types] for [plantingSeasonId], grouped
+   * by planting season.
+   *
+   * A season that has never dismissed a notification has all of its events returned; a season with
+   * no undismissed events of the requested types is absent from the result.
+   */
+  fun getNotifications(
+      plantingSeasonId: PlantingSeasonId,
+      types: Collection<PlantingSeasonNotificationType>,
+  ): List<PlantingSeasonNotificationGroupModel> =
+      getNotifications(PLANTING_SEASONS.ID.eq(plantingSeasonId), types)
+
+  private fun getNotifications(
+      condition: Condition,
       types: Collection<PlantingSeasonNotificationType>,
   ): List<PlantingSeasonNotificationGroupModel> {
-    require(organizationId != null || plantingSeasonId != null) {
-      "Either organizationId or plantingSeasonId must be specified."
-    }
-
     val requestedTypes = types.toSet()
     val eventClasses = eventClassesToFetch(requestedTypes)
     if (eventClasses.isEmpty()) {
       return emptyList()
     }
-
-    val condition =
-        if (plantingSeasonId != null) PLANTING_SEASONS.ID.eq(plantingSeasonId)
-        else PLANTING_SEASONS.plantingSites.ORGANIZATION_ID.eq(organizationId)
 
     val seasonInfoById = fetchSeasonInfoByCondition(condition)
 

--- a/src/main/kotlin/com/terraformation/backend/plantingmanagement/event/PlantingSeasonAllocatedSpeciesPersistentEvent.kt
+++ b/src/main/kotlin/com/terraformation/backend/plantingmanagement/event/PlantingSeasonAllocatedSpeciesPersistentEvent.kt
@@ -7,14 +7,14 @@ import com.terraformation.backend.db.tracking.PlantingSiteId
 import com.terraformation.backend.eventlog.EntityCreatedPersistentEvent
 import com.terraformation.backend.eventlog.EntityDeletedPersistentEvent
 import com.terraformation.backend.eventlog.FieldsUpdatedPersistentEvent
-import com.terraformation.backend.eventlog.PersistentEvent
 import com.terraformation.backend.i18n.Messages
 import com.terraformation.backend.util.nullIfEquals
 
-sealed interface PlantingSeasonAllocatedSpeciesPersistentEvent : PersistentEvent {
-  val organizationId: OrganizationId
-  val plantingSeasonId: PlantingSeasonId
-  val plantingSiteId: PlantingSiteId
+sealed interface PlantingSeasonAllocatedSpeciesPersistentEvent :
+    PlantingSeasonRelatedPersistentEvent {
+  override val organizationId: OrganizationId
+  override val plantingSeasonId: PlantingSeasonId
+  override val plantingSiteId: PlantingSiteId
   val speciesId: SpeciesId
 }
 

--- a/src/test/kotlin/com/terraformation/backend/plantingmanagement/db/PlantingSeasonNotificationsServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/plantingmanagement/db/PlantingSeasonNotificationsServiceTest.kt
@@ -129,7 +129,6 @@ internal class PlantingSeasonNotificationsServiceTest : DatabaseTest(), RunsAsDa
               )
           ),
           service.getNotifications(
-              null,
               plantingSeasonId,
               PlantingSeasonNotificationCategory.InventoryPlanning.notificationTypes,
           ),
@@ -146,7 +145,6 @@ internal class PlantingSeasonNotificationsServiceTest : DatabaseTest(), RunsAsDa
       assertEquals(
           listOf(model(newer.id, listOf(targetUpdated(speciesName1)))),
           service.getNotifications(
-              null,
               plantingSeasonId,
               PlantingSeasonNotificationCategory.InventoryPlanning.notificationTypes,
           ),
@@ -162,7 +160,6 @@ internal class PlantingSeasonNotificationsServiceTest : DatabaseTest(), RunsAsDa
       assertEquals(
           listOf(model(expected.id, listOf(targetAdded(speciesName1)))),
           service.getNotifications(
-              null,
               plantingSeasonId,
               PlantingSeasonNotificationCategory.InventoryPlanning.notificationTypes,
           ),
@@ -178,7 +175,6 @@ internal class PlantingSeasonNotificationsServiceTest : DatabaseTest(), RunsAsDa
       assertEquals(
           listOf(model(target.id, listOf(targetAdded(speciesName1)))),
           service.getNotifications(
-              null,
               plantingSeasonId,
               PlantingSeasonNotificationCategory.InventoryPlanning.notificationTypes,
           ),
@@ -193,7 +189,6 @@ internal class PlantingSeasonNotificationsServiceTest : DatabaseTest(), RunsAsDa
       assertEquals(
           emptyList<PlantingSeasonNotificationGroupModel>(),
           service.getNotifications(
-              null,
               plantingSeasonId,
               PlantingSeasonNotificationCategory.InventoryPlanning.notificationTypes,
           ),
@@ -206,7 +201,6 @@ internal class PlantingSeasonNotificationsServiceTest : DatabaseTest(), RunsAsDa
 
       assertThrows<PlantingSeasonNotFoundException> {
         service.getNotifications(
-            null,
             plantingSeasonId,
             PlantingSeasonNotificationCategory.InventoryPlanning.notificationTypes,
         )
@@ -220,7 +214,6 @@ internal class PlantingSeasonNotificationsServiceTest : DatabaseTest(), RunsAsDa
       assertEquals(
           listOf(model(event.id, listOf(allocationQuantitiesUpdated))),
           service.getNotifications(
-              null,
               plantingSeasonId,
               PlantingSeasonNotificationCategory.PlantingSeasonPlanning.notificationTypes,
           ),
@@ -236,7 +229,6 @@ internal class PlantingSeasonNotificationsServiceTest : DatabaseTest(), RunsAsDa
       assertEquals(
           listOf(model(latest.id, listOf(allocationQuantitiesUpdated))),
           service.getNotifications(
-              null,
               plantingSeasonId,
               PlantingSeasonNotificationCategory.PlantingSeasonPlanning.notificationTypes,
           ),
@@ -267,7 +259,6 @@ internal class PlantingSeasonNotificationsServiceTest : DatabaseTest(), RunsAsDa
           service
               .getNotifications(
                   organizationId,
-                  null,
                   PlantingSeasonNotificationCategory.InventoryPlanning.notificationTypes,
               )
               .associateBy { it.plantingSeasonId },
@@ -301,7 +292,6 @@ internal class PlantingSeasonNotificationsServiceTest : DatabaseTest(), RunsAsDa
           service
               .getNotifications(
                   organizationId,
-                  null,
                   PlantingSeasonNotificationCategory.InventoryPlanning.notificationTypes,
               )
               .associateBy { it.plantingSeasonId },
@@ -327,7 +317,6 @@ internal class PlantingSeasonNotificationsServiceTest : DatabaseTest(), RunsAsDa
           service
               .getNotifications(
                   organizationId,
-                  null,
                   PlantingSeasonNotificationCategory.InventoryPlanning.notificationTypes,
               )
               .associateBy { it.plantingSeasonId },
@@ -341,7 +330,6 @@ internal class PlantingSeasonNotificationsServiceTest : DatabaseTest(), RunsAsDa
       assertThrows<PlantingSeasonNotFoundException> {
         service.getNotifications(
             organizationId,
-            null,
             PlantingSeasonNotificationCategory.InventoryPlanning.notificationTypes,
         )
       }
@@ -358,7 +346,6 @@ internal class PlantingSeasonNotificationsServiceTest : DatabaseTest(), RunsAsDa
       val notifications =
           service
               .getNotifications(
-                  null,
                   plantingSeasonId,
                   PlantingSeasonNotificationCategory.InventoryPlanning.notificationTypes,
               )
@@ -388,7 +375,6 @@ internal class PlantingSeasonNotificationsServiceTest : DatabaseTest(), RunsAsDa
       val notifications =
           service
               .getNotifications(
-                  null,
                   plantingSeasonId,
                   PlantingSeasonNotificationCategory.InventoryPlanning.notificationTypes,
               )
@@ -421,7 +407,6 @@ internal class PlantingSeasonNotificationsServiceTest : DatabaseTest(), RunsAsDa
               )
           ),
           service.getNotifications(
-              null,
               plantingSeasonId,
               PlantingSeasonNotificationCategory.InventoryPlanning.notificationTypes,
           ),
@@ -449,7 +434,6 @@ internal class PlantingSeasonNotificationsServiceTest : DatabaseTest(), RunsAsDa
       assertEquals(
           listOf(model(closedEvent.id, listOf(pastEndDate, closed))),
           service.getNotifications(
-              null,
               plantingSeasonId,
               PlantingSeasonNotificationCategory.InventoryPlanning.notificationTypes,
           ),

--- a/src/test/kotlin/com/terraformation/backend/plantingmanagement/db/PlantingSeasonNotificationsServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/plantingmanagement/db/PlantingSeasonNotificationsServiceTest.kt
@@ -18,9 +18,14 @@ import com.terraformation.backend.db.tracking.SubstratumHistoryId
 import com.terraformation.backend.db.tracking.SubstratumId
 import com.terraformation.backend.eventlog.db.EventLogStore
 import com.terraformation.backend.eventlog.model.EventLogEntry
+import com.terraformation.backend.plantingmanagement.PlantingSeasonNotificationCategory
 import com.terraformation.backend.plantingmanagement.PlantingSeasonNotificationGroupModel
 import com.terraformation.backend.plantingmanagement.PlantingSeasonNotificationModel
 import com.terraformation.backend.plantingmanagement.PlantingSeasonNotificationType
+import com.terraformation.backend.plantingmanagement.event.PlantingSeasonAllocatedSpeciesCreatedEvent
+import com.terraformation.backend.plantingmanagement.event.PlantingSeasonAllocatedSpeciesPersistentEvent
+import com.terraformation.backend.plantingmanagement.event.PlantingSeasonAllocatedSpeciesUpdatedEvent
+import com.terraformation.backend.plantingmanagement.event.PlantingSeasonAllocatedSpeciesUpdatedEventValues
 import com.terraformation.backend.plantingmanagement.event.PlantingSeasonCreatedEvent
 import com.terraformation.backend.plantingmanagement.event.PlantingSeasonRelatedPersistentEvent
 import com.terraformation.backend.plantingmanagement.event.PlantingSeasonSpeciesTargetCreatedEvent
@@ -30,7 +35,6 @@ import com.terraformation.backend.plantingmanagement.event.PlantingSeasonUpdated
 import com.terraformation.backend.plantingmanagement.event.PlantingSeasonUpdatedEventValues
 import java.time.LocalDate
 import org.junit.jupiter.api.Assertions.assertEquals
-import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
@@ -88,13 +92,13 @@ internal class PlantingSeasonNotificationsServiceTest : DatabaseTest(), RunsAsDa
           notifications = events,
       )
 
-  private fun added(vararg speciesNames: String) =
+  private fun targetAdded(vararg speciesNames: String) =
       PlantingSeasonNotificationModel(
           PlantingSeasonNotificationType.SpeciesTargetsAdded,
           speciesNames.toSet(),
       )
 
-  private fun updated(vararg speciesNames: String) =
+  private fun targetUpdated(vararg speciesNames: String) =
       PlantingSeasonNotificationModel(
           PlantingSeasonNotificationType.SpeciesTargetsUpdated,
           speciesNames.toSet(),
@@ -106,8 +110,11 @@ internal class PlantingSeasonNotificationsServiceTest : DatabaseTest(), RunsAsDa
   private val closed =
       PlantingSeasonNotificationModel(PlantingSeasonNotificationType.PlantingSeasonClosed)
 
+  private val allocationQuantitiesUpdated =
+      PlantingSeasonNotificationModel(PlantingSeasonNotificationType.AllocationQuantitiesUpdated)
+
   @Nested
-  inner class GetInventoryPlanningNotificationsByPlantingSeason {
+  inner class GetNotificationsBySeason {
     @Test
     fun `returns all notifications when the season has never dismissed a notification`() {
       insertSpeciesTargetCreatedEvent(speciesId = speciesId1)
@@ -115,8 +122,17 @@ internal class PlantingSeasonNotificationsServiceTest : DatabaseTest(), RunsAsDa
       val updatedEvent = insertSpeciesTargetUpdatedEvent(speciesId = speciesId1)
 
       assertEquals(
-          model(updatedEvent.id, listOf(added(speciesName1), updated(speciesName1))),
-          service.getInventoryPlanningNotifications(plantingSeasonId),
+          listOf(
+              model(
+                  updatedEvent.id,
+                  listOf(targetAdded(speciesName1), targetUpdated(speciesName1)),
+              )
+          ),
+          service.getNotifications(
+              null,
+              plantingSeasonId,
+              PlantingSeasonNotificationCategory.InventoryPlanning.notificationTypes,
+          ),
       )
     }
 
@@ -128,8 +144,12 @@ internal class PlantingSeasonNotificationsServiceTest : DatabaseTest(), RunsAsDa
       insertPlantingSeasonNotification(lastDismissedEventLogId = dismissed.id)
 
       assertEquals(
-          model(newer.id, listOf(updated(speciesName1))),
-          service.getInventoryPlanningNotifications(plantingSeasonId),
+          listOf(model(newer.id, listOf(targetUpdated(speciesName1)))),
+          service.getNotifications(
+              null,
+              plantingSeasonId,
+              PlantingSeasonNotificationCategory.InventoryPlanning.notificationTypes,
+          ),
       )
     }
 
@@ -140,8 +160,12 @@ internal class PlantingSeasonNotificationsServiceTest : DatabaseTest(), RunsAsDa
       insertSpeciesTargetCreatedEvent(speciesId = speciesId1, plantingSeasonId = otherSeasonId)
 
       assertEquals(
-          model(expected.id, listOf(added(speciesName1))),
-          service.getInventoryPlanningNotifications(plantingSeasonId),
+          listOf(model(expected.id, listOf(targetAdded(speciesName1)))),
+          service.getNotifications(
+              null,
+              plantingSeasonId,
+              PlantingSeasonNotificationCategory.InventoryPlanning.notificationTypes,
+          ),
       )
     }
 
@@ -152,17 +176,28 @@ internal class PlantingSeasonNotificationsServiceTest : DatabaseTest(), RunsAsDa
       val target = insertSpeciesTargetCreatedEvent(speciesId = speciesId1)
 
       assertEquals(
-          model(target.id, listOf(added(speciesName1))),
-          service.getInventoryPlanningNotifications(plantingSeasonId),
+          listOf(model(target.id, listOf(targetAdded(speciesName1)))),
+          service.getNotifications(
+              null,
+              plantingSeasonId,
+              PlantingSeasonNotificationCategory.InventoryPlanning.notificationTypes,
+          ),
       )
     }
 
     @Test
-    fun `returns null when there are no undismissed events`() {
+    fun `returns no notifications when there are no undismissed events`() {
       val dismissed = insertSpeciesTargetCreatedEvent(speciesId = speciesId1)
       insertPlantingSeasonNotification(lastDismissedEventLogId = dismissed.id)
 
-      assertNull(service.getInventoryPlanningNotifications(plantingSeasonId))
+      assertEquals(
+          emptyList<PlantingSeasonNotificationGroupModel>(),
+          service.getNotifications(
+              null,
+              plantingSeasonId,
+              PlantingSeasonNotificationCategory.InventoryPlanning.notificationTypes,
+          ),
+      )
     }
 
     @Test
@@ -170,13 +205,47 @@ internal class PlantingSeasonNotificationsServiceTest : DatabaseTest(), RunsAsDa
       deleteOrganizationUser()
 
       assertThrows<PlantingSeasonNotFoundException> {
-        service.getInventoryPlanningNotifications(plantingSeasonId)
+        service.getNotifications(
+            null,
+            plantingSeasonId,
+            PlantingSeasonNotificationCategory.InventoryPlanning.notificationTypes,
+        )
       }
+    }
+
+    @Test
+    fun `maps allocated species events to an allocation quantities updated notification`() {
+      val event = insertSpeciesAllocatedCreatedEvent(speciesId = speciesId1)
+
+      assertEquals(
+          listOf(model(event.id, listOf(allocationQuantitiesUpdated))),
+          service.getNotifications(
+              null,
+              plantingSeasonId,
+              PlantingSeasonNotificationCategory.PlantingSeasonPlanning.notificationTypes,
+          ),
+      )
+    }
+
+    @Test
+    fun `combines events of the same type`() {
+      insertSpeciesAllocatedCreatedEvent(speciesId = speciesId1)
+      clock.instant = clock.instant.plusSeconds(1)
+      val latest = insertSpeciesAllocatedUpdatedEvent(speciesId = speciesId2)
+
+      assertEquals(
+          listOf(model(latest.id, listOf(allocationQuantitiesUpdated))),
+          service.getNotifications(
+              null,
+              plantingSeasonId,
+              PlantingSeasonNotificationCategory.PlantingSeasonPlanning.notificationTypes,
+          ),
+      )
     }
   }
 
   @Nested
-  inner class GetInventoryPlanningNotificationsByOrganization {
+  inner class GetNotificationsByOrganization {
     @Test
     fun `groups notifications by planting season`() {
       val otherSeasonId = insertPlantingSeason(name = "Other Season")
@@ -186,18 +255,22 @@ internal class PlantingSeasonNotificationsServiceTest : DatabaseTest(), RunsAsDa
 
       assertEquals(
           mapOf(
-              plantingSeasonId to model(firstSeasonEvent.id, listOf(added(speciesName1))),
+              plantingSeasonId to model(firstSeasonEvent.id, listOf(targetAdded(speciesName1))),
               otherSeasonId to
                   model(
                       otherSeasonEvent.id,
-                      listOf(added(speciesName1)),
+                      listOf(targetAdded(speciesName1)),
                       plantingSeasonId = otherSeasonId,
                       plantingSeasonName = "Other Season",
                   ),
           ),
-          service.getInventoryPlanningNotifications(organizationId).associateBy {
-            it.plantingSeasonId
-          },
+          service
+              .getNotifications(
+                  organizationId,
+                  null,
+                  PlantingSeasonNotificationCategory.InventoryPlanning.notificationTypes,
+              )
+              .associateBy { it.plantingSeasonId },
       )
     }
 
@@ -216,18 +289,22 @@ internal class PlantingSeasonNotificationsServiceTest : DatabaseTest(), RunsAsDa
 
       assertEquals(
           mapOf(
-              plantingSeasonId to model(firstSeasonNewer.id, listOf(updated(speciesName1))),
+              plantingSeasonId to model(firstSeasonNewer.id, listOf(targetUpdated(speciesName1))),
               otherSeasonId to
                   model(
                       otherSeasonEvent.id,
-                      listOf(added(speciesName1)),
+                      listOf(targetAdded(speciesName1)),
                       plantingSeasonId = otherSeasonId,
                       plantingSeasonName = "Other Season",
                   ),
           ),
-          service.getInventoryPlanningNotifications(organizationId).associateBy {
-            it.plantingSeasonId
-          },
+          service
+              .getNotifications(
+                  organizationId,
+                  null,
+                  PlantingSeasonNotificationCategory.InventoryPlanning.notificationTypes,
+              )
+              .associateBy { it.plantingSeasonId },
       )
     }
 
@@ -246,20 +323,14 @@ internal class PlantingSeasonNotificationsServiceTest : DatabaseTest(), RunsAsDa
       )
 
       assertEquals(
-          mapOf(plantingSeasonId to model(expected.id, listOf(added(speciesName1)))),
-          service.getInventoryPlanningNotifications(organizationId).associateBy {
-            it.plantingSeasonId
-          },
-      )
-    }
-
-    @Test
-    fun `returns empty list when the organization has no planting seasons`() {
-      val emptyOrganizationId = insertOrganization()
-
-      assertEquals(
-          emptyList<PlantingSeasonNotificationGroupModel>(),
-          service.getInventoryPlanningNotifications(emptyOrganizationId),
+          mapOf(plantingSeasonId to model(expected.id, listOf(targetAdded(speciesName1)))),
+          service
+              .getNotifications(
+                  organizationId,
+                  null,
+                  PlantingSeasonNotificationCategory.InventoryPlanning.notificationTypes,
+              )
+              .associateBy { it.plantingSeasonId },
       )
     }
 
@@ -268,7 +339,11 @@ internal class PlantingSeasonNotificationsServiceTest : DatabaseTest(), RunsAsDa
       deleteOrganizationUser()
 
       assertThrows<PlantingSeasonNotFoundException> {
-        service.getInventoryPlanningNotifications(organizationId)
+        service.getNotifications(
+            organizationId,
+            null,
+            PlantingSeasonNotificationCategory.InventoryPlanning.notificationTypes,
+        )
       }
     }
   }
@@ -280,11 +355,19 @@ internal class PlantingSeasonNotificationsServiceTest : DatabaseTest(), RunsAsDa
       insertSpeciesTargetUpdatedEvent(speciesId = speciesId1)
       insertSpeciesTargetUpdatedEvent(speciesId = speciesId2)
 
-      val notification = service.getInventoryPlanningNotifications(plantingSeasonId)
+      val notifications =
+          service
+              .getNotifications(
+                  null,
+                  plantingSeasonId,
+                  PlantingSeasonNotificationCategory.InventoryPlanning.notificationTypes,
+              )
+              .single()
+              .notifications
 
       assertEquals(
-          listOf(updated(speciesName1, speciesName2)),
-          notification?.notifications,
+          listOf(targetUpdated(speciesName1, speciesName2)),
+          notifications,
       )
     }
 
@@ -302,11 +385,19 @@ internal class PlantingSeasonNotificationsServiceTest : DatabaseTest(), RunsAsDa
           changedTo = PlantingSeasonSpeciesTargetUpdatedEventValues(quantity = 5),
       )
 
-      val notification = service.getInventoryPlanningNotifications(plantingSeasonId)
+      val notifications =
+          service
+              .getNotifications(
+                  null,
+                  plantingSeasonId,
+                  PlantingSeasonNotificationCategory.InventoryPlanning.notificationTypes,
+              )
+              .single()
+              .notifications
 
       assertEquals(
-          listOf(updated(speciesName1, speciesName2)),
-          notification?.notifications,
+          listOf(targetUpdated(speciesName1, speciesName2)),
+          notifications,
       )
     }
 
@@ -323,8 +414,17 @@ internal class PlantingSeasonNotificationsServiceTest : DatabaseTest(), RunsAsDa
           )
 
       assertEquals(
-          model(close.id, listOf(added(speciesName1), updated(speciesName1), closed)),
-          service.getInventoryPlanningNotifications(plantingSeasonId),
+          listOf(
+              model(
+                  close.id,
+                  listOf(targetAdded(speciesName1), targetUpdated(speciesName1), closed),
+              )
+          ),
+          service.getNotifications(
+              null,
+              plantingSeasonId,
+              PlantingSeasonNotificationCategory.InventoryPlanning.notificationTypes,
+          ),
       )
     }
 
@@ -347,8 +447,12 @@ internal class PlantingSeasonNotificationsServiceTest : DatabaseTest(), RunsAsDa
           )
 
       assertEquals(
-          model(closedEvent.id, listOf(pastEndDate, closed)),
-          service.getInventoryPlanningNotifications(plantingSeasonId),
+          listOf(model(closedEvent.id, listOf(pastEndDate, closed))),
+          service.getNotifications(
+              null,
+              plantingSeasonId,
+              PlantingSeasonNotificationCategory.InventoryPlanning.notificationTypes,
+          ),
       )
     }
   }
@@ -356,9 +460,9 @@ internal class PlantingSeasonNotificationsServiceTest : DatabaseTest(), RunsAsDa
   private fun insertUpdatedEvent(
       changedFrom: PlantingSeasonUpdatedEventValues = PlantingSeasonUpdatedEventValues(),
       changedTo: PlantingSeasonUpdatedEventValues = PlantingSeasonUpdatedEventValues(),
+      organizationId: OrganizationId = this.organizationId,
       plantingSeasonId: PlantingSeasonId = this.plantingSeasonId,
       plantingSiteId: PlantingSiteId = this.plantingSiteId,
-      organizationId: OrganizationId = this.organizationId,
   ): EventLogEntry<PlantingSeasonRelatedPersistentEvent> {
     val event =
         PlantingSeasonUpdatedEvent(
@@ -373,10 +477,10 @@ internal class PlantingSeasonNotificationsServiceTest : DatabaseTest(), RunsAsDa
   }
 
   private fun insertCreatedEvent(
-      plantingSeasonId: PlantingSeasonId = this.plantingSeasonId,
       name: String = "Season",
-      plantingSiteId: PlantingSiteId = this.plantingSiteId,
       organizationId: OrganizationId = this.organizationId,
+      plantingSeasonId: PlantingSeasonId = this.plantingSeasonId,
+      plantingSiteId: PlantingSiteId = this.plantingSiteId,
   ): EventLogEntry<PlantingSeasonRelatedPersistentEvent> {
     val event =
         PlantingSeasonCreatedEvent(
@@ -393,12 +497,12 @@ internal class PlantingSeasonNotificationsServiceTest : DatabaseTest(), RunsAsDa
   }
 
   private fun insertSpeciesTargetCreatedEvent(
-      speciesId: SpeciesId = speciesId1,
-      quantity: Int = 1,
-      substratumId: SubstratumId = substratumId1,
+      organizationId: OrganizationId = this.organizationId,
       plantingSeasonId: PlantingSeasonId = this.plantingSeasonId,
       plantingSiteId: PlantingSiteId = this.plantingSiteId,
-      organizationId: OrganizationId = this.organizationId,
+      quantity: Int = 1,
+      speciesId: SpeciesId = speciesId1,
+      substratumId: SubstratumId = substratumId1,
   ): EventLogEntry<PlantingSeasonRelatedPersistentEvent> {
     val event =
         PlantingSeasonSpeciesTargetCreatedEvent(
@@ -417,15 +521,15 @@ internal class PlantingSeasonNotificationsServiceTest : DatabaseTest(), RunsAsDa
   }
 
   private fun insertSpeciesTargetUpdatedEvent(
-      speciesId: SpeciesId = speciesId1,
       changedFrom: PlantingSeasonSpeciesTargetUpdatedEventValues =
           PlantingSeasonSpeciesTargetUpdatedEventValues(quantity = 5),
       changedTo: PlantingSeasonSpeciesTargetUpdatedEventValues =
           PlantingSeasonSpeciesTargetUpdatedEventValues(quantity = 7),
-      substratumId: SubstratumId = substratumId1,
+      organizationId: OrganizationId = this.organizationId,
       plantingSeasonId: PlantingSeasonId = this.plantingSeasonId,
       plantingSiteId: PlantingSiteId = this.plantingSiteId,
-      organizationId: OrganizationId = this.organizationId,
+      speciesId: SpeciesId = speciesId1,
+      substratumId: SubstratumId = substratumId1,
   ): EventLogEntry<PlantingSeasonRelatedPersistentEvent> {
     val event =
         PlantingSeasonSpeciesTargetUpdatedEvent(
@@ -439,6 +543,48 @@ internal class PlantingSeasonNotificationsServiceTest : DatabaseTest(), RunsAsDa
             substratumHistoryId = SubstratumHistoryId(substratumId.value),
             substratumId = substratumId,
             substratumName = "Substratum",
+        )
+
+    return EventLogEntry(user.userId, clock.instant, event, eventLogStore.insertEvent(event))
+  }
+
+  private fun insertSpeciesAllocatedCreatedEvent(
+      organizationId: OrganizationId = this.organizationId,
+      plantingSeasonId: PlantingSeasonId = this.plantingSeasonId,
+      plantingSiteId: PlantingSiteId = this.plantingSiteId,
+      quantity: Int = 1,
+      speciesId: SpeciesId = speciesId1,
+  ): EventLogEntry<PlantingSeasonAllocatedSpeciesPersistentEvent> {
+    val event =
+        PlantingSeasonAllocatedSpeciesCreatedEvent(
+            organizationId = organizationId,
+            plantingSeasonId = plantingSeasonId,
+            plantingSiteId = plantingSiteId,
+            quantity = quantity,
+            speciesId = speciesId,
+        )
+
+    return EventLogEntry(user.userId, clock.instant, event, eventLogStore.insertEvent(event))
+  }
+
+  private fun insertSpeciesAllocatedUpdatedEvent(
+      changedFrom: PlantingSeasonAllocatedSpeciesUpdatedEventValues =
+          PlantingSeasonAllocatedSpeciesUpdatedEventValues(quantity = 5),
+      changedTo: PlantingSeasonAllocatedSpeciesUpdatedEventValues =
+          PlantingSeasonAllocatedSpeciesUpdatedEventValues(quantity = 7),
+      organizationId: OrganizationId = this.organizationId,
+      plantingSeasonId: PlantingSeasonId = this.plantingSeasonId,
+      plantingSiteId: PlantingSiteId = this.plantingSiteId,
+      speciesId: SpeciesId = speciesId1,
+  ): EventLogEntry<PlantingSeasonAllocatedSpeciesPersistentEvent> {
+    val event =
+        PlantingSeasonAllocatedSpeciesUpdatedEvent(
+            changedFrom = changedFrom,
+            changedTo = changedTo,
+            organizationId = organizationId,
+            plantingSeasonId = plantingSeasonId,
+            plantingSiteId = plantingSiteId,
+            speciesId = speciesId,
         )
 
     return EventLogEntry(user.userId, clock.instant, event, eventLogStore.insertEvent(event))


### PR DESCRIPTION
Update the notifications endpoint to allow retrieving notifications for only one planting season.

Update the category enum class to include the list of notification types that should be retrieved, since a third category is coming later.

Make `PlantingSeasonAllocatedSpeciesPersistentEvent`also be a `PlantingSeasonRelatedPersistentEvent` and add it to the list of `PlantingSeasonPlanning` types.