### PR TITLE
SW-8420 Publish planting season withdrawal event

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/nursery/db/BatchStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/nursery/db/BatchStore.kt
@@ -851,9 +851,11 @@ class BatchStore(
 
         eventPublisher.publishEvent(
             PlantingSeasonWithdrawalCreatedEvent(
+                facilityId = withdrawal.facilityId,
                 organizationId = organizationId,
                 plantingSeasonId = plantingSeasonId,
                 plantingSiteId = plantingSiteId,
+                withdrawalDate = withdrawal.withdrawnDate,
                 withdrawalId = withdrawalId,
             )
         )

--- a/src/main/kotlin/com/terraformation/backend/nursery/db/BatchStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/nursery/db/BatchStore.kt
@@ -71,6 +71,8 @@ import com.terraformation.backend.nursery.model.WithdrawalModel
 import com.terraformation.backend.nursery.model.toModel
 import com.terraformation.backend.plantingmanagement.db.PlantingSeasonDateRequestNotFoundException
 import com.terraformation.backend.plantingmanagement.db.PlantingSeasonScheduledDateNotFoundException
+import com.terraformation.backend.plantingmanagement.db.SeasonHelper
+import com.terraformation.backend.plantingmanagement.event.PlantingSeasonWithdrawalCreatedEvent
 import com.terraformation.backend.seedbank.event.AccessionSpeciesChangedEvent
 import jakarta.inject.Named
 import java.time.Clock
@@ -99,6 +101,7 @@ class BatchStore(
     private val identifierGenerator: IdentifierGenerator,
     private val parentStore: ParentStore,
     private val projectsDao: ProjectsDao,
+    private val seasonHelper: SeasonHelper,
     private val subLocationsDao: SubLocationsDao,
     private val withdrawalsDao: WithdrawalsDao,
 ) {
@@ -838,6 +841,20 @@ class BatchStore(
         eventPublisher.publishEvent(
             WithdrawalAssociatedWithPlantingDateRequestEvent(
                 withdrawal.scheduledPlantingDateRequestId
+            )
+        )
+      }
+
+      withdrawalsRow.plantingSeasonId?.let { plantingSeasonId ->
+        val (plantingSiteId, organizationId) =
+            seasonHelper.fetchPlantingSiteAndOrganization(plantingSeasonId)
+
+        eventPublisher.publishEvent(
+            PlantingSeasonWithdrawalCreatedEvent(
+                organizationId = organizationId,
+                plantingSeasonId = plantingSeasonId,
+                plantingSiteId = plantingSiteId,
+                withdrawalId = withdrawalId,
             )
         )
       }

--- a/src/main/resources/db/migration/0500/V508__PlantingSeasonWithdrawalCreatedEvents.sql
+++ b/src/main/resources/db/migration/0500/V508__PlantingSeasonWithdrawalCreatedEvents.sql
@@ -1,0 +1,17 @@
+INSERT INTO event_log (created_by, created_time, event_class, payload)
+SELECT
+    withdrawals.created_by,
+    withdrawals.created_time,
+    'com.terraformation.backend.plantingmanagement.event.PlantingSeasonWithdrawalCreatedEventV1',
+    json_object(
+        '_historical' VALUE true,
+        'organizationId' VALUE sites.organization_id,
+        'plantingSeasonId' VALUE seasons.id,
+        'plantingSiteId' VALUE sites.id,
+        'withdrawalId' VALUE withdrawals.id
+        ABSENT ON NULL
+    )::JSONB
+FROM nursery.withdrawals withdrawals
+JOIN tracking.planting_seasons seasons ON withdrawals.planting_season_id = seasons.id
+JOIN tracking.planting_sites sites ON seasons.planting_site_id = sites.id
+WHERE withdrawals.planting_season_id IS NOT NULL;

--- a/src/main/resources/db/migration/0500/V508__PlantingSeasonWithdrawalCreatedEvents.sql
+++ b/src/main/resources/db/migration/0500/V508__PlantingSeasonWithdrawalCreatedEvents.sql
@@ -5,9 +5,11 @@ SELECT
     'com.terraformation.backend.plantingmanagement.event.PlantingSeasonWithdrawalCreatedEventV1',
     json_object(
         '_historical' VALUE true,
+        'facilityId' VALUE withdrawals.facility_id,
         'organizationId' VALUE sites.organization_id,
         'plantingSeasonId' VALUE seasons.id,
         'plantingSiteId' VALUE sites.id,
+        'withdrawalDate' VALUE withdrawals.withdrawn_date,
         'withdrawalId' VALUE withdrawals.id
         ABSENT ON NULL
     )::JSONB

--- a/src/test/kotlin/com/terraformation/backend/customer/ProjectServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/ProjectServiceTest.kt
@@ -25,6 +25,7 @@ import com.terraformation.backend.dummyKeycloakInfo
 import com.terraformation.backend.i18n.Messages
 import com.terraformation.backend.mockUser
 import com.terraformation.backend.nursery.db.BatchStore
+import com.terraformation.backend.plantingmanagement.db.SeasonHelper
 import com.terraformation.backend.seedbank.db.AccessionStore
 import com.terraformation.backend.seedbank.db.BagStore
 import com.terraformation.backend.seedbank.db.GeolocationStore
@@ -83,6 +84,7 @@ class ProjectServiceTest : DatabaseTest(), RunsAsUser {
             identifierGenerator,
             parentStore,
             projectsDao,
+            SeasonHelper(dslContext),
             subLocationsDao,
             nurseryWithdrawalsDao,
         ),

--- a/src/test/kotlin/com/terraformation/backend/nursery/BatchServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/nursery/BatchServiceTest.kt
@@ -15,6 +15,7 @@ import com.terraformation.backend.nursery.db.BatchStore
 import com.terraformation.backend.nursery.db.batchStore.BatchStoreTest
 import com.terraformation.backend.nursery.model.BatchWithdrawalModel
 import com.terraformation.backend.nursery.model.NewWithdrawalModel
+import com.terraformation.backend.plantingmanagement.db.SeasonHelper
 import com.terraformation.backend.tracking.db.DeliveryStore
 import com.terraformation.backend.tracking.db.DeliveryStoreTest
 import io.mockk.every
@@ -49,6 +50,7 @@ internal class BatchServiceTest : DatabaseTest(), RunsAsUser {
             IdentifierGenerator(clock, dslContext),
             parentStore,
             projectsDao,
+            SeasonHelper(dslContext),
             subLocationsDao,
             nurseryWithdrawalsDao,
         ),

--- a/src/test/kotlin/com/terraformation/backend/nursery/db/BatchImporterTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/nursery/db/BatchImporterTest.kt
@@ -33,6 +33,7 @@ import com.terraformation.backend.i18n.Messages
 import com.terraformation.backend.i18n.use
 import com.terraformation.backend.mapTo1IndexedIds
 import com.terraformation.backend.mockUser
+import com.terraformation.backend.plantingmanagement.db.SeasonHelper
 import com.terraformation.backend.species.db.SpeciesStore
 import io.mockk.CapturingSlot
 import io.mockk.every
@@ -74,6 +75,7 @@ internal class BatchImporterTest : DatabaseTest(), RunsAsUser {
         IdentifierGenerator(clock, dslContext),
         parentStore,
         projectsDao,
+        SeasonHelper(dslContext),
         subLocationsDao,
         nurseryWithdrawalsDao,
     )

--- a/src/test/kotlin/com/terraformation/backend/nursery/db/batchStore/BatchStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/nursery/db/batchStore/BatchStoreTest.kt
@@ -13,6 +13,7 @@ import com.terraformation.backend.db.default_schema.SpeciesId
 import com.terraformation.backend.mockUser
 import com.terraformation.backend.nursery.db.BatchStore
 import com.terraformation.backend.nursery.model.NewBatchModel
+import com.terraformation.backend.plantingmanagement.db.SeasonHelper
 import io.mockk.every
 import java.time.LocalDate
 import org.junit.jupiter.api.BeforeEach
@@ -36,6 +37,7 @@ internal abstract class BatchStoreTest : DatabaseTest(), RunsAsUser {
         IdentifierGenerator(clock, dslContext),
         ParentStore(dslContext),
         projectsDao,
+        SeasonHelper(dslContext),
         subLocationsDao,
         nurseryWithdrawalsDao,
     )

--- a/src/test/kotlin/com/terraformation/backend/nursery/db/batchStore/BatchStoreWithdrawalSeasonEventTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/nursery/db/batchStore/BatchStoreWithdrawalSeasonEventTest.kt
@@ -1,0 +1,99 @@
+package com.terraformation.backend.nursery.db.batchStore
+
+import com.terraformation.backend.db.nursery.BatchId
+import com.terraformation.backend.db.nursery.WithdrawalPurpose
+import com.terraformation.backend.db.tracking.PlantingSeasonId
+import com.terraformation.backend.db.tracking.PlantingSiteId
+import com.terraformation.backend.nursery.model.BatchWithdrawalModel
+import com.terraformation.backend.nursery.model.NewWithdrawalModel
+import com.terraformation.backend.plantingmanagement.event.PlantingSeasonWithdrawalCreatedEvent
+import io.mockk.every
+import java.time.LocalDate
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+internal class BatchStoreWithdrawalSeasonEventTest : BatchStoreTest() {
+  private lateinit var batchId: BatchId
+  private lateinit var plantingSiteId: PlantingSiteId
+  private lateinit var plantingSeasonId: PlantingSeasonId
+
+  @BeforeEach
+  fun setUpSeasonAndBatch() {
+    batchId =
+        insertBatch(
+            speciesId = speciesId,
+            germinatingQuantity = 10,
+            activeGrowthQuantity = 20,
+            readyQuantity = 30,
+            hardeningOffQuantity = 40,
+        )
+    plantingSiteId = insertPlantingSite()
+    plantingSeasonId = insertPlantingSeason()
+
+    every { user.canReadWithdrawal(any()) } returns true
+  }
+
+  @Test
+  fun `publishes event when withdrawal has a planting season`() {
+    val withdrawalId = withdraw(plantingSeasonId = plantingSeasonId)
+
+    eventPublisher.assertEventPublished(
+        PlantingSeasonWithdrawalCreatedEvent(
+            organizationId = organizationId,
+            plantingSeasonId = plantingSeasonId,
+            plantingSiteId = plantingSiteId,
+            withdrawalId = withdrawalId,
+        )
+    )
+  }
+
+  @Test
+  fun `publishes event when undoing a withdrawal with a planting season`() {
+    val withdrawalId = withdraw(plantingSeasonId = plantingSeasonId)
+    eventPublisher.clear()
+
+    val undo = store.undoWithdrawal(withdrawalId)
+
+    eventPublisher.assertEventPublished(
+        PlantingSeasonWithdrawalCreatedEvent(
+            organizationId = organizationId,
+            plantingSeasonId = plantingSeasonId,
+            plantingSiteId = plantingSiteId,
+            withdrawalId = undo.id,
+        )
+    )
+  }
+
+  @Test
+  fun `does not publish event when withdrawal has no planting season`() {
+    withdraw(plantingSeasonId = null, purpose = WithdrawalPurpose.Other)
+
+    eventPublisher.assertEventNotPublished<PlantingSeasonWithdrawalCreatedEvent>()
+  }
+
+  private fun withdraw(
+      plantingSeasonId: PlantingSeasonId? = null,
+      purpose: WithdrawalPurpose = WithdrawalPurpose.OutPlant,
+  ) =
+      store
+          .withdraw(
+              NewWithdrawalModel(
+                  batchWithdrawals =
+                      listOf(
+                          BatchWithdrawalModel(
+                              batchId = batchId,
+                              germinatingQuantityWithdrawn = 1,
+                              activeGrowthQuantityWithdrawn = 2,
+                              readyQuantityWithdrawn = 3,
+                              hardeningOffQuantityWithdrawn = 4,
+                          )
+                      ),
+                  facilityId = facilityId,
+                  id = null,
+                  plantingSeasonId = plantingSeasonId,
+                  purpose = purpose,
+                  withdrawnDate = LocalDate.EPOCH,
+              )
+          )
+          .id
+}

--- a/src/test/kotlin/com/terraformation/backend/nursery/db/batchStore/BatchStoreWithdrawalSeasonEventTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/nursery/db/batchStore/BatchStoreWithdrawalSeasonEventTest.kt
@@ -4,6 +4,7 @@ import com.terraformation.backend.db.nursery.BatchId
 import com.terraformation.backend.db.nursery.WithdrawalPurpose
 import com.terraformation.backend.db.tracking.PlantingSeasonId
 import com.terraformation.backend.db.tracking.PlantingSiteId
+import com.terraformation.backend.i18n.TimeZones
 import com.terraformation.backend.nursery.model.BatchWithdrawalModel
 import com.terraformation.backend.nursery.model.NewWithdrawalModel
 import com.terraformation.backend.plantingmanagement.event.PlantingSeasonWithdrawalCreatedEvent
@@ -39,9 +40,11 @@ internal class BatchStoreWithdrawalSeasonEventTest : BatchStoreTest() {
 
     eventPublisher.assertEventPublished(
         PlantingSeasonWithdrawalCreatedEvent(
+            facilityId = facilityId,
             organizationId = organizationId,
             plantingSeasonId = plantingSeasonId,
             plantingSiteId = plantingSiteId,
+            withdrawalDate = LocalDate.EPOCH,
             withdrawalId = withdrawalId,
         )
     )
@@ -52,13 +55,17 @@ internal class BatchStoreWithdrawalSeasonEventTest : BatchStoreTest() {
     val withdrawalId = withdraw(plantingSeasonId = plantingSeasonId)
     eventPublisher.clear()
 
+    clock.instant = clock.instant().plusSeconds(86400)
+
     val undo = store.undoWithdrawal(withdrawalId)
 
     eventPublisher.assertEventPublished(
         PlantingSeasonWithdrawalCreatedEvent(
+            facilityId = facilityId,
             organizationId = organizationId,
             plantingSeasonId = plantingSeasonId,
             plantingSiteId = plantingSiteId,
+            withdrawalDate = LocalDate.EPOCH.plusDays(1),
             withdrawalId = undo.id,
         )
     )
@@ -92,7 +99,7 @@ internal class BatchStoreWithdrawalSeasonEventTest : BatchStoreTest() {
                   id = null,
                   plantingSeasonId = plantingSeasonId,
                   purpose = purpose,
-                  withdrawnDate = LocalDate.EPOCH,
+                  withdrawnDate = LocalDate.ofInstant(clock.instant(), TimeZones.UTC),
               )
           )
           .id

--- a/src/test/kotlin/com/terraformation/backend/report/SeedFundReportServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/report/SeedFundReportServiceTest.kt
@@ -42,6 +42,7 @@ import com.terraformation.backend.file.GoogleDriveWriter
 import com.terraformation.backend.i18n.Messages
 import com.terraformation.backend.mockUser
 import com.terraformation.backend.nursery.db.BatchStore
+import com.terraformation.backend.plantingmanagement.db.SeasonHelper
 import com.terraformation.backend.report.db.SeedFundReportStore
 import com.terraformation.backend.report.model.SeedFundReportBodyModelV1
 import com.terraformation.backend.report.model.SeedFundReportMetadata
@@ -121,6 +122,7 @@ class SeedFundReportServiceTest : DatabaseTest(), RunsAsUser {
             mockk(),
             parentStore,
             projectsDao,
+            SeasonHelper(dslContext),
             subLocationsDao,
             nurseryWithdrawalsDao,
         ),


### PR DESCRIPTION
Publish the new `PlantingSeasonWithdrawalCreatedEvent` when a planting season is created and has a `plantingSeasonId`.

Backfill for staging.

Co-authored-by: Claude Opus 4.8 (1M context) [noreply@anthropic.com](mailto:noreply@anthropic.com)