### PR TITLE
SW-8420 Add planting season withdrawal notification

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/plantingmanagement/Models.kt
+++ b/src/main/kotlin/com/terraformation/backend/plantingmanagement/Models.kt
@@ -90,7 +90,10 @@ enum class PlantingSeasonNotificationCategory {
                   PlantingSeasonNotificationType.SpeciesTargetsUpdated,
               )
           PlantingSeasonPlanning ->
-              setOf(PlantingSeasonNotificationType.AllocationQuantitiesUpdated)
+              setOf(
+                  PlantingSeasonNotificationType.AllocationQuantitiesUpdated,
+                  PlantingSeasonNotificationType.SeasonWithdrawalRecorded,
+              )
         }
 }
 

--- a/src/main/kotlin/com/terraformation/backend/plantingmanagement/db/PlantingSeasonNotificationsService.kt
+++ b/src/main/kotlin/com/terraformation/backend/plantingmanagement/db/PlantingSeasonNotificationsService.kt
@@ -21,6 +21,7 @@ import com.terraformation.backend.plantingmanagement.event.PlantingSeasonSpecies
 import com.terraformation.backend.plantingmanagement.event.PlantingSeasonSpeciesTargetPersistentEvent
 import com.terraformation.backend.plantingmanagement.event.PlantingSeasonSpeciesTargetUpdatedEvent
 import com.terraformation.backend.plantingmanagement.event.PlantingSeasonUpdatedEvent
+import com.terraformation.backend.plantingmanagement.event.PlantingSeasonWithdrawalCreatedEvent
 import jakarta.inject.Named
 import kotlin.reflect.KClass
 import org.jooq.Condition
@@ -44,6 +45,8 @@ class PlantingSeasonNotificationsService(
               PlantingSeasonSpeciesTargetPersistentEvent::class,
           PlantingSeasonNotificationType.AllocationQuantitiesUpdated to
               PlantingSeasonAllocatedSpeciesPersistentEvent::class,
+          PlantingSeasonNotificationType.SeasonWithdrawalRecorded to
+              PlantingSeasonWithdrawalCreatedEvent::class,
       )
 
   /**
@@ -198,6 +201,8 @@ class PlantingSeasonNotificationsService(
               }
           is PlantingSeasonAllocatedSpeciesPersistentEvent ->
               PlantingSeasonNotificationType.AllocationQuantitiesUpdated
+          is PlantingSeasonWithdrawalCreatedEvent ->
+              PlantingSeasonNotificationType.SeasonWithdrawalRecorded
           else -> null
         }
 

--- a/src/test/kotlin/com/terraformation/backend/plantingmanagement/db/PlantingSeasonNotificationsServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/plantingmanagement/db/PlantingSeasonNotificationsServiceTest.kt
@@ -232,7 +232,6 @@ internal class PlantingSeasonNotificationsServiceTest : DatabaseTest(), RunsAsDa
       assertEquals(
           listOf(model(event.id, listOf(seasonWithdrawalRecorded))),
           service.getNotifications(
-              null,
               plantingSeasonId,
               PlantingSeasonNotificationCategory.PlantingSeasonPlanning.notificationTypes,
           ),
@@ -253,7 +252,6 @@ internal class PlantingSeasonNotificationsServiceTest : DatabaseTest(), RunsAsDa
               )
           ),
           service.getNotifications(
-              null,
               plantingSeasonId,
               PlantingSeasonNotificationCategory.PlantingSeasonPlanning.notificationTypes,
           ),

--- a/src/test/kotlin/com/terraformation/backend/plantingmanagement/db/PlantingSeasonNotificationsServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/plantingmanagement/db/PlantingSeasonNotificationsServiceTest.kt
@@ -10,6 +10,7 @@ import com.terraformation.backend.db.default_schema.EventLogId
 import com.terraformation.backend.db.default_schema.OrganizationId
 import com.terraformation.backend.db.default_schema.Role
 import com.terraformation.backend.db.default_schema.SpeciesId
+import com.terraformation.backend.db.nursery.WithdrawalId
 import com.terraformation.backend.db.tracking.PlantingSeasonId
 import com.terraformation.backend.db.tracking.PlantingSeasonStatus
 import com.terraformation.backend.db.tracking.PlantingSiteId
@@ -33,6 +34,7 @@ import com.terraformation.backend.plantingmanagement.event.PlantingSeasonSpecies
 import com.terraformation.backend.plantingmanagement.event.PlantingSeasonSpeciesTargetUpdatedEventValues
 import com.terraformation.backend.plantingmanagement.event.PlantingSeasonUpdatedEvent
 import com.terraformation.backend.plantingmanagement.event.PlantingSeasonUpdatedEventValues
+import com.terraformation.backend.plantingmanagement.event.PlantingSeasonWithdrawalCreatedEvent
 import java.time.LocalDate
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
@@ -112,6 +114,9 @@ internal class PlantingSeasonNotificationsServiceTest : DatabaseTest(), RunsAsDa
 
   private val allocationQuantitiesUpdated =
       PlantingSeasonNotificationModel(PlantingSeasonNotificationType.AllocationQuantitiesUpdated)
+
+  private val seasonWithdrawalRecorded =
+      PlantingSeasonNotificationModel(PlantingSeasonNotificationType.SeasonWithdrawalRecorded)
 
   @Nested
   inner class GetNotificationsBySeason {
@@ -214,6 +219,41 @@ internal class PlantingSeasonNotificationsServiceTest : DatabaseTest(), RunsAsDa
       assertEquals(
           listOf(model(event.id, listOf(allocationQuantitiesUpdated))),
           service.getNotifications(
+              plantingSeasonId,
+              PlantingSeasonNotificationCategory.PlantingSeasonPlanning.notificationTypes,
+          ),
+      )
+    }
+
+    @Test
+    fun `maps withdrawal events to a season withdrawal recorded notification`() {
+      val event = insertWithdrawalCreatedEvent()
+
+      assertEquals(
+          listOf(model(event.id, listOf(seasonWithdrawalRecorded))),
+          service.getNotifications(
+              null,
+              plantingSeasonId,
+              PlantingSeasonNotificationCategory.PlantingSeasonPlanning.notificationTypes,
+          ),
+      )
+    }
+
+    @Test
+    fun `combines withdrawal events with allocation events under planting season planning`() {
+      insertSpeciesAllocatedCreatedEvent(speciesId = speciesId1)
+      clock.instant = clock.instant.plusSeconds(1)
+      val latest = insertWithdrawalCreatedEvent(withdrawalId = WithdrawalId(2))
+
+      assertEquals(
+          listOf(
+              model(
+                  latest.id,
+                  listOf(allocationQuantitiesUpdated, seasonWithdrawalRecorded),
+              )
+          ),
+          service.getNotifications(
+              null,
               plantingSeasonId,
               PlantingSeasonNotificationCategory.PlantingSeasonPlanning.notificationTypes,
           ),
@@ -546,6 +586,23 @@ internal class PlantingSeasonNotificationsServiceTest : DatabaseTest(), RunsAsDa
             plantingSiteId = plantingSiteId,
             quantity = quantity,
             speciesId = speciesId,
+        )
+
+    return EventLogEntry(user.userId, clock.instant, event, eventLogStore.insertEvent(event))
+  }
+
+  private fun insertWithdrawalCreatedEvent(
+      organizationId: OrganizationId = this.organizationId,
+      plantingSeasonId: PlantingSeasonId = this.plantingSeasonId,
+      plantingSiteId: PlantingSiteId = this.plantingSiteId,
+      withdrawalId: WithdrawalId = WithdrawalId(1),
+  ): EventLogEntry<PlantingSeasonWithdrawalCreatedEvent> {
+    val event =
+        PlantingSeasonWithdrawalCreatedEvent(
+            organizationId = organizationId,
+            plantingSeasonId = plantingSeasonId,
+            plantingSiteId = plantingSiteId,
+            withdrawalId = withdrawalId,
         )
 
     return EventLogEntry(user.userId, clock.instant, event, eventLogStore.insertEvent(event))

--- a/src/test/kotlin/com/terraformation/backend/plantingmanagement/db/PlantingSeasonNotificationsServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/plantingmanagement/db/PlantingSeasonNotificationsServiceTest.kt
@@ -7,6 +7,7 @@ import com.terraformation.backend.TestClock
 import com.terraformation.backend.customer.model.TerrawareUser
 import com.terraformation.backend.db.DatabaseTest
 import com.terraformation.backend.db.default_schema.EventLogId
+import com.terraformation.backend.db.default_schema.FacilityId
 import com.terraformation.backend.db.default_schema.OrganizationId
 import com.terraformation.backend.db.default_schema.Role
 import com.terraformation.backend.db.default_schema.SpeciesId
@@ -59,6 +60,7 @@ internal class PlantingSeasonNotificationsServiceTest : DatabaseTest(), RunsAsDa
   private val speciesName1 = "Species A"
   private val speciesName2 = "Species B"
 
+  private lateinit var facilityId: FacilityId
   private lateinit var organizationId: OrganizationId
   private lateinit var plantingSiteId: PlantingSiteId
   private lateinit var stratumId1: StratumId
@@ -66,6 +68,7 @@ internal class PlantingSeasonNotificationsServiceTest : DatabaseTest(), RunsAsDa
   private lateinit var plantingSeasonId: PlantingSeasonId
   private lateinit var speciesId1: SpeciesId
   private lateinit var speciesId2: SpeciesId
+  private lateinit var withdrawalId: WithdrawalId
 
   @BeforeEach
   fun setUp() {
@@ -77,6 +80,8 @@ internal class PlantingSeasonNotificationsServiceTest : DatabaseTest(), RunsAsDa
     plantingSeasonId = insertPlantingSeason(name = plantingSeasonName)
     speciesId1 = insertSpecies(scientificName = speciesName1)
     speciesId2 = insertSpecies(scientificName = speciesName2)
+    facilityId = insertFacility()
+    withdrawalId = insertNurseryWithdrawal()
   }
 
   private fun model(
@@ -239,10 +244,10 @@ internal class PlantingSeasonNotificationsServiceTest : DatabaseTest(), RunsAsDa
     }
 
     @Test
-    fun `combines withdrawal events with allocation events under planting season planning`() {
+    fun `returns all notification types for PlantingSeasonPlanning`() {
       insertSpeciesAllocatedCreatedEvent(speciesId = speciesId1)
       clock.instant = clock.instant.plusSeconds(1)
-      val latest = insertWithdrawalCreatedEvent(withdrawalId = WithdrawalId(2))
+      val latest = insertWithdrawalCreatedEvent(withdrawalId = withdrawalId)
 
       assertEquals(
           listOf(
@@ -593,13 +598,15 @@ internal class PlantingSeasonNotificationsServiceTest : DatabaseTest(), RunsAsDa
       organizationId: OrganizationId = this.organizationId,
       plantingSeasonId: PlantingSeasonId = this.plantingSeasonId,
       plantingSiteId: PlantingSiteId = this.plantingSiteId,
-      withdrawalId: WithdrawalId = WithdrawalId(1),
+      withdrawalId: WithdrawalId = this.withdrawalId,
   ): EventLogEntry<PlantingSeasonWithdrawalCreatedEvent> {
     val event =
         PlantingSeasonWithdrawalCreatedEvent(
+            facilityId = facilityId,
             organizationId = organizationId,
             plantingSeasonId = plantingSeasonId,
             plantingSiteId = plantingSiteId,
+            withdrawalDate = LocalDate.EPOCH,
             withdrawalId = withdrawalId,
         )
 


### PR DESCRIPTION
Add `SeasonWithdrawalRecorded` to the types of notifications that should show up in the `PlantingSeasonPlanning` page by using the new persistent event. 

Co-authored-by: Claude Opus 4.8 (1M context) [noreply@anthropic.com](mailto:noreply@anthropic.com)