### PR TITLE
SW-8434 Retain some plots when deleting incomplete plots

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/admin/AdminObservationsController.kt
+++ b/src/main/kotlin/com/terraformation/backend/admin/AdminObservationsController.kt
@@ -1,11 +1,15 @@
 package com.terraformation.backend.admin
 
 import com.terraformation.backend.api.RequireGlobalRole
+import com.terraformation.backend.db.asNonNullable
 import com.terraformation.backend.db.default_schema.GlobalRole
+import com.terraformation.backend.db.tracking.MonitoringPlotId
 import com.terraformation.backend.db.tracking.ObservationId
+import com.terraformation.backend.db.tracking.tables.references.MONITORING_PLOTS
 import com.terraformation.backend.log.perClassLogger
 import com.terraformation.backend.tracking.ObservationService
 import com.terraformation.backend.tracking.db.ObservationStore
+import org.jooq.DSLContext
 import org.springframework.stereotype.Controller
 import org.springframework.validation.annotation.Validated
 import org.springframework.web.bind.annotation.GetMapping
@@ -19,6 +23,7 @@ import org.springframework.web.servlet.mvc.support.RedirectAttributes
 @RequireGlobalRole([GlobalRole.SuperAdmin])
 @Validated
 class AdminObservationsController(
+    private val dslContext: DSLContext,
     private val observationService: ObservationService,
     private val observationStore: ObservationStore,
 ) {
@@ -48,12 +53,41 @@ class AdminObservationsController(
   @PostMapping("/deleteIncompletePlots")
   fun adminDeleteIncompletePlots(
       @RequestParam observationId: ObservationId,
+      @RequestParam retainObservationIds: List<ObservationId>?,
+      @RequestParam dryRun: Boolean,
       redirectAttributes: RedirectAttributes,
   ): String {
     try {
-      observationStore.deleteIncompletePlots(observationId)
+      val (retainedPlotIds, deletedPlotIds) =
+          observationStore.deleteIncompletePlots(
+              observationId,
+              retainObservationIds ?: emptyList(),
+              dryRun,
+          )
+
+      val plotNumbersById =
+          with(MONITORING_PLOTS) {
+            dslContext
+                .select(ID, PLOT_NUMBER)
+                .from(MONITORING_PLOTS)
+                .where(ID.`in`(retainedPlotIds + deletedPlotIds))
+                .fetchMap(ID.asNonNullable(), PLOT_NUMBER.asNonNullable())
+          }
+
+      fun sortedPlotNumberList(ids: List<MonitoringPlotId>) =
+          ids.map { plotNumbersById[it] ?: -1 }.sorted().joinToString()
+
       redirectAttributes.successMessage =
-          "Deleted incomplete plots from observation $observationId."
+          if (dryRun) {
+            "Dry run results for observation $observationId"
+          } else {
+            "Deleted incomplete plots from observation $observationId"
+          }
+      redirectAttributes.successDetails =
+          listOf(
+              "Retain plots: " + sortedPlotNumberList(retainedPlotIds),
+              "Delete plots: " + sortedPlotNumberList(deletedPlotIds),
+          )
     } catch (e: Exception) {
       log.error("Failed to delete incomplete plots from observation $observationId", e)
       redirectAttributes.failureMessage = "Failed to delete incomplete plots from observation: $e"

--- a/src/main/kotlin/com/terraformation/backend/tracking/db/ObservationStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/db/ObservationStore.kt
@@ -2762,7 +2762,7 @@ class ObservationStore(
                 .and(MONITORING_PLOT_ID.notIn(retainedPlotIds))
                 .fetch(MONITORING_PLOT_ID.asNonNullable())
 
-        if (!dryRun && retainedPlotIds.isNotEmpty()) {
+        if (!dryRun && deletedPlotIds.isNotEmpty()) {
           dslContext
               .deleteFrom(OBSERVATION_PLOTS)
               .where(OBSERVATION_ID.eq(observationId))

--- a/src/main/kotlin/com/terraformation/backend/tracking/db/ObservationStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/db/ObservationStore.kt
@@ -2704,7 +2704,19 @@ class ObservationStore(
     }
   }
 
-  fun deleteIncompletePlots(observationId: ObservationId) {
+  /**
+   * Deletes incomplete plots from an observation. Optionally retains permanent plots that weren't
+   * observed in a list of other observations.
+   *
+   * @param dryRun If true, calculate the lists of plot IDs that would be retained and deleted, but
+   *   don't actually delete anything.
+   * @return The list of retained plot IDs and the list of deleted plot IDs
+   */
+  fun deleteIncompletePlots(
+      observationId: ObservationId,
+      retainFromObservationIds: Collection<ObservationId>,
+      dryRun: Boolean = false,
+  ): Pair<List<MonitoringPlotId>, List<MonitoringPlotId>> {
     requirePermissions { manageObservation(observationId) }
 
     val currentState =
@@ -2717,12 +2729,50 @@ class ObservationStore(
       )
     }
 
-    with(OBSERVATION_PLOTS) {
-      dslContext
-          .deleteFrom(OBSERVATION_PLOTS)
-          .where(OBSERVATION_ID.eq(observationId))
-          .and(STATUS_ID.ne(ObservationPlotStatus.Completed))
-          .execute()
+    return observationLocker.withLockedObservation(observationId) {
+      with(OBSERVATION_PLOTS) {
+        val innerObservationPlots = OBSERVATION_PLOTS.`as`("inner")
+
+        val retainedPlotIds =
+            if (retainFromObservationIds.isNotEmpty()) {
+              dslContext
+                  .select(MONITORING_PLOT_ID)
+                  .from(OBSERVATION_PLOTS)
+                  .where(OBSERVATION_ID.eq(observationId))
+                  .and(STATUS_ID.ne(ObservationPlotStatus.Completed))
+                  .and(IS_PERMANENT.isTrue)
+                  .andNotExists(
+                      DSL.selectOne()
+                          .from(innerObservationPlots)
+                          .where(innerObservationPlots.MONITORING_PLOT_ID.eq(MONITORING_PLOT_ID))
+                          .and(innerObservationPlots.STATUS_ID.eq(ObservationPlotStatus.Completed))
+                          .and(innerObservationPlots.OBSERVATION_ID.`in`(retainFromObservationIds))
+                  )
+                  .fetch(MONITORING_PLOT_ID.asNonNullable())
+            } else {
+              emptyList()
+            }
+
+        val deletedPlotIds =
+            dslContext
+                .select(MONITORING_PLOT_ID)
+                .from(OBSERVATION_PLOTS)
+                .where(OBSERVATION_ID.eq(observationId))
+                .and(STATUS_ID.ne(ObservationPlotStatus.Completed))
+                .and(MONITORING_PLOT_ID.notIn(retainedPlotIds))
+                .fetch(MONITORING_PLOT_ID.asNonNullable())
+
+        if (!dryRun && retainedPlotIds.isNotEmpty()) {
+          dslContext
+              .deleteFrom(OBSERVATION_PLOTS)
+              .where(OBSERVATION_ID.eq(observationId))
+              .and(MONITORING_PLOT_ID.`in`(deletedPlotIds))
+              .and(STATUS_ID.ne(ObservationPlotStatus.Completed))
+              .execute()
+        }
+
+        retainedPlotIds to deletedPlotIds
+      }
     }
   }
 

--- a/src/main/resources/templates/admin/observations.html
+++ b/src/main/resources/templates/admin/observations.html
@@ -29,15 +29,27 @@
 <h3>Remove Incomplete Plots from Abandoned Observation</h3>
 
 <p>
-    Remove all the plots in an abandoned observation that weren't completed, so they don't clutter
-    up the user's view of the observation. The observation will continue to be marked as abandoned
-    even though all its plots will be completed.
+    Remove all the plots that weren't completed in an abandoned observation. Optionally retain
+    incomplete permanent plots that weren't observed in a specific set of observations.
+    The observation will continue to be marked as abandoned even if its remaining plots are all
+    completed.
 </p>
 
 <form method="POST" action="/admin/deleteIncompletePlots">
     <label>
         Observation ID
         <input type="text" name="observationId" required/>
+    </label>
+    <label>
+        Retain permanent plots not observed in observation IDs (comma-separated)
+        <input type="text" name="retainObservationIds"/>
+    </label>
+    <label>
+        Mode
+        <select name="dryRun">
+            <option value="true" selected>Dry Run</option>
+            <option value="false">Apply Changes</option>
+        </select>
     </label>
     <input type="submit" value="Remove Incomplete Plots"/>
 </form>

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/observationStore/ObservationStoreDeleteIncompletePlotsTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/observationStore/ObservationStoreDeleteIncompletePlotsTest.kt
@@ -6,6 +6,7 @@ import com.terraformation.backend.db.tracking.ObservationState
 import com.terraformation.backend.db.tracking.tables.references.OBSERVATION_PLOTS
 import io.mockk.every
 import java.time.Instant
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.springframework.security.access.AccessDeniedException
@@ -33,9 +34,55 @@ class ObservationStoreDeleteIncompletePlotsTest : BaseObservationStoreTest() {
     insertMonitoringPlot()
     insertObservationPlot()
 
-    store.deleteIncompletePlots(observationId)
+    store.deleteIncompletePlots(observationId, emptyList())
 
     assertTableEquals(observationPlotsWithOnlyCompletedPlot)
+  }
+
+  @Test
+  fun `retains permanent plots that also were not observed in other observations`() {
+    insertUserGlobalRole(role = GlobalRole.SuperAdmin)
+    insertStratum()
+    insertSubstratum()
+
+    // An incomplete permanent plot that wasn't observed elsewhere; it shouldn't be removed.
+    val neverObservedPlotId = insertMonitoringPlot()
+    val observationId =
+        insertObservation(completedTime = Instant.EPOCH, state = ObservationState.Abandoned)
+    insertObservationPlot(isPermanent = true, statusId = ObservationPlotStatus.NotObserved)
+
+    val observationPlotsWithOnlyRetainedPlot = dslContext.fetch(OBSERVATION_PLOTS)
+
+    // A permanent plot that was observed elsewhere; it should be removed.
+    val observedElsewherePlotId = insertMonitoringPlot()
+    insertObservationPlot(isPermanent = true, statusId = ObservationPlotStatus.NotObserved)
+
+    val otherObservationId =
+        insertObservation(
+            completedTime = Instant.ofEpochSecond(1),
+            state = ObservationState.Abandoned,
+        )
+    insertObservationPlot(
+        monitoringPlotId = neverObservedPlotId,
+        isPermanent = true,
+        statusId = ObservationPlotStatus.NotObserved,
+    )
+    insertObservationPlot(
+        monitoringPlotId = observedElsewherePlotId,
+        completedBy = user.userId,
+        isPermanent = true,
+    )
+
+    assertEquals(
+        listOf(neverObservedPlotId) to listOf(observedElsewherePlotId),
+        store.deleteIncompletePlots(observationId, listOf(otherObservationId)),
+        "Retained and deleted plot IDs",
+    )
+
+    assertTableEquals(
+        observationPlotsWithOnlyRetainedPlot,
+        where = OBSERVATION_PLOTS.OBSERVATION_ID.eq(observationId),
+    )
   }
 
   @Test
@@ -47,7 +94,7 @@ class ObservationStoreDeleteIncompletePlotsTest : BaseObservationStoreTest() {
     val observationId = insertObservation()
     insertObservationPlot()
 
-    assertThrows<IllegalStateException> { store.deleteIncompletePlots(observationId) }
+    assertThrows<IllegalStateException> { store.deleteIncompletePlots(observationId, emptyList()) }
   }
 
   @Test
@@ -60,6 +107,6 @@ class ObservationStoreDeleteIncompletePlotsTest : BaseObservationStoreTest() {
 
     every { user.canManageObservation(observationId) } returns false
 
-    assertThrows<AccessDeniedException> { store.deleteIncompletePlots(observationId) }
+    assertThrows<AccessDeniedException> { store.deleteIncompletePlots(observationId, emptyList()) }
   }
 }


### PR DESCRIPTION
When we're deleting incomplete plots from observations, it turns out that we need
to be a bit more selective: if a permanent plot wasn't observed in the target
observation or in a list of other observations, we want to keep it.

Add a dry-run option to the incomplete-plot deletion function so the admin can
verify that the expected list of plots will be retained.