### PR TITLE
Make GBIF admin controller more general

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/admin/AdminSpeciesController.kt
+++ b/src/main/kotlin/com/terraformation/backend/admin/AdminSpeciesController.kt
@@ -6,6 +6,7 @@ import com.terraformation.backend.log.perClassLogger
 import com.terraformation.backend.species.db.GbifImporter
 import java.net.URI
 import java.nio.file.Files
+import java.nio.file.Path
 import java.nio.file.StandardCopyOption
 import java.util.zip.ZipFile
 import kotlin.io.path.deleteIfExists
@@ -20,7 +21,7 @@ import org.springframework.web.servlet.mvc.support.RedirectAttributes
 @RequestMapping("/admin")
 @RequireGlobalRole([GlobalRole.SuperAdmin])
 @Validated
-class AdminGbifController(
+class AdminSpeciesController(
     private val gbifImporter: GbifImporter,
 ) {
   private val log = perClassLogger()
@@ -30,25 +31,33 @@ class AdminGbifController(
       @RequestParam url: URI,
       redirectAttributes: RedirectAttributes,
   ): String {
+    try {
+      withDownloadedZipFile(url) { zipFilePath ->
+        ZipFile(zipFilePath.toFile()).use { zipFile -> gbifImporter.import(zipFile) }
+      }
+
+      redirectAttributes.successMessage = "GBIF data imported successfully."
+    } catch (e: Exception) {
+      redirectAttributes.failureMessage = "Import failed: ${e.message}"
+    }
+
+    return redirectToAdminHome()
+  }
+
+  private fun withDownloadedZipFile(url: URI, func: (Path) -> Unit) {
     val tempFile = kotlin.io.path.createTempFile(suffix = ".zip")
 
     try {
-      log.info("Copying GBIF zipfile to local filesystem: $tempFile")
+      log.info("Copying $url to local filesystem: $tempFile")
 
       url.toURL().openStream().use { zipFileStream ->
         Files.copy(zipFileStream, tempFile, StandardCopyOption.REPLACE_EXISTING)
       }
 
-      ZipFile(tempFile.toFile()).use { gbifImporter.import(it) }
-
-      redirectAttributes.successMessage = "GBIF data imported successfully."
-    } catch (e: Exception) {
-      redirectAttributes.failureMessage = "Import failed: ${e.message}"
+      func(tempFile)
     } finally {
       tempFile.deleteIfExists()
     }
-
-    return redirectToAdminHome()
   }
 
   private fun redirectToAdminHome() = "redirect:/admin/"

--- a/src/main/kotlin/com/terraformation/backend/admin/AdminSpeciesController.kt
+++ b/src/main/kotlin/com/terraformation/backend/admin/AdminSpeciesController.kt
@@ -32,7 +32,7 @@ class AdminSpeciesController(
       redirectAttributes: RedirectAttributes,
   ): String {
     try {
-      withDownloadedZipFile(url) { zipFilePath ->
+      withDownloadedFile(url) { zipFilePath ->
         ZipFile(zipFilePath.toFile()).use { zipFile -> gbifImporter.import(zipFile) }
       }
 
@@ -44,14 +44,14 @@ class AdminSpeciesController(
     return redirectToAdminHome()
   }
 
-  private fun withDownloadedZipFile(url: URI, func: (Path) -> Unit) {
-    val tempFile = kotlin.io.path.createTempFile(suffix = ".zip")
+  private fun withDownloadedFile(url: URI, suffix: String = ".zip", func: (Path) -> Unit) {
+    val tempFile = kotlin.io.path.createTempFile(suffix = suffix)
 
     try {
       log.info("Copying $url to local filesystem: $tempFile")
 
-      url.toURL().openStream().use { zipFileStream ->
-        Files.copy(zipFileStream, tempFile, StandardCopyOption.REPLACE_EXISTING)
+      url.toURL().openStream().use { fileStream ->
+        Files.copy(fileStream, tempFile, StandardCopyOption.REPLACE_EXISTING)
       }
 
       func(tempFile)


### PR DESCRIPTION
In preparation for adding import features for various additional species-related
datasets, rename the admin controller to make it non-GBIF-specific, and pull the
"download and process a zipfile" logic into a helper function.