### PR TITLE
SW-8537 Look up botanical countries of WCVP distributions

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/gis/RegionMetadataService.kt
+++ b/src/main/kotlin/com/terraformation/backend/gis/RegionMetadataService.kt
@@ -97,6 +97,25 @@ class RegionMetadataService(private val dslContext: DSLContext) {
                   .where(BOTANICAL_COUNTRIES.LEVEL3_CODE.eq(WCVP_DISTRIBUTIONS.LEVEL3_CODE)),
           )
           .execute()
+
+      val botanicalCountriesPopulated = dslContext.fetchExists(BOTANICAL_COUNTRIES)
+      if (botanicalCountriesPopulated) {
+        val unknownLevel3Codes =
+            dslContext
+                .selectDistinct(WCVP_DISTRIBUTIONS.LEVEL3_CODE)
+                .from(WCVP_DISTRIBUTIONS)
+                .where(WCVP_DISTRIBUTIONS.LEVEL3_CODE.isNotNull)
+                .and(WCVP_DISTRIBUTIONS.BOTANICAL_COUNTRY_ID.isNull)
+                .orderBy(WCVP_DISTRIBUTIONS.LEVEL3_CODE)
+                .fetch(WCVP_DISTRIBUTIONS.LEVEL3_CODE)
+
+        if (unknownLevel3Codes.isNotEmpty()) {
+          log.warn(
+              "WCVP distributions had level 3 region codes that were not in botanical countries " +
+                  "list: $unknownLevel3Codes"
+          )
+        }
+      }
     }
   }
 }

--- a/src/main/kotlin/com/terraformation/backend/gis/RegionMetadataService.kt
+++ b/src/main/kotlin/com/terraformation/backend/gis/RegionMetadataService.kt
@@ -4,9 +4,11 @@ import com.terraformation.backend.db.asNonNullable
 import com.terraformation.backend.db.default_schema.tables.references.BOTANICAL_COUNTRIES
 import com.terraformation.backend.db.default_schema.tables.references.ECOREGIONS
 import com.terraformation.backend.db.default_schema.tables.references.ECOREGION_BOTANICAL_COUNTRIES
+import com.terraformation.backend.db.default_schema.tables.references.WCVP_DISTRIBUTIONS
 import com.terraformation.backend.gis.event.BotanicalCountriesImportedEvent
 import com.terraformation.backend.gis.event.EcoregionsImportedEvent
 import com.terraformation.backend.log.perClassLogger
+import com.terraformation.backend.species.event.WcvpImportedEvent
 import com.terraformation.backend.util.intersectsFast
 import jakarta.inject.Named
 import kotlinx.coroutines.Dispatchers
@@ -24,11 +26,17 @@ class RegionMetadataService(private val dslContext: DSLContext) {
   @EventListener
   fun on(event: BotanicalCountriesImportedEvent) {
     updateEcoregionMapping()
+    updateWcvpBotanicalCountryMapping()
   }
 
   @EventListener
   fun on(event: EcoregionsImportedEvent) {
     updateEcoregionMapping()
+  }
+
+  @EventListener
+  fun on(event: WcvpImportedEvent) {
+    updateWcvpBotanicalCountryMapping()
   }
 
   private fun updateEcoregionMapping() {
@@ -73,6 +81,22 @@ class RegionMetadataService(private val dslContext: DSLContext) {
             .valuesOfRows(ecoregionBotanicalCountriesRows)
             .execute()
       }
+    }
+  }
+
+  private fun updateWcvpBotanicalCountryMapping() {
+    log.info("Linking botanical countries to WCVP distributions")
+
+    dslContext.transaction { _ ->
+      dslContext
+          .update(WCVP_DISTRIBUTIONS)
+          .set(
+              WCVP_DISTRIBUTIONS.BOTANICAL_COUNTRY_ID,
+              DSL.select(BOTANICAL_COUNTRIES.ID)
+                  .from(BOTANICAL_COUNTRIES)
+                  .where(BOTANICAL_COUNTRIES.LEVEL3_CODE.eq(WCVP_DISTRIBUTIONS.LEVEL3_CODE)),
+          )
+          .execute()
     }
   }
 }

--- a/src/test/kotlin/com/terraformation/backend/db/DatabaseBackedTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/db/DatabaseBackedTest.kt
@@ -173,6 +173,7 @@ import com.terraformation.backend.db.default_schema.UploadStatus
 import com.terraformation.backend.db.default_schema.UploadType
 import com.terraformation.backend.db.default_schema.UserId
 import com.terraformation.backend.db.default_schema.UserType
+import com.terraformation.backend.db.default_schema.WcvpTaxonId
 import com.terraformation.backend.db.default_schema.keys.USERS_PKEY
 import com.terraformation.backend.db.default_schema.tables.daos.AutomationsDao
 import com.terraformation.backend.db.default_schema.tables.daos.BirdnetResultsDao
@@ -239,6 +240,8 @@ import com.terraformation.backend.db.default_schema.tables.pojos.UserGlobalRoles
 import com.terraformation.backend.db.default_schema.tables.records.BotanicalCountriesRecord
 import com.terraformation.backend.db.default_schema.tables.records.EcoregionBotanicalCountriesRecord
 import com.terraformation.backend.db.default_schema.tables.records.EcoregionsRecord
+import com.terraformation.backend.db.default_schema.tables.records.WcvpDistributionsRecord
+import com.terraformation.backend.db.default_schema.tables.records.WcvpTaxaRecord
 import com.terraformation.backend.db.default_schema.tables.references.AUTOMATIONS
 import com.terraformation.backend.db.default_schema.tables.references.DEVICES
 import com.terraformation.backend.db.default_schema.tables.references.FACILITIES
@@ -5875,6 +5878,62 @@ abstract class DatabaseBackedTest {
       ecoregionId: EcoregionId = inserted.ecoregionId,
   ) {
     EcoregionBotanicalCountriesRecord(ecoregionId, botanicalCountryId).attach(dslContext).insert()
+  }
+
+  private var nextWcvpTaxonId: Long = 1
+
+  fun insertWcvpTaxon(
+      taxonId: Any = nextWcvpTaxonId++,
+      acceptedNameUsageId: Any? = null,
+      family: String = "family",
+      genus: String = "genus",
+      infraspecificEpithet: String? = "infra",
+      originalNameUsageId: Any? = null,
+      parentNameUsageId: Any? = null,
+      scientificName: String = "Scientific name",
+      specificEpithet: String? = "specific",
+      taxonRank: String = "Species",
+      taxonomicStatus: String = "Accepted",
+  ): WcvpTaxonId {
+    val taxonIdWrapper = WcvpTaxonId("$taxonId")
+
+    WcvpTaxaRecord(
+            acceptedNameUsageId = acceptedNameUsageId?.let { WcvpTaxonId("$it") },
+            family = family,
+            genus = genus,
+            infraspecificEpithet = infraspecificEpithet,
+            originalNameUsageId = originalNameUsageId?.let { WcvpTaxonId("$it") },
+            parentNameUsageId = parentNameUsageId?.let { WcvpTaxonId("$it") },
+            scientificName = scientificName,
+            specificEpithet = specificEpithet,
+            taxonId = taxonIdWrapper,
+            taxonomicStatus = taxonomicStatus,
+            taxonRank = taxonRank,
+        )
+        .attach(dslContext)
+        .insert()
+
+    return taxonIdWrapper.also { inserted.wcvpTaxonIds.add(it) }
+  }
+
+  fun insertWcvpDistribution(
+      botanicalCountryId: BotanicalCountryId? = null,
+      establishmentMeans: String? = null,
+      level3Code: String = "COD",
+      occurrenceStatus: String? = null,
+      taxonId: WcvpTaxonId = inserted.wcvpTaxonId,
+      threatStatus: String? = null,
+  ) {
+    WcvpDistributionsRecord(
+            botanicalCountryId = botanicalCountryId,
+            establishmentMeans = establishmentMeans,
+            level3Code = level3Code,
+            occurrenceStatus = occurrenceStatus,
+            taxonId = taxonId,
+            threatStatus = threatStatus,
+        )
+        .attach(dslContext)
+        .insert()
   }
 
   protected fun setupStableIdVariables(): Map<StableId, VariableId> {

--- a/src/test/kotlin/com/terraformation/backend/db/InsertedDatabaseIds.kt
+++ b/src/test/kotlin/com/terraformation/backend/db/InsertedDatabaseIds.kt
@@ -32,6 +32,7 @@ import com.terraformation.backend.db.default_schema.SubLocationId
 import com.terraformation.backend.db.default_schema.TimeseriesId
 import com.terraformation.backend.db.default_schema.UploadId
 import com.terraformation.backend.db.default_schema.UserId
+import com.terraformation.backend.db.default_schema.WcvpTaxonId
 import com.terraformation.backend.db.docprod.DocumentId
 import com.terraformation.backend.db.docprod.DocumentTemplateId
 import com.terraformation.backend.db.docprod.VariableId
@@ -134,6 +135,7 @@ class InsertedDatabaseIds {
   val variableWorkflowHistoryIds = mutableListOf<VariableWorkflowHistoryId>()
   val viabilityTestIds = mutableListOf<ViabilityTestId>()
   val viabilityTestResultIds = mutableListOf<ViabilityTestResultId>()
+  val wcvpTaxonIds = mutableListOf<WcvpTaxonId>()
   val withdrawalIds = mutableListOf<com.terraformation.backend.db.nursery.WithdrawalId>()
 
   val accessionId
@@ -312,6 +314,9 @@ class InsertedDatabaseIds {
 
   val viabilityTestResultId
     get() = viabilityTestResultIds.last()
+
+  val wcvpTaxonId
+    get() = wcvpTaxonIds.last()
 
   val withdrawalId
     get() = withdrawalIds.last()

--- a/src/test/kotlin/com/terraformation/backend/gis/RegionMetadataServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/gis/RegionMetadataServiceTest.kt
@@ -3,10 +3,12 @@ package com.terraformation.backend.gis
 import com.terraformation.backend.assertIsEventListener
 import com.terraformation.backend.db.DatabaseTest
 import com.terraformation.backend.db.default_schema.tables.records.EcoregionBotanicalCountriesRecord
+import com.terraformation.backend.db.default_schema.tables.records.WcvpDistributionsRecord
 import com.terraformation.backend.db.default_schema.tables.references.ECOREGION_BOTANICAL_COUNTRIES
 import com.terraformation.backend.gis.event.BotanicalCountriesImportedEvent
 import com.terraformation.backend.gis.event.EcoregionsImportedEvent
 import com.terraformation.backend.rectangle
+import com.terraformation.backend.species.event.WcvpImportedEvent
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 
@@ -17,6 +19,7 @@ class RegionMetadataServiceTest : DatabaseTest() {
   fun `listens for events`() {
     assertIsEventListener<BotanicalCountriesImportedEvent>(service)
     assertIsEventListener<EcoregionsImportedEvent>(service)
+    assertIsEventListener<WcvpImportedEvent>(service)
   }
 
   @Nested
@@ -60,6 +63,50 @@ class RegionMetadataServiceTest : DatabaseTest() {
               EcoregionBotanicalCountriesRecord(ecoregionId1, countryId1),
               EcoregionBotanicalCountriesRecord(ecoregionId2, countryId1),
               EcoregionBotanicalCountriesRecord(ecoregionId2, countryId2),
+          )
+      )
+    }
+  }
+
+  @Nested
+  inner class UpdateWcvpBotanicalCountryMapping {
+    @Test
+    fun `updates botanical country IDs based on level 3 codes`() {
+      val countryId1 = insertBotanicalCountry(level3Code = "AAA")
+      val countryId2 = insertBotanicalCountry(level3Code = "BBB")
+      insertBotanicalCountry(level3Code = "CCC")
+
+      val taxonId1 = insertWcvpTaxon()
+      insertWcvpDistribution(level3Code = "AAA")
+      val taxonId2 = insertWcvpTaxon()
+      insertWcvpDistribution(level3Code = "AAA")
+      insertWcvpDistribution(level3Code = "BBB")
+      val taxonId3 = insertWcvpTaxon()
+      insertWcvpDistribution(level3Code = "XXX")
+
+      service.on(WcvpImportedEvent())
+
+      assertTableEquals(
+          listOf(
+              WcvpDistributionsRecord(
+                  taxonId = taxonId1,
+                  level3Code = "AAA",
+                  botanicalCountryId = countryId1,
+              ),
+              WcvpDistributionsRecord(
+                  taxonId = taxonId2,
+                  level3Code = "AAA",
+                  botanicalCountryId = countryId1,
+              ),
+              WcvpDistributionsRecord(
+                  taxonId = taxonId2,
+                  level3Code = "BBB",
+                  botanicalCountryId = countryId2,
+              ),
+              WcvpDistributionsRecord(
+                  taxonId = taxonId3,
+                  level3Code = "XXX",
+              ),
           )
       )
     }


### PR DESCRIPTION
To make it more efficient to match ecoregions to WCVP distribution data, look up
the botanical country IDs for the distributions after the WCVP species list is
imported.