### PR TITLE
SW-8549 Change allocated quantity check to >= 0

### DIFF
--- a/src/main/resources/db/migration/0500/V511__SeasonAllocatedQuantityCheck.sql
+++ b/src/main/resources/db/migration/0500/V511__SeasonAllocatedQuantityCheck.sql
@@ -1,0 +1,4 @@
+ALTER TABLE tracking.planting_season_allocated_species
+    DROP CONSTRAINT planting_season_allocated_species_quantity_check;
+ALTER TABLE tracking.planting_season_allocated_species
+    ADD CONSTRAINT planting_season_allocated_species_quantity_check CHECK (quantity >= 0);


### PR DESCRIPTION
The other quantity checks are already `>= 0` but the allocated check was `> 0` causing 500 errors when setting 0 in the FE. Change this to `>= 0`.