### PR TITLE
SW-8420 Add all notification types and categories

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/plantingmanagement/Models.kt
+++ b/src/main/kotlin/com/terraformation/backend/plantingmanagement/Models.kt
@@ -67,17 +67,20 @@ data class ExistingPlantingSeasonScheduledDateModel(
 )
 
 enum class PlantingSeasonNotificationType {
+  AllocationQuantitiesUpdated,
   PlantingSeasonClosed,
   PlantingSeasonPastEndDate,
+  SeasonWithdrawalRecorded,
+  ScheduledPlantingDateRequested,
   SpeciesTargetsAdded,
   SpeciesTargetsUpdated,
-  AllocationQuantitiesUpdated,
-  SeasonWithdrawalRecorded,
 }
 
 enum class PlantingSeasonNotificationCategory {
   InventoryPlanning,
-  PlantingSeasonPlanning;
+  PlantingSeasonPlanning,
+  Inventory,
+  Withdrawals;
 
   val notificationTypes: Set<PlantingSeasonNotificationType>
     get() =
@@ -85,7 +88,6 @@ enum class PlantingSeasonNotificationCategory {
           InventoryPlanning ->
               setOf(
                   PlantingSeasonNotificationType.PlantingSeasonClosed,
-                  PlantingSeasonNotificationType.PlantingSeasonPastEndDate,
                   PlantingSeasonNotificationType.SpeciesTargetsAdded,
                   PlantingSeasonNotificationType.SpeciesTargetsUpdated,
               )
@@ -93,6 +95,19 @@ enum class PlantingSeasonNotificationCategory {
               setOf(
                   PlantingSeasonNotificationType.AllocationQuantitiesUpdated,
                   PlantingSeasonNotificationType.SeasonWithdrawalRecorded,
+                  PlantingSeasonNotificationType.PlantingSeasonPastEndDate,
+              )
+          Inventory ->
+              setOf(
+                  PlantingSeasonNotificationType.SpeciesTargetsAdded,
+                  PlantingSeasonNotificationType.SpeciesTargetsUpdated,
+                  PlantingSeasonNotificationType.PlantingSeasonClosed,
+                  PlantingSeasonNotificationType.ScheduledPlantingDateRequested,
+              )
+          Withdrawals ->
+              setOf(
+                  PlantingSeasonNotificationType.ScheduledPlantingDateRequested,
+                  PlantingSeasonNotificationType.PlantingSeasonClosed,
               )
         }
 }

--- a/src/main/kotlin/com/terraformation/backend/plantingmanagement/db/PlantingSeasonNotificationsService.kt
+++ b/src/main/kotlin/com/terraformation/backend/plantingmanagement/db/PlantingSeasonNotificationsService.kt
@@ -14,6 +14,7 @@ import com.terraformation.backend.eventlog.model.EventLogEntry
 import com.terraformation.backend.plantingmanagement.PlantingSeasonNotificationGroupModel
 import com.terraformation.backend.plantingmanagement.PlantingSeasonNotificationModel
 import com.terraformation.backend.plantingmanagement.PlantingSeasonNotificationType
+import com.terraformation.backend.plantingmanagement.event.PlantingDateRequestPersistentEvent
 import com.terraformation.backend.plantingmanagement.event.PlantingSeasonAllocatedSpeciesPersistentEvent
 import com.terraformation.backend.plantingmanagement.event.PlantingSeasonPersistentEvent
 import com.terraformation.backend.plantingmanagement.event.PlantingSeasonRelatedPersistentEvent
@@ -35,18 +36,20 @@ class PlantingSeasonNotificationsService(
   private val eventClassesByNotificationType:
       Map<PlantingSeasonNotificationType, KClass<out PlantingSeasonRelatedPersistentEvent>> =
       mapOf(
+          PlantingSeasonNotificationType.AllocationQuantitiesUpdated to
+              PlantingSeasonAllocatedSpeciesPersistentEvent::class,
           PlantingSeasonNotificationType.PlantingSeasonClosed to
               PlantingSeasonPersistentEvent::class,
           PlantingSeasonNotificationType.PlantingSeasonPastEndDate to
               PlantingSeasonPersistentEvent::class,
+          PlantingSeasonNotificationType.ScheduledPlantingDateRequested to
+              PlantingDateRequestPersistentEvent::class,
+          PlantingSeasonNotificationType.SeasonWithdrawalRecorded to
+              PlantingSeasonWithdrawalCreatedEvent::class,
           PlantingSeasonNotificationType.SpeciesTargetsAdded to
               PlantingSeasonSpeciesTargetPersistentEvent::class,
           PlantingSeasonNotificationType.SpeciesTargetsUpdated to
               PlantingSeasonSpeciesTargetPersistentEvent::class,
-          PlantingSeasonNotificationType.AllocationQuantitiesUpdated to
-              PlantingSeasonAllocatedSpeciesPersistentEvent::class,
-          PlantingSeasonNotificationType.SeasonWithdrawalRecorded to
-              PlantingSeasonWithdrawalCreatedEvent::class,
       )
 
   /**
@@ -187,6 +190,10 @@ class PlantingSeasonNotificationsService(
   private val PlantingSeasonRelatedPersistentEvent.notificationType: PlantingSeasonNotificationType?
     get() =
         when (this) {
+          is PlantingSeasonAllocatedSpeciesPersistentEvent ->
+              PlantingSeasonNotificationType.AllocationQuantitiesUpdated
+          is PlantingDateRequestPersistentEvent ->
+              PlantingSeasonNotificationType.ScheduledPlantingDateRequested
           is PlantingSeasonSpeciesTargetCreatedEvent ->
               PlantingSeasonNotificationType.SpeciesTargetsAdded
           is PlantingSeasonSpeciesTargetUpdatedEvent ->
@@ -199,8 +206,6 @@ class PlantingSeasonNotificationsService(
               } else {
                 null
               }
-          is PlantingSeasonAllocatedSpeciesPersistentEvent ->
-              PlantingSeasonNotificationType.AllocationQuantitiesUpdated
           is PlantingSeasonWithdrawalCreatedEvent ->
               PlantingSeasonNotificationType.SeasonWithdrawalRecorded
           else -> null

--- a/src/main/kotlin/com/terraformation/backend/plantingmanagement/event/PlantingDateRequestPersistentEvent.kt
+++ b/src/main/kotlin/com/terraformation/backend/plantingmanagement/event/PlantingDateRequestPersistentEvent.kt
@@ -7,15 +7,14 @@ import com.terraformation.backend.db.tracking.PlantingSiteId
 import com.terraformation.backend.db.tracking.ScheduledPlantingDateId
 import com.terraformation.backend.eventlog.EntityCreatedPersistentEvent
 import com.terraformation.backend.eventlog.FieldsUpdatedPersistentEvent
-import com.terraformation.backend.eventlog.PersistentEvent
 import com.terraformation.backend.i18n.Messages
 import com.terraformation.backend.i18n.currentLocale
 import java.time.LocalDate
 
-sealed interface PlantingDateRequestPersistentEvent : PersistentEvent {
-  val organizationId: OrganizationId
-  val plantingSeasonId: PlantingSeasonId
-  val plantingSiteId: PlantingSiteId
+sealed interface PlantingDateRequestPersistentEvent : PlantingSeasonRelatedPersistentEvent {
+  override val organizationId: OrganizationId
+  override val plantingSeasonId: PlantingSeasonId
+  override val plantingSiteId: PlantingSiteId
   val scheduledPlantingDateId: ScheduledPlantingDateId
 }
 

--- a/src/test/kotlin/com/terraformation/backend/plantingmanagement/db/PlantingSeasonNotificationsServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/plantingmanagement/db/PlantingSeasonNotificationsServiceTest.kt
@@ -12,9 +12,11 @@ import com.terraformation.backend.db.default_schema.OrganizationId
 import com.terraformation.backend.db.default_schema.Role
 import com.terraformation.backend.db.default_schema.SpeciesId
 import com.terraformation.backend.db.nursery.WithdrawalId
+import com.terraformation.backend.db.tracking.PlantingDateRequestStatus
 import com.terraformation.backend.db.tracking.PlantingSeasonId
 import com.terraformation.backend.db.tracking.PlantingSeasonStatus
 import com.terraformation.backend.db.tracking.PlantingSiteId
+import com.terraformation.backend.db.tracking.ScheduledPlantingDateId
 import com.terraformation.backend.db.tracking.StratumId
 import com.terraformation.backend.db.tracking.SubstratumHistoryId
 import com.terraformation.backend.db.tracking.SubstratumId
@@ -24,6 +26,7 @@ import com.terraformation.backend.plantingmanagement.PlantingSeasonNotificationC
 import com.terraformation.backend.plantingmanagement.PlantingSeasonNotificationGroupModel
 import com.terraformation.backend.plantingmanagement.PlantingSeasonNotificationModel
 import com.terraformation.backend.plantingmanagement.PlantingSeasonNotificationType
+import com.terraformation.backend.plantingmanagement.event.PlantingDateRequestCreatedEvent
 import com.terraformation.backend.plantingmanagement.event.PlantingSeasonAllocatedSpeciesCreatedEvent
 import com.terraformation.backend.plantingmanagement.event.PlantingSeasonAllocatedSpeciesPersistentEvent
 import com.terraformation.backend.plantingmanagement.event.PlantingSeasonAllocatedSpeciesUpdatedEvent
@@ -122,6 +125,9 @@ internal class PlantingSeasonNotificationsServiceTest : DatabaseTest(), RunsAsDa
 
   private val seasonWithdrawalRecorded =
       PlantingSeasonNotificationModel(PlantingSeasonNotificationType.SeasonWithdrawalRecorded)
+
+  private val scheduledPlantingDateRequested =
+      PlantingSeasonNotificationModel(PlantingSeasonNotificationType.ScheduledPlantingDateRequested)
 
   @Nested
   inner class GetNotificationsBySeason {
@@ -244,21 +250,94 @@ internal class PlantingSeasonNotificationsServiceTest : DatabaseTest(), RunsAsDa
     }
 
     @Test
-    fun `returns all notification types for PlantingSeasonPlanning`() {
-      insertSpeciesAllocatedCreatedEvent(speciesId = speciesId1)
+    fun `returns all notification types for InventoryPlanning`() {
+      insertSpeciesTargetCreatedEvent(speciesId = speciesId1)
       clock.instant = clock.instant.plusSeconds(1)
-      val latest = insertWithdrawalCreatedEvent(withdrawalId = withdrawalId)
+      insertSpeciesTargetUpdatedEvent(speciesId = speciesId1)
+      clock.instant = clock.instant.plusSeconds(1)
+      val latest = insertClosedEvent()
 
       assertEquals(
           listOf(
               model(
                   latest.id,
-                  listOf(allocationQuantitiesUpdated, seasonWithdrawalRecorded),
+                  listOf(targetAdded(speciesName1), targetUpdated(speciesName1), closed),
+              )
+          ),
+          service.getNotifications(
+              plantingSeasonId,
+              PlantingSeasonNotificationCategory.InventoryPlanning.notificationTypes,
+          ),
+      )
+    }
+
+    @Test
+    fun `returns all notification types for PlantingSeasonPlanning`() {
+      insertSpeciesAllocatedCreatedEvent(speciesId = speciesId1)
+      clock.instant = clock.instant.plusSeconds(1)
+      insertWithdrawalCreatedEvent(withdrawalId = withdrawalId)
+      clock.instant = clock.instant.plusSeconds(1)
+      val latest = insertPastEndDateEvent()
+
+      assertEquals(
+          listOf(
+              model(
+                  latest.id,
+                  listOf(allocationQuantitiesUpdated, seasonWithdrawalRecorded, pastEndDate),
               )
           ),
           service.getNotifications(
               plantingSeasonId,
               PlantingSeasonNotificationCategory.PlantingSeasonPlanning.notificationTypes,
+          ),
+      )
+    }
+
+    @Test
+    fun `returns all notification types for Inventory`() {
+      insertSpeciesTargetCreatedEvent(speciesId = speciesId1)
+      clock.instant = clock.instant.plusSeconds(1)
+      insertSpeciesTargetUpdatedEvent(speciesId = speciesId1)
+      clock.instant = clock.instant.plusSeconds(1)
+      insertPlantingDateRequestedEvent()
+      clock.instant = clock.instant.plusSeconds(1)
+      val latest = insertClosedEvent()
+
+      assertEquals(
+          listOf(
+              model(
+                  latest.id,
+                  listOf(
+                      targetAdded(speciesName1),
+                      targetUpdated(speciesName1),
+                      scheduledPlantingDateRequested,
+                      closed,
+                  ),
+              )
+          ),
+          service.getNotifications(
+              plantingSeasonId,
+              PlantingSeasonNotificationCategory.Inventory.notificationTypes,
+          ),
+      )
+    }
+
+    @Test
+    fun `returns all notification types for Withdrawals`() {
+      insertPlantingDateRequestedEvent()
+      clock.instant = clock.instant.plusSeconds(1)
+      val latest = insertClosedEvent()
+
+      assertEquals(
+          listOf(
+              model(
+                  latest.id,
+                  listOf(scheduledPlantingDateRequested, closed),
+              )
+          ),
+          service.getNotifications(
+              plantingSeasonId,
+              PlantingSeasonNotificationCategory.Withdrawals.notificationTypes,
           ),
       )
     }
@@ -455,33 +534,6 @@ internal class PlantingSeasonNotificationsServiceTest : DatabaseTest(), RunsAsDa
           ),
       )
     }
-
-    @Test
-    fun `maps status change notifications correctly`() {
-      insertUpdatedEvent(
-          changedFrom = PlantingSeasonUpdatedEventValues(name = "A"),
-          changedTo = PlantingSeasonUpdatedEventValues(name = "B"),
-      )
-      clock.instant = clock.instant.plusSeconds(1)
-      insertUpdatedEvent(
-          changedFrom = PlantingSeasonUpdatedEventValues(status = PlantingSeasonStatus.Active),
-          changedTo = PlantingSeasonUpdatedEventValues(status = PlantingSeasonStatus.PastEndDate),
-      )
-      val closedEvent =
-          insertUpdatedEvent(
-              changedFrom =
-                  PlantingSeasonUpdatedEventValues(status = PlantingSeasonStatus.PastEndDate),
-              changedTo = PlantingSeasonUpdatedEventValues(status = PlantingSeasonStatus.Closed),
-          )
-
-      assertEquals(
-          listOf(model(closedEvent.id, listOf(pastEndDate, closed))),
-          service.getNotifications(
-              plantingSeasonId,
-              PlantingSeasonNotificationCategory.InventoryPlanning.notificationTypes,
-          ),
-      )
-    }
   }
 
   private fun insertUpdatedEvent(
@@ -498,6 +550,39 @@ internal class PlantingSeasonNotificationsServiceTest : DatabaseTest(), RunsAsDa
             organizationId = organizationId,
             plantingSeasonId = plantingSeasonId,
             plantingSiteId = plantingSiteId,
+        )
+
+    return EventLogEntry(user.userId, clock.instant, event, eventLogStore.insertEvent(event))
+  }
+
+  private fun insertClosedEvent() =
+      insertUpdatedEvent(
+          changedFrom = PlantingSeasonUpdatedEventValues(status = PlantingSeasonStatus.Active),
+          changedTo = PlantingSeasonUpdatedEventValues(status = PlantingSeasonStatus.Closed),
+      )
+
+  private fun insertPastEndDateEvent() =
+      insertUpdatedEvent(
+          changedFrom = PlantingSeasonUpdatedEventValues(status = PlantingSeasonStatus.Active),
+          changedTo = PlantingSeasonUpdatedEventValues(status = PlantingSeasonStatus.PastEndDate),
+      )
+
+  private fun insertPlantingDateRequestedEvent(
+      organizationId: OrganizationId = this.organizationId,
+      plantingSeasonId: PlantingSeasonId = this.plantingSeasonId,
+      plantingSiteId: PlantingSiteId = this.plantingSiteId,
+      scheduledPlantingDateId: ScheduledPlantingDateId =
+          insertPlantingSeasonScheduledDate(plantingSeasonId = plantingSeasonId),
+  ): EventLogEntry<PlantingSeasonRelatedPersistentEvent> {
+    val event =
+        PlantingDateRequestCreatedEvent(
+            date = LocalDate.EPOCH,
+            notes = null,
+            organizationId = organizationId,
+            plantingSeasonId = plantingSeasonId,
+            plantingSiteId = plantingSiteId,
+            scheduledPlantingDateId = scheduledPlantingDateId,
+            status = PlantingDateRequestStatus.Pending,
         )
 
     return EventLogEntry(user.userId, clock.instant, event, eventLogStore.insertEvent(event))


### PR DESCRIPTION
Now that the infrastructure is in place, add the rest of the notification types and categories for planting season notifications. This also requires making `PlantingDateRequestPersistentEvent` a `PlantingSeasonRelatedPersistentEvent` to match the rest.