### PR TITLE
SW-8420 Add endpoint to dismiss planting season notifications per page

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/plantingmanagement/api/PlantingSeasonNotificationsController.kt
+++ b/src/main/kotlin/com/terraformation/backend/plantingmanagement/api/PlantingSeasonNotificationsController.kt
@@ -65,7 +65,7 @@ class PlantingSeasonNotificationsController(
               "specified event log id. The event log id should be the lastEventLogId returned by " +
               "the notifications listing endpoint.",
   )
-  @PostMapping("/notifications")
+  @PostMapping("/notifications/dismiss")
   fun dismissPlantingSeasonNotifications(
       @RequestBody payload: DismissPlantingSeasonNotificationsRequestPayload,
   ): SimpleSuccessResponsePayload {

--- a/src/main/kotlin/com/terraformation/backend/plantingmanagement/api/PlantingSeasonNotificationsController.kt
+++ b/src/main/kotlin/com/terraformation/backend/plantingmanagement/api/PlantingSeasonNotificationsController.kt
@@ -1,6 +1,7 @@
 package com.terraformation.backend.plantingmanagement.api
 
 import com.terraformation.backend.api.ApiResponse200
+import com.terraformation.backend.api.SimpleSuccessResponsePayload
 import com.terraformation.backend.api.SuccessResponsePayload
 import com.terraformation.backend.api.TrackingEndpoint
 import com.terraformation.backend.db.default_schema.EventLogId
@@ -13,7 +14,9 @@ import com.terraformation.backend.plantingmanagement.PlantingSeasonNotificationT
 import com.terraformation.backend.plantingmanagement.db.PlantingSeasonNotificationsService
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.media.Schema
+import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
@@ -53,7 +56,39 @@ class PlantingSeasonNotificationsController(
         notifications.map { PlantingSeasonNotificationGroupPayload(it) }
     )
   }
+
+  @ApiResponse200
+  @Operation(
+      summary = "Dismisses planting season notifications for the specified page.",
+      description =
+          "Dismisses all notifications for the planting season and page up to and including the " +
+              "specified event log id. The event log id should be the lastEventLogId returned by " +
+              "the notifications listing endpoint.",
+  )
+  @DeleteMapping("/notifications")
+  fun dismissPlantingSeasonNotifications(
+      @RequestBody payload: DismissPlantingSeasonNotificationsRequestPayload,
+  ): SimpleSuccessResponsePayload {
+    plantingSeasonNotificationsService.dismissNotifications(
+        payload.plantingSeasonId,
+        payload.notificationPage,
+        payload.lastEventLogId,
+    )
+
+    return SimpleSuccessResponsePayload()
+  }
 }
+
+data class DismissPlantingSeasonNotificationsRequestPayload(
+    val plantingSeasonId: PlantingSeasonId,
+    val notificationPage: PlantingSeasonNotificationPage,
+    @Schema(
+        description =
+            "The last event log id returned for the list of notifications within the specified " +
+                "page. All notifications up to and including this event will be dismissed."
+    )
+    val lastEventLogId: EventLogId,
+)
 
 data class GetPlantingSeasonNotificationsResponsePayload(
     val notifications: List<PlantingSeasonNotificationGroupPayload>

--- a/src/main/kotlin/com/terraformation/backend/plantingmanagement/api/PlantingSeasonNotificationsController.kt
+++ b/src/main/kotlin/com/terraformation/backend/plantingmanagement/api/PlantingSeasonNotificationsController.kt
@@ -14,8 +14,8 @@ import com.terraformation.backend.plantingmanagement.PlantingSeasonNotificationT
 import com.terraformation.backend.plantingmanagement.db.PlantingSeasonNotificationsService
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.media.Schema
-import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
@@ -65,7 +65,7 @@ class PlantingSeasonNotificationsController(
               "specified event log id. The event log id should be the lastEventLogId returned by " +
               "the notifications listing endpoint.",
   )
-  @DeleteMapping("/notifications")
+  @PostMapping("/notifications")
   fun dismissPlantingSeasonNotifications(
       @RequestBody payload: DismissPlantingSeasonNotificationsRequestPayload,
   ): SimpleSuccessResponsePayload {

--- a/src/main/kotlin/com/terraformation/backend/plantingmanagement/db/PlantingSeasonNotificationsService.kt
+++ b/src/main/kotlin/com/terraformation/backend/plantingmanagement/db/PlantingSeasonNotificationsService.kt
@@ -82,6 +82,32 @@ class PlantingSeasonNotificationsService(
   ): List<PlantingSeasonNotificationGroupModel> =
       getNotifications(PLANTING_SEASONS.ID.eq(plantingSeasonId), page)
 
+  /**
+   * Dismisses the notifications for [page] of [plantingSeasonId] up to and including [eventLogId].
+   *
+   * [eventLogId] is the last event log id the client received from [getNotifications]; subsequent
+   * calls to [getNotifications] will only return notifications for events logged after it.
+   */
+  fun dismissNotifications(
+      plantingSeasonId: PlantingSeasonId,
+      page: PlantingSeasonNotificationPage,
+      eventLogId: EventLogId,
+  ) {
+    requirePermissions { updatePlantingSeason(plantingSeasonId) }
+
+    with(PLANTING_SEASON_NOTIFICATIONS) {
+      dslContext
+          .insertInto(PLANTING_SEASON_NOTIFICATIONS)
+          .set(PLANTING_SEASON_ID, plantingSeasonId)
+          .set(PAGE_ID, page)
+          .set(LAST_DISMISSED_EVENT_LOG_ID, eventLogId)
+          .onConflict(PLANTING_SEASON_ID, PAGE_ID)
+          .doUpdate()
+          .set(LAST_DISMISSED_EVENT_LOG_ID, eventLogId)
+          .execute()
+    }
+  }
+
   private fun getNotifications(
       condition: Condition,
       page: PlantingSeasonNotificationPage,

--- a/src/test/kotlin/com/terraformation/backend/plantingmanagement/db/PlantingSeasonNotificationsServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/plantingmanagement/db/PlantingSeasonNotificationsServiceTest.kt
@@ -45,6 +45,7 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
+import org.springframework.security.access.AccessDeniedException
 
 internal class PlantingSeasonNotificationsServiceTest : DatabaseTest(), RunsAsDatabaseUser {
   override lateinit var user: TerrawareUser
@@ -606,6 +607,140 @@ internal class PlantingSeasonNotificationsServiceTest : DatabaseTest(), RunsAsDa
               PlantingSeasonNotificationPage.InventoryPlanning,
           ),
       )
+    }
+  }
+
+  @Nested
+  inner class DismissNotifications {
+    @Test
+    fun `dismisses notifications up to and including the given event`() {
+      insertSpeciesTargetCreatedEvent(speciesId = speciesId1)
+      clock.instant = clock.instant.plusSeconds(1)
+      val latest = insertSpeciesTargetUpdatedEvent(speciesId = speciesId1)
+
+      service.dismissNotifications(
+          plantingSeasonId,
+          PlantingSeasonNotificationPage.InventoryPlanning,
+          latest.id,
+      )
+
+      assertEquals(
+          emptyList<PlantingSeasonNotificationGroupModel>(),
+          service.getNotifications(
+              plantingSeasonId,
+              PlantingSeasonNotificationPage.InventoryPlanning,
+          ),
+      )
+    }
+
+    @Test
+    fun `keeps notifications for events logged after the dismissed event`() {
+      val dismissed = insertSpeciesTargetCreatedEvent(speciesId = speciesId1)
+      clock.instant = clock.instant.plusSeconds(1)
+      val newer = insertSpeciesTargetUpdatedEvent(speciesId = speciesId1)
+
+      service.dismissNotifications(
+          plantingSeasonId,
+          PlantingSeasonNotificationPage.InventoryPlanning,
+          dismissed.id,
+      )
+
+      assertEquals(
+          listOf(model(newer.id, listOf(targetUpdated(speciesName1)))),
+          service.getNotifications(
+              plantingSeasonId,
+              PlantingSeasonNotificationPage.InventoryPlanning,
+          ),
+      )
+    }
+
+    @Test
+    fun `only dismisses notifications for the specified page and planting season`() {
+      val otherSeasonId = insertPlantingSeason(name = "Other Season")
+      val event = insertSpeciesTargetCreatedEvent(speciesId = speciesId1)
+      val otherSeasonEvent =
+          insertSpeciesTargetCreatedEvent(speciesId = speciesId1, plantingSeasonId = otherSeasonId)
+
+      service.dismissNotifications(
+          plantingSeasonId,
+          PlantingSeasonNotificationPage.InventoryPlanning,
+          event.id,
+      )
+
+      assertEquals(
+          emptyList<PlantingSeasonNotificationGroupModel>(),
+          service.getNotifications(
+              plantingSeasonId,
+              PlantingSeasonNotificationPage.InventoryPlanning,
+          ),
+          "InventoryPlanning page should have no undismissed notifications",
+      )
+
+      assertEquals(
+          listOf(
+              model(
+                  event.id,
+                  listOf(targetAdded(speciesName1)),
+                  notificationPage = PlantingSeasonNotificationPage.Inventory,
+              )
+          ),
+          service.getNotifications(plantingSeasonId, PlantingSeasonNotificationPage.Inventory),
+          "Inventory page should still show the undismissed notification",
+      )
+
+      assertEquals(
+          listOf(
+              model(
+                  otherSeasonEvent.id,
+                  listOf(targetAdded(speciesName1)),
+                  plantingSeasonId = otherSeasonId,
+                  plantingSeasonName = "Other Season",
+              )
+          ),
+          service.getNotifications(otherSeasonId, PlantingSeasonNotificationPage.InventoryPlanning),
+          "Other planting season should still show the undismissed notification",
+      )
+    }
+
+    @Test
+    fun `advances an existing dismissal watermark`() {
+      val first = insertSpeciesTargetCreatedEvent(speciesId = speciesId1)
+      clock.instant = clock.instant.plusSeconds(1)
+      val second = insertSpeciesTargetUpdatedEvent(speciesId = speciesId1)
+
+      service.dismissNotifications(
+          plantingSeasonId,
+          PlantingSeasonNotificationPage.InventoryPlanning,
+          first.id,
+      )
+      service.dismissNotifications(
+          plantingSeasonId,
+          PlantingSeasonNotificationPage.InventoryPlanning,
+          second.id,
+      )
+
+      assertEquals(
+          emptyList<PlantingSeasonNotificationGroupModel>(),
+          service.getNotifications(
+              plantingSeasonId,
+              PlantingSeasonNotificationPage.InventoryPlanning,
+          ),
+      )
+    }
+
+    @Test
+    fun `throws exception when user has no permission to update the planting season`() {
+      val event = insertSpeciesTargetCreatedEvent(speciesId = speciesId1)
+      deleteOrganizationUser()
+      insertOrganizationUser(role = Role.Contributor)
+
+      assertThrows<AccessDeniedException> {
+        service.dismissNotifications(
+            plantingSeasonId,
+            PlantingSeasonNotificationPage.InventoryPlanning,
+            event.id,
+        )
+      }
     }
   }
 


### PR DESCRIPTION
Now that all notification pages are setup, add an endpoint to dismiss planting season notifications per page (and per season) using the lastEventLogId returned in the GET endpoint.