### PR TITLE
Increase default heap size limit to 5GB

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -9,6 +9,7 @@ WORKDIR /app
 # application code. This way, pulling a new version of the application when the
 # dependencies haven't changed will be able to reuse the existing image layer from
 # the previous version.
+COPY --chown=$USER_ID --chmod=755 start.sh ./
 COPY --chown=$USER_ID dependencies/ ./
 COPY --chown=$USER_ID spring-boot-loader/ ./
 COPY --chown=$USER_ID snapshot-dependencies/ ./
@@ -17,10 +18,4 @@ COPY --chown=$USER_ID application/ ./
 EXPOSE 8080
 
 USER $USER_ID
-CMD [ \
-    "java", \
-        "-Djava.locale.providers=SPI,CLDR", \
-        "--sun-misc-unsafe-memory-access=allow", \
-        "--enable-native-access=ALL-UNNAMED", \
-        "org.springframework.boot.loader.launch.JarLauncher" \
-]
+CMD [ "/bin/bash", "start.sh" ]

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -2,7 +2,8 @@ IMAGE_NAME=terraware-server
 
 BUILD_DIR=../build/docker
 FILES=\
-	$(BUILD_DIR)/Dockerfile
+	$(BUILD_DIR)/Dockerfile \
+	$(BUILD_DIR)/start.sh
 
 DEFAULT: image
 

--- a/docker/start.sh
+++ b/docker/start.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+# Default to a 5GB maximum heap size.
+JAVA_OPTS=${JAVA_OPTS:--Xmx5g}
+
+exec java \
+    -Djava.locale.providers=SPI,CLDR \
+    --sun-misc-unsafe-memory-access=allow \
+    --enable-native-access=ALL-UNNAMED \
+    ${JAVA_OPTS} \
+    "org.springframework.boot.loader.launch.JarLauncher"


### PR DESCRIPTION
Previously we weren't specifying a default heap size when the server was launched
in a container using the Docker image, so the JVM used its default of 25% of the
container's memory limit, a bit under 2GB on our 8GB staging servers. Change the
startup process to pass in a heap size argument (5GB by default) which can be
overridden using an environment variable if needed.