### PR TITLE
SW-8411 Don't require water depth for mangrove plots

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/tracking/api/BiomassPayloads.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/api/BiomassPayloads.kt
@@ -306,7 +306,11 @@ data class ExistingBiomassMeasurementPayload(
     val tideTime: Instant?,
     val treeSpeciesCount: Int,
     val trees: List<ExistingTreePayload>,
-    @Schema(description = "Measured in centimeters.") //
+    @Schema(
+        description =
+            "Measured in centimeters. Only valid for Mangrove forests. A null value indicates " +
+                "that there was no water."
+    )
     val waterDepth: Int?,
 ) {
   companion object {
@@ -381,7 +385,11 @@ data class NewBiomassMeasurementPayload(
                 "recorded trees will be saved as an additional herbaceous species."
     )
     val species: List<BiomassSpeciesPayload>,
-    @Schema(description = "Measured in centimeters. Required for Mangrove forest.")
+    @Schema(
+        description =
+            "Measured in centimeters. Only valid for Mangrove forests. A null value indicates " +
+                "that there was no water."
+    )
     val waterDepth: Int?,
 ) {
   fun toModel(): NewBiomassDetailsModel {

--- a/src/main/kotlin/com/terraformation/backend/tracking/model/BiomassDetailsModel.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/model/BiomassDetailsModel.kt
@@ -179,9 +179,6 @@ data class BiomassDetailsModel<
       if (tideTime == null) {
         throw IllegalStateException("tideTime required for Mangrove")
       }
-      if (waterDepthCm == null) {
-        throw IllegalStateException("waterDepth required for Mangrove")
-      }
     }
 
     if (description != null && description.length > 50) {

--- a/src/main/resources/db/migration/0500/V514__BiomassWaterDepth.sql
+++ b/src/main/resources/db/migration/0500/V514__BiomassWaterDepth.sql
@@ -1,0 +1,21 @@
+-- Previous version is in V333__ObservationPlotBiomassDetails.sql
+ALTER TABLE tracking.observation_biomass_details
+    DROP CONSTRAINT mangrove_required_values;
+
+ALTER TABLE tracking.observation_biomass_details
+    ADD CONSTRAINT mangrove_required_values
+        CHECK (
+            -- Terrestrial
+            (forest_type_id = 1
+                AND water_depth_cm IS NULL
+                AND salinity_ppt IS NULL
+                AND ph IS NULL
+                AND tide_id IS NULL
+                AND tide_time IS NULL) OR
+            -- Mangrove
+            (forest_type_id = 2
+                AND salinity_ppt IS NOT NULL
+                AND ph IS NOT NULL
+                AND tide_id IS NOT NULL
+                AND tide_time IS NOT NULL)
+            );

--- a/src/main/resources/db/migration/R__Comments.sql
+++ b/src/main/resources/db/migration/R__Comments.sql
@@ -504,7 +504,7 @@ COMMENT ON COLUMN tracking.observation_biomass_details.ph IS 'Acidity of water i
 COMMENT ON COLUMN tracking.observation_biomass_details.salinity_ppt IS 'Salinity of water in parts per thousand (ppt). Must be non-null if forest type is "Mangrove".';
 COMMENT ON COLUMN tracking.observation_biomass_details.tide_id IS 'High/low tide during observation. Must be non-null if forest type is "Mangrove".';
 COMMENT ON COLUMN tracking.observation_biomass_details.tide_time IS 'Time when the tide is recorded. Must be non-null if forest type is "Mangrove".';
-COMMENT ON COLUMN tracking.observation_biomass_details.water_depth_cm IS 'Depth of water in centimeters (cm). Must be non-null if forest type is "Mangrove".';
+COMMENT ON COLUMN tracking.observation_biomass_details.water_depth_cm IS 'Depth of water in centimeters (cm). Only allowed if forest type is "Mangrove". Null value indicates no water in monitoring plot.';
 
 COMMENT ON TABLE tracking.observation_biomass_species IS 'Herbaceous and tree species data for a biomass observation.';
 COMMENT ON COLUMN tracking.observation_biomass_species.common_name IS 'The user-supplied common name of the plant''s species. Null if ID is known.';

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/biomassStore/BiomassStoreUpdateBiomassDetailsTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/biomassStore/BiomassStoreUpdateBiomassDetailsTest.kt
@@ -215,6 +215,72 @@ class BiomassStoreUpdateBiomassDetailsTest : BaseBiomassStoreTest() {
   }
 
   @Test
+  fun `updates mangrove-only values`() {
+    dslContext.deleteFrom(OBSERVATION_BIOMASS_DETAILS).execute()
+    insertObservationBiomassDetails(
+        description = "Original description",
+        forestType = BiomassForestType.Mangrove,
+        herbaceousCoverPercent = 10,
+        ph = BigDecimal.ONE,
+        salinityPpt = BigDecimal.TWO,
+        smallTreesCountLow = 1,
+        smallTreesCountHigh = 4,
+        soilAssessment = "Original soil assessment",
+        tideId = MangroveTide.Low,
+        tideTime = Instant.EPOCH,
+        waterDepthCm = 1,
+    )
+
+    val before = dslContext.fetchSingle(OBSERVATION_BIOMASS_DETAILS)
+
+    store.updateBiomassDetails(inserted.observationId, inserted.monitoringPlotId) {
+      it.copy(
+          ph = BigDecimal.TEN,
+          salinityPpt = BigDecimal.ONE,
+          tide = MangroveTide.High,
+          tideTime = Instant.ofEpochSecond(120),
+          waterDepthCm = null,
+      )
+    }
+
+    val expected =
+        before.copy().apply {
+          ph = BigDecimal.TEN
+          salinityPpt = BigDecimal.ONE
+          tideId = MangroveTide.High
+          tideTime = Instant.ofEpochSecond(120)
+          waterDepthCm = null
+        }
+
+    assertTableEquals(expected)
+
+    eventPublisher.assertEventPublished(
+        BiomassDetailsUpdatedEvent(
+            changedFrom =
+                BiomassDetailsUpdatedEventValues(
+                    ph = BigDecimal.ONE,
+                    salinity = BigDecimal.TWO,
+                    tide = MangroveTide.Low,
+                    tideTime = Instant.EPOCH,
+                    waterDepth = 1,
+                ),
+            changedTo =
+                BiomassDetailsUpdatedEventValues(
+                    ph = BigDecimal.TEN,
+                    salinity = BigDecimal.ONE,
+                    tide = MangroveTide.High,
+                    tideTime = Instant.ofEpochSecond(120),
+                    waterDepth = null,
+                ),
+            monitoringPlotId = inserted.monitoringPlotId,
+            observationId = inserted.observationId,
+            organizationId = inserted.organizationId,
+            plantingSiteId = inserted.plantingSiteId,
+        )
+    )
+  }
+
+  @Test
   fun `omits unmodified values from events`() {
     val before = dslContext.fetchSingle(OBSERVATION_BIOMASS_DETAILS)
 


### PR DESCRIPTION
It's normal for some monitoring plots at mangrove sites to not be covered by water
depending on the tide and season. Stop requiring a water depth value for mangrove
biomass observations.