### PR TITLE
SW-8574 Add endpoint for public stats

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/api/Annotations.kt
+++ b/src/main/kotlin/com/terraformation/backend/api/Annotations.kt
@@ -61,6 +61,11 @@ annotation class FunderEndpoint
 annotation class InternalEndpoint
 
 @Retention(AnnotationRetention.RUNTIME)
+@Tag(name = "Public")
+@Target(AnnotationTarget.CLASS, AnnotationTarget.FUNCTION)
+annotation class PublicEndpoint
+
+@Retention(AnnotationRetention.RUNTIME)
 @Target(AnnotationTarget.ANNOTATION_CLASS, AnnotationTarget.FUNCTION)
 @ApiResponse(
     content =

--- a/src/main/kotlin/com/terraformation/backend/auth/SecurityConfig.kt
+++ b/src/main/kotlin/com/terraformation/backend/auth/SecurityConfig.kt
@@ -71,6 +71,9 @@ class SecurityConfig(
         // Allow unauthenticated users to check their app versions for compatibility.
         authorize("/api/v1/versions", permitAll)
 
+        // Allow unauthenticated users to fetch aggregate platform statistics.
+        authorize("/api/v1/public/**", permitAll)
+
         // Allow unauthenticated users to fetch OpenAPI docs.
         authorize("/v3/**", permitAll)
         authorize("/swagger-ui/**", permitAll)

--- a/src/main/kotlin/com/terraformation/backend/statistics/Models.kt
+++ b/src/main/kotlin/com/terraformation/backend/statistics/Models.kt
@@ -1,0 +1,9 @@
+package com.terraformation.backend.statistics
+
+import java.math.BigDecimal
+
+data class PublicStatisticsModel(
+    val totalOrganizations: Int,
+    val totalCountries: Int,
+    val totalAreaUnderRestorationHa: BigDecimal,
+)

--- a/src/main/kotlin/com/terraformation/backend/statistics/api/PublicStatisticsController.kt
+++ b/src/main/kotlin/com/terraformation/backend/statistics/api/PublicStatisticsController.kt
@@ -1,0 +1,48 @@
+package com.terraformation.backend.statistics.api
+
+import com.terraformation.backend.api.ApiResponse200
+import com.terraformation.backend.api.PublicEndpoint
+import com.terraformation.backend.api.SuccessResponsePayload
+import com.terraformation.backend.statistics.PublicStatisticsModel
+import com.terraformation.backend.statistics.db.PublicStatisticsStore
+import io.swagger.v3.oas.annotations.Operation
+import java.math.BigDecimal
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@PublicEndpoint
+@RestController
+@RequestMapping("/api/v1/public/statistics")
+class PublicStatisticsController(private val publicStatisticsStore: PublicStatisticsStore) {
+  @ApiResponse200
+  @GetMapping
+  @Operation(
+      summary = "Gets aggregate statistics about the Terraware platform.",
+      description =
+          "These statistics are aggregated across all organizations and do not require " +
+              "authentication. Organizations that are internal to Terraformation are excluded.",
+  )
+  fun getPublicStatistics(): GetPublicStatisticsResponsePayload {
+    return GetPublicStatisticsResponsePayload(
+        PublicStatisticsPayload(publicStatisticsStore.fetchStatistics())
+    )
+  }
+}
+
+data class PublicStatisticsPayload(
+    val totalOrganizations: Int,
+    val totalCountries: Int,
+    val totalAreaUnderRestorationHa: BigDecimal,
+) {
+  constructor(
+      model: PublicStatisticsModel
+  ) : this(
+      totalOrganizations = model.totalOrganizations,
+      totalCountries = model.totalCountries,
+      totalAreaUnderRestorationHa = model.totalAreaUnderRestorationHa,
+  )
+}
+
+data class GetPublicStatisticsResponsePayload(val statistics: PublicStatisticsPayload) :
+    SuccessResponsePayload

--- a/src/main/kotlin/com/terraformation/backend/statistics/db/PublicStatisticsStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/statistics/db/PublicStatisticsStore.kt
@@ -39,7 +39,11 @@ class PublicStatisticsStore(
               )
           )
 
-  fun fetchStatistics(): PublicStatisticsModel {
+  private val cachedStatistics: PublicStatisticsModel by lazy { computeStatistics() }
+
+  fun fetchStatistics(): PublicStatisticsModel = cachedStatistics
+
+  private fun computeStatistics(): PublicStatisticsModel {
     return PublicStatisticsModel(
         totalOrganizations = countOrganizations(),
         totalCountries = countCountries(),

--- a/src/main/kotlin/com/terraformation/backend/statistics/db/PublicStatisticsStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/statistics/db/PublicStatisticsStore.kt
@@ -1,0 +1,81 @@
+package com.terraformation.backend.statistics.db
+
+import com.terraformation.backend.customer.model.InternalTagIds
+import com.terraformation.backend.db.default_schema.tables.references.ORGANIZATIONS
+import com.terraformation.backend.db.default_schema.tables.references.ORGANIZATION_INTERNAL_TAGS
+import com.terraformation.backend.db.default_schema.tables.references.PROJECTS
+import com.terraformation.backend.db.tracking.tables.references.PLANTING_SITES
+import com.terraformation.backend.statistics.PublicStatisticsModel
+import jakarta.inject.Named
+import java.math.BigDecimal
+import org.jooq.DSLContext
+import org.jooq.impl.DSL
+
+/**
+ * Computes aggregate, non-sensitive statistics about the platform for display to unauthenticated
+ * clients.
+ *
+ * The methods here intentionally do not call `currentUser` or `requirePermissions`: the data is
+ * served from a public, unauthenticated endpoint, so there is no current user to check. Only
+ * platform-wide aggregate values that don't reveal anything about a specific organization should be
+ * returned from here.
+ *
+ * Organizations tagged with either [InternalTagIds.Internal] or [InternalTagIds.Testing], along
+ * with their projects and planting sites, are excluded from every statistic so that
+ * Terraformation's own internal organizations don't inflate the numbers.
+ */
+@Named
+class PublicStatisticsStore(
+    private val dslContext: DSLContext,
+) {
+  /** Subquery selecting the IDs of organizations that are tagged as internal to Terraformation. */
+  private val internalOrganizationIds =
+      DSL.select(ORGANIZATION_INTERNAL_TAGS.ORGANIZATION_ID)
+          .from(ORGANIZATION_INTERNAL_TAGS)
+          .where(
+              ORGANIZATION_INTERNAL_TAGS.INTERNAL_TAG_ID.`in`(
+                  InternalTagIds.Internal,
+                  InternalTagIds.Testing,
+              )
+          )
+
+  fun fetchStatistics(): PublicStatisticsModel {
+    return PublicStatisticsModel(
+        totalOrganizations = countOrganizations(),
+        totalCountries = countCountries(),
+        totalAreaUnderRestorationHa = sumPlantingSiteArea(),
+    )
+  }
+
+  private fun countOrganizations(): Int {
+    return dslContext
+        .selectCount()
+        .from(ORGANIZATIONS)
+        .where(ORGANIZATIONS.ID.notIn(internalOrganizationIds))
+        .fetchOne(0, Int::class.java) ?: 0
+  }
+
+  private fun countCountries(): Int {
+    val organizationCountries =
+        DSL.select(ORGANIZATIONS.COUNTRY_CODE)
+            .from(ORGANIZATIONS)
+            .where(ORGANIZATIONS.COUNTRY_CODE.isNotNull)
+            .and(ORGANIZATIONS.ID.notIn(internalOrganizationIds))
+
+    val projectCountries =
+        DSL.select(PROJECTS.COUNTRY_CODE)
+            .from(PROJECTS)
+            .where(PROJECTS.COUNTRY_CODE.isNotNull)
+            .and(PROJECTS.ORGANIZATION_ID.notIn(internalOrganizationIds))
+
+    return dslContext.fetchCount(organizationCountries.union(projectCountries))
+  }
+
+  private fun sumPlantingSiteArea(): BigDecimal {
+    return dslContext
+        .select(DSL.sum(PLANTING_SITES.AREA_HA))
+        .from(PLANTING_SITES)
+        .where(PLANTING_SITES.ORGANIZATION_ID.notIn(internalOrganizationIds))
+        .fetchOne(0, BigDecimal::class.java) ?: BigDecimal.ZERO
+  }
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -150,6 +150,7 @@ springdoc:
     - "com.terraformation.backend.seedbank.api"
     - "com.terraformation.backend.species.api"
     - "com.terraformation.backend.splat.api"
+    - "com.terraformation.backend.statistics.api"
     - "com.terraformation.backend.support.api"
     - "com.terraformation.backend.time.api"
     - "com.terraformation.backend.tracking.api"

--- a/src/test/kotlin/com/terraformation/backend/statistics/db/PublicStatisticsStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/statistics/db/PublicStatisticsStoreTest.kt
@@ -1,0 +1,88 @@
+package com.terraformation.backend.statistics.db
+
+import com.terraformation.backend.RunsAsDatabaseUser
+import com.terraformation.backend.customer.model.InternalTagIds
+import com.terraformation.backend.customer.model.TerrawareUser
+import com.terraformation.backend.db.DatabaseTest
+import com.terraformation.backend.statistics.PublicStatisticsModel
+import java.math.BigDecimal
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+internal class PublicStatisticsStoreTest : DatabaseTest(), RunsAsDatabaseUser {
+  override lateinit var user: TerrawareUser
+
+  private val store: PublicStatisticsStore by lazy { PublicStatisticsStore(dslContext) }
+
+  @Test
+  fun `returns zeroes when there is no data`() {
+    val statistics = store.fetchStatistics()
+
+    assertEquals(
+        PublicStatisticsModel(
+            totalOrganizations = 0,
+            totalCountries = 0,
+            totalAreaUnderRestorationHa = BigDecimal.ZERO,
+        ),
+        statistics,
+        "Should return zeros",
+    )
+  }
+
+  @Test
+  fun `counts organizations excluding ones tagged as internal or testing`() {
+    insertOrganization()
+    insertOrganization()
+    val internalOrganizationId = insertOrganization()
+    val testingOrganizationId = insertOrganization()
+    insertOrganizationInternalTag(internalOrganizationId, InternalTagIds.Internal)
+    insertOrganizationInternalTag(testingOrganizationId, InternalTagIds.Testing)
+
+    assertEquals(2, store.fetchStatistics().totalOrganizations)
+  }
+
+  @Test
+  fun `does not exclude organizations with other tags`() {
+    insertOrganization()
+    val reportingOrganizationId = insertOrganization()
+    insertOrganizationInternalTag(reportingOrganizationId, InternalTagIds.Reporter)
+
+    assertEquals(2, store.fetchStatistics().totalOrganizations)
+  }
+
+  @Test
+  fun `sums distinct countries, excluding internal organizations`() {
+    insertOrganization(countryCode = "US")
+    val kenyaOrganizationId = insertOrganization(countryCode = "KE")
+
+    // A project in a new country, plus one that duplicates the org's country.
+    insertProject(organizationId = kenyaOrganizationId, countryCode = "BR")
+    insertProject(organizationId = kenyaOrganizationId, countryCode = "KE")
+
+    insertOrganization(countryCode = null)
+
+    insertOrganization(countryCode = "MX")
+    insertOrganizationInternalTag(tagId = InternalTagIds.Internal)
+
+    insertOrganization(countryCode = "SE")
+    insertOrganizationInternalTag(tagId = InternalTagIds.Testing)
+
+    assertEquals(3, store.fetchStatistics().totalCountries)
+  }
+
+  @Test
+  fun `sums planting site area excluding internal organizations`() {
+    val organizationId = insertOrganization()
+    insertPlantingSite(organizationId = organizationId, areaHa = BigDecimal(10))
+    insertPlantingSite(organizationId = organizationId, areaHa = BigDecimal(5))
+
+    val internalOrganizationId = insertOrganization()
+    insertOrganizationInternalTag(internalOrganizationId, InternalTagIds.Internal)
+    insertPlantingSite(organizationId = internalOrganizationId, areaHa = BigDecimal(100))
+
+    assertEquals(
+        0,
+        BigDecimal(15).compareTo(store.fetchStatistics().totalAreaUnderRestorationHa),
+    )
+  }
+}

--- a/src/test/kotlin/com/terraformation/backend/statistics/db/PublicStatisticsStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/statistics/db/PublicStatisticsStoreTest.kt
@@ -71,6 +71,17 @@ internal class PublicStatisticsStoreTest : DatabaseTest(), RunsAsDatabaseUser {
   }
 
   @Test
+  fun `returns cached result on subsequent calls`() {
+    insertOrganization()
+    val firstResult = store.fetchStatistics()
+
+    insertOrganization()
+    val secondResult = store.fetchStatistics()
+
+    assertEquals(firstResult, secondResult, "Should return cached result")
+  }
+
+  @Test
   fun `sums planting site area excluding internal organizations`() {
     val organizationId = insertOrganization()
     insertPlantingSite(organizationId = organizationId, areaHa = BigDecimal(10))


### PR DESCRIPTION
Create an endpoint to expose public stats about Terraware, including org count, country count, and sum of area under restoration (ha). Exclude orgs tagged with `Internal` org `Testing`.

Expose this endpoint to non-logged-in clients.

Add a new `PublicEndpoint` annotation class for this endpoint.

Co-authored-by: Claude Opus 4.8 <noreply@anthropic.com>