### PR TITLE
SW-8574 Add seed/seedlings/plantings sums to public stats

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/statistics/Models.kt
+++ b/src/main/kotlin/com/terraformation/backend/statistics/Models.kt
@@ -6,4 +6,7 @@ data class PublicStatisticsModel(
     val totalOrganizations: Int,
     val totalCountries: Int,
     val totalAreaUnderRestorationHa: BigDecimal,
+    val totalSeedsInStorage: Long,
+    val totalSeedlingsInNurseries: Long,
+    val totalPlantings: Int,
 )

--- a/src/main/kotlin/com/terraformation/backend/statistics/api/PublicStatisticsController.kt
+++ b/src/main/kotlin/com/terraformation/backend/statistics/api/PublicStatisticsController.kt
@@ -34,6 +34,9 @@ data class PublicStatisticsPayload(
     val totalOrganizations: Int,
     val totalCountries: Int,
     val totalAreaUnderRestorationHa: BigDecimal,
+    val totalSeedsInStorage: Long,
+    val totalSeedlingsInNurseries: Long,
+    val totalPlantings: Int,
 ) {
   constructor(
       model: PublicStatisticsModel
@@ -41,6 +44,9 @@ data class PublicStatisticsPayload(
       totalOrganizations = model.totalOrganizations,
       totalCountries = model.totalCountries,
       totalAreaUnderRestorationHa = model.totalAreaUnderRestorationHa,
+      totalSeedsInStorage = model.totalSeedsInStorage,
+      totalSeedlingsInNurseries = model.totalSeedlingsInNurseries,
+      totalPlantings = model.totalPlantings,
   )
 }
 

--- a/src/main/kotlin/com/terraformation/backend/statistics/db/PublicStatisticsStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/statistics/db/PublicStatisticsStore.kt
@@ -1,9 +1,15 @@
 package com.terraformation.backend.statistics.db
 
 import com.terraformation.backend.customer.model.InternalTagIds
+import com.terraformation.backend.db.default_schema.tables.references.FACILITIES
 import com.terraformation.backend.db.default_schema.tables.references.ORGANIZATIONS
 import com.terraformation.backend.db.default_schema.tables.references.ORGANIZATION_INTERNAL_TAGS
 import com.terraformation.backend.db.default_schema.tables.references.PROJECTS
+import com.terraformation.backend.db.nursery.tables.references.BATCHES
+import com.terraformation.backend.db.seedbank.AccessionState
+import com.terraformation.backend.db.seedbank.SeedQuantityUnits
+import com.terraformation.backend.db.seedbank.tables.references.ACCESSIONS
+import com.terraformation.backend.db.tracking.tables.references.DELIVERIES
 import com.terraformation.backend.db.tracking.tables.references.PLANTING_SITES
 import com.terraformation.backend.statistics.PublicStatisticsModel
 import jakarta.inject.Named
@@ -48,6 +54,9 @@ class PublicStatisticsStore(
         totalOrganizations = countOrganizations(),
         totalCountries = countCountries(),
         totalAreaUnderRestorationHa = sumPlantingSiteArea(),
+        totalSeedsInStorage = sumSeedsInStorage(),
+        totalSeedlingsInNurseries = sumSeedlingsInNurseries(),
+        totalPlantings = countPlantings(),
     )
   }
 
@@ -81,5 +90,60 @@ class PublicStatisticsStore(
         .from(PLANTING_SITES)
         .where(PLANTING_SITES.ORGANIZATION_ID.notIn(internalOrganizationIds))
         .fetchOne(0, BigDecimal::class.java) ?: BigDecimal.ZERO
+  }
+
+  private fun sumSeedsInStorage(): Long {
+    val totalSeeds =
+        DSL.sum(
+            DSL.case_()
+                .`when`(
+                    ACCESSIONS.REMAINING_UNITS_ID.eq(SeedQuantityUnits.Seeds),
+                    ACCESSIONS.REMAINING_QUANTITY,
+                )
+                .`when`(
+                    ACCESSIONS.REMAINING_UNITS_ID.ne(SeedQuantityUnits.Seeds)
+                        .and(ACCESSIONS.SUBSET_COUNT.isNotNull)
+                        .and(ACCESSIONS.SUBSET_WEIGHT_GRAMS.isNotNull)
+                        .and(ACCESSIONS.REMAINING_GRAMS.isNotNull),
+                    ACCESSIONS.REMAINING_GRAMS.div(ACCESSIONS.SUBSET_WEIGHT_GRAMS)
+                        .mul(ACCESSIONS.SUBSET_COUNT),
+                )
+                .else_(BigDecimal.ZERO)
+        )
+
+    val activeStates = AccessionState.entries.filter { it.active }
+
+    return dslContext
+        .select(totalSeeds)
+        .from(ACCESSIONS)
+        .join(FACILITIES)
+        .on(ACCESSIONS.FACILITY_ID.eq(FACILITIES.ID))
+        .where(FACILITIES.ORGANIZATION_ID.notIn(internalOrganizationIds))
+        .and(ACCESSIONS.STATE_ID.`in`(activeStates))
+        .fetchOne { (total) -> (total ?: BigDecimal.ZERO).toLong() } ?: 0L
+  }
+
+  private fun sumSeedlingsInNurseries(): Long {
+    return dslContext
+        .select(
+            DSL.sum(
+                BATCHES.GERMINATING_QUANTITY.plus(BATCHES.ACTIVE_GROWTH_QUANTITY)
+                    .plus(BATCHES.READY_QUANTITY)
+                    .plus(BATCHES.HARDENING_OFF_QUANTITY)
+            )
+        )
+        .from(BATCHES)
+        .where(BATCHES.ORGANIZATION_ID.notIn(internalOrganizationIds))
+        .fetchOne(0, Long::class.java) ?: 0L
+  }
+
+  private fun countPlantings(): Int {
+    return dslContext
+        .selectCount()
+        .from(DELIVERIES)
+        .join(PLANTING_SITES)
+        .on(DELIVERIES.PLANTING_SITE_ID.eq(PLANTING_SITES.ID))
+        .where(PLANTING_SITES.ORGANIZATION_ID.notIn(internalOrganizationIds))
+        .fetchOne(0, Int::class.java) ?: 0
   }
 }

--- a/src/test/kotlin/com/terraformation/backend/statistics/db/PublicStatisticsStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/statistics/db/PublicStatisticsStoreTest.kt
@@ -4,6 +4,10 @@ import com.terraformation.backend.RunsAsDatabaseUser
 import com.terraformation.backend.customer.model.InternalTagIds
 import com.terraformation.backend.customer.model.TerrawareUser
 import com.terraformation.backend.db.DatabaseTest
+import com.terraformation.backend.db.default_schema.FacilityType
+import com.terraformation.backend.db.seedbank.AccessionState
+import com.terraformation.backend.db.seedbank.SeedQuantityUnits
+import com.terraformation.backend.db.seedbank.tables.pojos.AccessionsRow
 import com.terraformation.backend.statistics.PublicStatisticsModel
 import java.math.BigDecimal
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -23,6 +27,9 @@ internal class PublicStatisticsStoreTest : DatabaseTest(), RunsAsDatabaseUser {
             totalOrganizations = 0,
             totalCountries = 0,
             totalAreaUnderRestorationHa = BigDecimal.ZERO,
+            totalSeedsInStorage = 0L,
+            totalSeedlingsInNurseries = 0L,
+            totalPlantings = 0,
         ),
         statistics,
         "Should return zeros",
@@ -95,5 +102,138 @@ internal class PublicStatisticsStoreTest : DatabaseTest(), RunsAsDatabaseUser {
         0,
         BigDecimal(15).compareTo(store.fetchStatistics().totalAreaUnderRestorationHa),
     )
+  }
+
+  @Test
+  fun `sums seeds in storage using seed count units`() {
+    val organizationId = insertOrganization()
+    val facilityId = insertFacility(organizationId = organizationId, type = FacilityType.SeedBank)
+    insertAccession(
+        row =
+            AccessionsRow(
+                remainingQuantity = BigDecimal(100),
+                remainingUnitsId = SeedQuantityUnits.Seeds,
+            ),
+        facilityId = facilityId,
+        stateId = AccessionState.InStorage,
+    )
+    insertAccession(
+        row =
+            AccessionsRow(
+                remainingQuantity = BigDecimal(50),
+                remainingUnitsId = SeedQuantityUnits.Seeds,
+            ),
+        facilityId = facilityId,
+        stateId = AccessionState.Drying,
+    )
+
+    assertEquals(150L, store.fetchStatistics().totalSeedsInStorage)
+  }
+
+  @Test
+  fun `estimates seeds in storage from weight when no seed count available`() {
+    val organizationId = insertOrganization()
+    val facilityId = insertFacility(organizationId = organizationId, type = FacilityType.SeedBank)
+    // 10g remaining / 2g per subset * 100 seeds per subset = 500 estimated seeds
+    insertAccession(
+        row =
+            AccessionsRow(
+                remainingGrams = BigDecimal(10),
+                remainingQuantity = BigDecimal(10),
+                remainingUnitsId = SeedQuantityUnits.Grams,
+                subsetWeightGrams = BigDecimal(2),
+                subsetCount = 100,
+            ),
+        facilityId = facilityId,
+        stateId = AccessionState.InStorage,
+    )
+
+    assertEquals(500L, store.fetchStatistics().totalSeedsInStorage)
+  }
+
+  @Test
+  fun `excludes seeds in inactive accession states from storage count`() {
+    val organizationId = insertOrganization()
+    val facilityId = insertFacility(organizationId = organizationId, type = FacilityType.SeedBank)
+    for (state in listOf(AccessionState.Withdrawn, AccessionState.UsedUp, AccessionState.Nursery)) {
+      insertAccession(
+          row =
+              AccessionsRow(
+                  remainingQuantity = BigDecimal(100),
+                  remainingUnitsId = SeedQuantityUnits.Seeds,
+              ),
+          facilityId = facilityId,
+          stateId = state,
+      )
+    }
+
+    assertEquals(0L, store.fetchStatistics().totalSeedsInStorage)
+  }
+
+  @Test
+  fun `excludes seeds from internal organizations`() {
+    val internalOrgId = insertOrganization()
+    insertOrganizationInternalTag(internalOrgId, InternalTagIds.Internal)
+    val facilityId = insertFacility(organizationId = internalOrgId, type = FacilityType.SeedBank)
+    insertAccession(
+        row =
+            AccessionsRow(
+                remainingQuantity = BigDecimal(100),
+                remainingUnitsId = SeedQuantityUnits.Seeds,
+            ),
+        facilityId = facilityId,
+        stateId = AccessionState.InStorage,
+    )
+
+    assertEquals(0L, store.fetchStatistics().totalSeedsInStorage)
+  }
+
+  @Test
+  fun `sums all seedling quantities excluding internal organizations`() {
+    val organizationId = insertOrganization()
+    insertFacility(organizationId = organizationId, type = FacilityType.Nursery)
+    insertSpecies(organizationId = organizationId)
+    insertBatch(
+        organizationId = organizationId,
+        germinatingQuantity = 10,
+        activeGrowthQuantity = 20,
+        readyQuantity = 30,
+        hardeningOffQuantity = 5,
+    )
+
+    val internalOrgId = insertOrganization()
+    insertOrganizationInternalTag(internalOrgId, InternalTagIds.Internal)
+    insertFacility(organizationId = internalOrgId, type = FacilityType.Nursery)
+    insertSpecies(organizationId = internalOrgId)
+    insertBatch(
+        organizationId = internalOrgId,
+        germinatingQuantity = 100,
+        activeGrowthQuantity = 100,
+        readyQuantity = 100,
+        hardeningOffQuantity = 100,
+    )
+
+    assertEquals(65L, store.fetchStatistics().totalSeedlingsInNurseries)
+  }
+
+  @Test
+  fun `counts deliveries excluding internal organizations`() {
+    val organizationId = insertOrganization()
+    val facilityId = insertFacility(organizationId = organizationId, type = FacilityType.Nursery)
+    val plantingSiteId = insertPlantingSite(organizationId = organizationId)
+    val withdrawalId1 = insertNurseryWithdrawal(facilityId = facilityId)
+    val withdrawalId2 = insertNurseryWithdrawal(facilityId = facilityId)
+    insertDelivery(plantingSiteId = plantingSiteId, withdrawalId = withdrawalId1)
+    insertDelivery(plantingSiteId = plantingSiteId, withdrawalId = withdrawalId2)
+
+    val internalOrgId = insertOrganization()
+    insertOrganizationInternalTag(internalOrgId, InternalTagIds.Internal)
+    val internalFacilityId =
+        insertFacility(organizationId = internalOrgId, type = FacilityType.Nursery)
+    val internalPlantingSiteId = insertPlantingSite(organizationId = internalOrgId)
+    val internalWithdrawalId = insertNurseryWithdrawal(facilityId = internalFacilityId)
+    insertDelivery(plantingSiteId = internalPlantingSiteId, withdrawalId = internalWithdrawalId)
+
+    assertEquals(2, store.fetchStatistics().totalPlantings)
   }
 }


### PR DESCRIPTION
Some additional stats are needed for the Terraware microsite. Add seeds in storage, seedlings in nurseries, and total plantings to public stats. There is not yet any info on how these should be calculated, so for now guess how these are calculated. 

Co-authored-by: Claude Opus 4.8 [noreply@anthropic.com](mailto:noreply@anthropic.com)