### PR TITLE
SW-8420 Add dates to ScheduledPlantingDateRequested notifications

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/plantingmanagement/Models.kt
+++ b/src/main/kotlin/com/terraformation/backend/plantingmanagement/Models.kt
@@ -80,6 +80,7 @@ enum class PlantingSeasonNotificationType {
 data class PlantingSeasonNotificationModel(
     val type: PlantingSeasonNotificationType,
     val speciesScientificNames: Set<String>? = null,
+    val dates: Set<LocalDate>? = null,
 )
 
 data class PlantingSeasonNotificationGroupModel(

--- a/src/main/kotlin/com/terraformation/backend/plantingmanagement/api/PlantingSeasonNotificationsController.kt
+++ b/src/main/kotlin/com/terraformation/backend/plantingmanagement/api/PlantingSeasonNotificationsController.kt
@@ -14,6 +14,7 @@ import com.terraformation.backend.plantingmanagement.PlantingSeasonNotificationT
 import com.terraformation.backend.plantingmanagement.db.PlantingSeasonNotificationsService
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.media.Schema
+import java.time.LocalDate
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
@@ -97,12 +98,14 @@ data class GetPlantingSeasonNotificationsResponsePayload(
 data class PlantingSeasonNotificationPayload(
     val type: PlantingSeasonNotificationType,
     val speciesScientificNames: Set<String>? = null,
+    val dates: Set<LocalDate>? = null,
 ) {
   constructor(
       model: PlantingSeasonNotificationModel
   ) : this(
       type = model.type,
       speciesScientificNames = model.speciesScientificNames,
+      dates = model.dates,
   )
 }
 

--- a/src/main/kotlin/com/terraformation/backend/plantingmanagement/db/PlantingSeasonNotificationsService.kt
+++ b/src/main/kotlin/com/terraformation/backend/plantingmanagement/db/PlantingSeasonNotificationsService.kt
@@ -8,15 +8,15 @@ import com.terraformation.backend.db.default_schema.tables.references.SPECIES
 import com.terraformation.backend.db.tracking.PlantingSeasonId
 import com.terraformation.backend.db.tracking.PlantingSeasonNotificationPage
 import com.terraformation.backend.db.tracking.PlantingSeasonStatus
+import com.terraformation.backend.db.tracking.ScheduledPlantingDateId
 import com.terraformation.backend.db.tracking.tables.references.PLANTING_SEASONS
 import com.terraformation.backend.db.tracking.tables.references.PLANTING_SEASON_NOTIFICATIONS
+import com.terraformation.backend.db.tracking.tables.references.SCHEDULED_PLANTING_DATES
 import com.terraformation.backend.eventlog.db.EventLogStore
 import com.terraformation.backend.eventlog.model.EventLogEntry
 import com.terraformation.backend.plantingmanagement.PlantingSeasonNotificationGroupModel
 import com.terraformation.backend.plantingmanagement.PlantingSeasonNotificationModel
 import com.terraformation.backend.plantingmanagement.PlantingSeasonNotificationType
-import com.terraformation.backend.db.tracking.ScheduledPlantingDateId
-import com.terraformation.backend.db.tracking.tables.references.SCHEDULED_PLANTING_DATES
 import com.terraformation.backend.plantingmanagement.event.PlantingDateRequestPersistentEvent
 import com.terraformation.backend.plantingmanagement.event.PlantingSeasonAllocatedSpeciesPersistentEvent
 import com.terraformation.backend.plantingmanagement.event.PlantingSeasonPersistentEvent
@@ -252,7 +252,9 @@ class PlantingSeasonNotificationsService(
         scientificNamesBySpeciesId[event.speciesId]?.let { speciesNames.add(it) }
       }
       if (event is PlantingDateRequestPersistentEvent) {
-        datesByScheduledPlantingDateId[event.scheduledPlantingDateId]?.let { scheduledDates.add(it) }
+        datesByScheduledPlantingDateId[event.scheduledPlantingDateId]?.let {
+          scheduledDates.add(it)
+        }
       }
     }
 

--- a/src/main/kotlin/com/terraformation/backend/plantingmanagement/db/PlantingSeasonNotificationsService.kt
+++ b/src/main/kotlin/com/terraformation/backend/plantingmanagement/db/PlantingSeasonNotificationsService.kt
@@ -265,7 +265,9 @@ class PlantingSeasonNotificationsService(
           dates =
               if (type == PlantingSeasonNotificationType.ScheduledPlantingDateRequested) {
                 scheduledDates.ifEmpty { null }
-              } else null,
+              } else {
+                null
+              },
       )
     }
   }

--- a/src/main/kotlin/com/terraformation/backend/plantingmanagement/db/PlantingSeasonNotificationsService.kt
+++ b/src/main/kotlin/com/terraformation/backend/plantingmanagement/db/PlantingSeasonNotificationsService.kt
@@ -15,6 +15,8 @@ import com.terraformation.backend.eventlog.model.EventLogEntry
 import com.terraformation.backend.plantingmanagement.PlantingSeasonNotificationGroupModel
 import com.terraformation.backend.plantingmanagement.PlantingSeasonNotificationModel
 import com.terraformation.backend.plantingmanagement.PlantingSeasonNotificationType
+import com.terraformation.backend.db.tracking.ScheduledPlantingDateId
+import com.terraformation.backend.db.tracking.tables.references.SCHEDULED_PLANTING_DATES
 import com.terraformation.backend.plantingmanagement.event.PlantingDateRequestPersistentEvent
 import com.terraformation.backend.plantingmanagement.event.PlantingSeasonAllocatedSpeciesPersistentEvent
 import com.terraformation.backend.plantingmanagement.event.PlantingSeasonPersistentEvent
@@ -25,6 +27,7 @@ import com.terraformation.backend.plantingmanagement.event.PlantingSeasonSpecies
 import com.terraformation.backend.plantingmanagement.event.PlantingSeasonUpdatedEvent
 import com.terraformation.backend.plantingmanagement.event.PlantingSeasonWithdrawalCreatedEvent
 import jakarta.inject.Named
+import java.time.LocalDate
 import kotlin.reflect.KClass
 import org.jooq.Condition
 import org.jooq.DSLContext
@@ -134,8 +137,10 @@ class PlantingSeasonNotificationsService(
             )
             .groupBy { it.event.plantingSeasonId }
 
-    val scientificNamesBySpeciesId =
-        fetchScientificNamesBySpeciesId(speciesIdsOf(entriesBySeason.values.flatten()))
+    val allEntries = entriesBySeason.values.flatten()
+    val scientificNamesBySpeciesId = fetchScientificNamesBySpeciesId(speciesIdsOf(allEntries))
+    val datesByScheduledPlantingDateId =
+        fetchDatesByScheduledPlantingDateId(scheduledPlantingDateIdsOf(allEntries))
 
     return entriesBySeason.mapNotNull { (plantingSeasonId, entries) ->
       buildNotificationModel(
@@ -143,6 +148,7 @@ class PlantingSeasonNotificationsService(
           entries,
           seasonInfoById.getValue(plantingSeasonId),
           scientificNamesBySpeciesId,
+          datesByScheduledPlantingDateId,
           page,
           requestedTypes,
       )
@@ -189,11 +195,17 @@ class PlantingSeasonNotificationsService(
       entries: List<EventLogEntry<PlantingSeasonRelatedPersistentEvent>>,
       seasonInfo: SeasonInfo,
       scientificNamesBySpeciesId: Map<SpeciesId, String>,
+      datesByScheduledPlantingDateId: Map<ScheduledPlantingDateId, LocalDate>,
       page: PlantingSeasonNotificationPage,
       requestedTypes: Set<PlantingSeasonNotificationType>,
   ): PlantingSeasonNotificationGroupModel? {
     val notifications =
-        combineEvents(entries.map { it.event }, scientificNamesBySpeciesId, requestedTypes)
+        combineEvents(
+            entries.map { it.event },
+            scientificNamesBySpeciesId,
+            datesByScheduledPlantingDateId,
+            requestedTypes,
+        )
     if (notifications.isEmpty()) {
       return null
     }
@@ -222,6 +234,7 @@ class PlantingSeasonNotificationsService(
   private fun combineEvents(
       events: List<PlantingSeasonRelatedPersistentEvent>,
       scientificNamesBySpeciesId: Map<SpeciesId, String>,
+      datesByScheduledPlantingDateId: Map<ScheduledPlantingDateId, LocalDate>,
       requestedTypes: Set<PlantingSeasonNotificationType>,
   ): List<PlantingSeasonNotificationModel> {
     require(events.mapTo(mutableSetOf()) { it.plantingSeasonId }.size <= 1) {
@@ -229,6 +242,7 @@ class PlantingSeasonNotificationsService(
     }
 
     val speciesNamesByType = linkedMapOf<PlantingSeasonNotificationType, MutableSet<String>>()
+    val scheduledDates = mutableSetOf<LocalDate>()
 
     events.forEach { event ->
       val type = event.notificationType ?: return@forEach
@@ -237,12 +251,19 @@ class PlantingSeasonNotificationsService(
       if (event is PlantingSeasonSpeciesTargetPersistentEvent) {
         scientificNamesBySpeciesId[event.speciesId]?.let { speciesNames.add(it) }
       }
+      if (event is PlantingDateRequestPersistentEvent) {
+        datesByScheduledPlantingDateId[event.scheduledPlantingDateId]?.let { scheduledDates.add(it) }
+      }
     }
 
     return speciesNamesByType.map { (type, speciesNames) ->
       PlantingSeasonNotificationModel(
           type = type,
           speciesScientificNames = speciesNames.ifEmpty { null },
+          dates =
+              if (type == PlantingSeasonNotificationType.ScheduledPlantingDateRequested) {
+                scheduledDates.ifEmpty { null }
+              } else null,
       )
     }
   }
@@ -279,6 +300,14 @@ class PlantingSeasonNotificationsService(
           .filterIsInstance<PlantingSeasonSpeciesTargetPersistentEvent>()
           .mapTo(mutableSetOf()) { it.speciesId }
 
+  private fun scheduledPlantingDateIdsOf(
+      entries: List<EventLogEntry<PlantingSeasonRelatedPersistentEvent>>
+  ): Set<ScheduledPlantingDateId> =
+      entries
+          .map { it.event }
+          .filterIsInstance<PlantingDateRequestPersistentEvent>()
+          .mapTo(mutableSetOf()) { it.scheduledPlantingDateId }
+
   private fun fetchScientificNamesBySpeciesId(speciesIds: Set<SpeciesId>): Map<SpeciesId, String> {
     if (speciesIds.isEmpty()) {
       return emptyMap()
@@ -289,6 +318,20 @@ class PlantingSeasonNotificationsService(
         .from(SPECIES)
         .where(SPECIES.ID.`in`(speciesIds))
         .associate { it[SPECIES.ID]!! to it[SPECIES.SCIENTIFIC_NAME]!! }
+  }
+
+  private fun fetchDatesByScheduledPlantingDateId(
+      ids: Set<ScheduledPlantingDateId>
+  ): Map<ScheduledPlantingDateId, LocalDate> {
+    if (ids.isEmpty()) {
+      return emptyMap()
+    }
+
+    return dslContext
+        .select(SCHEDULED_PLANTING_DATES.ID, SCHEDULED_PLANTING_DATES.DATE)
+        .from(SCHEDULED_PLANTING_DATES)
+        .where(SCHEDULED_PLANTING_DATES.ID.`in`(ids))
+        .associate { it[SCHEDULED_PLANTING_DATES.ID]!! to it[SCHEDULED_PLANTING_DATES.DATE]!! }
   }
 
   /**

--- a/src/test/kotlin/com/terraformation/backend/plantingmanagement/db/PlantingSeasonNotificationsServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/plantingmanagement/db/PlantingSeasonNotificationsServiceTest.kt
@@ -27,6 +27,8 @@ import com.terraformation.backend.plantingmanagement.PlantingSeasonNotificationG
 import com.terraformation.backend.plantingmanagement.PlantingSeasonNotificationModel
 import com.terraformation.backend.plantingmanagement.PlantingSeasonNotificationType
 import com.terraformation.backend.plantingmanagement.event.PlantingDateRequestCreatedEvent
+import com.terraformation.backend.plantingmanagement.event.PlantingDateRequestUpdatedEvent
+import com.terraformation.backend.plantingmanagement.event.PlantingDateRequestUpdatedEventValues
 import com.terraformation.backend.plantingmanagement.event.PlantingSeasonAllocatedSpeciesCreatedEvent
 import com.terraformation.backend.plantingmanagement.event.PlantingSeasonAllocatedSpeciesPersistentEvent
 import com.terraformation.backend.plantingmanagement.event.PlantingSeasonAllocatedSpeciesUpdatedEvent
@@ -130,8 +132,11 @@ internal class PlantingSeasonNotificationsServiceTest : DatabaseTest(), RunsAsDa
   private val seasonWithdrawalRecorded =
       PlantingSeasonNotificationModel(PlantingSeasonNotificationType.SeasonWithdrawalRecorded)
 
-  private val scheduledPlantingDateRequested =
-      PlantingSeasonNotificationModel(PlantingSeasonNotificationType.ScheduledPlantingDateRequested)
+  private fun scheduledPlantingDateRequested(vararg dates: LocalDate) =
+      PlantingSeasonNotificationModel(
+          PlantingSeasonNotificationType.ScheduledPlantingDateRequested,
+          dates = dates.toSet().ifEmpty { null },
+      )
 
   @Nested
   inner class GetNotificationsBySeason {
@@ -375,7 +380,7 @@ internal class PlantingSeasonNotificationsServiceTest : DatabaseTest(), RunsAsDa
                   listOf(
                       targetAdded(speciesName1),
                       targetUpdated(speciesName1),
-                      scheduledPlantingDateRequested,
+                      scheduledPlantingDateRequested(LocalDate.EPOCH),
                       closed,
                   ),
                   notificationPage = PlantingSeasonNotificationPage.Inventory,
@@ -398,7 +403,7 @@ internal class PlantingSeasonNotificationsServiceTest : DatabaseTest(), RunsAsDa
           listOf(
               model(
                   latest.id,
-                  listOf(scheduledPlantingDateRequested, closed),
+                  listOf(scheduledPlantingDateRequested(LocalDate.EPOCH), closed),
                   notificationPage = PlantingSeasonNotificationPage.Withdrawals,
               )
           ),
@@ -581,6 +586,101 @@ internal class PlantingSeasonNotificationsServiceTest : DatabaseTest(), RunsAsDa
           listOf(targetUpdated(speciesName1, speciesName2)),
           notifications,
       )
+    }
+
+    @Test
+    fun `adds the date from a planting date request created event`() {
+      val date = LocalDate.of(2025, 1, 15)
+      insertPlantingDateRequestedEvent(date = date)
+
+      val notifications =
+          service
+              .getNotifications(plantingSeasonId, PlantingSeasonNotificationPage.Inventory)
+              .single()
+              .notifications
+
+      assertEquals(listOf(scheduledPlantingDateRequested(date)), notifications)
+    }
+
+    @Test
+    fun `accumulates dates from multiple planting date request created events`() {
+      val date1 = LocalDate.of(2025, 1, 15)
+      val date2 = LocalDate.of(2025, 2, 20)
+      insertPlantingDateRequestedEvent(date = date1)
+      clock.instant = clock.instant.plusSeconds(1)
+      insertPlantingDateRequestedEvent(date = date2)
+
+      val notifications =
+          service
+              .getNotifications(plantingSeasonId, PlantingSeasonNotificationPage.Inventory)
+              .single()
+              .notifications
+
+      assertEquals(listOf(scheduledPlantingDateRequested(date1, date2)), notifications)
+    }
+
+    @Test
+    fun `deduplicates dates when multiple created events share the same date`() {
+      val date = LocalDate.of(2025, 1, 15)
+      val scheduledId =
+          insertPlantingSeasonScheduledDate(date = date, plantingSeasonId = plantingSeasonId)
+      insertPlantingDateRequestedEvent(date = date, scheduledPlantingDateId = scheduledId)
+      clock.instant = clock.instant.plusSeconds(1)
+      insertPlantingDateRequestedEvent(date = date, scheduledPlantingDateId = scheduledId)
+
+      val notifications =
+          service
+              .getNotifications(plantingSeasonId, PlantingSeasonNotificationPage.Inventory)
+              .single()
+              .notifications
+
+      assertEquals(listOf(scheduledPlantingDateRequested(date)), notifications)
+    }
+
+    @Test
+    fun `shows the new date when the planting date request date was updated`() {
+      val originalDate = LocalDate.of(2025, 1, 15)
+      val newDate = LocalDate.of(2025, 3, 10)
+      // The DB reflects the current state after the update.
+      val scheduledId =
+          insertPlantingSeasonScheduledDate(date = newDate, plantingSeasonId = plantingSeasonId)
+      insertPlantingDateRequestedEvent(date = originalDate, scheduledPlantingDateId = scheduledId)
+      clock.instant = clock.instant.plusSeconds(1)
+      insertPlantingDateRequestUpdatedEvent(
+          changedFrom = PlantingDateRequestUpdatedEventValues(date = originalDate),
+          changedTo = PlantingDateRequestUpdatedEventValues(date = newDate),
+          scheduledPlantingDateId = scheduledId,
+      )
+
+      val notifications =
+          service
+              .getNotifications(plantingSeasonId, PlantingSeasonNotificationPage.Inventory)
+              .single()
+              .notifications
+
+      assertEquals(listOf(scheduledPlantingDateRequested(newDate)), notifications)
+    }
+
+    @Test
+    fun `shows the current date when the planting date request was updated without a date change`() {
+      val date = LocalDate.of(2025, 1, 15)
+      val scheduledId =
+          insertPlantingSeasonScheduledDate(date = date, plantingSeasonId = plantingSeasonId)
+      insertPlantingDateRequestedEvent(date = date, scheduledPlantingDateId = scheduledId)
+      clock.instant = clock.instant.plusSeconds(1)
+      insertPlantingDateRequestUpdatedEvent(
+          changedFrom = PlantingDateRequestUpdatedEventValues(notes = "old notes"),
+          changedTo = PlantingDateRequestUpdatedEventValues(notes = "new notes"),
+          scheduledPlantingDateId = scheduledId,
+      )
+
+      val notifications =
+          service
+              .getNotifications(plantingSeasonId, PlantingSeasonNotificationPage.Inventory)
+              .single()
+              .notifications
+
+      assertEquals(listOf(scheduledPlantingDateRequested(date)), notifications)
     }
 
     @Test
@@ -776,6 +876,30 @@ internal class PlantingSeasonNotificationsServiceTest : DatabaseTest(), RunsAsDa
       )
 
   private fun insertPlantingDateRequestedEvent(
+      date: LocalDate = LocalDate.EPOCH,
+      organizationId: OrganizationId = this.organizationId,
+      plantingSeasonId: PlantingSeasonId = this.plantingSeasonId,
+      plantingSiteId: PlantingSiteId = this.plantingSiteId,
+      scheduledPlantingDateId: ScheduledPlantingDateId =
+          insertPlantingSeasonScheduledDate(date = date, plantingSeasonId = plantingSeasonId),
+  ): EventLogEntry<PlantingSeasonRelatedPersistentEvent> {
+    val event =
+        PlantingDateRequestCreatedEvent(
+            date = date,
+            notes = null,
+            organizationId = organizationId,
+            plantingSeasonId = plantingSeasonId,
+            plantingSiteId = plantingSiteId,
+            scheduledPlantingDateId = scheduledPlantingDateId,
+            status = PlantingDateRequestStatus.Pending,
+        )
+
+    return EventLogEntry(user.userId, clock.instant, event, eventLogStore.insertEvent(event))
+  }
+
+  private fun insertPlantingDateRequestUpdatedEvent(
+      changedFrom: PlantingDateRequestUpdatedEventValues = PlantingDateRequestUpdatedEventValues(),
+      changedTo: PlantingDateRequestUpdatedEventValues = PlantingDateRequestUpdatedEventValues(),
       organizationId: OrganizationId = this.organizationId,
       plantingSeasonId: PlantingSeasonId = this.plantingSeasonId,
       plantingSiteId: PlantingSiteId = this.plantingSiteId,
@@ -783,14 +907,13 @@ internal class PlantingSeasonNotificationsServiceTest : DatabaseTest(), RunsAsDa
           insertPlantingSeasonScheduledDate(plantingSeasonId = plantingSeasonId),
   ): EventLogEntry<PlantingSeasonRelatedPersistentEvent> {
     val event =
-        PlantingDateRequestCreatedEvent(
-            date = LocalDate.EPOCH,
-            notes = null,
+        PlantingDateRequestUpdatedEvent(
+            changedFrom = changedFrom,
+            changedTo = changedTo,
             organizationId = organizationId,
             plantingSeasonId = plantingSeasonId,
             plantingSiteId = plantingSiteId,
             scheduledPlantingDateId = scheduledPlantingDateId,
-            status = PlantingDateRequestStatus.Pending,
         )
 
     return EventLogEntry(user.userId, clock.instant, event, eventLogStore.insertEvent(event))


### PR DESCRIPTION
The `ScheduledPlantingDateRequested` notification type was missing `dates` and `notes` fields. After talking with product, they decided to remove the `notes` field since that would add complexity. Add the dates as a `Set` of `LocalDate` by looking up the current date of all `scheduledPlantingDateId`s in the list of notifications. 