### PR TITLE
Add curly braces to match consistency elsewhere

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/notification/NotificationService.kt
+++ b/src/main/kotlin/com/terraformation/backend/notification/NotificationService.kt
@@ -911,7 +911,9 @@ class NotificationService(
                 config,
                 webAppUrls.fullDeliverable(deliverableId, organizationId, projectId).toString(),
             )
-          } else null
+          } else {
+            null
+          }
 
       log.info("Creating notifications for deliverable $deliverableId status updated")
 


### PR DESCRIPTION
While working on #4652 , an instance of `else null` was flagged as missing curly braces for consistency with the rest of the codebase. `NotificationService` was used as the reference, so make that consistent too.