### PR TITLE
SW-8411 Make all water measurements optional

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/tracking/api/BiomassPayloads.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/api/BiomassPayloads.kt
@@ -292,17 +292,33 @@ data class ExistingBiomassMeasurementPayload(
     val description: String?,
     val forestType: BiomassForestType,
     val herbaceousCoverPercent: Int,
+    @Schema(
+        description =
+            "Only valid for Mangrove forests. A null value indicates that there was no water."
+    )
     val ph: BigDecimal?,
     val quadrats: List<ExistingBiomassQuadratPayload>,
-    @Schema(description = "Measured in ppt") //
+    @Schema(
+        description =
+            "Measured in ppt. Only valid for Mangrove forests. A null value indicates that there " +
+                "was no water."
+    )
     val salinity: BigDecimal?,
     val smallTreeCountLow: Int,
     val smallTreeCountHigh: Int,
     val soilAssessment: String,
     val soilType: SoilType?,
-    @Schema(description = "Low or high tide.") //
+    @Schema(
+        description =
+            "Low or high tide. Only valid for Mangrove forests. A null value indicates that " +
+                "there was no water."
+    )
     val tide: MangroveTide?,
-    @Schema(description = "Time when ide is observed.") //
+    @Schema(
+        description =
+            "Time when ide is observed. Only valid for Mangrove forests. A null value indicates " +
+                "that there was no water."
+    )
     val tideTime: Instant?,
     val treeSpeciesCount: Int,
     val trees: List<ExistingTreePayload>,
@@ -357,15 +373,30 @@ data class ExistingBiomassMeasurementPayload(
   }
 }
 
+@Schema(
+    description =
+        "Measurements for terrestrial and mangrove biomass observations. Water measurements must " +
+            "either all be present or all be absent if forestType is Mangrove."
+)
 data class NewBiomassMeasurementPayload(
     val description: String?,
     val forestType: BiomassForestType,
     @Schema(minimum = "0", maximum = "100") //
     val herbaceousCoverPercent: Int,
-    @Schema(description = "Required for Mangrove forest.", minimum = "0", maximum = "14")
+    @Schema(
+        description =
+            "Only valid for Mangrove forests. A null value indicates that there was no water.",
+        minimum = "0",
+        maximum = "14",
+    )
     val ph: BigDecimal?,
     val quadrats: List<NewBiomassQuadratPayload>,
-    @Schema(description = "Measured in ppt. Required for Mangrove forest.", minimum = "0")
+    @Schema(
+        description =
+            "Measured in ppt. Only valid for Mangrove forests. A null value indicates that " +
+                "there was no water.",
+        minimum = "0",
+    )
     val salinity: BigDecimal?,
     @Schema(minimum = "0") //
     val smallTreeCountLow: Int,
@@ -373,9 +404,17 @@ data class NewBiomassMeasurementPayload(
     val smallTreeCountHigh: Int,
     val soilAssessment: String,
     val soilType: SoilType?,
-    @Schema(description = "Low or high tide. Required for Mangrove forest.")
+    @Schema(
+        description =
+            "Low or high tide. Only valid for Mangrove forests. A null value indicates that " +
+                "there was no water."
+    )
     val tide: MangroveTide?,
-    @Schema(description = "Time when ide is observed. Required for Mangrove forest.")
+    @Schema(
+        description =
+            "Time when tide is observed. Only valid for Mangrove forests. A null value " +
+                "indicates that there was no water."
+    )
     val tideTime: Instant?,
     val trees: List<NewTreePayload>,
     @Schema(

--- a/src/main/kotlin/com/terraformation/backend/tracking/api/BiomassPayloads.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/api/BiomassPayloads.kt
@@ -316,7 +316,7 @@ data class ExistingBiomassMeasurementPayload(
     val tide: MangroveTide?,
     @Schema(
         description =
-            "Time when ide is observed. Only valid for Mangrove forests. A null value indicates " +
+            "Time when tide is observed. Only valid for Mangrove forests. A null value indicates " +
                 "that there was no water."
     )
     val tideTime: Instant?,

--- a/src/main/kotlin/com/terraformation/backend/tracking/model/BiomassDetailsModel.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/model/BiomassDetailsModel.kt
@@ -166,18 +166,20 @@ data class BiomassDetailsModel<
     val waterDepthCm: Int? = null,
 ) {
   fun validate() {
-    if (forestType == BiomassForestType.Mangrove) {
-      if (ph == null) {
-        throw IllegalStateException("ph required for Mangrove")
-      }
-      if (salinityPpt == null) {
-        throw IllegalStateException("salinityPpt required for Mangrove")
-      }
-      if (tide == null) {
-        throw IllegalStateException("tide required for Mangrove")
-      }
-      if (tideTime == null) {
-        throw IllegalStateException("tideTime required for Mangrove")
+    val nonNullWaterValues = listOfNotNull(ph, salinityPpt, tide, tideTime, waterDepthCm)
+
+    if (nonNullWaterValues.isNotEmpty()) {
+      when (forestType) {
+        BiomassForestType.Mangrove -> {
+          if (nonNullWaterValues.size != 5) {
+            throw IllegalStateException(
+                "Water measurements must either all be set or all be absent"
+            )
+          }
+        }
+        BiomassForestType.Terrestrial -> {
+          throw IllegalStateException("Water measurements not allowed for Terrestrial forest type")
+        }
       }
     }
 

--- a/src/main/resources/db/migration/0500/V516__BiomassOptionalWater.sql
+++ b/src/main/resources/db/migration/0500/V516__BiomassOptionalWater.sql
@@ -1,0 +1,25 @@
+-- Previous version is in V514__BiomassWaterDepth.sql
+ALTER TABLE tracking.observation_biomass_details
+    DROP CONSTRAINT mangrove_required_values;
+
+ALTER TABLE tracking.observation_biomass_details
+    ADD CONSTRAINT mangrove_required_values
+        CHECK (
+            (
+                -- Terrestrial or mangroves with no water measurements
+                water_depth_cm IS NULL
+                AND salinity_ppt IS NULL
+                AND ph IS NULL
+                AND tide_id IS NULL
+                AND tide_time IS NULL
+            )
+            OR (
+                -- Mangrove: water measurements must all be set if any of them is set
+                forest_type_id = 2
+                AND water_depth_cm IS NOT NULL
+                AND salinity_ppt IS NOT NULL
+                AND ph IS NOT NULL
+                AND tide_id IS NOT NULL
+                AND tide_time IS NOT NULL
+            )
+        );

--- a/src/main/resources/db/migration/R__Comments.sql
+++ b/src/main/resources/db/migration/R__Comments.sql
@@ -500,10 +500,10 @@ COMMENT ON COLUMN tracking.observations.start_date IS 'First day of the observat
 COMMENT ON COLUMN tracking.observations.upcoming_notification_sent_time IS 'When the notification that the observation is starting in 1 month was sent. Null if the notification has not been sent yet.';
 
 COMMENT ON TABLE tracking.observation_biomass_details IS 'Recorded data for a biomass observation.';
-COMMENT ON COLUMN tracking.observation_biomass_details.ph IS 'Acidity of water in pH. Must only exists if forest type is "Mangrove".';
-COMMENT ON COLUMN tracking.observation_biomass_details.salinity_ppt IS 'Salinity of water in parts per thousand (ppt). Must be non-null if forest type is "Mangrove".';
-COMMENT ON COLUMN tracking.observation_biomass_details.tide_id IS 'High/low tide during observation. Must be non-null if forest type is "Mangrove".';
-COMMENT ON COLUMN tracking.observation_biomass_details.tide_time IS 'Time when the tide is recorded. Must be non-null if forest type is "Mangrove".';
+COMMENT ON COLUMN tracking.observation_biomass_details.ph IS 'Acidity of water in pH. Only allowed if forest type is "Mangrove". Null value indicates no water in monitoring plot.';
+COMMENT ON COLUMN tracking.observation_biomass_details.salinity_ppt IS 'Salinity of water in parts per thousand (ppt). Only allowed if forest type is "Mangrove". Null value indicates no water in monitoring plot.';
+COMMENT ON COLUMN tracking.observation_biomass_details.tide_id IS 'High/low tide during observation. Only allowed if forest type is "Mangrove". Null value indicates no water in monitoring plot.';
+COMMENT ON COLUMN tracking.observation_biomass_details.tide_time IS 'Time when the tide is recorded. Only allowed if forest type is "Mangrove". Null value indicates no water in monitoring plot.';
 COMMENT ON COLUMN tracking.observation_biomass_details.water_depth_cm IS 'Depth of water in centimeters (cm). Only allowed if forest type is "Mangrove". Null value indicates no water in monitoring plot.';
 
 COMMENT ON TABLE tracking.observation_biomass_species IS 'Herbaceous and tree species data for a biomass observation.';

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/biomassStore/BiomassStoreUpdateBiomassDetailsTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/biomassStore/BiomassStoreUpdateBiomassDetailsTest.kt
@@ -239,7 +239,7 @@ class BiomassStoreUpdateBiomassDetailsTest : BaseBiomassStoreTest() {
           salinityPpt = BigDecimal.ONE,
           tide = MangroveTide.High,
           tideTime = Instant.ofEpochSecond(120),
-          waterDepthCm = null,
+          waterDepthCm = 2,
       )
     }
 
@@ -249,7 +249,7 @@ class BiomassStoreUpdateBiomassDetailsTest : BaseBiomassStoreTest() {
           salinityPpt = BigDecimal.ONE
           tideId = MangroveTide.High
           tideTime = Instant.ofEpochSecond(120)
-          waterDepthCm = null
+          waterDepthCm = 2
         }
 
     assertTableEquals(expected)
@@ -270,8 +270,67 @@ class BiomassStoreUpdateBiomassDetailsTest : BaseBiomassStoreTest() {
                     salinity = BigDecimal.ONE,
                     tide = MangroveTide.High,
                     tideTime = Instant.ofEpochSecond(120),
-                    waterDepth = null,
+                    waterDepth = 2,
                 ),
+            monitoringPlotId = inserted.monitoringPlotId,
+            observationId = inserted.observationId,
+            organizationId = inserted.organizationId,
+            plantingSiteId = inserted.plantingSiteId,
+        )
+    )
+  }
+
+  @Test
+  fun `can clear mangrove-only water measurements`() {
+    dslContext.deleteFrom(OBSERVATION_BIOMASS_DETAILS).execute()
+    insertObservationBiomassDetails(
+        description = "Original description",
+        forestType = BiomassForestType.Mangrove,
+        herbaceousCoverPercent = 10,
+        ph = BigDecimal.ONE,
+        salinityPpt = BigDecimal.TWO,
+        smallTreesCountLow = 1,
+        smallTreesCountHigh = 4,
+        soilAssessment = "Original soil assessment",
+        tideId = MangroveTide.Low,
+        tideTime = Instant.EPOCH,
+        waterDepthCm = 1,
+    )
+
+    val before = dslContext.fetchSingle(OBSERVATION_BIOMASS_DETAILS)
+
+    store.updateBiomassDetails(inserted.observationId, inserted.monitoringPlotId) {
+      it.copy(
+          ph = null,
+          salinityPpt = null,
+          tide = null,
+          tideTime = null,
+          waterDepthCm = null,
+      )
+    }
+
+    val expected =
+        before.copy().apply {
+          ph = null
+          salinityPpt = null
+          tideId = null
+          tideTime = null
+          waterDepthCm = null
+        }
+
+    assertTableEquals(expected)
+
+    eventPublisher.assertEventPublished(
+        BiomassDetailsUpdatedEvent(
+            changedFrom =
+                BiomassDetailsUpdatedEventValues(
+                    ph = BigDecimal.ONE,
+                    salinity = BigDecimal.TWO,
+                    tide = MangroveTide.Low,
+                    tideTime = Instant.EPOCH,
+                    waterDepth = 1,
+                ),
+            changedTo = BiomassDetailsUpdatedEventValues(),
             monitoringPlotId = inserted.monitoringPlotId,
             observationId = inserted.observationId,
             organizationId = inserted.organizationId,


### PR DESCRIPTION
We got updated requirements for the ability to not specify water measurements in
mangrove biomass observations; rather than just the water depth being optional,
all the water-related measurements should be optional, but if any of them is
present, they all need to be specified. Update the database constraint and
validation logic accordingly.