### PR TITLE
SW-8411 Return "No water" for biomass water CSV columns

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/search/SearchTable.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/SearchTable.kt
@@ -19,6 +19,7 @@ import com.terraformation.backend.search.field.LocalDateTimeField
 import com.terraformation.backend.search.field.LocalizedTextField
 import com.terraformation.backend.search.field.LongField
 import com.terraformation.backend.search.field.NonLocalizableEnumField
+import com.terraformation.backend.search.field.NullMessageField
 import com.terraformation.backend.search.field.SearchField
 import com.terraformation.backend.search.field.StableIdField
 import com.terraformation.backend.search.field.TextField
@@ -289,6 +290,12 @@ abstract class SearchTable {
       fieldName: String,
       databaseField: Field<T?>,
   ) = NonLocalizableEnumField(fieldName, databaseField, this, T::class.java)
+
+  fun nullMessageField(
+      original: SearchField,
+      nullKey: String,
+      resourceBundleName: String = "i18n/Messages",
+  ) = NullMessageField(original, nullKey, resourceBundleName)
 
   fun textField(fieldName: String, databaseField: Field<String?>) =
       TextField(fieldName, databaseField, this)

--- a/src/main/kotlin/com/terraformation/backend/search/field/NullMessageField.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/field/NullMessageField.kt
@@ -1,0 +1,53 @@
+package com.terraformation.backend.search.field
+
+import com.terraformation.backend.i18n.currentLocale
+import com.terraformation.backend.search.FieldNode
+import java.util.Locale
+import java.util.ResourceBundle
+import java.util.concurrent.ConcurrentHashMap
+import org.jooq.Condition
+import org.jooq.Record
+
+/**
+ * Search field wrapper that returns a localized string instead of a null value if the original
+ * field's value is null.
+ */
+class NullMessageField(
+    private val original: SearchField,
+    /** Resource bundle key of the property with the text to use for null values. */
+    private val nullKey: String,
+    private val resourceBundleName: String,
+) : SearchField by original {
+  private val nullTextByLocale = ConcurrentHashMap<Locale, String>()
+
+  override fun getConditions(fieldNode: FieldNode): List<Condition> {
+    val nullText = getNullText()
+    val fieldNodeWithNull =
+        fieldNode.copy(
+            values =
+                fieldNode.values.map { searchValue ->
+                  if (searchValue == nullText) {
+                    null
+                  } else {
+                    searchValue
+                  }
+                }
+        )
+
+    return original.getConditions(fieldNodeWithNull)
+  }
+
+  override fun computeValue(record: Record): String {
+    return original.computeValue(record) ?: getNullText()
+  }
+
+  override fun raw(): SearchField? = original.raw()
+
+  private fun getNullText(): String {
+    val locale = currentLocale()
+    return nullTextByLocale.getOrPut(locale) {
+      val bundle = ResourceBundle.getBundle(resourceBundleName, locale)
+      bundle.getString(nullKey)
+    }
+  }
+}

--- a/src/main/kotlin/com/terraformation/backend/search/table/ObservationBiomassDetailsTable.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/table/ObservationBiomassDetailsTable.kt
@@ -78,15 +78,15 @@ class ObservationBiomassDetailsTable(private val tables: SearchTables) : SearchT
                       )
               ),
           ),
-          bigDecimalField("ph", OBSERVATION_BIOMASS_DETAILS.PH),
+          noWater(bigDecimalField("ph", OBSERVATION_BIOMASS_DETAILS.PH)),
           integerField("smallTreesCountHigh", OBSERVATION_BIOMASS_DETAILS.SMALL_TREES_COUNT_HIGH),
           integerField("smallTreesCountLow", OBSERVATION_BIOMASS_DETAILS.SMALL_TREES_COUNT_LOW),
-          bigDecimalField("salinity", OBSERVATION_BIOMASS_DETAILS.SALINITY_PPT),
+          noWater(bigDecimalField("salinity", OBSERVATION_BIOMASS_DETAILS.SALINITY_PPT)),
           textField("soilAssessment", OBSERVATION_BIOMASS_DETAILS.SOIL_ASSESSMENT),
           enumField("soilType", OBSERVATION_BIOMASS_DETAILS.SOIL_TYPE_ID),
-          enumField("tide", OBSERVATION_BIOMASS_DETAILS.TIDE_ID),
-          timestampField("tideTime", OBSERVATION_BIOMASS_DETAILS.TIDE_TIME),
-          integerField("waterDepth", OBSERVATION_BIOMASS_DETAILS.WATER_DEPTH_CM),
+          noWater(enumField("tide", OBSERVATION_BIOMASS_DETAILS.TIDE_ID)),
+          noWater(timestampField("tideTime", OBSERVATION_BIOMASS_DETAILS.TIDE_TIME)),
+          noWater(integerField("waterDepth", OBSERVATION_BIOMASS_DETAILS.WATER_DEPTH_CM)),
       )
 
   override val defaultOrderFields: List<OrderField<*>>
@@ -104,4 +104,7 @@ class ObservationBiomassDetailsTable(private val tables: SearchTables) : SearchT
         .join(OBSERVATIONS)
         .on(OBSERVATION_BIOMASS_DETAILS.OBSERVATION_ID.eq(OBSERVATIONS.ID))
   }
+
+  private fun noWater(original: SearchField) =
+      nullMessageField(original, "search.observationBiomassDetails.noWater")
 }

--- a/src/main/resources/i18n/Messages_en.properties
+++ b/src/main/resources/i18n/Messages_en.properties
@@ -799,6 +799,7 @@ search.nurseryWithdrawals.withdrawnDate=Date of withdrawal
 search.observationBiomassDetails.description=Plot description
 search.observationBiomassDetails.forestType=Forest type
 search.observationBiomassDetails.herbaceousCoverPercent=Herbaceous cover (%)
+search.observationBiomassDetails.noWater=No water
 search.observationBiomassDetails.numPlants=Number of plants
 search.observationBiomassDetails.numSpecies=Number of species
 search.observationBiomassDetails.ph=pH level

--- a/src/main/resources/i18n/Messages_es.properties
+++ b/src/main/resources/i18n/Messages_es.properties
@@ -1421,6 +1421,8 @@ search.observationBiomassDetails.description=Descripción de la parcela
 search.observationBiomassDetails.forestType=Tipo de bosque
 # ef1cf195
 search.observationBiomassDetails.herbaceousCoverPercent=Cobertura herbácea (%)
+# 1e0491f2
+search.observationBiomassDetails.noWater=Sin agua
 # c27180b6
 search.observationBiomassDetails.numPlants=Número de plantas
 # 5cc6f8e2

--- a/src/main/resources/i18n/Messages_fr.properties
+++ b/src/main/resources/i18n/Messages_fr.properties
@@ -1421,6 +1421,8 @@ search.observationBiomassDetails.description=Description de la parcelle
 search.observationBiomassDetails.forestType=Type de forêt
 # ef1cf195
 search.observationBiomassDetails.herbaceousCoverPercent=Couverture herbacée (%)
+# 1e0491f2
+search.observationBiomassDetails.noWater=Aucune eau
 # c27180b6
 search.observationBiomassDetails.numPlants=Nombre de plantes
 # 5cc6f8e2

--- a/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceNullValueTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceNullValueTest.kt
@@ -1,7 +1,10 @@
 package com.terraformation.backend.seedbank.search
 
+import com.terraformation.backend.db.tracking.BiomassForestType
+import com.terraformation.backend.db.tracking.ObservationType
 import com.terraformation.backend.search.FieldNode
 import com.terraformation.backend.search.NoConditionNode
+import com.terraformation.backend.search.SearchFieldPrefix
 import com.terraformation.backend.search.SearchFilterType
 import com.terraformation.backend.search.SearchResults
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -77,6 +80,32 @@ internal class SearchServiceNullValueTest : SearchServiceTest() {
             )
         ),
         searchAccessions(facilityId, fields, searchNode),
+    )
+  }
+
+  @Test
+  fun `null message field returns message for null values`() {
+    insertPlantingSite()
+    insertStratum()
+    insertSubstratum()
+    insertMonitoringPlot()
+    insertObservation(observationType = ObservationType.BiomassMeasurements)
+    insertObservationPlot()
+    insertObservationBiomassDetails(forestType = BiomassForestType.Mangrove)
+
+    val prefix = SearchFieldPrefix(tables.observationBiomassDetails)
+    val fields = listOf(prefix.resolve("waterDepth"))
+    val searchNode = NoConditionNode()
+
+    assertEquals(
+        SearchResults(
+            listOf(
+                mapOf(
+                    "waterDepth" to "No water",
+                )
+            )
+        ),
+        searchService.search(prefix, fields, mapOf(prefix to searchNode)),
     )
   }
 }


### PR DESCRIPTION
We want to include the text "No water" in exported CSVs of biomass observations
rather than leaving the water-related columns blank if there were no water
measurements in the observation.

Add a new search field type that supports rendering nulls as localizable messages
and use it on the water-related biomass observation fields.