### PR TITLE
SW-7489 Add collectedTime to accession create/update and response payloads

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/seedbank/api/AccessionsV2Controller.kt
+++ b/src/main/kotlin/com/terraformation/backend/seedbank/api/AccessionsV2Controller.kt
@@ -117,17 +117,8 @@ class AccessionsV2Controller(
   }
 }
 
-/**
- * Resolves the deprecated date-only `collectedDate` and the new `collectedTime` to a single
- * timestamp. Once web and mobile have fully migrated to `collectedTime`, `collectedDate` can be
- * removed from the request payloads and this helper deleted.
- */
-private fun resolveCollectedTime(collectedDate: LocalDate?, collectedTime: Instant?): Instant? {
-  if (collectedDate != null && collectedTime != null) {
-    throw IllegalArgumentException("Only one of collectedDate and collectedTime may be specified.")
-  }
-  return collectedTime ?: collectedDate?.atStartOfDay(ZoneOffset.UTC)?.toInstant()
-}
+private fun resolveCollectedTime(collectedDate: LocalDate?, collectedTime: Instant?): Instant? =
+    collectedTime ?: collectedDate?.atStartOfDay(ZoneOffset.UTC)?.toInstant()
 
 /**
  * Supported accession states. This is a subset of the values in [AccessionState], minus obsolete
@@ -181,12 +172,8 @@ data class AccessionPayloadV2(
     )
     val active: AccessionActive,
     val bagNumbers: Set<String>?,
-    @Schema(
-        description = "Use collectedTime instead.",
-        deprecated = true,
-    )
     val collectedDate: LocalDate?,
-    @Schema(description = "Date and time the seeds were collected, in UTC.")
+    @Schema(description = "Date and time the seeds were collected.") //
     val collectedTime: Instant?,
     val collectionSiteCity: String? = null,
     val collectionSiteCoordinates: Set<Geolocation>?,
@@ -343,17 +330,8 @@ data class AccessionPayloadV2(
 @JsonAutoDetect(getterVisibility = JsonAutoDetect.Visibility.NONE)
 data class CreateAccessionRequestPayloadV2(
     val bagNumbers: Set<String>? = null,
-    @Schema(
-        description = "Use collectedTime instead.",
-        deprecated = true,
-    )
     val collectedDate: LocalDate? = null,
-    @Schema(
-        description =
-            "Date and time the seeds were collected, in UTC. Optional for now to stay " +
-                "backwards compatible with the deprecated collectedDate; once web and mobile use " +
-                "this field, remove collectedDate."
-    )
+    @Schema(description = "Date and time the seeds were collected.")
     val collectedTime: Instant? = null,
     val collectionSiteCity: String? = null,
     val collectionSiteCoordinates: Set<Geolocation>? = null,
@@ -408,12 +386,8 @@ data class CreateAccessionRequestPayloadV2(
 @JsonAutoDetect(getterVisibility = JsonAutoDetect.Visibility.NONE)
 data class UpdateAccessionRequestPayloadV2(
     val bagNumbers: Set<String>? = null,
-    @Schema(
-        description = "Use collectedTime instead.",
-        deprecated = true,
-    )
     val collectedDate: LocalDate? = null,
-    @Schema(description = "Date and time the seeds were collected, in UTC.")
+    @Schema(description = "Date and time the seeds were collected.")
     val collectedTime: Instant? = null,
     val collectionSiteCity: String? = null,
     val collectionSiteCoordinates: Set<Geolocation>? = null,

--- a/src/main/kotlin/com/terraformation/backend/seedbank/api/AccessionsV2Controller.kt
+++ b/src/main/kotlin/com/terraformation/backend/seedbank/api/AccessionsV2Controller.kt
@@ -118,6 +118,18 @@ class AccessionsV2Controller(
 }
 
 /**
+ * Resolves the deprecated date-only `collectedDate` and the new `collectedTime` to a single
+ * timestamp. Once web and mobile have fully migrated to `collectedTime`, `collectedDate` can be
+ * removed from the request payloads and this helper deleted.
+ */
+private fun resolveCollectedTime(collectedDate: LocalDate?, collectedTime: Instant?): Instant? {
+  if (collectedDate != null && collectedTime != null) {
+    throw IllegalArgumentException("Only one of collectedDate and collectedTime may be specified.")
+  }
+  return collectedTime ?: collectedDate?.atStartOfDay(ZoneOffset.UTC)?.toInstant()
+}
+
+/**
  * Supported accession states. This is a subset of the values in [AccessionState], minus obsolete
  * states that can still appear in accessions' state histories (and thus need to be kept around as
  * [AccessionState] enum values) but that can no longer be used as the current states for any
@@ -169,7 +181,13 @@ data class AccessionPayloadV2(
     )
     val active: AccessionActive,
     val bagNumbers: Set<String>?,
+    @Schema(
+        description = "Use collectedTime instead.",
+        deprecated = true,
+    )
     val collectedDate: LocalDate?,
+    @Schema(description = "Date and time the seeds were collected, in UTC.")
+    val collectedTime: Instant?,
     val collectionSiteCity: String? = null,
     val collectionSiteCoordinates: Set<Geolocation>?,
     val collectionSiteCountryCode: String? = null,
@@ -278,6 +296,7 @@ data class AccessionPayloadV2(
       active = model.active,
       bagNumbers = model.bagNumbers.orNull(),
       collectedDate = model.collectedDate,
+      collectedTime = model.collectedTime,
       collectionSiteCity = model.collectionSiteCity,
       collectionSiteCoordinates = model.geolocations.orNull(),
       collectionSiteCountryCode = model.collectionSiteCountryCode,
@@ -324,7 +343,18 @@ data class AccessionPayloadV2(
 @JsonAutoDetect(getterVisibility = JsonAutoDetect.Visibility.NONE)
 data class CreateAccessionRequestPayloadV2(
     val bagNumbers: Set<String>? = null,
+    @Schema(
+        description = "Use collectedTime instead.",
+        deprecated = true,
+    )
     val collectedDate: LocalDate? = null,
+    @Schema(
+        description =
+            "Date and time the seeds were collected, in UTC. Optional for now to stay " +
+                "backwards compatible with the deprecated collectedDate; once web and mobile use " +
+                "this field, remove collectedDate."
+    )
+    val collectedTime: Instant? = null,
     val collectionSiteCity: String? = null,
     val collectionSiteCoordinates: Set<Geolocation>? = null,
     val collectionSiteCountryCode: String? = null,
@@ -351,7 +381,7 @@ data class CreateAccessionRequestPayloadV2(
         bagNumbers = bagNumbers.orEmpty(),
         clock = clock,
         collectedDate = collectedDate,
-        collectedTime = collectedDate?.atStartOfDay(ZoneOffset.UTC)?.toInstant(),
+        collectedTime = resolveCollectedTime(collectedDate, collectedTime),
         collectionSiteCity = collectionSiteCity,
         collectionSiteCountryCode = collectionSiteCountryCode,
         collectionSiteCountrySubdivision = collectionSiteCountrySubdivision,
@@ -378,7 +408,13 @@ data class CreateAccessionRequestPayloadV2(
 @JsonAutoDetect(getterVisibility = JsonAutoDetect.Visibility.NONE)
 data class UpdateAccessionRequestPayloadV2(
     val bagNumbers: Set<String>? = null,
+    @Schema(
+        description = "Use collectedTime instead.",
+        deprecated = true,
+    )
     val collectedDate: LocalDate? = null,
+    @Schema(description = "Date and time the seeds were collected, in UTC.")
+    val collectedTime: Instant? = null,
     val collectionSiteCity: String? = null,
     val collectionSiteCoordinates: Set<Geolocation>? = null,
     val collectionSiteCountryCode: String? = null,
@@ -420,7 +456,7 @@ data class UpdateAccessionRequestPayloadV2(
       model.copy(
           bagNumbers = bagNumbers.orEmpty(),
           collectedDate = collectedDate,
-          collectedTime = collectedDate?.atStartOfDay(ZoneOffset.UTC)?.toInstant(),
+          collectedTime = resolveCollectedTime(collectedDate, collectedTime),
           collectionSiteCity = collectionSiteCity,
           collectionSiteCountryCode = collectionSiteCountryCode,
           collectionSiteCountrySubdivision = collectionSiteCountrySubdivision,

--- a/src/test/kotlin/com/terraformation/backend/seedbank/db/accessionStore/AccessionStoreCreateTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/db/accessionStore/AccessionStoreCreateTest.kt
@@ -22,6 +22,7 @@ import com.terraformation.backend.seedbank.seeds
 import java.math.BigDecimal
 import java.time.Instant
 import java.time.LocalDate
+import java.time.ZoneOffset
 import kotlin.reflect.full.declaredMemberProperties
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotEquals
@@ -170,7 +171,7 @@ internal class AccessionStoreCreateTest : AccessionStoreTest() {
     val accession =
         CreateAccessionRequestPayloadV2(
             bagNumbers = setOf("abc"),
-            collectedDate = today,
+            collectedTime = today.atStartOfDay(ZoneOffset.UTC).toInstant(),
             collectionSiteCity = "city",
             collectionSiteCoordinates =
                 setOf(
@@ -211,9 +212,12 @@ internal class AccessionStoreCreateTest : AccessionStoreTest() {
     val accessionModelProperties = AccessionModel::class.declaredMemberProperties
     val propertyNames = createPayloadProperties.map { it.name }.toSet()
 
-    createPayloadProperties.forEach { prop ->
-      assertNotNull(prop.get(accession), "Field ${prop.name} is null in example object")
-    }
+    val deprecatedPayloadFields = setOf("collectedDate")
+    createPayloadProperties
+        .filter { it.name !in deprecatedPayloadFields }
+        .forEach { prop ->
+          assertNotNull(prop.get(accession), "Field ${prop.name} is null in example object")
+        }
 
     val stored = store.create(accession.toModel(clock))
 

--- a/src/test/kotlin/com/terraformation/backend/seedbank/db/accessionStore/AccessionStoreCreateTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/db/accessionStore/AccessionStoreCreateTest.kt
@@ -171,6 +171,7 @@ internal class AccessionStoreCreateTest : AccessionStoreTest() {
     val accession =
         CreateAccessionRequestPayloadV2(
             bagNumbers = setOf("abc"),
+            collectedDate = today,
             collectedTime = today.atStartOfDay(ZoneOffset.UTC).toInstant(),
             collectionSiteCity = "city",
             collectionSiteCoordinates =
@@ -212,12 +213,9 @@ internal class AccessionStoreCreateTest : AccessionStoreTest() {
     val accessionModelProperties = AccessionModel::class.declaredMemberProperties
     val propertyNames = createPayloadProperties.map { it.name }.toSet()
 
-    val deprecatedPayloadFields = setOf("collectedDate")
-    createPayloadProperties
-        .filter { it.name !in deprecatedPayloadFields }
-        .forEach { prop ->
-          assertNotNull(prop.get(accession), "Field ${prop.name} is null in example object")
-        }
+    createPayloadProperties.forEach { prop ->
+      assertNotNull(prop.get(accession), "Field ${prop.name} is null in example object")
+    }
 
     val stored = store.create(accession.toModel(clock))
 

--- a/src/test/kotlin/com/terraformation/backend/seedbank/db/accessionStore/AccessionStoreDatabaseTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/db/accessionStore/AccessionStoreDatabaseTest.kt
@@ -29,6 +29,7 @@ import com.terraformation.backend.seedbank.model.Geolocation
 import com.terraformation.backend.seedbank.seeds
 import java.math.BigDecimal
 import java.time.LocalDate
+import java.time.ZoneOffset
 import kotlin.reflect.KVisibility
 import kotlin.reflect.full.declaredMemberProperties
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -85,7 +86,7 @@ internal class AccessionStoreDatabaseTest : AccessionStoreTest() {
     val update =
         UpdateAccessionRequestPayloadV2(
             bagNumbers = setOf("abc"),
-            collectedDate = today,
+            collectedTime = today.atStartOfDay(ZoneOffset.UTC).toInstant(),
             collectionSiteCity = "city",
             collectionSiteCoordinates =
                 setOf(
@@ -134,8 +135,9 @@ internal class AccessionStoreDatabaseTest : AccessionStoreTest() {
     val accessionModelProperties = AccessionModel::class.declaredMemberProperties
     val propertyNames = updatePayloadProperties.map { it.name }.toSet()
 
+    val deprecatedPayloadFields = setOf("collectedDate")
     updatePayloadProperties.forEach { prop ->
-      if (prop.visibility == KVisibility.PUBLIC) {
+      if (prop.visibility == KVisibility.PUBLIC && prop.name !in deprecatedPayloadFields) {
         try {
           assertNotNull(prop.get(update), "Field ${prop.name} is null in example object")
         } catch (e: Exception) {

--- a/src/test/kotlin/com/terraformation/backend/seedbank/db/accessionStore/AccessionStoreDatabaseTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/db/accessionStore/AccessionStoreDatabaseTest.kt
@@ -86,6 +86,7 @@ internal class AccessionStoreDatabaseTest : AccessionStoreTest() {
     val update =
         UpdateAccessionRequestPayloadV2(
             bagNumbers = setOf("abc"),
+            collectedDate = today,
             collectedTime = today.atStartOfDay(ZoneOffset.UTC).toInstant(),
             collectionSiteCity = "city",
             collectionSiteCoordinates =
@@ -135,9 +136,8 @@ internal class AccessionStoreDatabaseTest : AccessionStoreTest() {
     val accessionModelProperties = AccessionModel::class.declaredMemberProperties
     val propertyNames = updatePayloadProperties.map { it.name }.toSet()
 
-    val deprecatedPayloadFields = setOf("collectedDate")
     updatePayloadProperties.forEach { prop ->
-      if (prop.visibility == KVisibility.PUBLIC && prop.name !in deprecatedPayloadFields) {
+      if (prop.visibility == KVisibility.PUBLIC) {
         try {
           assertNotNull(prop.get(update), "Field ${prop.name} is null in example object")
         } catch (e: Exception) {


### PR DESCRIPTION
Update the accessions controller to return the new `collectedTime` field in addition to the existing `collectedDate` . For Create/Update requests, accept both.

Co-authored-by: Claude Opus 4.8 [noreply@anthropic.com](mailto:noreply@anthropic.com)