### PR TITLE
SW-8351 Record substratum dependencies on completion and abandon

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/tracking/db/ObservationStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/db/ObservationStore.kt
@@ -38,10 +38,10 @@ import com.terraformation.backend.db.tracking.tables.pojos.RecordedPlantsRow
 import com.terraformation.backend.db.tracking.tables.records.ObservationPlotConditionsRecord
 import com.terraformation.backend.db.tracking.tables.records.ObservedPlotSpeciesTotalsRecord
 import com.terraformation.backend.db.tracking.tables.records.RecordedPlantsRecord
-import com.terraformation.backend.db.tracking.tables.references.DEPENDENT_SUBSTRATUM_OBSERVATION
 import com.terraformation.backend.db.tracking.tables.references.MONITORING_PLOTS
 import com.terraformation.backend.db.tracking.tables.references.MONITORING_PLOT_HISTORIES
 import com.terraformation.backend.db.tracking.tables.references.OBSERVATIONS
+import com.terraformation.backend.db.tracking.tables.references.OBSERVATION_DEPENDENT_SUBSTRATA
 import com.terraformation.backend.db.tracking.tables.references.OBSERVATION_MEDIA_FILES
 import com.terraformation.backend.db.tracking.tables.references.OBSERVATION_PLOTS
 import com.terraformation.backend.db.tracking.tables.references.OBSERVATION_PLOT_CONDITIONS
@@ -1648,17 +1648,17 @@ class ObservationStore(
         )
 
     dslContext
-        .deleteFrom(DEPENDENT_SUBSTRATUM_OBSERVATION)
-        .where(DEPENDENT_SUBSTRATUM_OBSERVATION.OBSERVATION_ID.eq(observationId))
+        .deleteFrom(OBSERVATION_DEPENDENT_SUBSTRATA)
+        .where(OBSERVATION_DEPENDENT_SUBSTRATA.OBSERVATION_ID.eq(observationId))
         .execute()
 
     dslContext
         .insertInto(
-            DEPENDENT_SUBSTRATUM_OBSERVATION,
-            DEPENDENT_SUBSTRATUM_OBSERVATION.OBSERVATION_ID,
-            DEPENDENT_SUBSTRATUM_OBSERVATION.SUBSTRATUM_HISTORY_ID,
-            DEPENDENT_SUBSTRATUM_OBSERVATION.DEPENDS_ON_OBSERVATION_ID,
-            DEPENDENT_SUBSTRATUM_OBSERVATION.DEPENDS_ON_SUBSTRATUM_HISTORY_ID,
+            OBSERVATION_DEPENDENT_SUBSTRATA,
+            OBSERVATION_DEPENDENT_SUBSTRATA.OBSERVATION_ID,
+            OBSERVATION_DEPENDENT_SUBSTRATA.SUBSTRATUM_HISTORY_ID,
+            OBSERVATION_DEPENDENT_SUBSTRATA.DEPENDS_ON_OBSERVATION_ID,
+            OBSERVATION_DEPENDENT_SUBSTRATA.DEPENDS_ON_SUBSTRATUM_HISTORY_ID,
         )
         .select(
             DSL.select(

--- a/src/main/kotlin/com/terraformation/backend/tracking/db/ObservationStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/db/ObservationStore.kt
@@ -112,8 +112,6 @@ import org.jooq.Condition
 import org.jooq.DSLContext
 import org.jooq.Field
 import org.jooq.Record
-import org.jooq.Record1
-import org.jooq.Select
 import org.jooq.impl.DSL
 import org.jooq.impl.SQLDataType
 import org.springframework.context.ApplicationEventPublisher
@@ -1582,15 +1580,15 @@ class ObservationStore(
   private fun computeLatestObservationForSubstratumField(
       observationId: ObservationId,
       substratumIdField: Field<SubstratumId?>,
-  ): Select<Record1<ObservationId?>> {
+  ): Field<ObservationId?> {
     val candidateObs = OBSERVATIONS.`as`("candidate_obs")
     val op = OBSERVATION_PLOTS.`as`("dep_op")
     val mph = MONITORING_PLOT_HISTORIES.`as`("dep_mph")
 
-    return DSL.select(candidateObs.ID)
-        .from(candidateObs)
-        .where(
-            DSL.exists(
+    return DSL.field(
+        DSL.select(candidateObs.ID)
+            .from(candidateObs)
+            .whereExists(
                 DSL.selectOne()
                     .from(op)
                     .join(mph)
@@ -1599,25 +1597,25 @@ class ObservationStore(
                     .and(op.COMPLETED_TIME.isNotNull)
                     .and(mph.SUBSTRATUM_ID.eq(substratumIdField))
             )
-        )
-        .and(
-            DSL.or(
-                candidateObs.ID.eq(observationId),
-                candidateObs.COMPLETED_TIME.le(
-                    DSL.select(OBSERVATIONS.COMPLETED_TIME)
-                        .from(OBSERVATIONS)
-                        .where(OBSERVATIONS.ID.eq(observationId))
-                ),
+            .and(
+                DSL.or(
+                    candidateObs.ID.eq(observationId),
+                    candidateObs.COMPLETED_TIME.le(
+                        DSL.select(OBSERVATIONS.COMPLETED_TIME)
+                            .from(OBSERVATIONS)
+                            .where(OBSERVATIONS.ID.eq(observationId))
+                    ),
+                )
             )
-        )
-        .and(candidateObs.IS_AD_HOC.isFalse)
-        .orderBy(
-            // Prefer results from the same observation as the `observationId` if it exists.
-            candidateObs.ID.eq(observationId).desc(),
-            // Otherwise take the results from the next latest observation for that area.
-            candidateObs.COMPLETED_TIME.desc(),
-        )
-        .limit(1)
+            .and(candidateObs.IS_AD_HOC.isFalse)
+            .orderBy(
+                // Prefer results from the same observation as the `observationId` if it exists.
+                candidateObs.ID.eq(observationId).desc(),
+                // Otherwise take the results from the next latest observation for that area.
+                candidateObs.COMPLETED_TIME.desc(),
+            )
+            .limit(1)
+    )
   }
 
   private fun recordSubstratumDependencies(observationId: ObservationId) {
@@ -1628,11 +1626,9 @@ class ObservationStore(
     val srcObs = OBSERVATIONS.`as`("src_obs")
 
     val dependsOnObservationId =
-        DSL.field(
-            computeLatestObservationForSubstratumField(
-                observationId,
-                consumingSsh.SUBSTRATUM_ID,
-            )
+        computeLatestObservationForSubstratumField(
+            observationId,
+            consumingSsh.SUBSTRATUM_ID,
         )
 
     val dependsOnSubstratumHistoryId =

--- a/src/main/kotlin/com/terraformation/backend/tracking/db/ObservationStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/db/ObservationStore.kt
@@ -38,6 +38,7 @@ import com.terraformation.backend.db.tracking.tables.pojos.RecordedPlantsRow
 import com.terraformation.backend.db.tracking.tables.records.ObservationPlotConditionsRecord
 import com.terraformation.backend.db.tracking.tables.records.ObservedPlotSpeciesTotalsRecord
 import com.terraformation.backend.db.tracking.tables.records.RecordedPlantsRecord
+import com.terraformation.backend.db.tracking.tables.references.DEPENDENT_SUBSTRATUM_OBSERVATION
 import com.terraformation.backend.db.tracking.tables.references.MONITORING_PLOTS
 import com.terraformation.backend.db.tracking.tables.references.MONITORING_PLOT_HISTORIES
 import com.terraformation.backend.db.tracking.tables.references.OBSERVATIONS
@@ -111,6 +112,8 @@ import org.jooq.Condition
 import org.jooq.DSLContext
 import org.jooq.Field
 import org.jooq.Record
+import org.jooq.Record1
+import org.jooq.Select
 import org.jooq.impl.DSL
 import org.jooq.impl.SQLDataType
 import org.springframework.context.ApplicationEventPublisher
@@ -930,6 +933,20 @@ class ObservationStore(
           plantCountsBySpecies,
       )
 
+      observationPlotsDao.update(
+          observationPlotsRow.copy(
+              completedBy = currentUser().userId,
+              completedTime = clock.instant(),
+              notes = notes,
+              observedTime = observedTime,
+              statusId = ObservationPlotStatus.Completed,
+          )
+      )
+
+      if (!isAdHoc) {
+        recordSubstratumDependencies(observationId)
+      }
+
       updateObservationResults(
           observationId,
           plantingSite,
@@ -939,16 +956,6 @@ class ObservationStore(
           substratumHistoryId,
           monitoringPlotId,
           isAdHoc,
-      )
-
-      observationPlotsDao.update(
-          observationPlotsRow.copy(
-              completedBy = currentUser().userId,
-              completedTime = clock.instant(),
-              notes = notes,
-              observedTime = observedTime,
-              statusId = ObservationPlotStatus.Completed,
-          )
       )
 
       if (substratumId != null) {
@@ -1545,6 +1552,7 @@ class ObservationStore(
         log.info("Marking observation $observationId as abandoned")
         abandonPlots(observationId)
         updateObservationState(observationId, ObservationState.Abandoned)
+        recordSubstratumDependencies(observationId)
         resetPlantPopulationSinceLastObservation(observation.plantingSiteId)
         recalculateSurvivalRateResults(observationId, observation.plantingSiteId)
       }
@@ -1561,6 +1569,7 @@ class ObservationStore(
   ) {
     updateObservationState(observationId, ObservationState.Completed)
     if (!isAdHoc) {
+      recordSubstratumDependencies(observationId)
       // Ad-hoc observations do not reset unobserved populations
       resetPlantPopulationSinceLastObservation(plantingSiteId)
       recalculateSurvivalRates(observationId, plantingSiteId)
@@ -1568,6 +1577,105 @@ class ObservationStore(
     }
 
     eventPublisher.publishEvent(ObservationCompletedEvent(observationId))
+  }
+
+  private fun computeLatestObservationForSubstratumField(
+      observationId: ObservationId,
+      substratumIdField: Field<SubstratumId?>,
+  ): Select<Record1<ObservationId?>> {
+    val candidateObs = OBSERVATIONS.`as`("candidate_obs")
+    val op = OBSERVATION_PLOTS.`as`("dep_op")
+    val mph = MONITORING_PLOT_HISTORIES.`as`("dep_mph")
+
+    return DSL.select(candidateObs.ID)
+        .from(candidateObs)
+        .where(
+            DSL.exists(
+                DSL.selectOne()
+                    .from(op)
+                    .join(mph)
+                    .on(mph.ID.eq(op.MONITORING_PLOT_HISTORY_ID))
+                    .where(op.OBSERVATION_ID.eq(candidateObs.ID))
+                    .and(op.COMPLETED_TIME.isNotNull)
+                    .and(mph.SUBSTRATUM_ID.eq(substratumIdField))
+            )
+        )
+        .and(
+            DSL.or(
+                candidateObs.ID.eq(observationId),
+                candidateObs.COMPLETED_TIME.le(
+                    DSL.select(OBSERVATIONS.COMPLETED_TIME)
+                        .from(OBSERVATIONS)
+                        .where(OBSERVATIONS.ID.eq(observationId))
+                ),
+            )
+        )
+        .and(candidateObs.IS_AD_HOC.isFalse)
+        .orderBy(
+            // Prefer results from the same observation as the `observationId` if it exists.
+            candidateObs.ID.eq(observationId).desc(),
+            // Otherwise take the results from the next latest observation for that area.
+            candidateObs.COMPLETED_TIME.desc(),
+        )
+        .limit(1)
+  }
+
+  private fun recordSubstratumDependencies(observationId: ObservationId) {
+    val consumingSsh = SUBSTRATUM_HISTORIES.`as`("consuming_ssh")
+    val consumingSh = STRATUM_HISTORIES.`as`("consuming_sh")
+    val srcSsh = SUBSTRATUM_HISTORIES.`as`("src_ssh")
+    val srcSh = STRATUM_HISTORIES.`as`("src_sh")
+    val srcObs = OBSERVATIONS.`as`("src_obs")
+
+    val dependsOnObservationId =
+        DSL.field(
+            computeLatestObservationForSubstratumField(
+                observationId,
+                consumingSsh.SUBSTRATUM_ID,
+            )
+        )
+
+    val dependsOnSubstratumHistoryId =
+        DSL.field(
+            DSL.select(srcSsh.ID)
+                .from(srcObs)
+                .join(srcSh)
+                .on(srcSh.PLANTING_SITE_HISTORY_ID.eq(srcObs.PLANTING_SITE_HISTORY_ID))
+                .join(srcSsh)
+                .on(srcSsh.STRATUM_HISTORY_ID.eq(srcSh.ID))
+                .where(srcObs.ID.eq(dependsOnObservationId))
+                .and(srcSsh.SUBSTRATUM_ID.eq(consumingSsh.SUBSTRATUM_ID))
+        )
+
+    dslContext
+        .deleteFrom(DEPENDENT_SUBSTRATUM_OBSERVATION)
+        .where(DEPENDENT_SUBSTRATUM_OBSERVATION.OBSERVATION_ID.eq(observationId))
+        .execute()
+
+    dslContext
+        .insertInto(
+            DEPENDENT_SUBSTRATUM_OBSERVATION,
+            DEPENDENT_SUBSTRATUM_OBSERVATION.OBSERVATION_ID,
+            DEPENDENT_SUBSTRATUM_OBSERVATION.SUBSTRATUM_HISTORY_ID,
+            DEPENDENT_SUBSTRATUM_OBSERVATION.DEPENDS_ON_OBSERVATION_ID,
+            DEPENDENT_SUBSTRATUM_OBSERVATION.DEPENDS_ON_SUBSTRATUM_HISTORY_ID,
+        )
+        .select(
+            DSL.select(
+                    DSL.value(observationId, OBSERVATIONS.ID),
+                    consumingSsh.ID,
+                    dependsOnObservationId,
+                    dependsOnSubstratumHistoryId,
+                )
+                .from(OBSERVATIONS)
+                .join(consumingSh)
+                .on(consumingSh.PLANTING_SITE_HISTORY_ID.eq(OBSERVATIONS.PLANTING_SITE_HISTORY_ID))
+                .join(consumingSsh)
+                .on(consumingSsh.STRATUM_HISTORY_ID.eq(consumingSh.ID))
+                .where(OBSERVATIONS.ID.eq(observationId))
+                .and(dependsOnObservationId.isNotNull)
+        )
+        .execute()
   }
 
   /**
@@ -1605,6 +1713,10 @@ class ObservationStore(
             .fetch()
 
     dslContext.transaction { _ ->
+      if (!isAdHoc) {
+        recordSubstratumDependencies(observationId)
+      }
+
       completedPlots.forEach { record ->
         updateObservationResults(
             observationId,

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/observationStore/ObservationStoreSubstratumDependenciesTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/observationStore/ObservationStoreSubstratumDependenciesTest.kt
@@ -3,7 +3,7 @@ package com.terraformation.backend.tracking.db.observationStore
 import com.terraformation.backend.db.tracking.RecordedPlantStatus
 import com.terraformation.backend.db.tracking.RecordedSpeciesCertainty
 import com.terraformation.backend.db.tracking.tables.pojos.RecordedPlantsRow
-import com.terraformation.backend.db.tracking.tables.records.DependentSubstratumObservationRecord
+import com.terraformation.backend.db.tracking.tables.records.ObservationDependentSubstrataRecord
 import com.terraformation.backend.mockUser
 import com.terraformation.backend.point
 import com.terraformation.backend.tracking.db.ObservationScenarioTest
@@ -50,7 +50,7 @@ class ObservationStoreSubstratumDependenciesTest : ObservationScenarioTest() {
     )
 
     assertTableEquals(
-        DependentSubstratumObservationRecord(
+        ObservationDependentSubstrataRecord(
             observationId = observationId,
             substratumHistoryId = substratumHistoryId,
             dependsOnObservationId = observationId,
@@ -131,13 +131,13 @@ class ObservationStoreSubstratumDependenciesTest : ObservationScenarioTest() {
     assertTableEquals(
         listOf(
             // observationId1 observed both substrata -> self-references.
-            DependentSubstratumObservationRecord(
+            ObservationDependentSubstrataRecord(
                 observationId = observationId1,
                 substratumHistoryId = substratumHistoryIdA,
                 dependsOnObservationId = observationId1,
                 dependsOnSubstratumHistoryId = substratumHistoryIdA,
             ),
-            DependentSubstratumObservationRecord(
+            ObservationDependentSubstrataRecord(
                 observationId = observationId1,
                 substratumHistoryId = substratumHistoryIdB,
                 dependsOnObservationId = observationId1,
@@ -145,13 +145,13 @@ class ObservationStoreSubstratumDependenciesTest : ObservationScenarioTest() {
             ),
             // observationId2 observed A -> self-reference; B was not observed -> points back to
             // observationId1.
-            DependentSubstratumObservationRecord(
+            ObservationDependentSubstrataRecord(
                 observationId = observationId2,
                 substratumHistoryId = substratumHistoryIdA,
                 dependsOnObservationId = observationId2,
                 dependsOnSubstratumHistoryId = substratumHistoryIdA,
             ),
-            DependentSubstratumObservationRecord(
+            ObservationDependentSubstrataRecord(
                 observationId = observationId2,
                 substratumHistoryId = substratumHistoryIdB,
                 dependsOnObservationId = observationId1,
@@ -236,19 +236,19 @@ class ObservationStoreSubstratumDependenciesTest : ObservationScenarioTest() {
 
     assertTableEquals(
         listOf(
-            DependentSubstratumObservationRecord(
+            ObservationDependentSubstrataRecord(
                 observationId = observationId1,
                 substratumHistoryId = substratumHistoryIdA,
                 dependsOnObservationId = observationId1,
                 dependsOnSubstratumHistoryId = substratumHistoryIdA,
             ),
-            DependentSubstratumObservationRecord(
+            ObservationDependentSubstrataRecord(
                 observationId = observationId1,
                 substratumHistoryId = substratumHistoryIdB,
                 dependsOnObservationId = observationId1,
                 dependsOnSubstratumHistoryId = substratumHistoryIdB,
             ),
-            DependentSubstratumObservationRecord(
+            ObservationDependentSubstrataRecord(
                 observationId = observationId2,
                 substratumHistoryId = substratumHistoryIdA,
                 dependsOnObservationId = observationId2,
@@ -256,7 +256,7 @@ class ObservationStoreSubstratumDependenciesTest : ObservationScenarioTest() {
             ),
             // B was requested but not observed in observationId2, so it rolls forward to the prior
             // observation that actually observed it rather than self-referencing.
-            DependentSubstratumObservationRecord(
+            ObservationDependentSubstrataRecord(
                 observationId = observationId2,
                 substratumHistoryId = substratumHistoryIdB,
                 dependsOnObservationId = observationId1,
@@ -287,7 +287,7 @@ class ObservationStoreSubstratumDependenciesTest : ObservationScenarioTest() {
     )
 
     assertTableEquals(
-        DependentSubstratumObservationRecord(
+        ObservationDependentSubstrataRecord(
             observationId = observationId,
             substratumHistoryId = substratumHistoryId,
             dependsOnObservationId = observationId,
@@ -328,7 +328,7 @@ class ObservationStoreSubstratumDependenciesTest : ObservationScenarioTest() {
     )
 
     assertTableEquals(
-        DependentSubstratumObservationRecord(
+        ObservationDependentSubstrataRecord(
             observationId = observationId,
             substratumHistoryId = substratumHistoryIdA,
             dependsOnObservationId = observationId,

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/observationStore/ObservationStoreSubstratumDependenciesTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/observationStore/ObservationStoreSubstratumDependenciesTest.kt
@@ -1,0 +1,340 @@
+package com.terraformation.backend.tracking.db.observationStore
+
+import com.terraformation.backend.db.tracking.RecordedPlantStatus
+import com.terraformation.backend.db.tracking.RecordedSpeciesCertainty
+import com.terraformation.backend.db.tracking.tables.pojos.RecordedPlantsRow
+import com.terraformation.backend.db.tracking.tables.records.DependentSubstratumObservationRecord
+import com.terraformation.backend.mockUser
+import com.terraformation.backend.point
+import com.terraformation.backend.tracking.db.ObservationScenarioTest
+import java.time.Instant
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class ObservationStoreSubstratumDependenciesTest : ObservationScenarioTest() {
+  override val user = mockUser()
+
+  private lateinit var recordedPlants: List<RecordedPlantsRow>
+
+  @BeforeEach
+  fun insertRecordedSpecies() {
+    val speciesId = insertSpecies()
+    recordedPlants =
+        listOf(
+            RecordedPlantsRow(
+                certaintyId = RecordedSpeciesCertainty.Known,
+                gpsCoordinates = point(1),
+                speciesId = speciesId,
+                statusId = RecordedPlantStatus.Live,
+            )
+        )
+  }
+
+  @Test
+  fun `records self-reference for an observed substratum`() {
+    insertStratum()
+    insertSubstratum()
+    val substratumHistoryId = inserted.substratumHistoryId
+    val plotId = insertMonitoringPlot(permanentIndex = 1)
+    val observationId = insertObservation()
+    insertObservationRequestedSubstratum()
+    insertObservationPlot(claimedBy = user.userId, isPermanent = true)
+
+    observationStore.completePlot(
+        observationId,
+        plotId,
+        emptySet(),
+        "Notes",
+        Instant.ofEpochSecond(1),
+        recordedPlants,
+    )
+
+    assertTableEquals(
+        DependentSubstratumObservationRecord(
+            observationId = observationId,
+            substratumHistoryId = substratumHistoryId,
+            dependsOnObservationId = observationId,
+            dependsOnSubstratumHistoryId = substratumHistoryId,
+        ),
+        "Observed substratum self-references this observation",
+    )
+  }
+
+  @Test
+  fun `records prior observation for a substratum not observed in the later observation`() {
+    insertStratum()
+    val substratumIdA = insertSubstratum()
+    val substratumHistoryIdA = inserted.substratumHistoryId
+    val plotIdA = insertMonitoringPlot(permanentIndex = 1, substratumId = substratumIdA)
+    val plotHistoryIdA = inserted.monitoringPlotHistoryId
+
+    val substratumIdB = insertSubstratum()
+    val substratumHistoryIdB = inserted.substratumHistoryId
+    val plotIdB = insertMonitoringPlot(permanentIndex = 2, substratumId = substratumIdB)
+    val plotHistoryIdB = inserted.monitoringPlotHistoryId
+
+    clock.instant = Instant.ofEpochSecond(1)
+    val observationId1 = insertObservation()
+    insertObservationRequestedSubstratum(substratumId = substratumIdA)
+    insertObservationRequestedSubstratum(substratumId = substratumIdB)
+    insertObservationPlot(
+        claimedBy = user.userId,
+        isPermanent = true,
+        monitoringPlotId = plotIdA,
+        monitoringPlotHistoryId = plotHistoryIdA,
+    )
+    insertObservationPlot(
+        claimedBy = user.userId,
+        isPermanent = true,
+        monitoringPlotId = plotIdB,
+        monitoringPlotHistoryId = plotHistoryIdB,
+    )
+
+    observationStore.completePlot(
+        observationId1,
+        plotIdA,
+        emptySet(),
+        "Notes",
+        clock.instant,
+        recordedPlants,
+    )
+    observationStore.completePlot(
+        observationId1,
+        plotIdB,
+        emptySet(),
+        "Notes",
+        clock.instant,
+        recordedPlants,
+    )
+
+    clock.instant = Instant.ofEpochSecond(2)
+    val observationId2 = insertObservation()
+    insertObservationRequestedSubstratum(substratumId = substratumIdA)
+    val plotIdA2 = insertMonitoringPlot(permanentIndex = 3, substratumId = substratumIdA)
+    val plotHistoryIdA2 = inserted.monitoringPlotHistoryId
+    insertObservationPlot(
+        claimedBy = user.userId,
+        isPermanent = true,
+        monitoringPlotId = plotIdA2,
+        monitoringPlotHistoryId = plotHistoryIdA2,
+    )
+
+    observationStore.completePlot(
+        observationId2,
+        plotIdA2,
+        emptySet(),
+        "Notes",
+        clock.instant,
+        recordedPlants,
+    )
+
+    assertTableEquals(
+        listOf(
+            // observationId1 observed both substrata -> self-references.
+            DependentSubstratumObservationRecord(
+                observationId = observationId1,
+                substratumHistoryId = substratumHistoryIdA,
+                dependsOnObservationId = observationId1,
+                dependsOnSubstratumHistoryId = substratumHistoryIdA,
+            ),
+            DependentSubstratumObservationRecord(
+                observationId = observationId1,
+                substratumHistoryId = substratumHistoryIdB,
+                dependsOnObservationId = observationId1,
+                dependsOnSubstratumHistoryId = substratumHistoryIdB,
+            ),
+            // observationId2 observed A -> self-reference; B was not observed -> points back to
+            // observationId1.
+            DependentSubstratumObservationRecord(
+                observationId = observationId2,
+                substratumHistoryId = substratumHistoryIdA,
+                dependsOnObservationId = observationId2,
+                dependsOnSubstratumHistoryId = substratumHistoryIdA,
+            ),
+            DependentSubstratumObservationRecord(
+                observationId = observationId2,
+                substratumHistoryId = substratumHistoryIdB,
+                dependsOnObservationId = observationId1,
+                dependsOnSubstratumHistoryId = substratumHistoryIdB,
+            ),
+        ),
+        "Later observation references prior observation for unobserved substratum",
+    )
+  }
+
+  @Test
+  fun `records prior observation for a requested but unobserved substratum`() {
+    insertStratum()
+    val substratumIdA = insertSubstratum()
+    val substratumHistoryIdA = inserted.substratumHistoryId
+    val plotIdA = insertMonitoringPlot(permanentIndex = 1, substratumId = substratumIdA)
+    val plotHistoryIdA = inserted.monitoringPlotHistoryId
+
+    val substratumIdB = insertSubstratum()
+    val substratumHistoryIdB = inserted.substratumHistoryId
+    val plotIdB = insertMonitoringPlot(permanentIndex = 2, substratumId = substratumIdB)
+    val plotHistoryIdB = inserted.monitoringPlotHistoryId
+
+    // observationId1 observes both substrata.
+    clock.instant = Instant.ofEpochSecond(1)
+    val observationId1 = insertObservation()
+    insertObservationRequestedSubstratum(substratumId = substratumIdA)
+    insertObservationRequestedSubstratum(substratumId = substratumIdB)
+    insertObservationPlot(
+        claimedBy = user.userId,
+        isPermanent = true,
+        monitoringPlotId = plotIdA,
+        monitoringPlotHistoryId = plotHistoryIdA,
+    )
+    insertObservationPlot(
+        claimedBy = user.userId,
+        isPermanent = true,
+        monitoringPlotId = plotIdB,
+        monitoringPlotHistoryId = plotHistoryIdB,
+    )
+
+    observationStore.completePlot(
+        observationId1,
+        plotIdA,
+        emptySet(),
+        "Notes",
+        clock.instant,
+        recordedPlants,
+    )
+    observationStore.completePlot(
+        observationId1,
+        plotIdB,
+        emptySet(),
+        "Notes",
+        clock.instant,
+        recordedPlants,
+    )
+
+    // observationId2 requests B but completes no plot in it (only A is observed), so B was
+    // requested yet never actually observed in this observation.
+    clock.instant = Instant.ofEpochSecond(2)
+    val observationId2 = insertObservation()
+    insertObservationRequestedSubstratum(substratumId = substratumIdA)
+    insertObservationRequestedSubstratum(substratumId = substratumIdB)
+    val plotIdA2 = insertMonitoringPlot(permanentIndex = 3, substratumId = substratumIdA)
+    val plotHistoryIdA2 = inserted.monitoringPlotHistoryId
+    insertObservationPlot(
+        claimedBy = user.userId,
+        isPermanent = true,
+        monitoringPlotId = plotIdA2,
+        monitoringPlotHistoryId = plotHistoryIdA2,
+    )
+
+    observationStore.completePlot(
+        observationId2,
+        plotIdA2,
+        emptySet(),
+        "Notes",
+        clock.instant,
+        recordedPlants,
+    )
+
+    assertTableEquals(
+        listOf(
+            DependentSubstratumObservationRecord(
+                observationId = observationId1,
+                substratumHistoryId = substratumHistoryIdA,
+                dependsOnObservationId = observationId1,
+                dependsOnSubstratumHistoryId = substratumHistoryIdA,
+            ),
+            DependentSubstratumObservationRecord(
+                observationId = observationId1,
+                substratumHistoryId = substratumHistoryIdB,
+                dependsOnObservationId = observationId1,
+                dependsOnSubstratumHistoryId = substratumHistoryIdB,
+            ),
+            DependentSubstratumObservationRecord(
+                observationId = observationId2,
+                substratumHistoryId = substratumHistoryIdA,
+                dependsOnObservationId = observationId2,
+                dependsOnSubstratumHistoryId = substratumHistoryIdA,
+            ),
+            // B was requested but not observed in observationId2, so it rolls forward to the prior
+            // observation that actually observed it rather than self-referencing.
+            DependentSubstratumObservationRecord(
+                observationId = observationId2,
+                substratumHistoryId = substratumHistoryIdB,
+                dependsOnObservationId = observationId1,
+                dependsOnSubstratumHistoryId = substratumHistoryIdB,
+            ),
+        ),
+        "Requested but unobserved substratum rolls forward instead of self-referencing",
+    )
+  }
+
+  @Test
+  fun `records dependencies for a site-wide observation with no requested substrata`() {
+    insertStratum()
+    insertSubstratum()
+    val substratumHistoryId = inserted.substratumHistoryId
+    val plotId = insertMonitoringPlot(permanentIndex = 1)
+    val observationId = insertObservation()
+    // No requested substrata: the observation covers the entire site.
+    insertObservationPlot(claimedBy = user.userId, isPermanent = true)
+
+    observationStore.completePlot(
+        observationId,
+        plotId,
+        emptySet(),
+        "Notes",
+        Instant.ofEpochSecond(1),
+        recordedPlants,
+    )
+
+    assertTableEquals(
+        DependentSubstratumObservationRecord(
+            observationId = observationId,
+            substratumHistoryId = substratumHistoryId,
+            dependsOnObservationId = observationId,
+            dependsOnSubstratumHistoryId = substratumHistoryId,
+        ),
+        "Site-wide observation self-references its observed substratum",
+    )
+  }
+
+  @Test
+  fun `records no row for a substratum never observed at or before the observation`() {
+    insertStratum()
+    val substratumIdA = insertSubstratum()
+    val substratumHistoryIdA = inserted.substratumHistoryId
+    val plotIdA = insertMonitoringPlot(permanentIndex = 1, substratumId = substratumIdA)
+    val plotHistoryIdA = inserted.monitoringPlotHistoryId
+
+    // Substratum B is present in the snapshot but never requested/observed.
+    val substratumIdB = insertSubstratum()
+    insertMonitoringPlot(permanentIndex = 2, substratumId = substratumIdB)
+
+    val observationId = insertObservation()
+    insertObservationRequestedSubstratum(substratumId = substratumIdA)
+    insertObservationPlot(
+        claimedBy = user.userId,
+        isPermanent = true,
+        monitoringPlotId = plotIdA,
+        monitoringPlotHistoryId = plotHistoryIdA,
+    )
+
+    observationStore.completePlot(
+        observationId,
+        plotIdA,
+        emptySet(),
+        "Notes",
+        Instant.ofEpochSecond(1),
+        recordedPlants,
+    )
+
+    assertTableEquals(
+        DependentSubstratumObservationRecord(
+            observationId = observationId,
+            substratumHistoryId = substratumHistoryIdA,
+            dependsOnObservationId = observationId,
+            dependsOnSubstratumHistoryId = substratumHistoryIdA,
+        ),
+        "Never-observed substratum has no dependency row",
+    )
+  }
+}


### PR DESCRIPTION
Adds recordSubstratumDependencies, which writes a dependent_substratum_observation
row for every substratum in a completed observation's snapshot (a self-reference
when the substratum was observed, otherwise the latest prior observation that
observed it). 

Co-Authored-By: Claude Opus 4.8 [noreply@anthropic.com](mailto:noreply@anthropic.com)