### PR TITLE
SW-8351 Maintain substratum dependencies across merge and deletion

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/tracking/db/ObservationStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/db/ObservationStore.kt
@@ -2619,7 +2619,48 @@ class ObservationStore(
               .execute()
         }
 
+        val dependentsOfSource =
+            dslContext
+                .selectDistinct(DEPENDENT_SUBSTRATUM_OBSERVATION.OBSERVATION_ID)
+                .from(DEPENDENT_SUBSTRATUM_OBSERVATION)
+                .where(
+                    DEPENDENT_SUBSTRATUM_OBSERVATION.DEPENDS_ON_OBSERVATION_ID.eq(
+                        sourceObservationId
+                    )
+                )
+                .and(DEPENDENT_SUBSTRATUM_OBSERVATION.OBSERVATION_ID.ne(sourceObservationId))
+                .fetch(DEPENDENT_SUBSTRATUM_OBSERVATION.OBSERVATION_ID.asNonNullable())
+
         dslContext.deleteFrom(OBSERVATIONS).where(OBSERVATIONS.ID.eq(sourceObservationId)).execute()
+
+        // The target absorbed the source's completed plots, which may have been completed later
+        // than
+        // the target's own. If the target is already completed/abandoned, realign its
+        // completed_time
+        // with its latest completed plot so dependency ordering (which ranks candidate sources by
+        // completed_time) treats the absorbed data as the most recent observation of its substrata,
+        // not an older one. An in-progress target keeps its null completed_time (the
+        // completed_time_and_state constraint requires it, and it is not yet a roll-forward
+        // source).
+        dslContext
+            .update(OBSERVATIONS)
+            .set(
+                OBSERVATIONS.COMPLETED_TIME,
+                DSL.field(
+                    DSL.select(DSL.max(OBSERVATION_PLOTS.COMPLETED_TIME))
+                        .from(OBSERVATION_PLOTS)
+                        .where(OBSERVATION_PLOTS.OBSERVATION_ID.eq(targetObservationId))
+                        .and(OBSERVATION_PLOTS.STATUS_ID.eq(ObservationPlotStatus.Completed))
+                ),
+            )
+            .where(OBSERVATIONS.ID.eq(targetObservationId))
+            .and(OBSERVATIONS.COMPLETED_TIME.isNotNull)
+            .execute()
+
+        recordSubstratumDependencies(targetObservationId)
+
+        // Recompute dependencies of downstream observations
+        dependentsOfSource.forEach { recordSubstratumDependencies(it) }
       }
     }
   }
@@ -2800,6 +2841,14 @@ class ObservationStore(
             .where(PLOT_T0_OBSERVATIONS.OBSERVATION_ID.eq(observationId))
             .fetch(PLOT_T0_OBSERVATIONS.MONITORING_PLOT_ID.asNonNullable())
 
+    val dependentObservationIds =
+        dslContext
+            .selectDistinct(DEPENDENT_SUBSTRATUM_OBSERVATION.OBSERVATION_ID)
+            .from(DEPENDENT_SUBSTRATUM_OBSERVATION)
+            .where(DEPENDENT_SUBSTRATUM_OBSERVATION.DEPENDS_ON_OBSERVATION_ID.eq(observationId))
+            .and(DEPENDENT_SUBSTRATUM_OBSERVATION.OBSERVATION_ID.ne(observationId))
+            .fetch(DEPENDENT_SUBSTRATUM_OBSERVATION.OBSERVATION_ID.asNonNullable())
+
     dslContext.transaction { _ ->
       if (t0PlotIds.isNotEmpty()) {
         dslContext
@@ -2809,6 +2858,9 @@ class ObservationStore(
       }
 
       dslContext.deleteFrom(OBSERVATIONS).where(OBSERVATIONS.ID.eq(observationId)).execute()
+
+      // Recompute dependencies of downstream observations
+      dependentObservationIds.forEach { recordSubstratumDependencies(it) }
     }
   }
 

--- a/src/main/kotlin/com/terraformation/backend/tracking/db/ObservationStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/db/ObservationStore.kt
@@ -2621,15 +2621,15 @@ class ObservationStore(
 
         val dependentsOfSource =
             dslContext
-                .selectDistinct(DEPENDENT_SUBSTRATUM_OBSERVATION.OBSERVATION_ID)
-                .from(DEPENDENT_SUBSTRATUM_OBSERVATION)
+                .selectDistinct(OBSERVATION_DEPENDENT_SUBSTRATA.OBSERVATION_ID)
+                .from(OBSERVATION_DEPENDENT_SUBSTRATA)
                 .where(
-                    DEPENDENT_SUBSTRATUM_OBSERVATION.DEPENDS_ON_OBSERVATION_ID.eq(
+                    OBSERVATION_DEPENDENT_SUBSTRATA.DEPENDS_ON_OBSERVATION_ID.eq(
                         sourceObservationId
                     )
                 )
-                .and(DEPENDENT_SUBSTRATUM_OBSERVATION.OBSERVATION_ID.ne(sourceObservationId))
-                .fetch(DEPENDENT_SUBSTRATUM_OBSERVATION.OBSERVATION_ID.asNonNullable())
+                .and(OBSERVATION_DEPENDENT_SUBSTRATA.OBSERVATION_ID.ne(sourceObservationId))
+                .fetch(OBSERVATION_DEPENDENT_SUBSTRATA.OBSERVATION_ID.asNonNullable())
 
         dslContext.deleteFrom(OBSERVATIONS).where(OBSERVATIONS.ID.eq(sourceObservationId)).execute()
 
@@ -2819,11 +2819,11 @@ class ObservationStore(
 
     val dependentObservationIds =
         dslContext
-            .selectDistinct(DEPENDENT_SUBSTRATUM_OBSERVATION.OBSERVATION_ID)
-            .from(DEPENDENT_SUBSTRATUM_OBSERVATION)
-            .where(DEPENDENT_SUBSTRATUM_OBSERVATION.DEPENDS_ON_OBSERVATION_ID.eq(observationId))
-            .and(DEPENDENT_SUBSTRATUM_OBSERVATION.OBSERVATION_ID.ne(observationId))
-            .fetch(DEPENDENT_SUBSTRATUM_OBSERVATION.OBSERVATION_ID.asNonNullable())
+            .selectDistinct(OBSERVATION_DEPENDENT_SUBSTRATA.OBSERVATION_ID)
+            .from(OBSERVATION_DEPENDENT_SUBSTRATA)
+            .where(OBSERVATION_DEPENDENT_SUBSTRATA.DEPENDS_ON_OBSERVATION_ID.eq(observationId))
+            .and(OBSERVATION_DEPENDENT_SUBSTRATA.OBSERVATION_ID.ne(observationId))
+            .fetch(OBSERVATION_DEPENDENT_SUBSTRATA.OBSERVATION_ID.asNonNullable())
 
     dslContext.transaction { _ ->
       if (t0PlotIds.isNotEmpty()) {

--- a/src/main/kotlin/com/terraformation/backend/tracking/db/ObservationStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/db/ObservationStore.kt
@@ -2633,30 +2633,6 @@ class ObservationStore(
 
         dslContext.deleteFrom(OBSERVATIONS).where(OBSERVATIONS.ID.eq(sourceObservationId)).execute()
 
-        // The target absorbed the source's completed plots, which may have been completed later
-        // than
-        // the target's own. If the target is already completed/abandoned, realign its
-        // completed_time
-        // with its latest completed plot so dependency ordering (which ranks candidate sources by
-        // completed_time) treats the absorbed data as the most recent observation of its substrata,
-        // not an older one. An in-progress target keeps its null completed_time (the
-        // completed_time_and_state constraint requires it, and it is not yet a roll-forward
-        // source).
-        dslContext
-            .update(OBSERVATIONS)
-            .set(
-                OBSERVATIONS.COMPLETED_TIME,
-                DSL.field(
-                    DSL.select(DSL.max(OBSERVATION_PLOTS.COMPLETED_TIME))
-                        .from(OBSERVATION_PLOTS)
-                        .where(OBSERVATION_PLOTS.OBSERVATION_ID.eq(targetObservationId))
-                        .and(OBSERVATION_PLOTS.STATUS_ID.eq(ObservationPlotStatus.Completed))
-                ),
-            )
-            .where(OBSERVATIONS.ID.eq(targetObservationId))
-            .and(OBSERVATIONS.COMPLETED_TIME.isNotNull)
-            .execute()
-
         recordSubstratumDependencies(targetObservationId)
 
         // Recompute dependencies of downstream observations

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/observationStore/ObservationStoreMergeObservationDataTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/observationStore/ObservationStoreMergeObservationDataTest.kt
@@ -73,37 +73,6 @@ class ObservationStoreMergeObservationDataTest : BaseObservationStoreTest() {
   }
 
   @Test
-  fun `realigns the target completed time with a later merged-in source plot`() {
-    val plotA = insertMonitoringPlot()
-    val plotB = insertMonitoringPlot()
-    val targetObservationId = insertObservation()
-    val sourceObservationId = insertObservation()
-
-    // The target completed earlier than the source it absorbs.
-    clock.instant = Instant.ofEpochSecond(100)
-    completePlotWith(targetObservationId, plotB, 1)
-    clock.instant = Instant.ofEpochSecond(500)
-    completePlotWith(sourceObservationId, plotA, 1)
-
-    store.mergeObservationData(sourceObservationId, targetObservationId)
-
-    // Dependency ordering ranks candidate sources by completed_time, so the target must adopt the
-    // absorbed plot's later completion time; otherwise a later observation could roll forward an
-    // observation completed between the target and the source instead of the merged data.
-    val targetCompletedTime =
-        dslContext
-            .select(OBSERVATIONS.COMPLETED_TIME)
-            .from(OBSERVATIONS)
-            .where(OBSERVATIONS.ID.eq(targetObservationId))
-            .fetchOne(OBSERVATIONS.COMPLETED_TIME)
-    assertEquals(
-        Instant.ofEpochSecond(500),
-        targetCompletedTime,
-        "Target completed_time after absorbing the later source plot",
-    )
-  }
-
-  @Test
   fun `conflict plot overwrites target data and drops t0 when target was the t0 observation`() {
     val plotId = insertMonitoringPlot()
     val sourceObservationId = insertObservation()

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/observationStore/ObservationStoreMergeObservationDataTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/observationStore/ObservationStoreMergeObservationDataTest.kt
@@ -7,9 +7,9 @@ import com.terraformation.backend.db.tracking.ObservationId
 import com.terraformation.backend.db.tracking.RecordedPlantStatus
 import com.terraformation.backend.db.tracking.RecordedSpeciesCertainty
 import com.terraformation.backend.db.tracking.tables.pojos.RecordedPlantsRow
-import com.terraformation.backend.db.tracking.tables.records.DependentSubstratumObservationRecord
-import com.terraformation.backend.db.tracking.tables.references.DEPENDENT_SUBSTRATUM_OBSERVATION
+import com.terraformation.backend.db.tracking.tables.records.ObservationDependentSubstrataRecord
 import com.terraformation.backend.db.tracking.tables.references.OBSERVATIONS
+import com.terraformation.backend.db.tracking.tables.references.OBSERVATION_DEPENDENT_SUBSTRATA
 import com.terraformation.backend.db.tracking.tables.references.OBSERVATION_MEDIA_FILES
 import com.terraformation.backend.db.tracking.tables.references.OBSERVATION_PLOTS
 import com.terraformation.backend.db.tracking.tables.references.OBSERVATION_PLOT_CONDITIONS
@@ -296,13 +296,13 @@ class ObservationStoreMergeObservationDataTest : BaseObservationStoreTest() {
     // The target absorbed the source's B plot, so it now self-references both substrata.
     assertTableEquals(
         listOf(
-            DependentSubstratumObservationRecord(
+            ObservationDependentSubstrataRecord(
                 target,
                 substratumAHistory,
                 target,
                 substratumAHistory,
             ),
-            DependentSubstratumObservationRecord(
+            ObservationDependentSubstrataRecord(
                 target,
                 substratumBHistory,
                 target,
@@ -312,9 +312,9 @@ class ObservationStoreMergeObservationDataTest : BaseObservationStoreTest() {
         "Target self-references both substrata after the merge",
     )
     assertTableEmpty(
-        DEPENDENT_SUBSTRATUM_OBSERVATION,
+        OBSERVATION_DEPENDENT_SUBSTRATA,
         "No dependency rows reference the deleted source",
-        where = DEPENDENT_SUBSTRATUM_OBSERVATION.DEPENDS_ON_OBSERVATION_ID.eq(source),
+        where = OBSERVATION_DEPENDENT_SUBSTRATA.DEPENDS_ON_OBSERVATION_ID.eq(source),
     )
   }
 
@@ -347,31 +347,31 @@ class ObservationStoreMergeObservationDataTest : BaseObservationStoreTest() {
     // each substratum in its snapshot.
     assertTableEquals(
         listOf(
-            DependentSubstratumObservationRecord(
+            ObservationDependentSubstrataRecord(
                 target,
                 substratumAHistory,
                 target,
                 substratumAHistory,
             ),
-            DependentSubstratumObservationRecord(
+            ObservationDependentSubstrataRecord(
                 source,
                 substratumAHistory,
                 target,
                 substratumAHistory,
             ),
-            DependentSubstratumObservationRecord(
-                source,
-                substratumBHistory,
+            ObservationDependentSubstrataRecord(
                 source,
                 substratumBHistory,
+                source,
+                substratumBHistory,
             ),
-            DependentSubstratumObservationRecord(
+            ObservationDependentSubstrataRecord(
                 later,
                 substratumAHistory,
                 later,
                 substratumAHistory,
             ),
-            DependentSubstratumObservationRecord(
+            ObservationDependentSubstrataRecord(
                 later,
                 substratumBHistory,
                 source,
@@ -387,25 +387,25 @@ class ObservationStoreMergeObservationDataTest : BaseObservationStoreTest() {
     // rather than from the deleted source (which would otherwise drop the substratum).
     assertTableEquals(
         listOf(
-            DependentSubstratumObservationRecord(
+            ObservationDependentSubstrataRecord(
                 target,
                 substratumAHistory,
                 target,
                 substratumAHistory,
             ),
-            DependentSubstratumObservationRecord(
+            ObservationDependentSubstrataRecord(
                 target,
                 substratumBHistory,
                 target,
                 substratumBHistory,
             ),
-            DependentSubstratumObservationRecord(
+            ObservationDependentSubstrataRecord(
                 later,
                 substratumAHistory,
                 later,
                 substratumAHistory,
             ),
-            DependentSubstratumObservationRecord(
+            ObservationDependentSubstrataRecord(
                 later,
                 substratumBHistory,
                 target,

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/observationStore/ObservationStoreMergeObservationDataTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/observationStore/ObservationStoreMergeObservationDataTest.kt
@@ -7,6 +7,8 @@ import com.terraformation.backend.db.tracking.ObservationId
 import com.terraformation.backend.db.tracking.RecordedPlantStatus
 import com.terraformation.backend.db.tracking.RecordedSpeciesCertainty
 import com.terraformation.backend.db.tracking.tables.pojos.RecordedPlantsRow
+import com.terraformation.backend.db.tracking.tables.records.DependentSubstratumObservationRecord
+import com.terraformation.backend.db.tracking.tables.references.DEPENDENT_SUBSTRATUM_OBSERVATION
 import com.terraformation.backend.db.tracking.tables.references.OBSERVATIONS
 import com.terraformation.backend.db.tracking.tables.references.OBSERVATION_MEDIA_FILES
 import com.terraformation.backend.db.tracking.tables.references.OBSERVATION_PLOTS
@@ -67,6 +69,37 @@ class ObservationStoreMergeObservationDataTest : BaseObservationStoreTest() {
     assertTableEmpty(
         RECORDED_PLANTS,
         where = RECORDED_PLANTS.OBSERVATION_ID.eq(sourceObservationId),
+    )
+  }
+
+  @Test
+  fun `realigns the target completed time with a later merged-in source plot`() {
+    val plotA = insertMonitoringPlot()
+    val plotB = insertMonitoringPlot()
+    val targetObservationId = insertObservation()
+    val sourceObservationId = insertObservation()
+
+    // The target completed earlier than the source it absorbs.
+    clock.instant = Instant.ofEpochSecond(100)
+    completePlotWith(targetObservationId, plotB, 1)
+    clock.instant = Instant.ofEpochSecond(500)
+    completePlotWith(sourceObservationId, plotA, 1)
+
+    store.mergeObservationData(sourceObservationId, targetObservationId)
+
+    // Dependency ordering ranks candidate sources by completed_time, so the target must adopt the
+    // absorbed plot's later completion time; otherwise a later observation could roll forward an
+    // observation completed between the target and the source instead of the merged data.
+    val targetCompletedTime =
+        dslContext
+            .select(OBSERVATIONS.COMPLETED_TIME)
+            .from(OBSERVATIONS)
+            .where(OBSERVATIONS.ID.eq(targetObservationId))
+            .fetchOne(OBSERVATIONS.COMPLETED_TIME)
+    assertEquals(
+        Instant.ofEpochSecond(500),
+        targetCompletedTime,
+        "Target completed_time after absorbing the later source plot",
     )
   }
 
@@ -268,6 +301,150 @@ class ObservationStoreMergeObservationDataTest : BaseObservationStoreTest() {
 
     assertEquals(expectedTotals, helper.fetchAllTotals(), "Species totals after rebuild")
     assertEquals(expectedResults, helper.fetchAllResults(), "Observation results after rebuild")
+  }
+
+  @Test
+  fun `merge folds the source's substratum into the target's dependencies`() {
+    val substratumA = inserted.substratumId
+    val substratumAHistory = inserted.substratumHistoryId
+    val substratumB = insertSubstratum()
+    val substratumBHistory = inserted.substratumHistoryId
+    val plotA = insertMonitoringPlot(substratumId = substratumA)
+    val plotB = insertMonitoringPlot(substratumId = substratumB)
+
+    // Each observation covers only part of the site: the target observes substratum A, the source
+    // observes substratum B.
+    clock.instant = Instant.ofEpochSecond(1)
+    val target = insertObservation()
+    completePlotWith(target, plotA, 1)
+
+    clock.instant = Instant.ofEpochSecond(2)
+    val source = insertObservation()
+    completePlotWith(source, plotB, 1)
+
+    store.mergeObservationData(source, target)
+
+    // The target absorbed the source's B plot, so it now self-references both substrata.
+    assertTableEquals(
+        listOf(
+            DependentSubstratumObservationRecord(
+                target,
+                substratumAHistory,
+                target,
+                substratumAHistory,
+            ),
+            DependentSubstratumObservationRecord(
+                target,
+                substratumBHistory,
+                target,
+                substratumBHistory,
+            ),
+        ),
+        "Target self-references both substrata after the merge",
+    )
+    assertTableEmpty(
+        DEPENDENT_SUBSTRATUM_OBSERVATION,
+        "No dependency rows reference the deleted source",
+        where = DEPENDENT_SUBSTRATUM_OBSERVATION.DEPENDS_ON_OBSERVATION_ID.eq(source),
+    )
+  }
+
+  @Test
+  fun `merge recomputes dependencies of observations that rolled the source forward`() {
+    val substratumA = inserted.substratumId
+    val substratumAHistory = inserted.substratumHistoryId
+    val substratumB = insertSubstratum()
+    val substratumBHistory = inserted.substratumHistoryId
+    val plotA = insertMonitoringPlot(substratumId = substratumA)
+    val plotB = insertMonitoringPlot(substratumId = substratumB)
+    val plotA2 = insertMonitoringPlot(substratumId = substratumA)
+
+    // Partial-site observations: target observes A, source observes B (the latest B data), and a
+    // later observation observes only A so it rolls B forward from the source.
+    clock.instant = Instant.ofEpochSecond(1)
+    val target = insertObservation()
+    completePlotWith(target, plotA, 1)
+
+    clock.instant = Instant.ofEpochSecond(2)
+    val source = insertObservation()
+    completePlotWith(source, plotB, 1)
+
+    clock.instant = Instant.ofEpochSecond(3)
+    val later = insertObservation()
+    completePlotWith(later, plotA2, 1)
+
+    // Before the merge, the later observation rolls B forward from the source. The source itself
+    // rolls A forward from the target (it never observed A), and every observation has a row for
+    // each substratum in its snapshot.
+    assertTableEquals(
+        listOf(
+            DependentSubstratumObservationRecord(
+                target,
+                substratumAHistory,
+                target,
+                substratumAHistory,
+            ),
+            DependentSubstratumObservationRecord(
+                source,
+                substratumAHistory,
+                target,
+                substratumAHistory,
+            ),
+            DependentSubstratumObservationRecord(
+                source,
+                substratumBHistory,
+                source,
+                substratumBHistory,
+            ),
+            DependentSubstratumObservationRecord(
+                later,
+                substratumAHistory,
+                later,
+                substratumAHistory,
+            ),
+            DependentSubstratumObservationRecord(
+                later,
+                substratumBHistory,
+                source,
+                substratumBHistory,
+            ),
+        ),
+        "Later observation rolls B forward from the source before the merge",
+    )
+
+    store.mergeObservationData(source, target)
+
+    // The target absorbed B, so the later observation must now roll B forward from the target
+    // rather than from the deleted source (which would otherwise drop the substratum).
+    assertTableEquals(
+        listOf(
+            DependentSubstratumObservationRecord(
+                target,
+                substratumAHistory,
+                target,
+                substratumAHistory,
+            ),
+            DependentSubstratumObservationRecord(
+                target,
+                substratumBHistory,
+                target,
+                substratumBHistory,
+            ),
+            DependentSubstratumObservationRecord(
+                later,
+                substratumAHistory,
+                later,
+                substratumAHistory,
+            ),
+            DependentSubstratumObservationRecord(
+                later,
+                substratumBHistory,
+                target,
+                substratumBHistory,
+            ),
+        ),
+        "Later observation rolls B forward from the target after the merge",
+    )
   }
 
   private fun livePlant(speciesId: SpeciesId = this.speciesId) =


### PR DESCRIPTION
Recompute dependencies when observations are merged or deleted.

Co-Authored-By: Claude Opus 4.8 [noreply@anthropic.com](mailto:noreply@anthropic.com)