### PR TITLE
SW-8351 Compute rolled-forward stats from the dependency table

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/tracking/db/ObservationStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/db/ObservationStore.kt
@@ -1378,16 +1378,16 @@ class ObservationStore(
                 .and(OBSERVATIONS.COMPLETED_TIME.gt(observation.completedTime))
                 .and(
                     OBSERVATIONS.ID.`in`(
-                        DSL.select(DEPENDENT_SUBSTRATUM_OBSERVATION.OBSERVATION_ID)
-                            .from(DEPENDENT_SUBSTRATUM_OBSERVATION)
+                        DSL.select(OBSERVATION_DEPENDENT_SUBSTRATA.OBSERVATION_ID)
+                            .from(OBSERVATION_DEPENDENT_SUBSTRATA)
                             .join(dependentSsh)
                             .on(
                                 dependentSsh.ID.eq(
-                                    DEPENDENT_SUBSTRATUM_OBSERVATION.SUBSTRATUM_HISTORY_ID
+                                    OBSERVATION_DEPENDENT_SUBSTRATA.SUBSTRATUM_HISTORY_ID
                                 )
                             )
                             .where(
-                                DEPENDENT_SUBSTRATUM_OBSERVATION.DEPENDS_ON_OBSERVATION_ID.eq(
+                                OBSERVATION_DEPENDENT_SUBSTRATA.DEPENDS_ON_OBSERVATION_ID.eq(
                                     observationId
                                 )
                             )

--- a/src/main/kotlin/com/terraformation/backend/tracking/db/ObservationStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/db/ObservationStore.kt
@@ -2784,13 +2784,6 @@ class ObservationStore(
             .and(OBSERVATION_DEPENDENT_SUBSTRATA.OBSERVATION_ID.ne(observationId))
             .fetch(OBSERVATION_DEPENDENT_SUBSTRATA.OBSERVATION_ID.asNonNullable())
 
-    val plantingSiteId =
-        dslContext
-            .select(OBSERVATIONS.PLANTING_SITE_ID.asNonNullable())
-            .from(OBSERVATIONS)
-            .where(OBSERVATIONS.ID.eq(observationId))
-            .fetchOne(OBSERVATIONS.PLANTING_SITE_ID.asNonNullable())
-
     dslContext.transaction { _ ->
       if (t0PlotIds.isNotEmpty()) {
         dslContext
@@ -2803,14 +2796,6 @@ class ObservationStore(
 
       // Recompute dependencies of downstream observations
       dependentObservationIds.forEach { recordSubstratumDependencies(it) }
-
-      if (plantingSiteId != null) {
-        dependentObservationIds.forEach {
-          recalculateSurvivalRates(it, plantingSiteId)
-          updateObservationResults(it, plantingSiteId)
-          recalculateSurvivalRateResults(it, plantingSiteId)
-        }
-      }
     }
   }
 

--- a/src/main/kotlin/com/terraformation/backend/tracking/db/ObservationStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/db/ObservationStore.kt
@@ -2591,27 +2591,11 @@ class ObservationStore(
                 .fetch(OBSERVATION_DEPENDENT_SUBSTRATA.OBSERVATION_ID.asNonNullable())
 
         dslContext.deleteFrom(OBSERVATIONS).where(OBSERVATIONS.ID.eq(sourceObservationId)).execute()
-        
+
         recordSubstratumDependencies(targetObservationId)
 
         // Recompute dependencies of downstream observations
         dependentsOfSource.forEach { recordSubstratumDependencies(it) }
-
-        // Rewriting the dependency rows changes which observation each substratum rolls forward
-        // from, so the dependents' materialized stratum/site totals must be rebuilt from the new
-        // rows. The caller's site-wide survival-rate recalc only refreshes the rate, not the live
-        // and density totals it reads. (The target is rebuilt by the caller.)
-        val plantingSiteId =
-            dslContext
-                .select(OBSERVATIONS.PLANTING_SITE_ID.asNonNullable())
-                .from(OBSERVATIONS)
-                .where(OBSERVATIONS.ID.eq(targetObservationId))
-                .fetchOne(OBSERVATIONS.PLANTING_SITE_ID.asNonNullable())!!
-        dependentsOfSource.forEach {
-          recalculateSurvivalRates(it, plantingSiteId)
-          updateObservationResults(it, plantingSiteId)
-          recalculateSurvivalRateResults(it, plantingSiteId)
-        }
       }
     }
   }
@@ -2820,10 +2804,6 @@ class ObservationStore(
       // Recompute dependencies of downstream observations
       dependentObservationIds.forEach { recordSubstratumDependencies(it) }
 
-      // The dependency rows above now point at a fallback source (or none); rebuild each
-      // dependent's
-      // materialized stratum/site totals from them, since the caller's site-wide survival-rate
-      // recalc refreshes only the rate, not the live and density totals it reads.
       if (plantingSiteId != null) {
         dependentObservationIds.forEach {
           recalculateSurvivalRates(it, plantingSiteId)

--- a/src/main/kotlin/com/terraformation/backend/tracking/db/ObservationStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/db/ObservationStore.kt
@@ -1368,87 +1368,38 @@ class ObservationStore(
         // Edits to an observation can affect stratum and site data for later observations, but only
         // if the edited observation hasn't been superseded by a newer observation of the same
         // substratum.
-        //
-        // So we want to update later observations that don't have newer results for the substratum
-        // we're editing, that is, observations for which this observation's substratum-level totals
-        // would be used to calculate the stratum- and site-level totals.
 
-        val latestObservations = OBSERVATIONS.`as`("latest_observations")
-        val observationWithLatestResultsForSubstratum =
-            DSL.field(
-                DSL.select(latestObservations.ID)
-                    .from(latestObservations)
-                    .join(OBSERVATION_REQUESTED_SUBSTRATA)
-                    .on(latestObservations.ID.eq(OBSERVATION_REQUESTED_SUBSTRATA.OBSERVATION_ID))
-                    .where(latestObservations.COMPLETED_TIME.ge(observation.completedTime))
-                    .and(latestObservations.COMPLETED_TIME.le(OBSERVATIONS.COMPLETED_TIME))
-                    .and(OBSERVATION_REQUESTED_SUBSTRATA.SUBSTRATUM_ID.eq(substratumId))
-                    .orderBy(latestObservations.COMPLETED_TIME.desc(), latestObservations.ID.desc())
-                    .limit(1)
-            )
-        val stratumHistoryIdAtTimeOfObservation =
-            DSL.field(
-                DSL.select(STRATUM_HISTORIES.ID)
-                    .from(STRATUM_HISTORIES)
-                    .join(SUBSTRATUM_HISTORIES)
-                    .on(STRATUM_HISTORIES.ID.eq(SUBSTRATUM_HISTORIES.STRATUM_HISTORY_ID))
-                    .where(
-                        STRATUM_HISTORIES.PLANTING_SITE_HISTORY_ID.eq(
-                            OBSERVATIONS.PLANTING_SITE_HISTORY_ID
-                        )
-                    )
-                    .and(SUBSTRATUM_HISTORIES.SUBSTRATUM_ID.eq(substratumId))
-            )
-        val stratumIdAtTimeOfObservation =
-            DSL.field(
-                DSL.select(STRATUM_HISTORIES.STRATUM_ID)
-                    .from(STRATUM_HISTORIES)
-                    .join(SUBSTRATUM_HISTORIES)
-                    .on(STRATUM_HISTORIES.ID.eq(SUBSTRATUM_HISTORIES.STRATUM_HISTORY_ID))
-                    .where(
-                        STRATUM_HISTORIES.PLANTING_SITE_HISTORY_ID.eq(
-                            OBSERVATIONS.PLANTING_SITE_HISTORY_ID
-                        )
-                    )
-                    .and(SUBSTRATUM_HISTORIES.SUBSTRATUM_ID.eq(substratumId))
-            )
-
+        val dependentSsh = SUBSTRATUM_HISTORIES.`as`("edit_dependent_ssh")
         val laterObservationsDependentOnSubstratumDataFromThisObservation =
             dslContext
-                .select(
-                    OBSERVATIONS.ID.asNonNullable(),
-                    OBSERVATIONS.PLANTING_SITE_HISTORY_ID.asNonNullable(),
-                    stratumHistoryIdAtTimeOfObservation.asNonNullable(),
-                    stratumIdAtTimeOfObservation,
-                )
+                .select(OBSERVATIONS.ID.asNonNullable())
                 .from(OBSERVATIONS)
                 .where(OBSERVATIONS.PLANTING_SITE_ID.eq(observation.plantingSiteId))
                 .and(OBSERVATIONS.COMPLETED_TIME.gt(observation.completedTime))
-                .and(observationWithLatestResultsForSubstratum.eq(observationId))
+                .and(
+                    OBSERVATIONS.ID.`in`(
+                        DSL.select(DEPENDENT_SUBSTRATUM_OBSERVATION.OBSERVATION_ID)
+                            .from(DEPENDENT_SUBSTRATUM_OBSERVATION)
+                            .join(dependentSsh)
+                            .on(
+                                dependentSsh.ID.eq(
+                                    DEPENDENT_SUBSTRATUM_OBSERVATION.SUBSTRATUM_HISTORY_ID
+                                )
+                            )
+                            .where(
+                                DEPENDENT_SUBSTRATUM_OBSERVATION.DEPENDS_ON_OBSERVATION_ID.eq(
+                                    observationId
+                                )
+                            )
+                            .and(dependentSsh.SUBSTRATUM_ID.eq(substratumId))
+                    )
+                )
                 .and(OBSERVATIONS.OBSERVATION_TYPE_ID.eq(ObservationType.Monitoring))
-                .fetch()
+                .fetch(OBSERVATIONS.ID.asNonNullable())
 
-        laterObservationsDependentOnSubstratumDataFromThisObservation.forEach {
-            (
-                laterObservationId,
-                laterPlantingSiteHistoryId,
-                stratumHistoryIdInLaterObservation,
-                stratumIdInLaterObservation,
-            ) ->
-          updateSpeciesTotals(
-              observationId = laterObservationId,
-              plantingSite = plantingSitesRow,
-              plantingSiteHistoryId = laterPlantingSiteHistoryId,
-              stratumId = stratumIdInLaterObservation,
-              stratumHistoryId = stratumHistoryIdInLaterObservation,
-              substratumId = null,
-              substratumHistoryId = null,
-              monitoringPlotId = null,
-              monitoringPlotHistoryId = null,
-              isAdHoc = observation.isAdHoc,
-              isPermanent = isPermanent,
-              plantCountsBySpecies = plantCountAdjustments,
-          )
+        laterObservationsDependentOnSubstratumDataFromThisObservation.forEach { laterObservationId
+          ->
+          recalculateSurvivalRates(laterObservationId, observation.plantingSiteId)
           updateObservationResults(laterObservationId, observation.plantingSiteId)
           recalculateSurvivalRateResults(laterObservationId, observation.plantingSiteId)
         }
@@ -1552,6 +1503,7 @@ class ObservationStore(
         updateObservationState(observationId, ObservationState.Abandoned)
         recordSubstratumDependencies(observationId)
         resetPlantPopulationSinceLastObservation(observation.plantingSiteId)
+        recalculateSurvivalRates(observationId, observation.plantingSiteId)
         recalculateSurvivalRateResults(observationId, observation.plantingSiteId)
       }
     } else {
@@ -1844,6 +1796,8 @@ class ObservationStore(
 
         with(OBSERVED_STRATUM_SPECIES_TOTALS) {
           val updateScope = ObservationSpeciesStratum(stratumHistoryId, stratumId)
+          // The live totals above roll each substratum forward from its latest observation, so the
+          // denominators must roll the same T0 densities forward to avoid inflating the rate.
           val survivalRatePermanentDenominator =
               getSurvivalRateDenominator(
                   updateScope,
@@ -1902,6 +1856,8 @@ class ObservationStore(
 
       with(OBSERVED_SITE_SPECIES_TOTALS) {
         val updateScope = ObservationSpeciesSite(plantingSiteId, plantingSiteHistoryId)
+        // Same as the stratum block: the site live totals roll substrata forward, so the
+        // denominators must too.
         val survivalRatePermanentDenominator =
             getSurvivalRateDenominator(
                 updateScope,
@@ -2077,6 +2033,7 @@ class ObservationStore(
     val table = updateScope.observedTotalsTable
     val speciesIdField = table.field("species_id", SPECIES.ID.dataType)
     val observationIdField = table.field("observation_id", OBSERVATIONS.ID.dataType)!!
+
     val survivalRatePermanentDenominator =
         getSurvivalRateDenominator(
             updateScope,
@@ -2202,6 +2159,7 @@ class ObservationStore(
                     .from(OBSERVATION_PLOTS)
                     .where(updateScope.observationPlotsCondition(observationIdField))
                     .and(OBSERVATION_PLOTS.COMPLETED_TIME.isNull)
+                    .and(OBSERVATION_PLOTS.STATUS_ID.ne(ObservationPlotStatus.NotObserved))
             ),
         )
 
@@ -2328,6 +2286,7 @@ class ObservationStore(
                         )
                     )
                     .and(OBSERVATION_PLOTS.COMPLETED_TIME.isNull)
+                    .and(OBSERVATION_PLOTS.STATUS_ID.ne(ObservationPlotStatus.NotObserved))
             )
             .not()
 
@@ -2632,11 +2591,27 @@ class ObservationStore(
                 .fetch(OBSERVATION_DEPENDENT_SUBSTRATA.OBSERVATION_ID.asNonNullable())
 
         dslContext.deleteFrom(OBSERVATIONS).where(OBSERVATIONS.ID.eq(sourceObservationId)).execute()
-
+        
         recordSubstratumDependencies(targetObservationId)
 
         // Recompute dependencies of downstream observations
         dependentsOfSource.forEach { recordSubstratumDependencies(it) }
+
+        // Rewriting the dependency rows changes which observation each substratum rolls forward
+        // from, so the dependents' materialized stratum/site totals must be rebuilt from the new
+        // rows. The caller's site-wide survival-rate recalc only refreshes the rate, not the live
+        // and density totals it reads. (The target is rebuilt by the caller.)
+        val plantingSiteId =
+            dslContext
+                .select(OBSERVATIONS.PLANTING_SITE_ID.asNonNullable())
+                .from(OBSERVATIONS)
+                .where(OBSERVATIONS.ID.eq(targetObservationId))
+                .fetchOne(OBSERVATIONS.PLANTING_SITE_ID.asNonNullable())!!
+        dependentsOfSource.forEach {
+          recalculateSurvivalRates(it, plantingSiteId)
+          updateObservationResults(it, plantingSiteId)
+          recalculateSurvivalRateResults(it, plantingSiteId)
+        }
       }
     }
   }
@@ -2825,6 +2800,13 @@ class ObservationStore(
             .and(OBSERVATION_DEPENDENT_SUBSTRATA.OBSERVATION_ID.ne(observationId))
             .fetch(OBSERVATION_DEPENDENT_SUBSTRATA.OBSERVATION_ID.asNonNullable())
 
+    val plantingSiteId =
+        dslContext
+            .select(OBSERVATIONS.PLANTING_SITE_ID.asNonNullable())
+            .from(OBSERVATIONS)
+            .where(OBSERVATIONS.ID.eq(observationId))
+            .fetchOne(OBSERVATIONS.PLANTING_SITE_ID.asNonNullable())
+
     dslContext.transaction { _ ->
       if (t0PlotIds.isNotEmpty()) {
         dslContext
@@ -2837,6 +2819,18 @@ class ObservationStore(
 
       // Recompute dependencies of downstream observations
       dependentObservationIds.forEach { recordSubstratumDependencies(it) }
+
+      // The dependency rows above now point at a fallback source (or none); rebuild each
+      // dependent's
+      // materialized stratum/site totals from them, since the caller's site-wide survival-rate
+      // recalc refreshes only the rate, not the live and density totals it reads.
+      if (plantingSiteId != null) {
+        dependentObservationIds.forEach {
+          recalculateSurvivalRates(it, plantingSiteId)
+          updateObservationResults(it, plantingSiteId)
+          recalculateSurvivalRateResults(it, plantingSiteId)
+        }
+      }
     }
   }
 
@@ -3800,6 +3794,19 @@ class ObservationStore(
       observationIdField: Field<ObservationId?>,
   ): Field<BigDecimal> {
     val opPerm = OBSERVATION_PLOTS.`as`("opPerm")
+    // Attribute each plot's T0 to its substratum's latest observation at or before this one,
+    // exactly
+    // as the live total does. A substratum observed in this observation resolves to the observation
+    // itself (a self-reference); one it did not observe resolves to the rolled-forward source.
+    val plotObservationCondition =
+        opPerm.IS_PERMANENT.isTrue.and(
+            opPerm.OBSERVATION_ID.eq(
+                latestObservationForSubstratumField(
+                    observationIdField,
+                    opPerm.monitoringPlotHistories.SUBSTRATUM_ID,
+                )
+            )
+        )
     return DSL.field(
         DSL.select(DSL.sum(PLOT_T0_DENSITIES.PLOT_DENSITY).mul(DSL.inline(HECTARES_PER_PLOT)))
             .from(PLOT_T0_DENSITIES)
@@ -3814,15 +3821,7 @@ class ObservationStore(
                     updateScope.alternateCompletedCondition(PLOT_T0_DENSITIES.MONITORING_PLOT_ID),
                 )
             )
-            .and(
-                opPerm.OBSERVATION_ID.eq(
-                    observationIdForPlot(
-                        PLOT_T0_DENSITIES.MONITORING_PLOT_ID,
-                        observationIdField,
-                        true,
-                    )
-                )
-            )
+            .and(plotObservationCondition)
     )
   }
 
@@ -3833,6 +3832,15 @@ class ObservationStore(
   ): Field<BigDecimal> {
     val opTemp = OBSERVATION_PLOTS.`as`("opTemp")
     return with(STRATUM_T0_TEMP_DENSITIES) {
+      val plotObservationCondition =
+          opTemp.IS_PERMANENT.isFalse.and(
+              opTemp.OBSERVATION_ID.eq(
+                  latestObservationForSubstratumField(
+                      observationIdField,
+                      opTemp.monitoringPlotHistories.SUBSTRATUM_ID,
+                  )
+              )
+          )
       DSL.field(
           DSL.select(DSL.sum(STRATUM_DENSITY).mul(DSL.inline(HECTARES_PER_PLOT)))
               .from(STRATUM_T0_TEMP_DENSITIES)
@@ -3852,15 +3860,7 @@ class ObservationStore(
                       updateScope.alternateCompletedCondition(opTemp.MONITORING_PLOT_ID),
                   )
               )
-              .and(
-                  opTemp.OBSERVATION_ID.eq(
-                      observationIdForPlot(
-                          opTemp.MONITORING_PLOT_ID,
-                          observationIdField,
-                          false,
-                      )
-                  )
-              )
+              .and(plotObservationCondition)
       )
     }
   }

--- a/src/main/kotlin/com/terraformation/backend/tracking/db/ObservationStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/db/ObservationStore.kt
@@ -3760,9 +3760,8 @@ class ObservationStore(
   ): Field<BigDecimal> {
     val opPerm = OBSERVATION_PLOTS.`as`("opPerm")
     // Attribute each plot's T0 to its substratum's latest observation at or before this one,
-    // exactly
-    // as the live total does. A substratum observed in this observation resolves to the observation
-    // itself (a self-reference); one it did not observe resolves to the rolled-forward source.
+    // exactly as the live total does. A substratum observed in this observation resolves to the
+    // observation itself; one it did not observe resolves to the rolled-forward source.
     val plotObservationCondition =
         opPerm.IS_PERMANENT.isTrue.and(
             opPerm.OBSERVATION_ID.eq(

--- a/src/main/kotlin/com/terraformation/backend/tracking/db/Queries.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/db/Queries.kt
@@ -3,6 +3,7 @@ package com.terraformation.backend.tracking.db
 import com.terraformation.backend.db.tracking.MonitoringPlotId
 import com.terraformation.backend.db.tracking.ObservationId
 import com.terraformation.backend.db.tracking.SubstratumId
+import com.terraformation.backend.db.tracking.tables.references.DEPENDENT_SUBSTRATUM_OBSERVATION
 import com.terraformation.backend.db.tracking.tables.references.MONITORING_PLOT_HISTORIES
 import com.terraformation.backend.db.tracking.tables.references.OBSERVATIONS
 import com.terraformation.backend.db.tracking.tables.references.OBSERVATION_PLOTS
@@ -11,45 +12,29 @@ import com.terraformation.backend.db.tracking.tables.references.STRATUM_HISTORIE
 import com.terraformation.backend.db.tracking.tables.references.SUBSTRATUM_HISTORIES
 import org.jooq.Condition
 import org.jooq.Field
+import org.jooq.Record1
+import org.jooq.Select
 import org.jooq.impl.DSL
 
 /**
- * Retrieves the most recent observationId for a substratum, with a completed time less than or
- * equal to the given observationId's completed time.
+ * Retrieves the most recent observationId for a substratum, or null if the substratum was not
+ * observed in or before the requested observation
  *
  * The substratum in question is assumed to be OBSERVED_SUBSTRATUM_SPECIES_TOTALS.SUBSTRATUM_ID.
  */
 fun latestObservationForSubstratumField(
     observationIdField: Field<ObservationId?>,
     substratumIdField: Field<SubstratumId?>,
-) =
-    DSL.select(OBSERVATIONS.ID)
-        .from(OBSERVATIONS)
-        .join(OBSERVATION_REQUESTED_SUBSTRATA)
-        .on(OBSERVATIONS.ID.eq(OBSERVATION_REQUESTED_SUBSTRATA.OBSERVATION_ID))
-        .where(OBSERVATION_REQUESTED_SUBSTRATA.SUBSTRATUM_ID.eq(substratumIdField))
-        .and(
-            DSL.or(
-                // Always consider the reference observation itself, even while it is still in
-                // progress and so has no completed time to compare against yet.
-                OBSERVATIONS.ID.eq(observationIdField),
-                OBSERVATIONS.COMPLETED_TIME.le(
-                    DSL.select(OBSERVATIONS.COMPLETED_TIME)
-                        .from(OBSERVATIONS)
-                        .where(OBSERVATIONS.ID.eq(observationIdField))
-                ),
-            )
-        )
-        .and(OBSERVATIONS.IS_AD_HOC.isFalse)
-        .orderBy(
-            // Prefer results from the same observation as the `observationId` if it exists.
-            // True is considered greater than false, so sorting by an "=" expression in
-            // descending order means the matches come first.
-            OBSERVATIONS.ID.eq(observationIdField).desc(),
-            // Otherwise take the results from the next latest observation for that area.
-            OBSERVATIONS.COMPLETED_TIME.desc(),
-        )
-        .limit(1)
+): Select<Record1<ObservationId?>> {
+  val dependentSsh = SUBSTRATUM_HISTORIES.`as`("dependent_obs_ssh")
+  return DSL.select(DEPENDENT_SUBSTRATUM_OBSERVATION.DEPENDS_ON_OBSERVATION_ID)
+      .from(DEPENDENT_SUBSTRATUM_OBSERVATION)
+      .join(dependentSsh)
+      .on(dependentSsh.ID.eq(DEPENDENT_SUBSTRATUM_OBSERVATION.SUBSTRATUM_HISTORY_ID))
+      .where(DEPENDENT_SUBSTRATUM_OBSERVATION.OBSERVATION_ID.eq(observationIdField))
+      .and(dependentSsh.SUBSTRATUM_ID.eq(substratumIdField))
+      .limit(1)
+}
 
 /**
  * Returns an observationId if the given monitoring plot is used in the observation results from

--- a/src/main/kotlin/com/terraformation/backend/tracking/db/Queries.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/db/Queries.kt
@@ -3,9 +3,9 @@ package com.terraformation.backend.tracking.db
 import com.terraformation.backend.db.tracking.MonitoringPlotId
 import com.terraformation.backend.db.tracking.ObservationId
 import com.terraformation.backend.db.tracking.SubstratumId
-import com.terraformation.backend.db.tracking.tables.references.DEPENDENT_SUBSTRATUM_OBSERVATION
 import com.terraformation.backend.db.tracking.tables.references.MONITORING_PLOT_HISTORIES
 import com.terraformation.backend.db.tracking.tables.references.OBSERVATIONS
+import com.terraformation.backend.db.tracking.tables.references.OBSERVATION_DEPENDENT_SUBSTRATA
 import com.terraformation.backend.db.tracking.tables.references.OBSERVATION_PLOTS
 import com.terraformation.backend.db.tracking.tables.references.OBSERVATION_REQUESTED_SUBSTRATA
 import com.terraformation.backend.db.tracking.tables.references.STRATUM_HISTORIES
@@ -27,11 +27,11 @@ fun latestObservationForSubstratumField(
     substratumIdField: Field<SubstratumId?>,
 ): Select<Record1<ObservationId?>> {
   val dependentSsh = SUBSTRATUM_HISTORIES.`as`("dependent_obs_ssh")
-  return DSL.select(DEPENDENT_SUBSTRATUM_OBSERVATION.DEPENDS_ON_OBSERVATION_ID)
-      .from(DEPENDENT_SUBSTRATUM_OBSERVATION)
+  return DSL.select(OBSERVATION_DEPENDENT_SUBSTRATA.DEPENDS_ON_OBSERVATION_ID)
+      .from(OBSERVATION_DEPENDENT_SUBSTRATA)
       .join(dependentSsh)
-      .on(dependentSsh.ID.eq(DEPENDENT_SUBSTRATUM_OBSERVATION.SUBSTRATUM_HISTORY_ID))
-      .where(DEPENDENT_SUBSTRATUM_OBSERVATION.OBSERVATION_ID.eq(observationIdField))
+      .on(dependentSsh.ID.eq(OBSERVATION_DEPENDENT_SUBSTRATA.SUBSTRATUM_HISTORY_ID))
+      .where(OBSERVATION_DEPENDENT_SUBSTRATA.OBSERVATION_ID.eq(observationIdField))
       .and(dependentSsh.SUBSTRATUM_ID.eq(substratumIdField))
       .limit(1)
 }

--- a/src/main/kotlin/com/terraformation/backend/tracking/util/ObservationResultsScope.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/util/ObservationResultsScope.kt
@@ -12,6 +12,7 @@ import com.terraformation.backend.db.tracking.SubstratumHistoryId
 import com.terraformation.backend.db.tracking.SubstratumId
 import com.terraformation.backend.db.tracking.tables.ObservationPlotResults
 import com.terraformation.backend.db.tracking.tables.ObservationPlots
+import com.terraformation.backend.db.tracking.tables.references.DEPENDENT_SUBSTRATUM_OBSERVATION
 import com.terraformation.backend.db.tracking.tables.references.MONITORING_PLOTS
 import com.terraformation.backend.db.tracking.tables.references.MONITORING_PLOT_HISTORIES
 import com.terraformation.backend.db.tracking.tables.references.OBSERVATIONS
@@ -465,16 +466,45 @@ class ObservationResultsStratum(
   override val observedTotalsCondition =
       OBSERVATION_STRATUM_RESULTS.STRATUM_HISTORY_ID.`in`(stratumHistorySelect)
 
+  /**
+   * For the plotId case, scopes the recalc to exactly the stratum result rows whose data is rolled
+   * up from the edited plot's observations.
+   */
   override val survivalRateRecalculationCondition: Condition
     get() =
         if (plotId != null) {
-          OBSERVATION_STRATUM_RESULTS.STRATUM_HISTORY_ID.`in`(
-              DSL.selectDistinct(SUBSTRATUM_HISTORIES.STRATUM_HISTORY_ID)
-                  .from(MONITORING_PLOT_HISTORIES)
-                  .join(SUBSTRATUM_HISTORIES)
-                  .on(SUBSTRATUM_HISTORIES.ID.eq(MONITORING_PLOT_HISTORIES.SUBSTRATUM_HISTORY_ID))
-                  .where(MONITORING_PLOT_HISTORIES.MONITORING_PLOT_ID.eq(plotId))
-          )
+          DSL.row(
+                  OBSERVATION_STRATUM_RESULTS.OBSERVATION_ID,
+                  OBSERVATION_STRATUM_RESULTS.STRATUM_HISTORY_ID,
+              )
+              .`in`(
+                  DSL.select(
+                          DEPENDENT_SUBSTRATUM_OBSERVATION.OBSERVATION_ID,
+                          SUBSTRATUM_HISTORIES.STRATUM_HISTORY_ID,
+                      )
+                      .from(DEPENDENT_SUBSTRATUM_OBSERVATION)
+                      .join(SUBSTRATUM_HISTORIES)
+                      .on(
+                          SUBSTRATUM_HISTORIES.ID.eq(
+                              DEPENDENT_SUBSTRATUM_OBSERVATION.SUBSTRATUM_HISTORY_ID
+                          )
+                      )
+                      .where(
+                          DSL.row(
+                                  DEPENDENT_SUBSTRATUM_OBSERVATION.DEPENDS_ON_OBSERVATION_ID,
+                                  DEPENDENT_SUBSTRATUM_OBSERVATION.DEPENDS_ON_SUBSTRATUM_HISTORY_ID,
+                              )
+                              .`in`(
+                                  DSL.select(
+                                          OBSERVATION_PLOTS.OBSERVATION_ID,
+                                          OBSERVATION_PLOTS.monitoringPlotHistories
+                                              .SUBSTRATUM_HISTORY_ID,
+                                      )
+                                      .from(OBSERVATION_PLOTS)
+                                      .where(OBSERVATION_PLOTS.MONITORING_PLOT_ID.eq(plotId))
+                              )
+                      )
+              )
         } else {
           observedTotalsCondition
         }

--- a/src/main/kotlin/com/terraformation/backend/tracking/util/ObservationResultsScope.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/util/ObservationResultsScope.kt
@@ -12,10 +12,10 @@ import com.terraformation.backend.db.tracking.SubstratumHistoryId
 import com.terraformation.backend.db.tracking.SubstratumId
 import com.terraformation.backend.db.tracking.tables.ObservationPlotResults
 import com.terraformation.backend.db.tracking.tables.ObservationPlots
-import com.terraformation.backend.db.tracking.tables.references.DEPENDENT_SUBSTRATUM_OBSERVATION
 import com.terraformation.backend.db.tracking.tables.references.MONITORING_PLOTS
 import com.terraformation.backend.db.tracking.tables.references.MONITORING_PLOT_HISTORIES
 import com.terraformation.backend.db.tracking.tables.references.OBSERVATIONS
+import com.terraformation.backend.db.tracking.tables.references.OBSERVATION_DEPENDENT_SUBSTRATA
 import com.terraformation.backend.db.tracking.tables.references.OBSERVATION_PLOTS
 import com.terraformation.backend.db.tracking.tables.references.OBSERVATION_PLOT_RESULTS
 import com.terraformation.backend.db.tracking.tables.references.OBSERVATION_SITE_RESULTS
@@ -479,20 +479,20 @@ class ObservationResultsStratum(
               )
               .`in`(
                   DSL.select(
-                          DEPENDENT_SUBSTRATUM_OBSERVATION.OBSERVATION_ID,
+                          OBSERVATION_DEPENDENT_SUBSTRATA.OBSERVATION_ID,
                           SUBSTRATUM_HISTORIES.STRATUM_HISTORY_ID,
                       )
-                      .from(DEPENDENT_SUBSTRATUM_OBSERVATION)
+                      .from(OBSERVATION_DEPENDENT_SUBSTRATA)
                       .join(SUBSTRATUM_HISTORIES)
                       .on(
                           SUBSTRATUM_HISTORIES.ID.eq(
-                              DEPENDENT_SUBSTRATUM_OBSERVATION.SUBSTRATUM_HISTORY_ID
+                              OBSERVATION_DEPENDENT_SUBSTRATA.SUBSTRATUM_HISTORY_ID
                           )
                       )
                       .where(
                           DSL.row(
-                                  DEPENDENT_SUBSTRATUM_OBSERVATION.DEPENDS_ON_OBSERVATION_ID,
-                                  DEPENDENT_SUBSTRATUM_OBSERVATION.DEPENDS_ON_SUBSTRATUM_HISTORY_ID,
+                                  OBSERVATION_DEPENDENT_SUBSTRATA.DEPENDS_ON_OBSERVATION_ID,
+                                  OBSERVATION_DEPENDENT_SUBSTRATA.DEPENDS_ON_SUBSTRATUM_HISTORY_ID,
                               )
                               .`in`(
                                   DSL.select(

--- a/src/test/kotlin/com/terraformation/backend/accelerator/db/ReportStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/db/ReportStoreTest.kt
@@ -6231,21 +6231,21 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
     // Dead plants: 20
 
     // observation2 observed substratumId2, incompleteSubstratum, and futureSubstratum
-    insertDependentSubstratumObservation(
+    insertObservationDependentSubstrata(
         observationId = site1observation2,
         substratumHistoryId = substratum2NewHistory,
     )
-    insertDependentSubstratumObservation(
+    insertObservationDependentSubstrata(
         observationId = site1observation2,
         substratumHistoryId = incompleteSubstratumHistory,
     )
-    insertDependentSubstratumObservation(
+    insertObservationDependentSubstrata(
         observationId = site1observation2,
         substratumHistoryId = futureSubstratumNewHistory,
     )
 
     // observation2 did not observe substratumId1
-    insertDependentSubstratumObservation(
+    insertObservationDependentSubstrata(
         observationId = site1observation2,
         substratumHistoryId = substratum1NewHistory,
         dependsOnObservationId = site1OldObservationId,
@@ -6253,7 +6253,7 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
     )
 
     // Site 2 only has one observation
-    insertDependentSubstratumObservation(
+    insertObservationDependentSubstrata(
         observationId = site2ObservationId,
         substratumHistoryId = site2Substratum1History,
     )
@@ -6531,11 +6531,11 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
     )
 
     // Each site only has one substratum and one observation. Site 3 is unobserved.
-    insertDependentSubstratumObservation(
+    insertObservationDependentSubstrata(
         observationId = site1ObservationId,
         substratumHistoryId = site1SubstratumHistory,
     )
-    insertDependentSubstratumObservation(
+    insertObservationDependentSubstrata(
         observationId = site2ObservationId,
         substratumHistoryId = site2SubstratumHistory,
     )

--- a/src/test/kotlin/com/terraformation/backend/accelerator/db/ReportStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/db/ReportStoreTest.kt
@@ -5602,7 +5602,7 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
             insertHistory = false,
         )
     val substratum1oldHistory = insertSubstratumHistory(stratumHistoryId = site1stratumOldHistory)
-    insertSubstratumHistory()
+    val substratum1NewHistory = insertSubstratumHistory()
     val substratum1plot1 = insertMonitoringPlot(permanentIndex = 1, insertHistory = false)
     val substratum1plot1OldHist =
         insertMonitoringPlotHistory(
@@ -5644,7 +5644,7 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
             insertHistory = false,
         )
     val substratum2oldHistory = insertSubstratumHistory(stratumHistoryId = site1stratumOldHistory)
-    insertSubstratumHistory()
+    val substratum2NewHistory = insertSubstratumHistory()
     // this plot was in observation1 but was reassigned from observation2
     val reassignedPlot = insertMonitoringPlot(permanentIndex = 2)
     val reassignedPlotHist = inserted.monitoringPlotHistoryId
@@ -5720,6 +5720,7 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
             areaHa = BigDecimal(1000),
             plantingCompletedTime = null,
         )
+    val incompleteSubstratumHistory = inserted.substratumHistoryId
     // plot was in a different substratum previously
     val incompleteSubstratumPlot1 = insertMonitoringPlot(permanentIndex = 5, insertHistory = false)
     val incompleteSubstratumPlot1OldHist =
@@ -5745,7 +5746,7 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
             insertHistory = false,
         )
     val futureSubstratumOldHist = insertSubstratumHistory(stratumHistoryId = site1stratumOldHistory)
-    insertSubstratumHistory()
+    val futureSubstratumNewHistory = insertSubstratumHistory()
     val futureSubstratumPlot1 = insertMonitoringPlot(permanentIndex = 6, insertHistory = false)
     val futureSubstratumPlot1OldHist =
         insertMonitoringPlotHistory(
@@ -5775,6 +5776,7 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
             areaHa = BigDecimal(30),
             plantingCompletedTime = plantingCompletedDate2.atStartOfDay().toInstant(ZoneOffset.UTC),
         )
+    val site2Substratum1History = inserted.substratumHistoryId
     val substratum3plot1 = insertMonitoringPlot(permanentIndex = 1)
     val substratum3plot1Hist = inserted.monitoringPlotHistoryId
     insertPlotT0Density(
@@ -6228,6 +6230,34 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
     // Total plants: 50
     // Dead plants: 20
 
+    // observation2 observed substratumId2, incompleteSubstratum, and futureSubstratum
+    insertDependentSubstratumObservation(
+        observationId = site1observation2,
+        substratumHistoryId = substratum2NewHistory,
+    )
+    insertDependentSubstratumObservation(
+        observationId = site1observation2,
+        substratumHistoryId = incompleteSubstratumHistory,
+    )
+    insertDependentSubstratumObservation(
+        observationId = site1observation2,
+        substratumHistoryId = futureSubstratumNewHistory,
+    )
+
+    // observation2 did not observe substratumId1
+    insertDependentSubstratumObservation(
+        observationId = site1observation2,
+        substratumHistoryId = substratum1NewHistory,
+        dependsOnObservationId = site1OldObservationId,
+        dependsOnSubstratumHistoryId = substratum1oldHistory,
+    )
+
+    // Site 2 only has one observation
+    insertDependentSubstratumObservation(
+        observationId = site2ObservationId,
+        substratumHistoryId = site2Substratum1History,
+    )
+
     // Populate the rolled-up stratum and site SRs that the project-level area-weighted
     // calculation reads from. Site 1's stratum has substrata of areas 10+20+1000+3000=4030 ha;
     // site 2 has one substratum of area 30 ha. With both stratum SRs=50, the project SR is
@@ -6498,6 +6528,16 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
         plantingSiteId = plantingSite3,
         plantingSiteHistoryId = plantingSiteHistory3,
         permanentLive = 51,
+    )
+
+    // Each site only has one substratum and one observation. Site 3 is unobserved.
+    insertDependentSubstratumObservation(
+        observationId = site1ObservationId,
+        substratumHistoryId = site1SubstratumHistory,
+    )
+    insertDependentSubstratumObservation(
+        observationId = site2ObservationId,
+        substratumHistoryId = site2SubstratumHistory,
     )
 
     // Populate the rolled-up site/stratum SR values that the project-level area-weighted

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/ObservationScenarioTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/ObservationScenarioTest.kt
@@ -99,6 +99,7 @@ abstract class ObservationScenarioTest : DatabaseTest(), RunsAsUser {
 
     every { user.canReadObservation(any()) } returns true
     every { user.canUpdateObservation(any()) } returns true
+    every { user.canUpdateObservationQuantities(any()) } returns true
     every { user.canReadPlantingSite(plantingSiteId) } returns true
   }
 

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/observationStore/ObservationStoreSurvivalRateCalculationTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/observationStore/ObservationStoreSurvivalRateCalculationTest.kt
@@ -10,7 +10,10 @@ import com.terraformation.backend.db.tracking.RecordedSpeciesCertainty
 import com.terraformation.backend.db.tracking.StratumId
 import com.terraformation.backend.db.tracking.SubstratumId
 import com.terraformation.backend.db.tracking.tables.pojos.RecordedPlantsRow
+import com.terraformation.backend.db.tracking.tables.records.ObservedStratumSpeciesTotalsRecord
 import com.terraformation.backend.db.tracking.tables.references.MONITORING_PLOTS
+import com.terraformation.backend.db.tracking.tables.references.OBSERVATION_STRATUM_RESULTS
+import com.terraformation.backend.db.tracking.tables.references.OBSERVED_STRATUM_SPECIES_TOTALS
 import com.terraformation.backend.db.tracking.tables.references.PLANTING_SITES
 import com.terraformation.backend.db.tracking.tables.references.STRATUM_T0_TEMP_DENSITIES
 import com.terraformation.backend.mockUser
@@ -26,6 +29,7 @@ import kotlin.math.roundToInt
 import org.jooq.impl.DSL
 import org.jooq.impl.SQLDataType
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertAll
@@ -810,6 +814,108 @@ class ObservationStoreSurvivalRateCalculationTest : ObservationScenarioTest() {
             mapOf(plantingSiteId to rates2),
         )
     assertSurvivalRates(expected2, "Survival rates includes species not in observation 2")
+  }
+
+  @Test
+  fun `survival rate recalc skips observations that do not depend on the edited plot's data`() {
+    every { user.canUpdateObservationQuantities(any()) } returns true
+
+    val species1 = insertSpecies()
+    insertPlotT0Density(plotDensity = BigDecimal.valueOf(10).toPlantsPerHectare())
+    val plotQ = insertMonitoringPlot(permanentIndex = 2)
+    insertPlotT0Density(plotDensity = BigDecimal.valueOf(10).toPlantsPerHectare())
+
+    observationStore.completePlot(
+        observationId,
+        plotId,
+        emptySet(),
+        "Notes",
+        observedTime,
+        listOf(
+            RecordedPlantsRow(
+                certaintyId = RecordedSpeciesCertainty.Known,
+                gpsCoordinates = point(1),
+                speciesId = species1,
+                statusId = RecordedPlantStatus.Live,
+            )
+        ),
+    )
+
+    val observation2 = insertObservation()
+    insertObservationRequestedSubstratum()
+    insertObservationPlot(
+        monitoringPlotId = plotQ,
+        observationId = observation2,
+        claimedBy = user.userId,
+        isPermanent = true,
+    )
+    observationStore.completePlot(
+        observation2,
+        plotQ,
+        emptySet(),
+        "Notes",
+        observedTime.plusSeconds(10),
+        listOf(
+            RecordedPlantsRow(
+                certaintyId = RecordedSpeciesCertainty.Known,
+                gpsCoordinates = point(1),
+                speciesId = species1,
+                statusId = RecordedPlantStatus.Live,
+            )
+        ),
+    )
+
+    // Stamp a sentinel into observation 2's stratum survival rate after completion. A correct
+    // recalc scoped to dependents of observation 1 must leave this untouched.
+    val sentinel = 999
+    dslContext
+        .update(OBSERVATION_STRATUM_RESULTS)
+        .set(OBSERVATION_STRATUM_RESULTS.SURVIVAL_RATE, sentinel)
+        .where(OBSERVATION_STRATUM_RESULTS.OBSERVATION_ID.eq(observation2))
+        .and(OBSERVATION_STRATUM_RESULTS.STRATUM_ID.eq(stratumId))
+        .execute()
+
+    // Edit observation 1's species totals for plot P, then run the recalc that the edit path
+    // triggers via the MonitoringSpeciesTotalsEditedEvent listener.
+    observationStore.updateMonitoringSpecies(
+        observationId,
+        plotId,
+        RecordedSpeciesCertainty.Known,
+        species1,
+        null,
+    ) { model ->
+      model.copy(totalLive = model.totalLive + 1)
+    }
+    observationStore.recalculateSurvivalRates(plotId)
+
+    val obs1StratumRate =
+        observationStratumResultsDao
+            .fetchByObservationId(observationId)
+            .single { it.stratumId == stratumId }
+            .survivalRate
+    val obs2StratumRate =
+        observationStratumResultsDao
+            .fetchByObservationId(observation2)
+            .single { it.stratumId == stratumId }
+            .survivalRate
+
+    assertAll(
+        {
+          assertEquals(
+              100 * 2 / 10,
+              obs1StratumRate,
+              "Observation 1 stratum survival rate is recomputed from the edited totals",
+          )
+        },
+        {
+          assertEquals(
+              sentinel,
+              obs2StratumRate,
+              "Observation 2 stratum survival rate is untouched because it does not depend on " +
+                  "observation 1",
+          )
+        },
+    )
   }
 
   @Test
@@ -1711,6 +1817,221 @@ class ObservationStoreSurvivalRateCalculationTest : ObservationScenarioTest() {
     }
 
     return SurvivalRates(plotRates, substratumRates, stratumRates, siteRates)
+  }
+
+  @Test
+  fun `abandoning an observation rolls its unobserved substrata forward into the rollups`() {
+    val speciesId = insertSpecies()
+    insertPlotT0Density(
+        monitoringPlotId = plotId,
+        speciesId = speciesId,
+        plotDensity = BigDecimal.valueOf(10).toPlantsPerHectare(),
+    )
+
+    val substratumB = insertSubstratum()
+    val plotB = insertMonitoringPlot(permanentIndex = 2, substratumId = substratumB)
+    insertPlotT0Density(
+        monitoringPlotId = plotB,
+        speciesId = speciesId,
+        plotDensity = BigDecimal.valueOf(20).toPlantsPerHectare(),
+    )
+
+    // observation 1 observes both A and B.
+    insertObservationRequestedSubstratum(observationId = observationId, substratumId = substratumB)
+    insertObservationPlot(
+        observationId = observationId,
+        monitoringPlotId = plotB,
+        claimedBy = user.userId,
+        isPermanent = true,
+    )
+    observationStore.completePlot(
+        observationId,
+        plotId,
+        emptySet(),
+        "Notes",
+        observedTime,
+        createPlantsRows(mapOf(speciesId to 8), RecordedPlantStatus.Live),
+    )
+    observationStore.completePlot(
+        observationId,
+        plotB,
+        emptySet(),
+        "Notes",
+        observedTime,
+        createPlantsRows(mapOf(speciesId to 16), RecordedPlantStatus.Live),
+    )
+
+    // observation 2 requests A and B and has plots in both, but only A's plot is completed before
+    // the observation is abandoned, leaving B requested-but-unobserved.
+    val observation2 = insertObservation()
+    insertObservationRequestedSubstratum(observationId = observation2, substratumId = substratumId)
+    insertObservationRequestedSubstratum(observationId = observation2, substratumId = substratumB)
+    insertObservationPlot(
+        observationId = observation2,
+        monitoringPlotId = plotId,
+        claimedBy = user.userId,
+        isPermanent = true,
+    )
+    insertObservationPlot(
+        observationId = observation2,
+        monitoringPlotId = plotB,
+        claimedBy = user.userId,
+        isPermanent = true,
+    )
+    observationStore.completePlot(
+        observation2,
+        plotId,
+        emptySet(),
+        "Notes",
+        observedTime.plusSeconds(10),
+        createPlantsRows(mapOf(speciesId to 9), RecordedPlantStatus.Live),
+    )
+
+    observationStore.abandonObservation(observation2)
+
+    // B was never observed in observation 2, so its dependency row rolls forward to observation 1.
+    val bDependency =
+        dependentSubstratumObservationDao.fetchByObservationId(observation2).single {
+          it.dependsOnObservationId != observation2
+        }
+    assertEquals(
+        observationId,
+        bDependency.dependsOnObservationId,
+        "B rolls forward to observation 1",
+    )
+
+    // An abandoned observation is treated like a completed one (its not-observed plot is ignored),
+    // so it rolls B forward into the stratum survival rate in both the numerator (live) and the
+    // denominator (T0): (A live 9 + B live 16) / (A T0 10 + B T0 20) = 25/30 ~= 83%.
+    val stratumResult =
+        observationStratumResultsDao.fetchByObservationId(observation2).single {
+          it.stratumId == stratumId
+        }
+    assertEquals(
+        83,
+        stratumResult.survivalRate,
+        "Abandoned observation rolls B's survival rate forward",
+    )
+    assertNotNull(stratumResult.plantDensity, "Abandoned observation rolls B's density forward")
+  }
+
+  @Test
+  fun `a full recalculation keeps a rolled-forward substratum's stratum survival rate consistent`() {
+    val speciesId = insertSpecies()
+    val stratumHistoryId = inserted.stratumHistoryId
+    insertPlotT0Density(
+        monitoringPlotId = plotId,
+        speciesId = speciesId,
+        plotDensity = BigDecimal.valueOf(10).toPlantsPerHectare(),
+    )
+
+    val substratumB = insertSubstratum()
+    val plotB = insertMonitoringPlot(permanentIndex = 2, substratumId = substratumB)
+    insertPlotT0Density(
+        monitoringPlotId = plotB,
+        speciesId = speciesId,
+        plotDensity = BigDecimal.valueOf(20).toPlantsPerHectare(),
+    )
+
+    // observation 1 observes both A and B.
+    insertObservationRequestedSubstratum(observationId = observationId, substratumId = substratumB)
+    insertObservationPlot(
+        observationId = observationId,
+        monitoringPlotId = plotB,
+        claimedBy = user.userId,
+        isPermanent = true,
+    )
+    observationStore.completePlot(
+        observationId,
+        plotId,
+        emptySet(),
+        "Notes",
+        observedTime,
+        createPlantsRows(mapOf(speciesId to 8), RecordedPlantStatus.Live),
+    )
+    observationStore.completePlot(
+        observationId,
+        plotB,
+        emptySet(),
+        "Notes",
+        observedTime,
+        createPlantsRows(mapOf(speciesId to 16), RecordedPlantStatus.Live),
+    )
+
+    // observation 2 observes only A and is abandoned
+    val observation2 = insertObservation()
+    insertObservationRequestedSubstratum(observationId = observation2, substratumId = substratumId)
+    insertObservationRequestedSubstratum(observationId = observation2, substratumId = substratumB)
+    insertObservationPlot(
+        observationId = observation2,
+        monitoringPlotId = plotId,
+        claimedBy = user.userId,
+        isPermanent = true,
+    )
+    insertObservationPlot(
+        observationId = observation2,
+        monitoringPlotId = plotB,
+        claimedBy = user.userId,
+        isPermanent = true,
+    )
+
+    clock.instant = Instant.ofEpochSecond(10)
+    observationStore.completePlot(
+        observation2,
+        plotId,
+        emptySet(),
+        "Notes",
+        observedTime.plusSeconds(10),
+        createPlantsRows(mapOf(speciesId to 9), RecordedPlantStatus.Live),
+    )
+
+    observationStore.abandonObservation(observation2)
+
+    assertTableEquals(
+        ObservedStratumSpeciesTotalsRecord(
+            observationId = observation2,
+            stratumId = stratumId,
+            stratumHistoryId = stratumHistoryId,
+            certaintyId = RecordedSpeciesCertainty.Known,
+            speciesId = speciesId,
+            speciesName = null,
+            totalLive = 9,
+            totalDead = 0,
+            totalExisting = 0,
+            permanentLive = 25,
+            survivalRate = 83,
+        ),
+        message = "Stratum species totals for observation 2 uses data from observation 1",
+        where = OBSERVED_STRATUM_SPECIES_TOTALS.OBSERVATION_ID.eq(observation2),
+    )
+
+    observationStore.updateMonitoringSpecies(
+        observationId,
+        plotB,
+        RecordedSpeciesCertainty.Known,
+        speciesId,
+        null,
+    ) { model ->
+      model.copy(totalLive = 6)
+    }
+
+    assertTableEquals(
+        ObservedStratumSpeciesTotalsRecord(
+            observationId = observation2,
+            stratumId = stratumId,
+            stratumHistoryId = stratumHistoryId,
+            certaintyId = RecordedSpeciesCertainty.Known,
+            speciesId = speciesId,
+            speciesName = null,
+            totalLive = 9,
+            totalDead = 0,
+            totalExisting = 0,
+            permanentLive = 15,
+            survivalRate = 50,
+        ),
+        message = "Stratum species totals for observation 2 after editing observation 1's B data",
+        where = OBSERVED_STRATUM_SPECIES_TOTALS.OBSERVATION_ID.eq(observation2),
+    )
   }
 
   private fun createPlantsRows(

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/observationStore/ObservationStoreSurvivalRateCalculationTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/observationStore/ObservationStoreSurvivalRateCalculationTest.kt
@@ -904,15 +904,16 @@ class ObservationStoreSurvivalRateCalculationTest : ObservationScenarioTest() {
           assertEquals(
               100 * 2 / 10,
               obs1StratumRate,
-              "Observation 1 stratum survival rate is recomputed from the edited totals",
+              "Observation 1 stratum survival rate should be recomputed from the " +
+                  "edited totals",
           )
         },
         {
           assertEquals(
               sentinel,
               obs2StratumRate,
-              "Observation 2 stratum survival rate is untouched because it does not depend on " +
-                  "observation 1",
+              "Observation 2 stratum survival rate should not be affected because it " +
+                  "does not depend on observation 1",
           )
         },
     )

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/observationStore/ObservationStoreSurvivalRateCalculationTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/observationStore/ObservationStoreSurvivalRateCalculationTest.kt
@@ -1891,7 +1891,7 @@ class ObservationStoreSurvivalRateCalculationTest : ObservationScenarioTest() {
 
     // B was never observed in observation 2, so its dependency row rolls forward to observation 1.
     val bDependency =
-        dependentSubstratumObservationDao.fetchByObservationId(observation2).single {
+        observationDependentSubstrataDao.fetchByObservationId(observation2).single {
           it.dependsOnObservationId != observation2
         }
     assertEquals(


### PR DESCRIPTION
Reads dependent_substratum_observation to roll an unobserved substratum's results
forward.

Co-Authored-By: Claude Opus 4.8 [noreply@anthropic.com](mailto:noreply@anthropic.com)