### PR TITLE
SW-8351 Use all dependent plots into the survival-rate std dev

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/tracking/db/ObservationStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/db/ObservationStore.kt
@@ -2169,10 +2169,8 @@ class ObservationStore(
         .where(recalculationCondition)
         .execute()
 
-    // Standard deviation and area are stored only for scopes that aggregate plots (substratum,
-    // stratum, site). They depend on the survival rate just computed above, so they're set in a
-    // separate statement that reads the stored value instead of recomputing the (large) survival
-    // rate expression for each column.
+    // Standard deviation and area are stored only for scopes that aggregate plots depends on the
+    // just computed survival rates.
     if (survivalRateStdDevField != null && survivalRateAreaField != null) {
       dslContext
           .update(table)
@@ -2180,7 +2178,7 @@ class ObservationStore(
               survivalRateStdDevField,
               DSL.if_(
                   survivalRateField.isNotNull,
-                  getSurvivalRateWeightedStandardDeviation(updateScope),
+                  getSurvivalRateWeightedStandardDeviation(updateScope, observationIdField),
                   DSL.castNull(SQLDataType.INTEGER),
               ),
           )
@@ -2310,7 +2308,10 @@ class ObservationStore(
                 survivalRateStdDevField,
                 DSL.if_(
                     survivalRateField.isNotNull,
-                    getSurvivalRateWeightedStandardDeviation(updateScope),
+                    getSurvivalRateWeightedStandardDeviation(
+                        updateScope,
+                        DSL.value(observationId, OBSERVATIONS.ID.dataType),
+                    ),
                     DSL.castNull(SQLDataType.INTEGER),
                 ),
             )
@@ -3835,6 +3836,7 @@ class ObservationStore(
    */
   private fun <ID : Any, HistoryId : Any> getSurvivalRateWeightedStandardDeviation(
       updateScope: ObservationResultsScope<ID, HistoryId>,
+      observationIdField: Field<ObservationId?>,
   ): Field<Int> {
     val plotResults = OBSERVATION_PLOT_RESULTS.`as`("plotResults")
     val survivalRate = plotResults.SURVIVAL_RATE.cast(SQLDataType.NUMERIC)
@@ -3857,7 +3859,13 @@ class ObservationStore(
                 )
             )
             .from(plotResults)
-            .where(updateScope.observationPlotResultsCondition(plotResults))
+            .where(updateScope.latestPlotResultsCondition(plotResults, observationIdField))
+            .and(
+                DSL.or(
+                    updateScope.observedTotalsPlantingSiteTempCondition,
+                    plotResults.observationPlots.IS_PERMANENT.isTrue,
+                )
+            )
             .and(plotResults.SURVIVAL_RATE.isNotNull)
     )
   }

--- a/src/main/kotlin/com/terraformation/backend/tracking/db/ObservationStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/db/ObservationStore.kt
@@ -2169,7 +2169,7 @@ class ObservationStore(
         .where(recalculationCondition)
         .execute()
 
-    // Standard deviation and area are stored only for scopes that aggregate plots depends on the
+    // Standard deviation and area are stored only for scopes that aggregate plots depend on the
     // just computed survival rates.
     if (survivalRateStdDevField != null && survivalRateAreaField != null) {
       dslContext

--- a/src/main/kotlin/com/terraformation/backend/tracking/util/ObservationResultsScope.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/util/ObservationResultsScope.kt
@@ -59,20 +59,26 @@ interface ObservationResultsScope<ID : Any, HistoryId : Any> :
 
   val latestLiveField: Field<Int>
 
-  /**
-   * Condition that covers all result table rows that could be affected by a change to the scoped
-   * entity. For ID-based scopes this is the same as [observedTotalsCondition]. For plotId-based
-   * scopes it expands to include all observations for every substratum/stratum the plot has ever
-   * historically belonged to, ensuring that observations which reference the plot's data via
-   * [observationIdForPlot] are also updated.
-   */
+  /** Condition that covers all result table rows that could be affected downstream. */
   val survivalRateRecalculationCondition: Condition
 
   fun anyChildHasNullSurvivalRateCondition(observationIdField: Field<ObservationId?>): Condition
 
   fun observationPlotsCondition(observationIdField: Field<ObservationId?>): Condition
 
-  fun observationPlotResultsCondition(plotResultsTable: ObservationPlotResults): Condition
+  /**
+   * Selects the [OBSERVATION_PLOT_RESULTS] rows that contribute to this scope when it is computed
+   * for [observationIdField]: the plots belonging to the scope, each taken from its substratum's
+   * latest observation at or before [observationIdField] (so a substratum that wasn't observed in
+   * the current observation still contributes its last-observed plots). This is the single
+   * definition of the rolled-forward plot set; the survival rate, plant density, and standard
+   * deviations all derive from it. Consumers that need only permanent plots add that filter
+   * themselves.
+   */
+  fun latestPlotResultsCondition(
+      plotResults: ObservationPlotResults,
+      observationIdField: Field<ObservationId?>,
+  ): Condition
 
   /**
    * Returns the SQL expression that produces the survival rate (as an integer percentage 0–100) for
@@ -119,7 +125,11 @@ interface ObservationResultsScope<ID : Any, HistoryId : Any> :
    * data to the rollup, matching how survival rate uses [latestObservationForSubstratumField].
    */
   fun latestPlantDensityField(observationIdField: Field<ObservationId?>): Field<Int?> =
-      observedPlantDensityField(observationIdField)
+      DSL.field(
+          DSL.select(DSL.avg(OBSERVATION_PLOT_RESULTS.PLANT_DENSITY).cast(SQLDataType.INTEGER))
+              .from(OBSERVATION_PLOT_RESULTS)
+              .where(latestPlotResultsCondition(OBSERVATION_PLOT_RESULTS, observationIdField))
+      )
 
   /**
    * Returns the SQL expression for this scope's plant density using only the plots observed in
@@ -146,8 +156,7 @@ interface ObservationResultsScope<ID : Any, HistoryId : Any> :
                   DSL.stddevSamp(OBSERVATION_PLOT_RESULTS.PLANT_DENSITY).cast(SQLDataType.INTEGER)
               )
               .from(OBSERVATION_PLOT_RESULTS)
-              .where(plotResultsCondition)
-              .and(OBSERVATION_PLOT_RESULTS.OBSERVATION_ID.eq(observationIdField))
+              .where(latestPlotResultsCondition(OBSERVATION_PLOT_RESULTS, observationIdField))
       )
 }
 
@@ -208,8 +217,12 @@ class ObservationResultsPlot(
       OBSERVATION_PLOTS.OBSERVATION_ID.eq(observationIdField)
           .and(OBSERVATION_PLOTS.MONITORING_PLOT_ID.eq(plotId))
 
-  override fun observationPlotResultsCondition(plotResultsTable: ObservationPlotResults) =
-      DSL.falseCondition()
+  override fun latestPlotResultsCondition(
+      plotResults: ObservationPlotResults,
+      observationIdField: Field<ObservationId?>,
+  ) =
+      plotResults.MONITORING_PLOT_ID.eq(plotId)
+          .and(plotResults.OBSERVATION_ID.eq(observationIdField))
 
   override fun tempStratumCondition(tempStratumTable: ObservationPlots) =
       tempStratumTable.MONITORING_PLOT_ID.eq(plotId)
@@ -320,17 +333,12 @@ class ObservationResultsSubstratum(
               )
           )
 
-  override fun observationPlotResultsCondition(plotResultsTable: ObservationPlotResults) =
-      DSL.and(
-          plotResultsTable.monitoringPlotHistories.SUBSTRATUM_HISTORY_ID.eq(
-              OBSERVATION_SUBSTRATUM_RESULTS.SUBSTRATUM_HISTORY_ID
-          ),
-          plotResultsTable.OBSERVATION_ID.eq(OBSERVATION_SUBSTRATUM_RESULTS.OBSERVATION_ID),
-          DSL.or(
-              observedTotalsPlantingSiteTempCondition,
-              plotResultsTable.observationPlots.IS_PERMANENT.isTrue,
-          ),
-      )
+  override fun latestPlotResultsCondition(
+      plotResults: ObservationPlotResults,
+      observationIdField: Field<ObservationId?>,
+  ) =
+      plotResults.monitoringPlotHistories.SUBSTRATUM_HISTORY_ID.`in`(substratumHistorySelect)
+          .and(plotResults.OBSERVATION_ID.eq(observationIdField))
 
   override fun tempStratumCondition(tempStratumTable: ObservationPlots) =
       tempStratumTable.monitoringPlotHistories.SUBSTRATUM_HISTORY_ID.`in`(substratumHistorySelect)
@@ -425,43 +433,6 @@ class ObservationResultsStratum(
                 )
         )
       }
-
-  private fun latestPlotDensityAggregate(
-      aggregate: Field<BigDecimal?>,
-      observationIdField: Field<ObservationId?>,
-  ): Field<Int?> =
-      DSL.field(
-          DSL.select(aggregate.cast(SQLDataType.INTEGER))
-              .from(OBSERVATION_PLOT_RESULTS)
-              .where(
-                  OBSERVATION_PLOT_RESULTS.monitoringPlotHistories.substratumHistories
-                      .STRATUM_HISTORY_ID
-                      .`in`(stratumHistorySelect)
-              )
-              .and(
-                  OBSERVATION_PLOT_RESULTS.OBSERVATION_ID.eq(
-                      latestObservationForSubstratumField(
-                          observationIdField,
-                          OBSERVATION_PLOT_RESULTS.monitoringPlotHistories.substratumHistories
-                              .SUBSTRATUM_ID,
-                      )
-                  )
-              )
-      )
-
-  override fun latestPlantDensityField(observationIdField: Field<ObservationId?>): Field<Int?> =
-      latestPlotDensityAggregate(
-          DSL.avg(OBSERVATION_PLOT_RESULTS.PLANT_DENSITY),
-          observationIdField,
-      )
-
-  override fun latestPlantDensityStdDevField(
-      observationIdField: Field<ObservationId?>
-  ): Field<Int?> =
-      latestPlotDensityAggregate(
-          DSL.stddevSamp(OBSERVATION_PLOT_RESULTS.PLANT_DENSITY),
-          observationIdField,
-      )
 
   override val observedTotalsCondition =
       OBSERVATION_STRATUM_RESULTS.STRATUM_HISTORY_ID.`in`(stratumHistorySelect)
@@ -558,17 +529,21 @@ class ObservationResultsStratum(
               )
           )
 
-  override fun observationPlotResultsCondition(plotResultsTable: ObservationPlotResults) =
-      DSL.and(
-          plotResultsTable.monitoringPlotHistories.substratumHistories.STRATUM_HISTORY_ID.eq(
-              OBSERVATION_STRATUM_RESULTS.STRATUM_HISTORY_ID
-          ),
-          plotResultsTable.OBSERVATION_ID.eq(OBSERVATION_STRATUM_RESULTS.OBSERVATION_ID),
-          DSL.or(
-              observedTotalsPlantingSiteTempCondition,
-              plotResultsTable.observationPlots.IS_PERMANENT.isTrue,
-          ),
-      )
+  override fun latestPlotResultsCondition(
+      plotResults: ObservationPlotResults,
+      observationIdField: Field<ObservationId?>,
+  ) =
+      plotResults.monitoringPlotHistories.substratumHistories.STRATUM_HISTORY_ID.`in`(
+              stratumHistorySelect
+          )
+          .and(
+              plotResults.OBSERVATION_ID.eq(
+                  latestObservationForSubstratumField(
+                      observationIdField,
+                      plotResults.monitoringPlotHistories.substratumHistories.SUBSTRATUM_ID,
+                  )
+              )
+          )
 
   override fun tempStratumCondition(tempStratumTable: ObservationPlots) =
       STRATUM_T0_TEMP_DENSITIES.STRATUM_ID.`in`(
@@ -688,44 +663,6 @@ class ObservationResultsSite(
         )
       }
 
-  private fun latestPlotDensityAggregate(
-      aggregate: Field<BigDecimal?>,
-      observationIdField: Field<ObservationId?>,
-  ): Field<Int?> =
-      DSL.field(
-          DSL.select(aggregate.cast(SQLDataType.INTEGER))
-              .from(OBSERVATION_PLOT_RESULTS)
-              .where(
-                  OBSERVATION_PLOT_RESULTS.monitoringPlotHistories.substratumHistories
-                      .stratumHistories
-                      .PLANTING_SITE_HISTORY_ID
-                      .`in`(siteHistorySelect)
-              )
-              .and(
-                  OBSERVATION_PLOT_RESULTS.OBSERVATION_ID.eq(
-                      latestObservationForSubstratumField(
-                          observationIdField,
-                          OBSERVATION_PLOT_RESULTS.monitoringPlotHistories.substratumHistories
-                              .SUBSTRATUM_ID,
-                      )
-                  )
-              )
-      )
-
-  override fun latestPlantDensityField(observationIdField: Field<ObservationId?>): Field<Int?> =
-      latestPlotDensityAggregate(
-          DSL.avg(OBSERVATION_PLOT_RESULTS.PLANT_DENSITY),
-          observationIdField,
-      )
-
-  override fun latestPlantDensityStdDevField(
-      observationIdField: Field<ObservationId?>
-  ): Field<Int?> =
-      latestPlotDensityAggregate(
-          DSL.stddevSamp(OBSERVATION_PLOT_RESULTS.PLANT_DENSITY),
-          observationIdField,
-      )
-
   override val observedTotalsCondition = OBSERVATION_SITE_RESULTS.PLANTING_SITE_ID.eq(siteSelect)
 
   override val survivalRateRecalculationCondition: Condition
@@ -808,17 +745,21 @@ class ObservationResultsSite(
       OBSERVATION_PLOTS.OBSERVATION_ID.eq(observationIdField)
           .and(OBSERVATION_PLOTS.monitoringPlots.PLANTING_SITE_ID.eq(siteSelect))
 
-  override fun observationPlotResultsCondition(plotResultsTable: ObservationPlotResults) =
-      DSL.and(
-          plotResultsTable.monitoringPlotHistories.substratumHistories.stratumHistories
-              .PLANTING_SITE_HISTORY_ID
-              .eq(OBSERVATION_SITE_RESULTS.PLANTING_SITE_HISTORY_ID),
-          plotResultsTable.OBSERVATION_ID.eq(OBSERVATION_SITE_RESULTS.OBSERVATION_ID),
-          DSL.or(
-              observedTotalsPlantingSiteTempCondition,
-              plotResultsTable.observationPlots.IS_PERMANENT.isTrue,
-          ),
-      )
+  override fun latestPlotResultsCondition(
+      plotResults: ObservationPlotResults,
+      observationIdField: Field<ObservationId?>,
+  ) =
+      plotResults.monitoringPlotHistories.substratumHistories.stratumHistories
+          .PLANTING_SITE_HISTORY_ID
+          .`in`(siteHistorySelect)
+          .and(
+              plotResults.OBSERVATION_ID.eq(
+                  latestObservationForSubstratumField(
+                      observationIdField,
+                      plotResults.monitoringPlotHistories.substratumHistories.SUBSTRATUM_ID,
+                  )
+              )
+          )
 
   override fun tempStratumCondition(tempStratumTable: ObservationPlots) =
       STRATUM_T0_TEMP_DENSITIES.strata.PLANTING_SITE_ID.eq(siteSelect)

--- a/src/main/kotlin/com/terraformation/backend/tracking/util/ObservationResultsScope.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/util/ObservationResultsScope.kt
@@ -68,12 +68,7 @@ interface ObservationResultsScope<ID : Any, HistoryId : Any> :
 
   /**
    * Selects the [OBSERVATION_PLOT_RESULTS] rows that contribute to this scope when it is computed
-   * for [observationIdField]: the plots belonging to the scope, each taken from its substratum's
-   * latest observation at or before [observationIdField] (so a substratum that wasn't observed in
-   * the current observation still contributes its last-observed plots). This is the single
-   * definition of the rolled-forward plot set; the survival rate, plant density, and standard
-   * deviations all derive from it. Consumers that need only permanent plots add that filter
-   * themselves.
+   * for [observationIdField], using latest observed plots from unobserved substratum
    */
   fun latestPlotResultsCondition(
       plotResults: ObservationPlotResults,

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/observationStore/ObservationStoreSurvivalRateCalculationTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/observationStore/ObservationStoreSurvivalRateCalculationTest.kt
@@ -1898,7 +1898,7 @@ class ObservationStoreSurvivalRateCalculationTest : ObservationScenarioTest() {
     assertEquals(
         observationId,
         bDependency.dependsOnObservationId,
-        "B rolls forward to observation 1",
+        "B should roll forward to observation 1",
     )
 
     // An abandoned observation is treated like a completed one (its not-observed plot is ignored),
@@ -1911,7 +1911,7 @@ class ObservationStoreSurvivalRateCalculationTest : ObservationScenarioTest() {
     assertEquals(
         83,
         stratumResult.survivalRate,
-        "Abandoned observation rolls B's survival rate forward",
+        "Abandoned observation should roll B's survival rate forward",
     )
     assertNotNull(stratumResult.plantDensity, "Abandoned observation rolls B's density forward")
     // The survival-rate std dev must weigh both A's observed plot and B's rolled-forward plot; with
@@ -1919,7 +1919,7 @@ class ObservationStoreSurvivalRateCalculationTest : ObservationScenarioTest() {
     assertEquals(
         5,
         stratumResult.survivalRateStdDev,
-        "Abandoned observation rolls B's plot into the survival-rate std dev",
+        "Abandoned observation should roll B's plot into the survival-rate std dev",
     )
   }
 

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/observationStore/ObservationStoreSurvivalRateCalculationTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/observationStore/ObservationStoreSurvivalRateCalculationTest.kt
@@ -1914,6 +1914,13 @@ class ObservationStoreSurvivalRateCalculationTest : ObservationScenarioTest() {
         "Abandoned observation rolls B's survival rate forward",
     )
     assertNotNull(stratumResult.plantDensity, "Abandoned observation rolls B's density forward")
+    // The survival-rate std dev must weigh both A's observed plot and B's rolled-forward plot; with
+    // only A's plot it would be 0 (a single sample).
+    assertEquals(
+        5,
+        stratumResult.survivalRateStdDev,
+        "Abandoned observation rolls B's plot into the survival-rate std dev",
+    )
   }
 
   @Test


### PR DESCRIPTION
Uses all latest observed plots per substratum for computing survival rate std dev

Co-Authored-By: Claude Opus 4.8 [noreply@anthropic.com](mailto:noreply@anthropic.com)