### PR TITLE
SW-8573 Make LocalizedTextField more flexible

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/search/SearchTable.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/SearchTable.kt
@@ -277,11 +277,12 @@ abstract class SearchTable {
   fun localDateTimeField(fieldName: String, databaseField: TableField<*, LocalDateTime?>) =
       LocalDateTimeField(fieldName, databaseField, this)
 
-  fun localizedTextField(
+  fun <T : Any> localizedTextField(
       fieldName: String,
-      databaseField: TableField<*, String?>,
+      databaseField: Field<T?>,
       resourceBundleName: String,
-  ) = LocalizedTextField(fieldName, databaseField, resourceBundleName, this)
+      prefix: String? = null,
+  ) = LocalizedTextField(fieldName, databaseField, resourceBundleName, prefix, this)
 
   fun longField(fieldName: String, databaseField: Field<Long?>, nullable: Boolean = true) =
       LongField(fieldName, databaseField, this)

--- a/src/main/kotlin/com/terraformation/backend/search/field/LocalizedTextField.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/field/LocalizedTextField.kt
@@ -42,7 +42,7 @@ class LocalizedTextField<T : Any>(
   private val orderByFields = ConcurrentHashMap<Locale, Field<Int>>()
 
   override val supportedFilterTypes: Set<SearchFilterType>
-    get() = EnumSet.of(SearchFilterType.Exact, SearchFilterType.Fuzzy, SearchFilterType.PhraseMatch)
+    get() = EnumSet.of(SearchFilterType.Exact)
 
   override fun getCondition(fieldNode: FieldNode): Condition {
     val locale = currentLocale()

--- a/src/main/kotlin/com/terraformation/backend/search/field/LocalizedTextField.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/field/LocalizedTextField.kt
@@ -118,11 +118,14 @@ class LocalizedTextField<T : Any>(
     return fieldValuesByLocalizedString.getOrPut(locale) {
       val bundle = ResourceBundle.getBundle(resourceBundleName, locale)
       val map =
-          bundle.keySet().associate { key ->
-            val fieldValue = prefix?.let { key.substringAfter(prefix) } ?: key
-            val localizedText = bundle.getString(key).lowercase(locale).removeDiacritics()
-            localizedText to fieldValue
-          }
+          bundle
+              .keySet()
+              .filter { key -> prefix == null || key.startsWith(prefix) }
+              .associate { key ->
+                val fieldValue = prefix?.let { key.substringAfter(prefix) } ?: key
+                val localizedText = bundle.getString(key).lowercase(locale).removeDiacritics()
+                localizedText to fieldValue
+              }
 
       map.keys.sortedWith(Collator.getInstance(locale)).associateWith { map[it]!! }
     }

--- a/src/main/kotlin/com/terraformation/backend/search/field/LocalizedTextField.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/field/LocalizedTextField.kt
@@ -14,19 +14,21 @@ import org.jooq.Condition
 import org.jooq.Field
 import org.jooq.Record
 import org.jooq.impl.DSL
+import org.jooq.impl.SQLDataType
 
 /**
  * Search field for values that are mapped to localized strings but are not represented as enums.
  */
-class LocalizedTextField(
+class LocalizedTextField<T : Any>(
     override val fieldName: String,
     /** The field that has the name of the string to look up in the resource bundle. */
-    override val databaseField: Field<String?>,
+    override val databaseField: Field<T?>,
     private val resourceBundleName: String,
+    private val prefix: String?,
     override val table: SearchTable,
     override val localize: Boolean = true,
     override val exportable: Boolean = true,
-) : SingleColumnSearchField<String>() {
+) : SingleColumnSearchField<T>() {
   /**
    * Maps lower-case diacritic-free localized strings to their corresponding database field values.
    * The interior Map is sorted alphabetically by localized string.
@@ -53,7 +55,7 @@ class LocalizedTextField(
           DSL.or(
               listOfNotNull(
                   if (nonNullFieldValues.isNotEmpty()) {
-                    databaseField.`in`(nonNullFieldValues)
+                    databaseField.cast(SQLDataType.VARCHAR).`in`(nonNullFieldValues)
                   } else {
                     null
                   },
@@ -66,17 +68,14 @@ class LocalizedTextField(
       SearchFilterType.Fuzzy ->
           throw IllegalArgumentException("Fuzzy search not supported for localized text fields")
       SearchFilterType.PhraseMatch ->
-          DSL.or(
-              listOfNotNull(if (fieldNode.values.any { it == null }) databaseField.isNull else null)
-                  .plus(phaseMatchCondition(nonNullFieldValues.filterNotNull()))
-          )
+          throw IllegalArgumentException("Phrase match not supported for localized text fields")
       SearchFilterType.Range ->
           throw IllegalArgumentException("Range search not supported for localized text fields")
     }
   }
 
   override fun computeValue(record: Record): String? {
-    return record[databaseField]?.let { getLocalizedString(it) }
+    return record[databaseField]?.let { getLocalizedString("$it") }
   }
 
   override val possibleValues: List<String>
@@ -93,7 +92,9 @@ class LocalizedTextField(
         val fieldValuesToPosition: Map<String?, Int> =
             valuesMap.entries.mapIndexed { index, (_, fieldValue) -> fieldValue to index }.toMap()
 
-        return DSL.case_(databaseField).mapValues(fieldValuesToPosition).else_(valuesMap.size)
+        return DSL.case_(databaseField.cast(SQLDataType.VARCHAR))
+            .mapValues(fieldValuesToPosition)
+            .else_(valuesMap.size)
       }
     }
 
@@ -108,7 +109,7 @@ class LocalizedTextField(
           bundle.keySet().associateWith { bundle.getString(it) }
         }
 
-    return stringsForLocale[databaseValue]
+    return stringsForLocale[stringKey(databaseValue)]
         ?: throw IllegalStateException("No localized string for $databaseValue in $locale")
   }
 
@@ -117,8 +118,15 @@ class LocalizedTextField(
     return fieldValuesByLocalizedString.getOrPut(locale) {
       val bundle = ResourceBundle.getBundle(resourceBundleName, locale)
       val map =
-          bundle.keySet().associateBy { bundle.getString(it).lowercase(locale).removeDiacritics() }
+          bundle.keySet().associate { key ->
+            val fieldValue = prefix?.let { key.substringAfter(prefix) } ?: key
+            val localizedText = bundle.getString(key).lowercase(locale).removeDiacritics()
+            localizedText to fieldValue
+          }
+
       map.keys.sortedWith(Collator.getInstance(locale)).associateWith { map[it]!! }
     }
   }
+
+  private fun stringKey(baseKey: String) = prefix?.let { "$prefix$baseKey" } ?: baseKey
 }


### PR DESCRIPTION
In preparation for adding ecoregions to the search API, update the search field
type that looks up localized text values so that it can use non-string table
fields to generate keys, and so that it can optionally include a prefix in the
key when it looks up strings.

Phrase matching was not usable on localized text fields because it tried to
do substring matches on the string key rather than on the localized values;
remove it.

This shouldn't change the behavior of existing uses of the field type; we don't
do any phrase matches on those fields at the moment (and even if we did, it
wouldn't have worked).