### PR TITLE
SW-7489 Use collectedTime to derive collectedDate

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/seedbank/api/AccessionsV2Controller.kt
+++ b/src/main/kotlin/com/terraformation/backend/seedbank/api/AccessionsV2Controller.kt
@@ -117,6 +117,7 @@ class AccessionsV2Controller(
   }
 }
 
+// For backwards compatibility, use a fallback of collectedDate at midnight
 private fun resolveCollectedTime(collectedDate: LocalDate?, collectedTime: Instant?): Instant? =
     collectedTime ?: collectedDate?.atStartOfDay(ZoneOffset.UTC)?.toInstant()
 

--- a/src/main/kotlin/com/terraformation/backend/seedbank/api/AccessionsV2Controller.kt
+++ b/src/main/kotlin/com/terraformation/backend/seedbank/api/AccessionsV2Controller.kt
@@ -29,7 +29,6 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse
 import java.time.Clock
 import java.time.Instant
 import java.time.LocalDate
-import java.time.ZoneOffset
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
@@ -116,10 +115,6 @@ class AccessionsV2Controller(
     return GetAccessionResponsePayloadV2(AccessionPayloadV2(accession))
   }
 }
-
-// For backwards compatibility, use a fallback of collectedDate at midnight
-private fun resolveCollectedTime(collectedDate: LocalDate?, collectedTime: Instant?): Instant? =
-    collectedTime ?: collectedDate?.atStartOfDay(ZoneOffset.UTC)?.toInstant()
 
 /**
  * Supported accession states. This is a subset of the values in [AccessionState], minus obsolete
@@ -361,7 +356,7 @@ data class CreateAccessionRequestPayloadV2(
         bagNumbers = bagNumbers.orEmpty(),
         clock = clock,
         collectedDate = collectedDate,
-        collectedTime = resolveCollectedTime(collectedDate, collectedTime),
+        collectedTime = collectedTime,
         collectionSiteCity = collectionSiteCity,
         collectionSiteCountryCode = collectionSiteCountryCode,
         collectionSiteCountrySubdivision = collectionSiteCountrySubdivision,
@@ -433,7 +428,7 @@ data class UpdateAccessionRequestPayloadV2(
       model.copy(
           bagNumbers = bagNumbers.orEmpty(),
           collectedDate = collectedDate,
-          collectedTime = resolveCollectedTime(collectedDate, collectedTime),
+          collectedTime = collectedTime,
           collectionSiteCity = collectionSiteCity,
           collectionSiteCountryCode = collectionSiteCountryCode,
           collectionSiteCountrySubdivision = collectionSiteCountrySubdivision,

--- a/src/main/kotlin/com/terraformation/backend/seedbank/api/AccessionsV2Controller.kt
+++ b/src/main/kotlin/com/terraformation/backend/seedbank/api/AccessionsV2Controller.kt
@@ -331,6 +331,7 @@ data class AccessionPayloadV2(
 @JsonAutoDetect(getterVisibility = JsonAutoDetect.Visibility.NONE)
 data class CreateAccessionRequestPayloadV2(
     val bagNumbers: Set<String>? = null,
+    @Schema(description = "Will be derived from collectedTime if present.", deprecated = true)
     val collectedDate: LocalDate? = null,
     @Schema(description = "Date and time the seeds were collected.")
     val collectedTime: Instant? = null,
@@ -387,6 +388,7 @@ data class CreateAccessionRequestPayloadV2(
 @JsonAutoDetect(getterVisibility = JsonAutoDetect.Visibility.NONE)
 data class UpdateAccessionRequestPayloadV2(
     val bagNumbers: Set<String>? = null,
+    @Schema(description = "Will be derived from collectedTime if present.", deprecated = true)
     val collectedDate: LocalDate? = null,
     @Schema(description = "Date and time the seeds were collected.")
     val collectedTime: Instant? = null,

--- a/src/main/kotlin/com/terraformation/backend/seedbank/db/AccessionHelper.kt
+++ b/src/main/kotlin/com/terraformation/backend/seedbank/db/AccessionHelper.kt
@@ -1,0 +1,28 @@
+package com.terraformation.backend.seedbank.db
+
+import com.terraformation.backend.auth.currentUser
+import com.terraformation.backend.customer.db.ParentStore
+import com.terraformation.backend.db.default_schema.FacilityId
+import com.terraformation.backend.seedbank.model.AccessionModel
+import jakarta.inject.Named
+import java.time.LocalDate
+import java.time.ZoneId
+
+@Named
+class AccessionHelper(
+    private val parentStore: ParentStore,
+) {
+
+  fun collectionTimeZone(facilityId: FacilityId): ZoneId =
+      currentUser().timeZone ?: parentStore.getEffectiveTimeZone(facilityId)
+
+  fun effectiveCollectedDate(
+      accession: AccessionModel,
+      facilityId: FacilityId,
+  ): LocalDate? =
+      if (accession.collectedTime != null) {
+        LocalDate.ofInstant(accession.collectedTime, collectionTimeZone(facilityId))
+      } else {
+        accession.collectedDate
+      }
+}

--- a/src/main/kotlin/com/terraformation/backend/seedbank/db/AccessionImporter.kt
+++ b/src/main/kotlin/com/terraformation/backend/seedbank/db/AccessionImporter.kt
@@ -34,7 +34,6 @@ import java.io.InputStream
 import java.text.NumberFormat
 import java.time.Clock
 import java.time.LocalDate
-import java.time.ZoneOffset
 import java.util.Locale
 import java.util.ResourceBundle
 import java.util.concurrent.ConcurrentHashMap
@@ -46,6 +45,7 @@ import org.springframework.context.annotation.Lazy
 @Named
 class AccessionImporter(
     private val accessionStore: AccessionStore,
+    private val accessionHelper: AccessionHelper,
     dslContext: DSLContext,
     private val facilityStore: FacilityStore,
     fileStore: FileStore,
@@ -205,7 +205,10 @@ class AccessionImporter(
               collectionSiteCountrySubdivision = collectionCountrySubdivision,
               collectionSiteLandowner = collectionLandowner,
               collectedDate = collectionDate,
-              collectedTime = collectionDate.atStartOfDay(ZoneOffset.UTC).toInstant(),
+              collectedTime =
+                  collectionDate
+                      .atStartOfDay(accessionHelper.collectionTimeZone(facilityId))
+                      .toInstant(),
               collectionSiteName = collectionSiteName,
               collectionSiteNotes = collectionSiteDescription,
               collectors = collectorName?.let { listOf(it) } ?: emptyList(),
@@ -224,7 +227,10 @@ class AccessionImporter(
               accessionNumber = accessionNumber,
               clock = clock,
               collectedDate = collectionDate,
-              collectedTime = collectionDate.atStartOfDay(ZoneOffset.UTC).toInstant(),
+              collectedTime =
+                  collectionDate
+                      .atStartOfDay(accessionHelper.collectionTimeZone(facilityId))
+                      .toInstant(),
               collectionSiteCity = collectionCity,
               collectionSiteCountryCode = collectionCountryCode,
               collectionSiteCountrySubdivision = collectionCountrySubdivision,

--- a/src/main/kotlin/com/terraformation/backend/seedbank/db/AccessionStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/seedbank/db/AccessionStore.kt
@@ -55,6 +55,7 @@ import jakarta.inject.Named
 import java.math.BigDecimal
 import java.time.Clock
 import java.time.LocalDate
+import java.time.ZoneId
 import java.time.ZoneOffset
 import org.jooq.Condition
 import org.jooq.DSLContext
@@ -279,7 +280,7 @@ class AccessionStore(
               with(ACCESSIONS) {
                 dslContext
                     .insertInto(ACCESSIONS)
-                    .set(COLLECTED_DATE, accession.collectedDate)
+                    .set(COLLECTED_DATE, effectiveCollectedDate(accession, facilityId))
                     .set(
                         COLLECTED_TIME,
                         accession.collectedTime
@@ -460,7 +461,7 @@ class AccessionStore(
           with(ACCESSIONS) {
             dslContext
                 .update(ACCESSIONS)
-                .set(COLLECTED_DATE, accession.collectedDate)
+                .set(COLLECTED_DATE, effectiveCollectedDate(accession, facilityId))
                 .set(
                     COLLECTED_TIME,
                     accession.collectedTime
@@ -1130,4 +1131,17 @@ class AccessionStore(
       }
     } while (nextAccessionId != null)
   }
+
+  private fun collectionTimeZone(facilityId: FacilityId): ZoneId =
+      currentUser().timeZone ?: parentStore.getEffectiveTimeZone(facilityId)
+
+  private fun effectiveCollectedDate(
+      accession: AccessionModel,
+      facilityId: FacilityId,
+  ): LocalDate? =
+      if (accession.collectedTime != null) {
+        LocalDate.ofInstant(accession.collectedTime, collectionTimeZone(facilityId))
+      } else {
+        accession.collectedDate
+      }
 }

--- a/src/main/kotlin/com/terraformation/backend/seedbank/db/AccessionStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/seedbank/db/AccessionStore.kt
@@ -55,8 +55,6 @@ import jakarta.inject.Named
 import java.math.BigDecimal
 import java.time.Clock
 import java.time.LocalDate
-import java.time.ZoneId
-import java.time.ZoneOffset
 import org.jooq.Condition
 import org.jooq.DSLContext
 import org.jooq.Field
@@ -71,6 +69,7 @@ import org.springframework.security.access.AccessDeniedException
 
 @Named
 class AccessionStore(
+    private val accessionHelper: AccessionHelper,
     private val dslContext: DSLContext,
     private val bagStore: BagStore,
     private val facilitiesDao: FacilitiesDao,
@@ -280,11 +279,16 @@ class AccessionStore(
               with(ACCESSIONS) {
                 dslContext
                     .insertInto(ACCESSIONS)
-                    .set(COLLECTED_DATE, effectiveCollectedDate(accession, facilityId))
+                    .set(
+                        COLLECTED_DATE,
+                        accessionHelper.effectiveCollectedDate(accession, facilityId),
+                    )
                     .set(
                         COLLECTED_TIME,
                         accession.collectedTime
-                            ?: accession.collectedDate?.atStartOfDay(ZoneOffset.UTC)?.toInstant(),
+                            ?: accession.collectedDate
+                                ?.atStartOfDay(accessionHelper.collectionTimeZone(facilityId))
+                                ?.toInstant(),
                     )
                     .set(COLLECTION_SITE_CITY, accession.collectionSiteCity)
                     .set(COLLECTION_SITE_COUNTRY_CODE, accession.collectionSiteCountryCode)
@@ -461,11 +465,13 @@ class AccessionStore(
           with(ACCESSIONS) {
             dslContext
                 .update(ACCESSIONS)
-                .set(COLLECTED_DATE, effectiveCollectedDate(accession, facilityId))
+                .set(COLLECTED_DATE, accessionHelper.effectiveCollectedDate(accession, facilityId))
                 .set(
                     COLLECTED_TIME,
                     accession.collectedTime
-                        ?: accession.collectedDate?.atStartOfDay(ZoneOffset.UTC)?.toInstant(),
+                        ?: accession.collectedDate
+                            ?.atStartOfDay(accessionHelper.collectionTimeZone(facilityId))
+                            ?.toInstant(),
                 )
                 .set(COLLECTION_SITE_CITY, accession.collectionSiteCity)
                 .set(COLLECTION_SITE_COUNTRY_CODE, accession.collectionSiteCountryCode)
@@ -1131,17 +1137,4 @@ class AccessionStore(
       }
     } while (nextAccessionId != null)
   }
-
-  private fun collectionTimeZone(facilityId: FacilityId): ZoneId =
-      currentUser().timeZone ?: parentStore.getEffectiveTimeZone(facilityId)
-
-  private fun effectiveCollectedDate(
-      accession: AccessionModel,
-      facilityId: FacilityId,
-  ): LocalDate? =
-      if (accession.collectedTime != null) {
-        LocalDate.ofInstant(accession.collectedTime, collectionTimeZone(facilityId))
-      } else {
-        accession.collectedDate
-      }
 }

--- a/src/test/kotlin/com/terraformation/backend/customer/ProjectServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/ProjectServiceTest.kt
@@ -26,6 +26,7 @@ import com.terraformation.backend.i18n.Messages
 import com.terraformation.backend.mockUser
 import com.terraformation.backend.nursery.db.BatchStore
 import com.terraformation.backend.plantingmanagement.db.SeasonHelper
+import com.terraformation.backend.seedbank.db.AccessionHelper
 import com.terraformation.backend.seedbank.db.AccessionStore
 import com.terraformation.backend.seedbank.db.BagStore
 import com.terraformation.backend.seedbank.db.GeolocationStore
@@ -59,6 +60,7 @@ class ProjectServiceTest : DatabaseTest(), RunsAsUser {
   private val service: ProjectService by lazy {
     ProjectService(
         AccessionStore(
+            AccessionHelper(parentStore),
             dslContext,
             BagStore(dslContext),
             facilitiesDao,

--- a/src/test/kotlin/com/terraformation/backend/notification/NotificationServiceAppTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/notification/NotificationServiceAppTest.kt
@@ -90,6 +90,7 @@ import com.terraformation.backend.mockUser
 import com.terraformation.backend.nursery.event.NurserySeedlingBatchReadyEvent
 import com.terraformation.backend.report.event.SeedFundReportCreatedEvent
 import com.terraformation.backend.report.model.SeedFundReportMetadata
+import com.terraformation.backend.seedbank.db.AccessionHelper
 import com.terraformation.backend.seedbank.db.AccessionStore
 import com.terraformation.backend.seedbank.db.BagStore
 import com.terraformation.backend.seedbank.db.GeolocationStore
@@ -182,6 +183,7 @@ internal class NotificationServiceAppTest : DatabaseTest(), RunsAsUser {
 
     accessionStore =
         AccessionStore(
+            AccessionHelper(parentStore),
             dslContext,
             BagStore(dslContext),
             facilitiesDao,

--- a/src/test/kotlin/com/terraformation/backend/report/SeedFundReportServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/report/SeedFundReportServiceTest.kt
@@ -97,6 +97,7 @@ class SeedFundReportServiceTest : DatabaseTest(), RunsAsUser {
   private val service by lazy {
     SeedFundReportService(
         AccessionStore(
+            mockk(),
             dslContext,
             mockk(),
             mockk(),

--- a/src/test/kotlin/com/terraformation/backend/seedbank/db/AccessionHelperTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/db/AccessionHelperTest.kt
@@ -1,0 +1,113 @@
+package com.terraformation.backend.seedbank.db
+
+import com.terraformation.backend.RunsAsDatabaseUser
+import com.terraformation.backend.TestClock
+import com.terraformation.backend.customer.db.ParentStore
+import com.terraformation.backend.customer.model.TerrawareUser
+import com.terraformation.backend.db.DatabaseTest
+import com.terraformation.backend.db.default_schema.FacilityId
+import com.terraformation.backend.db.default_schema.Role
+import com.terraformation.backend.seedbank.model.AccessionModel
+import java.time.Instant
+import java.time.LocalDate
+import java.time.ZoneId
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+internal class AccessionHelperTest : DatabaseTest(), RunsAsDatabaseUser {
+  override lateinit var user: TerrawareUser
+
+  private val clock = TestClock()
+  private lateinit var parentStore: ParentStore
+  private lateinit var helper: AccessionHelper
+  private lateinit var facilityId: FacilityId
+
+  @BeforeEach
+  fun setUp() {
+    insertOrganization()
+    facilityId = insertFacility()
+    insertOrganizationUser(role = Role.Admin)
+    parentStore = ParentStore(dslContext)
+    helper = AccessionHelper(parentStore)
+  }
+
+  @Nested
+  inner class EffectiveCollectedDate {
+    @Test
+    fun `collectedTime null returns collectedDate`() {
+      val date = LocalDate.of(2024, 3, 20)
+      val accession = AccessionModel(clock = clock, facilityId = facilityId, collectedDate = date)
+
+      assertEquals(date, helper.effectiveCollectedDate(accession, facilityId))
+    }
+
+    @Test
+    fun `collectedTime and collectedDate both null returns null`() {
+      val accession = AccessionModel(clock = clock, facilityId = facilityId)
+
+      assertNull(helper.effectiveCollectedDate(accession, facilityId))
+    }
+
+    @Test
+    fun `derives date from collectedTime using user timezone`() {
+      // Jan 15 at 10pm in America/New_York
+      val collectedTime = Instant.parse("2024-01-16T03:00:00Z")
+      val userId = insertUser(timeZone = ZoneId.of("America/New_York"))
+      insertOrganizationUser(userId = userId, role = Role.Admin)
+      switchToUser(userId)
+
+      val accession =
+          AccessionModel(clock = clock, facilityId = facilityId, collectedTime = collectedTime)
+
+      assertEquals(LocalDate.of(2024, 1, 15), helper.effectiveCollectedDate(accession, facilityId))
+    }
+
+    @Test
+    fun `derives date from collectedTime using facility timezone when user has none`() {
+      // Jan 15 at 10pm in America/New_York
+      val collectedTime = Instant.parse("2024-01-16T03:00:00Z")
+      val orgId = insertOrganization(timeZone = ZoneId.of("America/New_York"))
+      val facilityId = insertFacility(organizationId = orgId)
+      insertOrganizationUser(organizationId = orgId, role = Role.Admin)
+
+      val accession =
+          AccessionModel(clock = clock, facilityId = facilityId, collectedTime = collectedTime)
+
+      assertEquals(LocalDate.of(2024, 1, 15), helper.effectiveCollectedDate(accession, facilityId))
+    }
+
+    @Test
+    fun `derives date from collectedTime using UTC when no timezone configured`() {
+      val collectedTime = Instant.parse("2024-01-16T03:00:00Z")
+
+      val accession =
+          AccessionModel(clock = clock, facilityId = facilityId, collectedTime = collectedTime)
+
+      assertEquals(LocalDate.of(2024, 1, 16), helper.effectiveCollectedDate(accession, facilityId))
+    }
+  }
+
+  @Nested
+  inner class CollectionTimeZone {
+    @Test
+    fun `returns user timezone when set`() {
+      val userId = insertUser(timeZone = ZoneId.of("America/Chicago"))
+      insertOrganizationUser(userId = userId, role = Role.Admin)
+      switchToUser(userId)
+
+      assertEquals(ZoneId.of("America/Chicago"), helper.collectionTimeZone(facilityId))
+    }
+
+    @Test
+    fun `returns facility timezone when user has no timezone`() {
+      val orgId = insertOrganization(timeZone = ZoneId.of("Europe/London"))
+      val fId = insertFacility(organizationId = orgId)
+      insertOrganizationUser(organizationId = orgId, role = Role.Admin)
+
+      assertEquals(ZoneId.of("Europe/London"), helper.collectionTimeZone(fId))
+    }
+  }
+}

--- a/src/test/kotlin/com/terraformation/backend/seedbank/db/AccessionImporterTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/db/AccessionImporterTest.kt
@@ -71,8 +71,10 @@ internal class AccessionImporterTest : DatabaseTest(), RunsAsUser {
   override val user = mockUser()
 
   private val publisher = TestEventPublisher()
+  private val accessionHelper: AccessionHelper by lazy { AccessionHelper(parentStore) }
   private val accessionStore: AccessionStore by lazy {
     AccessionStore(
+        accessionHelper,
         dslContext,
         BagStore(dslContext),
         facilitiesDao,
@@ -103,6 +105,7 @@ internal class AccessionImporterTest : DatabaseTest(), RunsAsUser {
   private val importer: AccessionImporter by lazy {
     AccessionImporter(
         accessionStore,
+        accessionHelper,
         dslContext,
         facilityStore,
         fileStore,
@@ -181,7 +184,7 @@ internal class AccessionImporterTest : DatabaseTest(), RunsAsUser {
           listOf(
               AccessionsRow(
                   collectedDate = LocalDate.of(2022, 3, 4),
-                  collectedTime = LocalDate.of(2022, 3, 4).atStartOfDay(ZoneOffset.UTC).toInstant(),
+                  collectedTime = LocalDate.of(2022, 3, 4).atStartOfDay(user.timeZone).toInstant(),
                   collectionSiteCity = "City name",
                   collectionSiteCountryCode = "US",
                   collectionSiteCountrySubdivision = "Hawaii",
@@ -207,7 +210,7 @@ internal class AccessionImporterTest : DatabaseTest(), RunsAsUser {
               ),
               AccessionsRow(
                   collectedDate = LocalDate.of(2022, 3, 5),
-                  collectedTime = LocalDate.of(2022, 3, 5).atStartOfDay(ZoneOffset.UTC).toInstant(),
+                  collectedTime = LocalDate.of(2022, 3, 5).atStartOfDay(user.timeZone).toInstant(),
                   collectionSiteCountryCode = "UG",
                   collectionSourceId = CollectionSource.Wild,
                   createdBy = user.userId,
@@ -262,7 +265,7 @@ internal class AccessionImporterTest : DatabaseTest(), RunsAsUser {
           listOf(
               AccessionsRow(
                   collectedDate = LocalDate.of(2023, 6, 1),
-                  collectedTime = LocalDate.of(2023, 6, 1).atStartOfDay(ZoneOffset.UTC).toInstant(),
+                  collectedTime = LocalDate.of(2023, 6, 1).atStartOfDay(user.timeZone).toInstant(),
                   createdBy = user.userId,
                   createdTime = Instant.EPOCH,
                   dataSourceId = DataSource.FileImport,
@@ -279,7 +282,7 @@ internal class AccessionImporterTest : DatabaseTest(), RunsAsUser {
               ),
               AccessionsRow(
                   collectedDate = LocalDate.of(2023, 6, 1),
-                  collectedTime = LocalDate.of(2023, 6, 1).atStartOfDay(ZoneOffset.UTC).toInstant(),
+                  collectedTime = LocalDate.of(2023, 6, 1).atStartOfDay(user.timeZone).toInstant(),
                   createdBy = user.userId,
                   createdTime = Instant.EPOCH,
                   dataSourceId = DataSource.FileImport,
@@ -324,7 +327,7 @@ internal class AccessionImporterTest : DatabaseTest(), RunsAsUser {
           listOf(
               AccessionsRow(
                   collectedDate = LocalDate.of(2022, 3, 5),
-                  collectedTime = LocalDate.of(2022, 3, 5).atStartOfDay(ZoneOffset.UTC).toInstant(),
+                  collectedTime = LocalDate.of(2022, 3, 5).atStartOfDay(user.timeZone).toInstant(),
                   collectionSiteCountryCode = "UG",
                   collectionSourceId = CollectionSource.Wild,
                   createdBy = user.userId,
@@ -1020,7 +1023,7 @@ internal class AccessionImporterTest : DatabaseTest(), RunsAsUser {
           listOf(
               AccessionsRow(
                   collectedDate = LocalDate.of(2022, 3, 4),
-                  collectedTime = LocalDate.of(2022, 3, 4).atStartOfDay(ZoneOffset.UTC).toInstant(),
+                  collectedTime = LocalDate.of(2022, 3, 4).atStartOfDay(user.timeZone).toInstant(),
                   collectionSiteCity = "New City",
                   collectionSiteCountryCode = "GB",
                   collectionSiteCountrySubdivision = "New State",

--- a/src/test/kotlin/com/terraformation/backend/seedbank/db/PhotoRepositoryTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/db/PhotoRepositoryTest.kt
@@ -77,6 +77,7 @@ class PhotoRepositoryTest : DatabaseTest(), RunsAsUser {
   fun setUp() {
     accessionStore =
         AccessionStore(
+            mockk(),
             dslContext,
             mockk(),
             mockk(),

--- a/src/test/kotlin/com/terraformation/backend/seedbank/db/accessionStore/AccessionStoreCreateTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/db/accessionStore/AccessionStoreCreateTest.kt
@@ -4,6 +4,7 @@ import com.terraformation.backend.db.FacilityNotFoundException
 import com.terraformation.backend.db.FacilityTypeMismatchException
 import com.terraformation.backend.db.ProjectInDifferentOrganizationException
 import com.terraformation.backend.db.default_schema.FacilityType
+import com.terraformation.backend.db.default_schema.Role
 import com.terraformation.backend.db.default_schema.tables.references.IDENTIFIER_SEQUENCES
 import com.terraformation.backend.db.seedbank.AccessionQuantityHistoryType
 import com.terraformation.backend.db.seedbank.AccessionState
@@ -22,6 +23,7 @@ import com.terraformation.backend.seedbank.seeds
 import java.math.BigDecimal
 import java.time.Instant
 import java.time.LocalDate
+import java.time.ZoneId
 import java.time.ZoneOffset
 import kotlin.reflect.full.declaredMemberProperties
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -255,5 +257,60 @@ internal class AccessionStoreCreateTest : AccessionStoreTest() {
     assertThrows<ProjectInDifferentOrganizationException> {
       store.create(accessionModel(projectId = projectId))
     }
+  }
+
+  @Test
+  fun `create derives collectedDate from collectedTime using user timezone`() {
+    // Jan 15 at 10pm in America/New_York
+    val collectedTime = Instant.parse("2024-01-16T03:00:00Z")
+    val userId = insertUser(timeZone = ZoneId.of("America/New_York"))
+    insertOrganizationUser(userId = userId, role = Role.Admin)
+    switchToUser(userId)
+
+    val accessionId = store.create(accessionModel().copy(collectedTime = collectedTime)).id!!
+
+    assertEquals(
+        LocalDate.of(2024, 1, 15),
+        accessionsDao.fetchOneById(accessionId)?.collectedDate,
+    )
+  }
+
+  @Test
+  fun `create derives collectedDate from collectedTime using org timezone when user has none`() {
+    // Jan 15 at 10pm in America/New_York
+    val collectedTime = Instant.parse("2024-01-16T03:00:00Z")
+    val orgId = insertOrganization(timeZone = ZoneId.of("America/New_York"))
+    val facId = insertFacility(organizationId = orgId)
+    insertOrganizationUser(organizationId = orgId, role = Role.Admin)
+
+    val accessionId =
+        store.create(accessionModel(facilityId = facId).copy(collectedTime = collectedTime)).id!!
+
+    assertEquals(
+        LocalDate.of(2024, 1, 15),
+        accessionsDao.fetchOneById(accessionId)?.collectedDate,
+    )
+  }
+
+  @Test
+  fun `create derives collectedDate from collectedTime using UTC when no timezone is configured`() {
+    // Jan 15 at 10pm in America/New_York
+    val collectedTime = Instant.parse("2024-01-16T03:00:00Z")
+
+    val accessionId = store.create(accessionModel().copy(collectedTime = collectedTime)).id!!
+
+    assertEquals(
+        LocalDate.of(2024, 1, 16),
+        accessionsDao.fetchOneById(accessionId)?.collectedDate,
+    )
+  }
+
+  @Test
+  fun `create preserves explicit collectedDate when collectedTime is null`() {
+    val date = LocalDate.of(2024, 3, 20)
+
+    val accessionId = store.create(accessionModel().copy(collectedDate = date)).id!!
+
+    assertEquals(date, accessionsDao.fetchOneById(accessionId)?.collectedDate)
   }
 }

--- a/src/test/kotlin/com/terraformation/backend/seedbank/db/accessionStore/AccessionStoreCreateTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/db/accessionStore/AccessionStoreCreateTest.kt
@@ -313,4 +313,50 @@ internal class AccessionStoreCreateTest : AccessionStoreTest() {
 
     assertEquals(date, accessionsDao.fetchOneById(accessionId)?.collectedDate)
   }
+
+  @Test
+  fun `create derives collectedTime from collectedDate using user timezone`() {
+    // Midnight on Jan 15 in America/New_York (UTC-5) = 05:00 UTC
+    val date = LocalDate.of(2024, 1, 15)
+    val userId = insertUser(timeZone = ZoneId.of("America/New_York"))
+    insertOrganizationUser(userId = userId, role = Role.Admin)
+    switchToUser(userId)
+
+    val accessionId = store.create(accessionModel().copy(collectedDate = date)).id!!
+
+    assertEquals(
+        Instant.parse("2024-01-15T05:00:00Z"),
+        accessionsDao.fetchOneById(accessionId)?.collectedTime,
+    )
+  }
+
+  @Test
+  fun `create derives collectedTime from collectedDate using org timezone when user has none`() {
+    // Midnight on Jan 15 in America/New_York (UTC-5) = 05:00 UTC
+    val date = LocalDate.of(2024, 1, 15)
+    val orgId = insertOrganization(timeZone = ZoneId.of("America/New_York"))
+    val facId = insertFacility(organizationId = orgId)
+    insertOrganizationUser(organizationId = orgId, role = Role.Admin)
+
+    val accessionId =
+        store.create(accessionModel(facilityId = facId).copy(collectedDate = date)).id!!
+
+    assertEquals(
+        Instant.parse("2024-01-15T05:00:00Z"),
+        accessionsDao.fetchOneById(accessionId)?.collectedTime,
+    )
+  }
+
+  @Test
+  fun `create derives collectedTime from collectedDate using UTC when no timezone is configured`() {
+    // Midnight on Jan 15 in UTC = 00:00 UTC
+    val date = LocalDate.of(2024, 1, 15)
+
+    val accessionId = store.create(accessionModel().copy(collectedDate = date)).id!!
+
+    assertEquals(
+        Instant.parse("2024-01-15T00:00:00Z"),
+        accessionsDao.fetchOneById(accessionId)?.collectedTime,
+    )
+  }
 }

--- a/src/test/kotlin/com/terraformation/backend/seedbank/db/accessionStore/AccessionStoreCreateTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/db/accessionStore/AccessionStoreCreateTest.kt
@@ -260,8 +260,8 @@ internal class AccessionStoreCreateTest : AccessionStoreTest() {
   }
 
   @Test
-  fun `create derives collectedDate from collectedTime using user timezone`() {
-    // Jan 15 at 10pm in America/New_York
+  fun `create uses configured timezone when deriving collectedDate from collectedTime`() {
+    // Jan 15 at 10pm in America/New_York (UTC-5)
     val collectedTime = Instant.parse("2024-01-16T03:00:00Z")
     val userId = insertUser(timeZone = ZoneId.of("America/New_York"))
     insertOrganizationUser(userId = userId, role = Role.Admin)
@@ -272,91 +272,6 @@ internal class AccessionStoreCreateTest : AccessionStoreTest() {
     assertEquals(
         LocalDate.of(2024, 1, 15),
         accessionsDao.fetchOneById(accessionId)?.collectedDate,
-    )
-  }
-
-  @Test
-  fun `create derives collectedDate from collectedTime using org timezone when user has none`() {
-    // Jan 15 at 10pm in America/New_York
-    val collectedTime = Instant.parse("2024-01-16T03:00:00Z")
-    val orgId = insertOrganization(timeZone = ZoneId.of("America/New_York"))
-    val facId = insertFacility(organizationId = orgId)
-    insertOrganizationUser(organizationId = orgId, role = Role.Admin)
-
-    val accessionId =
-        store.create(accessionModel(facilityId = facId).copy(collectedTime = collectedTime)).id!!
-
-    assertEquals(
-        LocalDate.of(2024, 1, 15),
-        accessionsDao.fetchOneById(accessionId)?.collectedDate,
-    )
-  }
-
-  @Test
-  fun `create derives collectedDate from collectedTime using UTC when no timezone is configured`() {
-    // Jan 15 at 10pm in America/New_York
-    val collectedTime = Instant.parse("2024-01-16T03:00:00Z")
-
-    val accessionId = store.create(accessionModel().copy(collectedTime = collectedTime)).id!!
-
-    assertEquals(
-        LocalDate.of(2024, 1, 16),
-        accessionsDao.fetchOneById(accessionId)?.collectedDate,
-    )
-  }
-
-  @Test
-  fun `create preserves explicit collectedDate when collectedTime is null`() {
-    val date = LocalDate.of(2024, 3, 20)
-
-    val accessionId = store.create(accessionModel().copy(collectedDate = date)).id!!
-
-    assertEquals(date, accessionsDao.fetchOneById(accessionId)?.collectedDate)
-  }
-
-  @Test
-  fun `create derives collectedTime from collectedDate using user timezone`() {
-    // Midnight on Jan 15 in America/New_York (UTC-5) = 05:00 UTC
-    val date = LocalDate.of(2024, 1, 15)
-    val userId = insertUser(timeZone = ZoneId.of("America/New_York"))
-    insertOrganizationUser(userId = userId, role = Role.Admin)
-    switchToUser(userId)
-
-    val accessionId = store.create(accessionModel().copy(collectedDate = date)).id!!
-
-    assertEquals(
-        Instant.parse("2024-01-15T05:00:00Z"),
-        accessionsDao.fetchOneById(accessionId)?.collectedTime,
-    )
-  }
-
-  @Test
-  fun `create derives collectedTime from collectedDate using org timezone when user has none`() {
-    // Midnight on Jan 15 in America/New_York (UTC-5) = 05:00 UTC
-    val date = LocalDate.of(2024, 1, 15)
-    val orgId = insertOrganization(timeZone = ZoneId.of("America/New_York"))
-    val facId = insertFacility(organizationId = orgId)
-    insertOrganizationUser(organizationId = orgId, role = Role.Admin)
-
-    val accessionId =
-        store.create(accessionModel(facilityId = facId).copy(collectedDate = date)).id!!
-
-    assertEquals(
-        Instant.parse("2024-01-15T05:00:00Z"),
-        accessionsDao.fetchOneById(accessionId)?.collectedTime,
-    )
-  }
-
-  @Test
-  fun `create derives collectedTime from collectedDate using UTC when no timezone is configured`() {
-    // Midnight on Jan 15 in UTC = 00:00 UTC
-    val date = LocalDate.of(2024, 1, 15)
-
-    val accessionId = store.create(accessionModel().copy(collectedDate = date)).id!!
-
-    assertEquals(
-        Instant.parse("2024-01-15T00:00:00Z"),
-        accessionsDao.fetchOneById(accessionId)?.collectedTime,
     )
   }
 }

--- a/src/test/kotlin/com/terraformation/backend/seedbank/db/accessionStore/AccessionStoreDatabaseTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/db/accessionStore/AccessionStoreDatabaseTest.kt
@@ -3,6 +3,7 @@ package com.terraformation.backend.seedbank.db.accessionStore
 import com.terraformation.backend.db.AccessionSpeciesHasDeliveriesException
 import com.terraformation.backend.db.ProjectInDifferentOrganizationException
 import com.terraformation.backend.db.default_schema.FacilityType
+import com.terraformation.backend.db.default_schema.Role
 import com.terraformation.backend.db.nursery.tables.pojos.BatchesRow
 import com.terraformation.backend.db.seedbank.CollectionSource
 import com.terraformation.backend.db.seedbank.DataSource
@@ -28,7 +29,9 @@ import com.terraformation.backend.seedbank.model.AccessionModel
 import com.terraformation.backend.seedbank.model.Geolocation
 import com.terraformation.backend.seedbank.seeds
 import java.math.BigDecimal
+import java.time.Instant
 import java.time.LocalDate
+import java.time.ZoneId
 import java.time.ZoneOffset
 import kotlin.reflect.KVisibility
 import kotlin.reflect.full.declaredMemberProperties
@@ -334,5 +337,63 @@ internal class AccessionStoreDatabaseTest : AccessionStoreTest() {
     val fetched = store.fetchOneById(initial.id!!)
 
     assertEquals(initial.species, fetched.species)
+  }
+
+  @Test
+  fun `update derives collectedDate from collectedTime using user timezone`() {
+    // Jan 15 at 10pm in America/New_York
+    val collectedTime = Instant.parse("2024-01-16T03:00:00Z")
+    val userId = insertUser(timeZone = ZoneId.of("America/New_York"))
+    insertOrganizationUser(userId = userId, role = Role.Admin)
+    switchToUser(userId)
+
+    val initial = store.create(accessionModel())
+    store.update(initial.copy(collectedTime = collectedTime))
+
+    assertEquals(
+        LocalDate.of(2024, 1, 15),
+        accessionsDao.fetchOneById(initial.id!!)?.collectedDate,
+    )
+  }
+
+  @Test
+  fun `update derives collectedDate from collectedTime using org timezone when user has none`() {
+    // Jan 15 at 10pm in America/New_York
+    val collectedTime = Instant.parse("2024-01-16T03:00:00Z")
+    val orgId = insertOrganization(timeZone = ZoneId.of("America/New_York"))
+    val facId = insertFacility(organizationId = orgId)
+    insertOrganizationUser(organizationId = orgId, role = Role.Admin)
+
+    val initial = store.create(accessionModel(facilityId = facId))
+    store.update(initial.copy(collectedTime = collectedTime))
+
+    assertEquals(
+        LocalDate.of(2024, 1, 15),
+        accessionsDao.fetchOneById(initial.id!!)?.collectedDate,
+    )
+  }
+
+  @Test
+  fun `update derives collectedDate from collectedTime using UTC when no timezone is configured`() {
+    // Jan 15 at 10pm in America/New_York
+    val collectedTime = Instant.parse("2024-01-16T03:00:00Z")
+
+    val initial = store.create(accessionModel())
+    store.update(initial.copy(collectedTime = collectedTime))
+
+    assertEquals(
+        LocalDate.of(2024, 1, 16),
+        accessionsDao.fetchOneById(initial.id!!)?.collectedDate,
+    )
+  }
+
+  @Test
+  fun `update preserves explicit collectedDate when collectedTime is null`() {
+    val date = LocalDate.of(2024, 3, 20)
+
+    val initial = store.create(accessionModel())
+    store.update(initial.copy(collectedDate = date))
+
+    assertEquals(date, accessionsDao.fetchOneById(initial.id!!)?.collectedDate)
   }
 }

--- a/src/test/kotlin/com/terraformation/backend/seedbank/db/accessionStore/AccessionStoreDatabaseTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/db/accessionStore/AccessionStoreDatabaseTest.kt
@@ -340,8 +340,8 @@ internal class AccessionStoreDatabaseTest : AccessionStoreTest() {
   }
 
   @Test
-  fun `update derives collectedDate from collectedTime using user timezone`() {
-    // Jan 15 at 10pm in America/New_York
+  fun `update uses configured timezone when deriving collectedDate from collectedTime`() {
+    // Jan 15 at 10pm in America/New_York (UTC-5)
     val collectedTime = Instant.parse("2024-01-16T03:00:00Z")
     val userId = insertUser(timeZone = ZoneId.of("America/New_York"))
     insertOrganizationUser(userId = userId, role = Role.Admin)
@@ -353,95 +353,6 @@ internal class AccessionStoreDatabaseTest : AccessionStoreTest() {
     assertEquals(
         LocalDate.of(2024, 1, 15),
         accessionsDao.fetchOneById(initial.id!!)?.collectedDate,
-    )
-  }
-
-  @Test
-  fun `update derives collectedDate from collectedTime using org timezone when user has none`() {
-    // Jan 15 at 10pm in America/New_York
-    val collectedTime = Instant.parse("2024-01-16T03:00:00Z")
-    val orgId = insertOrganization(timeZone = ZoneId.of("America/New_York"))
-    val facId = insertFacility(organizationId = orgId)
-    insertOrganizationUser(organizationId = orgId, role = Role.Admin)
-
-    val initial = store.create(accessionModel(facilityId = facId))
-    store.update(initial.copy(collectedTime = collectedTime))
-
-    assertEquals(
-        LocalDate.of(2024, 1, 15),
-        accessionsDao.fetchOneById(initial.id!!)?.collectedDate,
-    )
-  }
-
-  @Test
-  fun `update derives collectedDate from collectedTime using UTC when no timezone is configured`() {
-    // Jan 15 at 10pm in America/New_York
-    val collectedTime = Instant.parse("2024-01-16T03:00:00Z")
-
-    val initial = store.create(accessionModel())
-    store.update(initial.copy(collectedTime = collectedTime))
-
-    assertEquals(
-        LocalDate.of(2024, 1, 16),
-        accessionsDao.fetchOneById(initial.id!!)?.collectedDate,
-    )
-  }
-
-  @Test
-  fun `update preserves explicit collectedDate when collectedTime is null`() {
-    val date = LocalDate.of(2024, 3, 20)
-
-    val initial = store.create(accessionModel())
-    store.update(initial.copy(collectedDate = date))
-
-    assertEquals(date, accessionsDao.fetchOneById(initial.id!!)?.collectedDate)
-  }
-
-  @Test
-  fun `update derives collectedTime from collectedDate using user timezone`() {
-    // Midnight on Jan 15 in America/New_York (UTC-5) = 05:00 UTC
-    val date = LocalDate.of(2024, 1, 15)
-    val userId = insertUser(timeZone = ZoneId.of("America/New_York"))
-    insertOrganizationUser(userId = userId, role = Role.Admin)
-    switchToUser(userId)
-
-    val initial = store.create(accessionModel())
-    store.update(initial.copy(collectedDate = date))
-
-    assertEquals(
-        Instant.parse("2024-01-15T05:00:00Z"),
-        accessionsDao.fetchOneById(initial.id!!)?.collectedTime,
-    )
-  }
-
-  @Test
-  fun `update derives collectedTime from collectedDate using org timezone when user has none`() {
-    // Midnight on Jan 15 in America/New_York (UTC-5) = 05:00 UTC
-    val date = LocalDate.of(2024, 1, 15)
-    val orgId = insertOrganization(timeZone = ZoneId.of("America/New_York"))
-    val facId = insertFacility(organizationId = orgId)
-    insertOrganizationUser(organizationId = orgId, role = Role.Admin)
-
-    val initial = store.create(accessionModel(facilityId = facId))
-    store.update(initial.copy(collectedDate = date))
-
-    assertEquals(
-        Instant.parse("2024-01-15T05:00:00Z"),
-        accessionsDao.fetchOneById(initial.id!!)?.collectedTime,
-    )
-  }
-
-  @Test
-  fun `update derives collectedTime from collectedDate using UTC when no timezone is configured`() {
-    // Midnight on Jan 15 in UTC = 00:00 UTC
-    val date = LocalDate.of(2024, 1, 15)
-
-    val initial = store.create(accessionModel())
-    store.update(initial.copy(collectedDate = date))
-
-    assertEquals(
-        Instant.parse("2024-01-15T00:00:00Z"),
-        accessionsDao.fetchOneById(initial.id!!)?.collectedTime,
     )
   }
 }

--- a/src/test/kotlin/com/terraformation/backend/seedbank/db/accessionStore/AccessionStoreDatabaseTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/db/accessionStore/AccessionStoreDatabaseTest.kt
@@ -396,4 +396,52 @@ internal class AccessionStoreDatabaseTest : AccessionStoreTest() {
 
     assertEquals(date, accessionsDao.fetchOneById(initial.id!!)?.collectedDate)
   }
+
+  @Test
+  fun `update derives collectedTime from collectedDate using user timezone`() {
+    // Midnight on Jan 15 in America/New_York (UTC-5) = 05:00 UTC
+    val date = LocalDate.of(2024, 1, 15)
+    val userId = insertUser(timeZone = ZoneId.of("America/New_York"))
+    insertOrganizationUser(userId = userId, role = Role.Admin)
+    switchToUser(userId)
+
+    val initial = store.create(accessionModel())
+    store.update(initial.copy(collectedDate = date))
+
+    assertEquals(
+        Instant.parse("2024-01-15T05:00:00Z"),
+        accessionsDao.fetchOneById(initial.id!!)?.collectedTime,
+    )
+  }
+
+  @Test
+  fun `update derives collectedTime from collectedDate using org timezone when user has none`() {
+    // Midnight on Jan 15 in America/New_York (UTC-5) = 05:00 UTC
+    val date = LocalDate.of(2024, 1, 15)
+    val orgId = insertOrganization(timeZone = ZoneId.of("America/New_York"))
+    val facId = insertFacility(organizationId = orgId)
+    insertOrganizationUser(organizationId = orgId, role = Role.Admin)
+
+    val initial = store.create(accessionModel(facilityId = facId))
+    store.update(initial.copy(collectedDate = date))
+
+    assertEquals(
+        Instant.parse("2024-01-15T05:00:00Z"),
+        accessionsDao.fetchOneById(initial.id!!)?.collectedTime,
+    )
+  }
+
+  @Test
+  fun `update derives collectedTime from collectedDate using UTC when no timezone is configured`() {
+    // Midnight on Jan 15 in UTC = 00:00 UTC
+    val date = LocalDate.of(2024, 1, 15)
+
+    val initial = store.create(accessionModel())
+    store.update(initial.copy(collectedDate = date))
+
+    assertEquals(
+        Instant.parse("2024-01-15T00:00:00Z"),
+        accessionsDao.fetchOneById(initial.id!!)?.collectedTime,
+    )
+  }
 }

--- a/src/test/kotlin/com/terraformation/backend/seedbank/db/accessionStore/AccessionStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/db/accessionStore/AccessionStoreTest.kt
@@ -16,6 +16,7 @@ import com.terraformation.backend.db.seedbank.AccessionState
 import com.terraformation.backend.db.seedbank.DataSource
 import com.terraformation.backend.db.seedbank.ViabilityTestType
 import com.terraformation.backend.i18n.Messages
+import com.terraformation.backend.seedbank.db.AccessionHelper
 import com.terraformation.backend.seedbank.db.AccessionStore
 import com.terraformation.backend.seedbank.db.BagStore
 import com.terraformation.backend.seedbank.db.GeolocationStore
@@ -58,6 +59,7 @@ internal abstract class AccessionStoreTest : DatabaseTest(), RunsAsDatabaseUser 
 
     store =
         AccessionStore(
+            AccessionHelper(parentStore),
             dslContext,
             BagStore(dslContext),
             facilitiesDao,

--- a/src/test/kotlin/com/terraformation/backend/seedbank/search/AccessionServiceSearchSummaryTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/search/AccessionServiceSearchSummaryTest.kt
@@ -3,6 +3,7 @@ package com.terraformation.backend.seedbank.search
 import com.terraformation.backend.RunsAsUser
 import com.terraformation.backend.TestClock
 import com.terraformation.backend.TestEventPublisher
+import com.terraformation.backend.customer.db.ParentStore
 import com.terraformation.backend.customer.model.TerrawareUser
 import com.terraformation.backend.db.DatabaseTest
 import com.terraformation.backend.db.default_schema.Role
@@ -15,6 +16,7 @@ import com.terraformation.backend.search.SearchFilterType
 import com.terraformation.backend.search.SearchService
 import com.terraformation.backend.search.table.SearchTables
 import com.terraformation.backend.seedbank.AccessionService
+import com.terraformation.backend.seedbank.db.AccessionHelper
 import com.terraformation.backend.seedbank.db.AccessionStore
 import com.terraformation.backend.seedbank.model.AccessionSummaryStatistics
 import io.mockk.every
@@ -30,6 +32,7 @@ internal class AccessionServiceSearchSummaryTest : DatabaseTest(), RunsAsUser {
 
   private val accessionStore: AccessionStore by lazy {
     AccessionStore(
+        AccessionHelper(ParentStore(dslContext)),
         dslContext,
         mockk(),
         mockk(),


### PR DESCRIPTION
Update `AccessionStore` to derive `collectedDate` if `collectedTime` is present. Prefer the timezone in this order: user, org, UTC.

Also derive `collectedTime` from `collectedDate` if `collectedTime` is not present. This was partially implemented before, but was not using the corrct timezone priority.

Update the `AccessionImporter` to set the`collectedTime` using the correct timezone.

Waiting to merge till the [FE PRs](https://github.com/terraware/terraware-web/pull/5951) are all confirmed. 

Co-authored-by: Claude Opus 4.8 \<noreply@anthropic.com>