### PR TITLE
Update GBIF importer to work with recent zipfiles

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/species/db/GbifImporter.kt
+++ b/src/main/kotlin/com/terraformation/backend/species/db/GbifImporter.kt
@@ -80,7 +80,11 @@ class GbifImporter(
      */
     private val SEARCHABLE_TAXON_RANKS = setOf("species", "subspecies", "variety", "form")
 
-    /** All the tables affected by the import process. Existing data is deleted before importing. */
+    /**
+     * All the tables affected by the import process. The order is important here: it needs to start
+     * at the leaf nodes of the tree of foreign key relationships (that is, child tables first)
+     * since the bulk delete at the start of the import is done in the order listed here.
+     */
     private val GBIF_TABLES =
         listOf(
             GBIF_NAME_WORDS,
@@ -140,8 +144,10 @@ class GbifImporter(
   private fun deleteAll() {
     log.info("Deleting existing GBIF data")
 
-    // Need to truncate all tables at once because they share foreign key relationships.
-    dslContext.truncate(GBIF_TABLES).execute()
+    GBIF_TABLES.forEach { table ->
+      log.debug("Deleting from ${table.name}")
+      dslContext.deleteFrom(table).execute()
+    }
   }
 
   /**

--- a/src/main/kotlin/com/terraformation/backend/species/db/GbifImporter.kt
+++ b/src/main/kotlin/com/terraformation/backend/species/db/GbifImporter.kt
@@ -80,11 +80,7 @@ class GbifImporter(
      */
     private val SEARCHABLE_TAXON_RANKS = setOf("species", "subspecies", "variety", "form")
 
-    /**
-     * All the tables affected by the import process. The order is important here: it needs to start
-     * at the leaf nodes of the tree of foreign key relationships (that is, child tables first)
-     * since the bulk delete at the start of the import is done in the order listed here.
-     */
+    /** All the tables affected by the import process. Existing data is deleted before importing. */
     private val GBIF_TABLES =
         listOf(
             GBIF_NAME_WORDS,
@@ -103,7 +99,10 @@ class GbifImporter(
 
   fun import(zipFile: ZipFile) {
     import { fileName ->
-      val entry = zipFile.getEntry("backbone/$fileName") ?: throw FileNotFoundException(fileName)
+      val entry =
+          zipFile.getEntry(fileName)
+              ?: zipFile.getEntry("backbone/$fileName")
+              ?: throw FileNotFoundException(fileName)
       zipFile.getInputStream(entry)
     }
   }
@@ -141,10 +140,8 @@ class GbifImporter(
   private fun deleteAll() {
     log.info("Deleting existing GBIF data")
 
-    GBIF_TABLES.forEach { table ->
-      log.debug("Deleting from ${table.name}")
-      dslContext.deleteFrom(table).execute()
-    }
+    // Need to truncate all tables at once because they share foreign key relationships.
+    dslContext.truncate(GBIF_TABLES).execute()
   }
 
   /**


### PR DESCRIPTION
GBIF stopped putting the data files under a `backbone` subdirectory in the
Backbone Taxonomy zipfile, but the GBIF importer was still expecting the
subdirectory. Make it accept either form.

The importer was also using an unnecessarily slow technique for clearing existing
data; make it faster.