### PR TITLE
Fix "final field mutated reflectively" warnings

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/accelerator/PreScreenBoundarySubmissionFetcher.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/PreScreenBoundarySubmissionFetcher.kt
@@ -12,7 +12,7 @@ import org.springframework.beans.factory.annotation.Value
 @Named
 class PreScreenBoundarySubmissionFetcher(
     private val applicationStore: ApplicationStore,
-    @Value("68") // From deliverables spreadsheet
+    @param:Value("68") // From deliverables spreadsheet
     val boundaryDeliverableId: DeliverableId,
 ) {
   companion object {

--- a/src/main/kotlin/com/terraformation/backend/splat/api/SplatsController.kt
+++ b/src/main/kotlin/com/terraformation/backend/splat/api/SplatsController.kt
@@ -30,7 +30,6 @@ import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.Parameter
 import jakarta.ws.rs.ServiceUnavailableException
 import java.math.BigDecimal
-import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
@@ -46,7 +45,7 @@ import org.springframework.web.bind.annotation.RestController
 @RestController
 @TrackingEndpoint
 class SplatsController(
-    @Autowired(required = false) private val splatServiceDependency: SplatService?,
+    private val splatServiceDependency: SplatService?,
 ) {
   private val splatService: SplatService
     get() =

--- a/src/main/kotlin/com/terraformation/backend/tracking/api/OrganizationSplatsController.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/api/OrganizationSplatsController.kt
@@ -20,7 +20,6 @@ import com.terraformation.backend.splat.api.GetObservationSplatInfoResponsePaylo
 import com.terraformation.backend.splat.api.SetSplatAnnotationsRequestPayload
 import io.swagger.v3.oas.annotations.Operation
 import jakarta.ws.rs.ServiceUnavailableException
-import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
@@ -35,7 +34,7 @@ import org.springframework.web.bind.annotation.RestController
 @RestController
 @CustomerEndpoint
 class OrganizationSplatsController(
-    @Autowired(required = false) private val splatServiceDependency: SplatService?,
+    private val splatServiceDependency: SplatService?,
 ) {
   private val splatService: SplatService
     get() =


### PR DESCRIPTION
Java 26 added a warning when a final field is modified using reflection, because
future Java/JVM versions will remove the ability to do that.

We had annotations on some Spring bean parameters that were causing Spring to
do field injection rather than constructor injection. Adjust them or remove them
in cases where they aren't actually needed.