### PR TITLE
Upgrade Node dependencies once a month

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -27,9 +27,13 @@
         {
             description: 'Group Node dependencies',
             matchFileNames: [
+                '.nvmrc',
                 'package.json',
             ],
             groupName: 'Node dependencies',
+            schedule: [
+                'on the first day of the month',
+            ],
         },
         {
             description: 'Group Python dependencies',


### PR DESCRIPTION
We only use Node.js to render email templates, so there's no point telling
Renovate to update us to the latest Node versions the instant they're released.