### PR TITLE
Don't delete outdated ecoregions

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/admin/AdminSpeciesController.kt
+++ b/src/main/kotlin/com/terraformation/backend/admin/AdminSpeciesController.kt
@@ -80,9 +80,18 @@ class AdminSpeciesController(
       redirectAttributes: RedirectAttributes,
   ): String {
     try {
-      withDownloadedFile(url) { zipFilePath -> ecoregionImporter.importEcoregions(zipFilePath) }
+      val result =
+          withDownloadedFile(url) { zipFilePath -> ecoregionImporter.importEcoregions(zipFilePath) }
 
       redirectAttributes.successMessage = "Ecoregions imported successfully."
+
+      if (result.obsoleteEcoregions.isNotEmpty()) {
+        redirectAttributes.successDetails =
+            result.obsoleteEcoregions.map { (ecoregionId, name) ->
+              "Ecoregion $ecoregionId ($name) was deleted from ecoregions list; keeping it " +
+                  "around in Terraware so it can be referenced by historical data."
+            }
+      }
     } catch (e: Exception) {
       log.error("Ecoregion import failed", e)
       redirectAttributes.failureMessage = "Import failed: ${e.message}"
@@ -137,7 +146,7 @@ class AdminSpeciesController(
     return redirectToAdminHome()
   }
 
-  private fun withDownloadedFile(url: URI, suffix: String = ".zip", func: (Path) -> Unit) {
+  private fun <T> withDownloadedFile(url: URI, suffix: String = ".zip", func: (Path) -> T): T {
     val tempFile = kotlin.io.path.createTempFile(suffix = suffix)
 
     try {
@@ -147,7 +156,7 @@ class AdminSpeciesController(
         Files.copy(fileStream, tempFile, StandardCopyOption.REPLACE_EXISTING)
       }
 
-      func(tempFile)
+      return func(tempFile)
     } finally {
       tempFile.deleteIfExists()
     }

--- a/src/main/kotlin/com/terraformation/backend/gis/EcoregionImporter.kt
+++ b/src/main/kotlin/com/terraformation/backend/gis/EcoregionImporter.kt
@@ -54,7 +54,9 @@ class EcoregionImporter(
 
   private val log = perClassLogger()
 
-  fun importEcoregions(zipFilePath: Path) {
+  fun importEcoregions(zipFilePath: Path): EcoregionImportResult {
+    val obsoleteEcoregions = mutableMapOf<EcoregionId, String>()
+
     val validCountryCodes =
         dslContext.select(COUNTRIES.CODE).from(COUNTRIES).fetchSet(COUNTRIES.CODE.asNonNullable())
 
@@ -86,7 +88,20 @@ class EcoregionImporter(
             .set(REALM, DSL.excluded(REALM))
             .execute()
 
-        dslContext.deleteFrom(ECOREGIONS).where(ID.notIn(entries.map { it.id })).execute()
+        val allEcoregionIds = entries.map { it.id }
+
+        // Flag ecoregions that are no longer on the list.
+        dslContext
+            .select(ID.asNonNullable(), ECO_NAME.asNonNullable())
+            .from(ECOREGIONS)
+            .where(ID.notIn(allEcoregionIds))
+            .orderBy(ID)
+            .fetch()
+            .forEach { (ecoregionId, ecoregionName) ->
+              log.warn("Ecoregion $ecoregionId ($ecoregionName) was deleted from ecoregions list.")
+
+              obsoleteEcoregions[ecoregionId] = ecoregionName
+            }
       }
 
       log.info("Imported raw ecoregions data; calculating ecoregion-country mappings")
@@ -130,6 +145,8 @@ class EcoregionImporter(
 
       eventPublisher.publishEvent(EcoregionsImportedEvent())
     }
+
+    return EcoregionImportResult(obsoleteEcoregions)
   }
 
   private fun loadEcoregionEntries(zipFilePath: Path): List<EcoregionEntry> {
@@ -184,6 +201,8 @@ class EcoregionImporter(
       )
     }
   }
+
+  data class EcoregionImportResult(val obsoleteEcoregions: Map<EcoregionId, String>)
 
   data class EcoregionEntry(
       val biomeName: String?,

--- a/src/test/kotlin/com/terraformation/backend/tracking/EcoregionImporterTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/EcoregionImporterTest.kt
@@ -11,6 +11,7 @@ import java.nio.file.StandardCopyOption
 import kotlin.io.path.Path
 import kotlin.io.path.exists
 import org.junit.Assume.assumeNotNull
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 
@@ -33,6 +34,7 @@ class EcoregionImporterTest : DatabaseTest() {
 
   @Test
   fun `import ecoregions data`() {
+    val deletedEcoregionId = insertEcoregion(id = 1234567, ecoName = "Old Region")
     val path = Path("build/ecoregions.zip").toAbsolutePath()
 
     if (!path.exists()) {
@@ -43,8 +45,15 @@ class EcoregionImporterTest : DatabaseTest() {
       }
     }
 
-    importer.importEcoregions(path)
+    val result = importer.importEcoregions(path)
 
     eventPublisher.assertEventPublished(EcoregionsImportedEvent())
+
+    assertEquals(
+        EcoregionImporter.EcoregionImportResult(
+            obsoleteEcoregions = mapOf(deletedEcoregionId to "Old Region"),
+        ),
+        result,
+    )
   }
 }


### PR DESCRIPTION
We don't expect ecoregions to ever be deleted from the master list because there
are too many downstream datasets (WCVP, etc.) that depend on ecoregion IDs
remaining stable. But if one _is_ deleted at some point, we want to know about it.

Replace the ecoregion importer's old deletion logic with new logic to show
warnings when existing ecoregions aren't found in the ecoregions shapefile.