### PR TITLE
Remove redundant PathVariable parameters

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/accelerator/api/ActivitiesAdminController.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/api/ActivitiesAdminController.kt
@@ -68,7 +68,7 @@ class ActivitiesAdminController(
   @RequireGlobalRole(
       [GlobalRole.ReadOnly, GlobalRole.TFExpert, GlobalRole.AcceleratorAdmin, GlobalRole.SuperAdmin]
   )
-  fun adminGetActivity(@PathVariable("id") id: ActivityId): AdminGetActivityResponsePayload {
+  fun adminGetActivity(@PathVariable id: ActivityId): AdminGetActivityResponsePayload {
     val activity = activityStore.fetchOneById(id, ActivityMediaDepth.All)
 
     return AdminGetActivityResponsePayload(AdminActivityPayload(activity))
@@ -89,7 +89,7 @@ class ActivitiesAdminController(
   @PutMapping("/{id}")
   @RequireGlobalRole([GlobalRole.TFExpert, GlobalRole.AcceleratorAdmin, GlobalRole.SuperAdmin])
   fun adminUpdateActivity(
-      @PathVariable("id") id: ActivityId,
+      @PathVariable id: ActivityId,
       @RequestBody payload: AdminUpdateActivityRequestPayload,
   ): SimpleSuccessResponsePayload {
     activityStore.updateForAdmin(id, payload::applyTo)

--- a/src/main/kotlin/com/terraformation/backend/accelerator/api/ProjectScoresController.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/api/ProjectScoresController.kt
@@ -36,7 +36,7 @@ class ProjectScoresController(
   @GetMapping
   @Operation(summary = "Gets score selections for a single project.")
   fun getProjectScores(
-      @PathVariable("projectId") projectId: ProjectId,
+      @PathVariable projectId: ProjectId,
   ): GetProjectScoresResponsePayload {
     val scoresByPhase = projectScoreStore.fetchScores(projectId)
 
@@ -61,7 +61,7 @@ class ProjectScoresController(
               "exist, a new entry is created. Setting a `score` to `null` removes the score.",
   )
   fun upsertProjectScores(
-      @PathVariable("projectId") projectId: ProjectId,
+      @PathVariable projectId: ProjectId,
       @RequestBody @Valid payload: UpsertProjectScoresRequestPayload,
   ): SimpleSuccessResponsePayload {
     projectScoreStore.updateScores(projectId, payload.phase, payload.scores.map { it.toModel() })

--- a/src/main/kotlin/com/terraformation/backend/accelerator/api/ProjectScoresControllerV2.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/api/ProjectScoresControllerV2.kt
@@ -31,7 +31,7 @@ class ProjectScoresControllerV2(
   @GetMapping
   @Operation(summary = "Gets overall score for a single project. ")
   fun getProjectOverallScore(
-      @PathVariable("projectId") projectId: ProjectId,
+      @PathVariable projectId: ProjectId,
   ): GetProjectOverallScoreResponsePayload {
     val model = projectOverallScoreStore.fetch(projectId)
     return GetProjectOverallScoreResponsePayload(ProjectOverallScorePayload(model))
@@ -42,7 +42,7 @@ class ProjectScoresControllerV2(
   @PutMapping
   @Operation(summary = "Updates overall score for a single project.")
   fun upsertProjectScores(
-      @PathVariable("projectId") projectId: ProjectId,
+      @PathVariable projectId: ProjectId,
       @RequestBody @Valid payload: UpdateProjectOverallScoreRequestPayload,
   ): SimpleSuccessResponsePayload {
     projectOverallScoreStore.update(projectId) { payload.score.toModel(projectId) }

--- a/src/main/kotlin/com/terraformation/backend/accelerator/api/ProjectVotesController.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/api/ProjectVotesController.kt
@@ -43,7 +43,7 @@ class ProjectVotesController(
               "contain a list of eligible voters and their selections. ",
   )
   fun getProjectVotes(
-      @PathVariable("projectId") projectId: ProjectId,
+      @PathVariable projectId: ProjectId,
   ): GetProjectVotesResponsePayload {
     val votes = voteStore.fetchAllVotes(projectId)
     val decisions = voteStore.fetchAllVoteDecisions(projectId)
@@ -62,7 +62,7 @@ class ProjectVotesController(
               "exist, a new entry is created. Setting a `voteOption` to `null` removes the vote.",
   )
   fun upsertProjectVotes(
-      @PathVariable("projectId") projectId: ProjectId,
+      @PathVariable projectId: ProjectId,
       @RequestBody payload: UpsertProjectVotesRequestPayload,
   ): SimpleSuccessResponsePayload {
     payload.votes.forEach {
@@ -86,7 +86,7 @@ class ProjectVotesController(
               "`phaseDelete` to `true`",
   )
   fun deleteProjectVotes(
-      @PathVariable("projectId") projectId: ProjectId,
+      @PathVariable projectId: ProjectId,
       @RequestBody payload: DeleteProjectVotesRequestPayload,
   ): SimpleSuccessResponsePayload {
     if (payload.userId == null && payload.phaseDelete != true) {

--- a/src/main/kotlin/com/terraformation/backend/admin/AdminDevicesController.kt
+++ b/src/main/kotlin/com/terraformation/backend/admin/AdminDevicesController.kt
@@ -75,7 +75,7 @@ class AdminDevicesController(
 
   @GetMapping("/deviceManagers/{deviceManagerId}")
   fun getDeviceManager(
-      @PathVariable("deviceManagerId") deviceManagerId: DeviceManagerId,
+      @PathVariable deviceManagerId: DeviceManagerId,
       model: Model,
   ): String {
     val manager = deviceManagerStore.fetchOneById(deviceManagerId)
@@ -145,7 +145,7 @@ class AdminDevicesController(
   @PostMapping("/deviceManagers/{deviceManagerId}")
   fun updateDeviceManager(
       redirectAttributes: RedirectAttributes,
-      @PathVariable("deviceManagerId") deviceManagerId: DeviceManagerId,
+      @PathVariable deviceManagerId: DeviceManagerId,
       @ModelAttribute row: DeviceManagersRow,
   ): String {
     row.id = deviceManagerId
@@ -193,7 +193,7 @@ class AdminDevicesController(
   @PostMapping("/deviceManagers/{deviceManagerId}/generateToken")
   fun generateToken(
       redirectAttributes: RedirectAttributes,
-      @PathVariable("deviceManagerId") deviceManagerId: DeviceManagerId,
+      @PathVariable deviceManagerId: DeviceManagerId,
   ): String {
     try {
       val row = deviceManagerStore.fetchOneById(deviceManagerId)

--- a/src/main/kotlin/com/terraformation/backend/admin/AdminInternalTagsController.kt
+++ b/src/main/kotlin/com/terraformation/backend/admin/AdminInternalTagsController.kt
@@ -78,7 +78,7 @@ class AdminInternalTagsController(
 
   @PostMapping("/updateInternalTag/{id}")
   fun updateInternalTag(
-      @PathVariable("id") id: InternalTagId,
+      @PathVariable id: InternalTagId,
       @RequestParam name: String,
       @RequestParam description: String?,
       redirectAttributes: RedirectAttributes,
@@ -96,7 +96,7 @@ class AdminInternalTagsController(
 
   @PostMapping("/deleteInternalTag/{id}")
   fun deleteInternalTag(
-      @PathVariable("id") id: InternalTagId,
+      @PathVariable id: InternalTagId,
       redirectAttributes: RedirectAttributes,
   ): String {
     try {

--- a/src/main/kotlin/com/terraformation/backend/customer/api/GlobalRolesController.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/api/GlobalRolesController.kt
@@ -48,7 +48,7 @@ class GlobalRolesController(
   @PostMapping("/users/{userId}/globalRoles")
   @Operation(summary = "Apply the supplied global roles to the user.")
   fun updateGlobalRoles(
-      @PathVariable("userId") userId: UserId,
+      @PathVariable userId: UserId,
       @RequestBody payload: UpdateGlobalRolesRequestPayload,
   ): SuccessResponsePayload {
     userStore.updateGlobalRoles(setOf(userId), payload.globalRoles)

--- a/src/main/kotlin/com/terraformation/backend/customer/api/OrganizationsController.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/api/OrganizationsController.kt
@@ -82,7 +82,7 @@ class OrganizationsController(
   @GetMapping("/{organizationId}")
   @Operation(summary = "Gets information about an organization.")
   fun getOrganization(
-      @PathVariable("organizationId")
+      @PathVariable
       @Schema(description = "ID of organization to get. User must be a member of the organization.")
       organizationId: OrganizationId,
       @RequestParam("depth", defaultValue = "Organization")
@@ -109,7 +109,7 @@ class OrganizationsController(
   @Operation(summary = "Updates an existing organization.")
   @PutMapping("/{organizationId}")
   fun updateOrganization(
-      @PathVariable("organizationId") organizationId: OrganizationId,
+      @PathVariable organizationId: OrganizationId,
       @RequestBody @Valid payload: UpdateOrganizationRequestPayload,
   ): SimpleSuccessResponsePayload {
     organizationStore.update(payload.toRow().copy(id = organizationId))
@@ -125,7 +125,7 @@ class OrganizationsController(
   )
   @DeleteMapping("/{organizationId}")
   fun deleteOrganization(
-      @PathVariable("organizationId") organizationId: OrganizationId
+      @PathVariable organizationId: OrganizationId
   ): SimpleSuccessResponsePayload {
     try {
       organizationService.deleteOrganization(organizationId)
@@ -138,7 +138,7 @@ class OrganizationsController(
   @Operation(summary = "Lists the features available to an organization.")
   @GetMapping("/{organizationId}/features")
   fun listOrganizationFeatures(
-      @PathVariable("organizationId") organizationId: OrganizationId
+      @PathVariable organizationId: OrganizationId
   ): ListOrganizationFeaturesResponsePayload {
     val features = organizationFeatureStore.listOrganizationFeatureProjects(organizationId)
     return ListOrganizationFeaturesResponsePayload(features)
@@ -147,7 +147,7 @@ class OrganizationsController(
   @Operation(summary = "Lists the roles in an organization.")
   @GetMapping("/{organizationId}/roles")
   fun listOrganizationRoles(
-      @PathVariable("organizationId") organizationId: OrganizationId
+      @PathVariable organizationId: OrganizationId
   ): ListOrganizationRolesResponsePayload {
     val roleCounts = organizationStore.countRoleUsers(organizationId)
     return ListOrganizationRolesResponsePayload(
@@ -158,7 +158,7 @@ class OrganizationsController(
   @GetMapping("/{organizationId}/users")
   @Operation(summary = "Lists the users in an organization.")
   fun listOrganizationUsers(
-      @PathVariable("organizationId") organizationId: OrganizationId,
+      @PathVariable organizationId: OrganizationId,
   ): ListOrganizationUsersResponsePayload {
     val users = organizationStore.fetchUsers(organizationId)
     return ListOrganizationUsersResponsePayload(users.map { OrganizationUserPayload(it) })
@@ -167,7 +167,7 @@ class OrganizationsController(
   @PostMapping("/{organizationId}/users")
   @Operation(summary = "Adds a user to an organization.")
   fun addOrganizationUser(
-      @PathVariable("organizationId") organizationId: OrganizationId,
+      @PathVariable organizationId: OrganizationId,
       @RequestBody payload: AddOrganizationUserRequestPayload,
   ): CreateOrganizationUserResponsePayload {
     if (!emailValidator.isValid(payload.email)) {
@@ -181,8 +181,8 @@ class OrganizationsController(
   @GetMapping("/{organizationId}/users/{userId}")
   @Operation(summary = "Gets information about a user's membership in an organization.")
   fun getOrganizationUser(
-      @PathVariable("organizationId") organizationId: OrganizationId,
-      @PathVariable("userId") userId: UserId,
+      @PathVariable organizationId: OrganizationId,
+      @PathVariable userId: UserId,
   ): GetOrganizationUserResponsePayload {
     val model =
         try {
@@ -207,8 +207,8 @@ class OrganizationsController(
       description = "Does not remove any data created by the user.",
   )
   fun deleteOrganizationUser(
-      @PathVariable("organizationId") organizationId: OrganizationId,
-      @PathVariable("userId") userId: UserId,
+      @PathVariable organizationId: OrganizationId,
+      @PathVariable userId: UserId,
   ): SimpleSuccessResponsePayload {
     try {
       organizationStore.removeUser(organizationId, userId)
@@ -233,8 +233,8 @@ class OrganizationsController(
               "administrators.",
   )
   fun updateOrganizationUser(
-      @PathVariable("organizationId") organizationId: OrganizationId,
-      @PathVariable("userId") userId: UserId,
+      @PathVariable organizationId: OrganizationId,
+      @PathVariable userId: UserId,
       @RequestBody payload: UpdateOrganizationUserRequestPayload,
   ): SimpleSuccessResponsePayload {
     // Currently, the only setting is the user's role.

--- a/src/main/kotlin/com/terraformation/backend/customer/api/UsersController.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/api/UsersController.kt
@@ -166,7 +166,7 @@ class UsersController(private val clock: InstantSource, private val userStore: U
   @GetMapping("/{userId}")
   @Operation(summary = "Get a user by ID, if they exist.")
   fun getUser(
-      @PathVariable("userId") userId: UserId,
+      @PathVariable userId: UserId,
   ): GetUserResponsePayload {
     val user = userStore.fetchOneByIdAccelerator(userId)
     return GetUserResponsePayload(UserProfilePayload(user))

--- a/src/main/kotlin/com/terraformation/backend/device/api/AutomationsController.kt
+++ b/src/main/kotlin/com/terraformation/backend/device/api/AutomationsController.kt
@@ -51,9 +51,7 @@ class AutomationsController(
 
   @GetMapping("/{automationId}")
   @Operation(summary = "Gets the details of a single automation for a device or facility.")
-  fun getAutomation(
-      @PathVariable("automationId") automationId: AutomationId
-  ): GetAutomationResponsePayload {
+  fun getAutomation(@PathVariable automationId: AutomationId): GetAutomationResponsePayload {
     val automation = automationStore.fetchOneById(automationId)
     return GetAutomationResponsePayload(AutomationPayload(automation))
   }
@@ -83,7 +81,7 @@ class AutomationsController(
   @Operation(summary = "Updates an existing automation for a device or facility.")
   @PutMapping("/{automationId}")
   fun updateAutomation(
-      @PathVariable("automationId") automationId: AutomationId,
+      @PathVariable automationId: AutomationId,
       @RequestBody payload: UpdateAutomationRequestPayload,
   ): SimpleSuccessResponsePayload {
     val existing = automationStore.fetchOneById(automationId)
@@ -93,9 +91,7 @@ class AutomationsController(
 
   @DeleteMapping("/{automationId}")
   @Operation(summary = "Deletes an existing automation from a device or facility.")
-  fun deleteAutomation(
-      @PathVariable("automationId") automationId: AutomationId
-  ): SimpleSuccessResponsePayload {
+  fun deleteAutomation(@PathVariable automationId: AutomationId): SimpleSuccessResponsePayload {
     automationStore.delete(automationId)
     return SimpleSuccessResponsePayload()
   }

--- a/src/main/kotlin/com/terraformation/backend/documentproducer/api/DocumentsController.kt
+++ b/src/main/kotlin/com/terraformation/backend/documentproducer/api/DocumentsController.kt
@@ -73,14 +73,14 @@ class DocumentsController(
 
   @Operation(summary = "Gets a document.")
   @GetMapping("/{id}")
-  fun getDocument(@PathVariable("id") id: DocumentId): GetDocumentResponsePayload {
+  fun getDocument(@PathVariable id: DocumentId): GetDocumentResponsePayload {
     return GetDocumentResponsePayload(DocumentPayload(documentStore.fetchOneById(id)))
   }
 
   @Operation(summary = "Updates a document.")
   @PutMapping("/{id}")
   fun updateDocument(
-      @PathVariable("id") id: DocumentId,
+      @PathVariable id: DocumentId,
       @RequestBody payload: UpdateDocumentRequestPayload,
   ): SimpleSuccessResponsePayload {
     documentStore.updateDocument(id) { payload.applyChanges(it) }

--- a/src/main/kotlin/com/terraformation/backend/funder/api/FundingEntitiesController.kt
+++ b/src/main/kotlin/com/terraformation/backend/funder/api/FundingEntitiesController.kt
@@ -73,7 +73,7 @@ class FundingEntitiesController(
   @Operation(summary = "Updates an existing funding entity")
   @PutMapping("/{fundingEntityId}")
   fun updateFundingEntity(
-      @PathVariable("fundingEntityId") fundingEntityId: FundingEntityId,
+      @PathVariable fundingEntityId: FundingEntityId,
       @RequestBody @Valid payload: UpdateFundingEntityRequestPayload,
   ): SimpleSuccessResponsePayload {
     fundingEntityService.update(payload.toRow(fundingEntityId), payload.projects)
@@ -86,7 +86,7 @@ class FundingEntitiesController(
   )
   @DeleteMapping("/{fundingEntityId}")
   fun deleteFundingEntity(
-      @PathVariable("fundingEntityId") fundingEntityId: FundingEntityId
+      @PathVariable fundingEntityId: FundingEntityId
   ): SimpleSuccessResponsePayload {
     fundingEntityService.deleteFundingEntity(fundingEntityId)
     return SimpleSuccessResponsePayload()

--- a/src/main/kotlin/com/terraformation/backend/nursery/api/BatchesController.kt
+++ b/src/main/kotlin/com/terraformation/backend/nursery/api/BatchesController.kt
@@ -71,7 +71,7 @@ class BatchesController(
   @ApiResponse404
   @GetMapping("/{id}")
   @Operation(summary = "Gets information about a single seedling batch.")
-  fun getBatch(@PathVariable("id") id: BatchId): BatchResponsePayload {
+  fun getBatch(@PathVariable id: BatchId): BatchResponsePayload {
     val row = batchStore.fetchOneById(id)
     return BatchResponsePayload(BatchPayload(row))
   }
@@ -92,7 +92,7 @@ class BatchesController(
   @ApiResponseSimpleSuccess
   @DeleteMapping("/{id}")
   @Operation(summary = "Deletes an existing seedling batch from a nursery.")
-  fun deleteBatch(@PathVariable("id") id: BatchId): SimpleSuccessResponsePayload {
+  fun deleteBatch(@PathVariable id: BatchId): SimpleSuccessResponsePayload {
     batchStore.delete(id)
     return SimpleSuccessResponsePayload()
   }
@@ -108,7 +108,7 @@ class BatchesController(
   @Operation(summary = "Updates non-quantity-related details about a batch.")
   @PutMapping("/{id}")
   fun updateBatch(
-      @PathVariable("id") id: BatchId,
+      @PathVariable id: BatchId,
       @RequestBody payload: UpdateBatchRequestPayload,
   ): BatchResponsePayload {
     batchStore.updateDetails(id, payload.version, payload::applyChanges)
@@ -126,7 +126,7 @@ class BatchesController(
   )
   @PutMapping("/{id}/quantities")
   fun updateBatchQuantities(
-      @PathVariable("id") id: BatchId,
+      @PathVariable id: BatchId,
       @RequestBody payload: UpdateBatchQuantitiesRequestPayload,
   ): BatchResponsePayload {
     batchStore.updateQuantities(
@@ -151,7 +151,7 @@ class BatchesController(
   )
   @PostMapping("/{id}/changeStatuses")
   fun changeBatchStatuses(
-      @PathVariable("id") id: BatchId,
+      @PathVariable id: BatchId,
       @RequestBody payload: ChangeBatchStatusRequestPayload,
   ): BatchResponsePayload {
     batchStore.changeStatuses(id, payload.initialPhase, payload.finalPhase, payload.quantity)

--- a/src/main/kotlin/com/terraformation/backend/nursery/api/SpeciesController.kt
+++ b/src/main/kotlin/com/terraformation/backend/nursery/api/SpeciesController.kt
@@ -22,9 +22,7 @@ class SpeciesController(
 ) {
   @GetMapping("/{speciesId}/summary")
   @Operation(summary = "Gets a summary of the numbers of plants of each species in all nurseries.")
-  fun getSpeciesSummary(
-      @PathVariable("speciesId") speciesId: SpeciesId
-  ): GetSpeciesSummaryResponsePayload {
+  fun getSpeciesSummary(@PathVariable speciesId: SpeciesId): GetSpeciesSummaryResponsePayload {
     val summary = batchStore.getSpeciesSummary(speciesId)
     return GetSpeciesSummaryResponsePayload(SpeciesSummaryPayload(summary))
   }

--- a/src/main/kotlin/com/terraformation/backend/nursery/api/WithdrawalsController.kt
+++ b/src/main/kotlin/com/terraformation/backend/nursery/api/WithdrawalsController.kt
@@ -76,7 +76,7 @@ class WithdrawalsController(
   @GetMapping("/{withdrawalId}")
   @Operation(summary = "Gets information about a specific nursery withdrawal.")
   fun getNurseryWithdrawal(
-      @PathVariable("withdrawalId") withdrawalId: WithdrawalId
+      @PathVariable withdrawalId: WithdrawalId
   ): GetNurseryWithdrawalResponsePayload {
     val withdrawal = batchStore.fetchWithdrawalById(withdrawalId)
     val batches = withdrawal.batchWithdrawals.map { batchStore.fetchOneById(it.batchId) }
@@ -112,7 +112,7 @@ class WithdrawalsController(
   @PostMapping("/{withdrawalId}/photos", consumes = [MediaType.MULTIPART_FORM_DATA_VALUE])
   @RequestBodyPhotoFile
   fun uploadWithdrawalPhoto(
-      @PathVariable("withdrawalId") withdrawalId: WithdrawalId,
+      @PathVariable withdrawalId: WithdrawalId,
       @RequestPart("file") file: MultipartFile,
   ): CreateNurseryWithdrawalPhotoResponsePayload {
     val contentType = file.getPlainContentType(SUPPORTED_PHOTO_TYPES)
@@ -140,8 +140,8 @@ class WithdrawalsController(
   )
   @ResponseBody
   fun getWithdrawalPhoto(
-      @PathVariable("withdrawalId") withdrawalId: WithdrawalId,
-      @PathVariable("photoId") photoId: FileId,
+      @PathVariable withdrawalId: WithdrawalId,
+      @PathVariable photoId: FileId,
       @QueryParam("maxWidth")
       @Schema(description = PHOTO_MAXWIDTH_DESCRIPTION)
       maxWidth: Int? = null,
@@ -159,7 +159,7 @@ class WithdrawalsController(
   @GetMapping("/{withdrawalId}/photos")
   @Operation(summary = "Lists all the photos of a withdrawal.")
   fun listWithdrawalPhotos(
-      @PathVariable("withdrawalId") withdrawalId: WithdrawalId,
+      @PathVariable withdrawalId: WithdrawalId,
   ): ListWithdrawalPhotosResponsePayload {
     val fileIds = withdrawalPhotoService.listPhotos(withdrawalId)
 

--- a/src/main/kotlin/com/terraformation/backend/report/api/ReportsController.kt
+++ b/src/main/kotlin/com/terraformation/backend/report/api/ReportsController.kt
@@ -85,7 +85,7 @@ class ReportsController(
 
   @GetMapping("/{id}")
   @Operation(summary = "Retrieves the contents of a report.")
-  fun getReport(@PathVariable("id") id: SeedFundReportId): GetReportResponsePayload {
+  fun getReport(@PathVariable id: SeedFundReportId): GetReportResponsePayload {
     val model = seedFundReportService.fetchOneById(id)
     val reportPayload = GetReportPayload.of(model, userStore::fetchFullNameById)
 
@@ -101,7 +101,7 @@ class ReportsController(
               "current user.",
   )
   @PostMapping("/{id}/lock")
-  fun lockReport(@PathVariable("id") id: SeedFundReportId): SimpleSuccessResponsePayload {
+  fun lockReport(@PathVariable id: SeedFundReportId): SimpleSuccessResponsePayload {
     seedFundReportStore.lock(id)
 
     return SimpleSuccessResponsePayload()
@@ -110,7 +110,7 @@ class ReportsController(
   @ApiResponse200("The report is now locked by the current user.")
   @Operation(summary = "Locks a report even if it is locked by another user already.")
   @PostMapping("/{id}/lock/force")
-  fun forceLockReport(@PathVariable("id") id: SeedFundReportId): SimpleSuccessResponsePayload {
+  fun forceLockReport(@PathVariable id: SeedFundReportId): SimpleSuccessResponsePayload {
     seedFundReportStore.lock(id, true)
 
     return SimpleSuccessResponsePayload()
@@ -120,7 +120,7 @@ class ReportsController(
   @ApiResponse409("The report is locked by another user.")
   @Operation(summary = "Releases the lock on a report.")
   @PostMapping("/{id}/unlock")
-  fun unlockReport(@PathVariable("id") id: SeedFundReportId): SimpleSuccessResponsePayload {
+  fun unlockReport(@PathVariable id: SeedFundReportId): SimpleSuccessResponsePayload {
     seedFundReportStore.unlock(id)
 
     return SimpleSuccessResponsePayload()
@@ -134,7 +134,7 @@ class ReportsController(
   )
   @PutMapping("/{id}")
   fun updateReport(
-      @PathVariable("id") id: SeedFundReportId,
+      @PathVariable id: SeedFundReportId,
       @RequestBody payload: PutReportRequestPayload,
   ): SimpleSuccessResponsePayload {
     seedFundReportService.update(id) { payload.report.copyTo(it) }
@@ -152,7 +152,7 @@ class ReportsController(
               "Once a report is submitted, it may no longer be locked or updated.",
   )
   @PostMapping("/{id}/submit")
-  fun submitReport(@PathVariable("id") id: SeedFundReportId): SimpleSuccessResponsePayload {
+  fun submitReport(@PathVariable id: SeedFundReportId): SimpleSuccessResponsePayload {
     try {
       seedFundReportStore.submit(id)
     } catch (e: SeedFundReportNotCompleteException) {
@@ -164,7 +164,7 @@ class ReportsController(
 
   @GetMapping("/{id}/photos")
   @Operation(summary = "Lists the photos associated with a report.")
-  fun listReportPhotos(@PathVariable("id") id: SeedFundReportId): ListReportPhotosResponsePayload {
+  fun listReportPhotos(@PathVariable id: SeedFundReportId): ListReportPhotosResponsePayload {
     val photos = seedFundReportFileService.listPhotos(id)
 
     return ListReportPhotosResponsePayload(photos.map { ListReportPhotosResponseElement(it) })
@@ -174,8 +174,8 @@ class ReportsController(
   @GetMapping("/{reportId}/photos/{photoId}")
   @Operation(summary = "Gets the contents of a photo.", description = PHOTO_OPERATION_DESCRIPTION)
   fun getReportPhoto(
-      @PathVariable("reportId") reportId: SeedFundReportId,
-      @PathVariable("photoId") photoId: FileId,
+      @PathVariable reportId: SeedFundReportId,
+      @PathVariable photoId: FileId,
       @QueryParam("maxWidth")
       @Schema(description = PHOTO_MAXWIDTH_DESCRIPTION)
       maxWidth: Int? = null,
@@ -193,8 +193,8 @@ class ReportsController(
   @Operation(summary = "Updates a photo's caption.")
   @PutMapping("/{reportId}/photos/{photoId}")
   fun updateReportPhoto(
-      @PathVariable("reportId") reportId: SeedFundReportId,
-      @PathVariable("photoId") photoId: FileId,
+      @PathVariable reportId: SeedFundReportId,
+      @PathVariable photoId: FileId,
       @RequestBody payload: UpdateReportPhotoRequestPayload,
   ): SimpleSuccessResponsePayload {
     val existing = seedFundReportFileService.getPhotoModel(reportId, photoId)
@@ -209,7 +209,7 @@ class ReportsController(
   @PostMapping("/{reportId}/photos", consumes = [MediaType.MULTIPART_FORM_DATA_VALUE])
   @RequestBodyPhotoFile
   fun uploadReportPhoto(
-      @PathVariable("reportId") reportId: SeedFundReportId,
+      @PathVariable reportId: SeedFundReportId,
       @RequestPart("file") file: MultipartFile,
   ): UploadReportFileResponsePayload {
     val contentType = file.getPlainContentType(SUPPORTED_PHOTO_TYPES)
@@ -229,8 +229,8 @@ class ReportsController(
   @Operation(summary = "Deletes a photo from a report.")
   @DeleteMapping("/{reportId}/photos/{photoId}")
   fun deleteReportPhoto(
-      @PathVariable("reportId") reportId: SeedFundReportId,
-      @PathVariable("photoId") photoId: FileId,
+      @PathVariable reportId: SeedFundReportId,
+      @PathVariable photoId: FileId,
   ): SimpleSuccessResponsePayload {
     seedFundReportFileService.deletePhoto(reportId, photoId)
 
@@ -239,7 +239,7 @@ class ReportsController(
 
   @GetMapping("/{id}/files")
   @Operation(summary = "Lists the files associated with a report.")
-  fun listReportFiles(@PathVariable("id") id: SeedFundReportId): ListReportFilesResponsePayload {
+  fun listReportFiles(@PathVariable id: SeedFundReportId): ListReportFilesResponsePayload {
     val files = seedFundReportFileService.listFiles(id)
 
     return ListReportFilesResponsePayload(files.map { ListReportFilesResponseElement(it) })
@@ -260,8 +260,8 @@ class ReportsController(
   @Operation(summary = "Downloads a file associated with a report.")
   @Produces
   fun downloadReportFile(
-      @PathVariable("reportId") reportId: SeedFundReportId,
-      @PathVariable("fileId") fileId: FileId,
+      @PathVariable reportId: SeedFundReportId,
+      @PathVariable fileId: FileId,
   ): ResponseEntity<InputStreamResource> {
     return try {
       val model = seedFundReportFileService.getFileModel(reportId, fileId)
@@ -281,7 +281,7 @@ class ReportsController(
       content = [Content(encoding = [Encoding(name = "file", contentType = MediaType.ALL_VALUE)])]
   )
   fun uploadReportFile(
-      @PathVariable("reportId") reportId: SeedFundReportId,
+      @PathVariable reportId: SeedFundReportId,
       @RequestPart("file") file: MultipartFile,
   ): UploadReportFileResponsePayload {
     val contentType = file.getPlainContentType() ?: MediaType.APPLICATION_OCTET_STREAM_VALUE
@@ -301,8 +301,8 @@ class ReportsController(
   @Operation(summary = "Deletes a file from a report.")
   @DeleteMapping("/{reportId}/files/{fileId}")
   fun deleteReportFile(
-      @PathVariable("reportId") reportId: SeedFundReportId,
-      @PathVariable("fileId") fileId: FileId,
+      @PathVariable reportId: SeedFundReportId,
+      @PathVariable fileId: FileId,
   ): SimpleSuccessResponsePayload {
     seedFundReportFileService.deleteFile(reportId, fileId)
 

--- a/src/main/kotlin/com/terraformation/backend/seedbank/api/TransfersController.kt
+++ b/src/main/kotlin/com/terraformation/backend/seedbank/api/TransfersController.kt
@@ -30,7 +30,7 @@ class TransfersController(
   @Operation(summary = "Transfers seeds to a nursery.")
   @PostMapping("/nursery")
   fun createNurseryTransferWithdrawal(
-      @PathVariable("accessionId") accessionId: AccessionId,
+      @PathVariable accessionId: AccessionId,
       @RequestBody payload: CreateNurseryTransferRequestPayload,
   ): CreateNurseryTransferResponsePayload {
     val (accession, batch) =

--- a/src/main/kotlin/com/terraformation/backend/seedbank/api/ViabilityTestsController.kt
+++ b/src/main/kotlin/com/terraformation/backend/seedbank/api/ViabilityTestsController.kt
@@ -40,7 +40,7 @@ class ViabilityTestsController(
   @GetMapping
   @Operation(summary = "List all of the accession's viability tests.")
   fun listViabilityTests(
-      @PathVariable("accessionId") accessionId: AccessionId
+      @PathVariable accessionId: AccessionId
   ): ListViabilityTestsResponsePayload {
     val tests = viabilityTestStore.fetchViabilityTests(accessionId)
     return ListViabilityTestsResponsePayload(tests.map { GetViabilityTestPayload(it) })
@@ -49,8 +49,8 @@ class ViabilityTestsController(
   @GetMapping("/{viabilityTestId}")
   @Operation(summary = "Get a single viability test.")
   fun getViabilityTest(
-      @PathVariable("accessionId") accessionId: AccessionId,
-      @PathVariable("viabilityTestId") viabilityTestId: ViabilityTestId,
+      @PathVariable accessionId: AccessionId,
+      @PathVariable viabilityTestId: ViabilityTestId,
   ): GetViabilityTestResponsePayload {
     val model = viabilityTestStore.fetchOneById(viabilityTestId)
     if (model.accessionId != accessionId) {
@@ -66,7 +66,7 @@ class ViabilityTestsController(
   )
   @PostMapping
   fun createViabilityTest(
-      @PathVariable("accessionId") accessionId: AccessionId,
+      @PathVariable accessionId: AccessionId,
       @RequestBody payload: CreateViabilityTestRequestPayload,
   ): UpdateAccessionResponsePayloadV2 {
     val accession = accessionService.createViabilityTest(payload.toModel(accessionId))
@@ -79,8 +79,8 @@ class ViabilityTestsController(
       description = "May cause the accession's remaining quantity to change.",
   )
   fun deleteViabilityTest(
-      @PathVariable("accessionId") accessionId: AccessionId,
-      @PathVariable("viabilityTestId") viabilityTestId: ViabilityTestId,
+      @PathVariable accessionId: AccessionId,
+      @PathVariable viabilityTestId: ViabilityTestId,
   ): UpdateAccessionResponsePayloadV2 {
     val accession = accessionService.deleteViabilityTest(accessionId, viabilityTestId)
     return UpdateAccessionResponsePayloadV2(AccessionPayloadV2(accession))
@@ -92,8 +92,8 @@ class ViabilityTestsController(
   )
   @PutMapping("/{viabilityTestId}")
   fun updateViabilityTest(
-      @PathVariable("accessionId") accessionId: AccessionId,
-      @PathVariable("viabilityTestId") viabilityTestId: ViabilityTestId,
+      @PathVariable accessionId: AccessionId,
+      @PathVariable viabilityTestId: ViabilityTestId,
       @RequestBody payload: UpdateViabilityTestRequestPayload,
   ): UpdateAccessionResponsePayloadV2 {
     val accession =

--- a/src/main/kotlin/com/terraformation/backend/seedbank/api/WithdrawalsController.kt
+++ b/src/main/kotlin/com/terraformation/backend/seedbank/api/WithdrawalsController.kt
@@ -33,9 +33,7 @@ class WithdrawalsController(
 ) {
   @GetMapping
   @Operation(summary = "List all the withdrawals from an accession.")
-  fun listWithdrawals(
-      @PathVariable("accessionId") accessionId: AccessionId
-  ): GetWithdrawalsResponsePayload {
+  fun listWithdrawals(@PathVariable accessionId: AccessionId): GetWithdrawalsResponsePayload {
     val withdrawals = withdrawalStore.fetchWithdrawals(accessionId)
     val payloads = withdrawals.map { GetWithdrawalPayload(it) }
 
@@ -45,8 +43,8 @@ class WithdrawalsController(
   @GetMapping("/{withdrawalId}")
   @Operation(summary = "Get a single withdrawal.")
   fun getWithdrawal(
-      @PathVariable("accessionId") accessionId: AccessionId,
-      @PathVariable("withdrawalId") withdrawalId: WithdrawalId,
+      @PathVariable accessionId: AccessionId,
+      @PathVariable withdrawalId: WithdrawalId,
   ): GetWithdrawalResponsePayload {
     val model = withdrawalStore.fetchOneById(withdrawalId)
     return GetWithdrawalResponsePayload(GetWithdrawalPayload(model))
@@ -58,7 +56,7 @@ class WithdrawalsController(
   )
   @PostMapping
   fun createWithdrawal(
-      @PathVariable("accessionId") accessionId: AccessionId,
+      @PathVariable accessionId: AccessionId,
       @RequestBody payload: CreateWithdrawalRequestPayload,
   ): UpdateAccessionResponsePayloadV2 {
     val accession = accessionService.createWithdrawal(payload.toModel(accessionId))
@@ -71,8 +69,8 @@ class WithdrawalsController(
   )
   @PutMapping("/{withdrawalId}")
   fun updateWithdrawal(
-      @PathVariable("accessionId") accessionId: AccessionId,
-      @PathVariable("withdrawalId") withdrawalId: WithdrawalId,
+      @PathVariable accessionId: AccessionId,
+      @PathVariable withdrawalId: WithdrawalId,
       @RequestBody payload: UpdateWithdrawalRequestPayload,
   ): UpdateAccessionResponsePayloadV2 {
     val accession =
@@ -86,8 +84,8 @@ class WithdrawalsController(
       description = "May cause the accession's remaining quantity to change.",
   )
   fun deleteWithdrawal(
-      @PathVariable("accessionId") accessionId: AccessionId,
-      @PathVariable("withdrawalId") withdrawalId: WithdrawalId,
+      @PathVariable accessionId: AccessionId,
+      @PathVariable withdrawalId: WithdrawalId,
   ): UpdateAccessionResponsePayloadV2 {
     val accession = accessionService.deleteWithdrawal(accessionId, withdrawalId)
     return UpdateAccessionResponsePayloadV2(AccessionPayloadV2(accession))

--- a/src/main/kotlin/com/terraformation/backend/species/api/SpeciesController.kt
+++ b/src/main/kotlin/com/terraformation/backend/species/api/SpeciesController.kt
@@ -155,7 +155,7 @@ class SpeciesController(
   @GetMapping("/problems/{problemId}")
   @Operation(description = "Returns details about a problem with a species.")
   fun getSpeciesProblem(
-      @PathVariable("problemId") problemId: SpeciesProblemId
+      @PathVariable problemId: SpeciesProblemId
   ): GetSpeciesProblemResponsePayload {
     val problem = speciesStore.fetchProblemById(problemId)
     return GetSpeciesProblemResponsePayload(SpeciesProblemElement(problem))
@@ -173,7 +173,7 @@ class SpeciesController(
   )
   @PostMapping("/problems/{problemId}")
   fun acceptProblemSuggestion(
-      @PathVariable("problemId") problemId: SpeciesProblemId
+      @PathVariable problemId: SpeciesProblemId
   ): GetSpeciesResponsePayload {
     val updatedRow = speciesStore.acceptProblemSuggestion(problemId)
     val remainingProblems = speciesStore.fetchProblemsBySpeciesId(updatedRow.id)
@@ -188,9 +188,7 @@ class SpeciesController(
           "Deletes information about a problem with a species without applying any suggested " +
               "changes."
   )
-  fun deleteProblem(
-      @PathVariable("problemId") problemId: SpeciesProblemId
-  ): SimpleSuccessResponsePayload {
+  fun deleteProblem(@PathVariable problemId: SpeciesProblemId): SimpleSuccessResponsePayload {
     speciesStore.deleteProblem(problemId)
     return SimpleSuccessResponsePayload()
   }

--- a/src/main/kotlin/com/terraformation/backend/tracking/api/PlantingSitesController.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/api/PlantingSitesController.kt
@@ -129,8 +129,8 @@ class PlantingSitesController(
   @GetMapping("/{id}/history/{historyId}")
   @Operation(summary = "Gets information about an older version of a planting site.")
   fun getPlantingSiteHistory(
-      @PathVariable("id") id: PlantingSiteId,
-      @PathVariable("historyId") historyId: PlantingSiteHistoryId,
+      @PathVariable id: PlantingSiteId,
+      @PathVariable historyId: PlantingSiteHistoryId,
       @RequestParam(defaultValue = "true") simplified: Boolean? = true,
   ): GetPlantingSiteHistoryResponsePayload {
     val model =
@@ -211,7 +211,7 @@ class PlantingSitesController(
   @Operation(summary = "Updates information about an existing planting site.")
   @PutMapping("/{id}")
   fun updatePlantingSite(
-      @PathVariable("id") id: PlantingSiteId,
+      @PathVariable id: PlantingSiteId,
       @RequestBody payload: UpdatePlantingSiteRequestPayload,
   ): SimpleSuccessResponsePayload {
     plantingSiteStore.updatePlantingSite(id, payload::applyTo)
@@ -228,7 +228,7 @@ class PlantingSitesController(
       description = "Planting site should not have any plantings.",
   )
   @DeleteMapping("/{id}")
-  fun deletePlantingSite(@PathVariable("id") id: PlantingSiteId): SimpleSuccessResponsePayload {
+  fun deletePlantingSite(@PathVariable id: PlantingSiteId): SimpleSuccessResponsePayload {
     plantingSiteService.deletePlantingSite(id)
     return SimpleSuccessResponsePayload()
   }


### PR DESCRIPTION
Spring automatically uses the parameter name as the path variable name, so there's
no need to specify it explicitly. This was flagged as a warning by IntelliJ.