### PR TITLE
Add activeDate to scheduled date species subject

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/eventlog/api/EventSubjectPayload.kt
+++ b/src/main/kotlin/com/terraformation/backend/eventlog/api/EventSubjectPayload.kt
@@ -589,7 +589,7 @@ data class PlantingSeasonScheduledDateSubjectPayload(
 
 @JsonTypeName("PlantingSeasonScheduledDateSpecies")
 data class PlantingSeasonScheduledDateSpeciesSubjectPayload(
-    val activeDate: LocalDate?,
+    val activeDate: LocalDate,
     override val fullText: String,
     val plantingSeasonId: PlantingSeasonId,
     val plantingSiteId: PlantingSiteId,
@@ -617,11 +617,11 @@ data class PlantingSeasonScheduledDateSpeciesSubjectPayload(
               ?.changedTo
               ?.date
               ?: context
-                  .lastEventBefore<PlantingSeasonScheduledDateCreatedEvent>(event) {
+                  .first<PlantingSeasonScheduledDateCreatedEvent> {
                     it.scheduledPlantingDateId == event.scheduledPlantingDateId
                   }
-                  ?.date
-      val dateText = activeDate?.toString() ?: event.scheduledPlantingDateId.toString()
+                  .date
+      val dateText = activeDate.toString()
 
       return PlantingSeasonScheduledDateSpeciesSubjectPayload(
           activeDate = activeDate,

--- a/src/main/kotlin/com/terraformation/backend/eventlog/api/EventSubjectPayload.kt
+++ b/src/main/kotlin/com/terraformation/backend/eventlog/api/EventSubjectPayload.kt
@@ -589,6 +589,7 @@ data class PlantingSeasonScheduledDateSubjectPayload(
 
 @JsonTypeName("PlantingSeasonScheduledDateSpecies")
 data class PlantingSeasonScheduledDateSpeciesSubjectPayload(
+    val activeDate: LocalDate?,
     override val fullText: String,
     val plantingSeasonId: PlantingSeasonId,
     val plantingSiteId: PlantingSiteId,
@@ -623,6 +624,7 @@ data class PlantingSeasonScheduledDateSpeciesSubjectPayload(
       val dateText = activeDate?.toString() ?: event.scheduledPlantingDateId.toString()
 
       return PlantingSeasonScheduledDateSpeciesSubjectPayload(
+          activeDate = activeDate,
           fullText =
               context.subjectFullText<PlantingSeasonScheduledDateSpeciesSubjectPayload>(
                   scientificName,


### PR DESCRIPTION
The copy for `PlantingSeasonScheduledDateSpecies` events in the change history should include the date string for the scheduled planting date that is being modified by these species. We already calculate the `activeDate` for these subjects for use in the `fullText`; expose the `LocalDate` to the FE. 