### PR TITLE
Allow Created Events to have initial values

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/eventlog/EventLogPayloadTransformer.kt
+++ b/src/main/kotlin/com/terraformation/backend/eventlog/EventLogPayloadTransformer.kt
@@ -8,6 +8,7 @@ import com.terraformation.backend.eventlog.api.BiomassQuadratSpeciesSubjectPaylo
 import com.terraformation.backend.eventlog.api.BiomassQuadratSubjectPayload
 import com.terraformation.backend.eventlog.api.BiomassSpeciesSubjectPayload
 import com.terraformation.backend.eventlog.api.CreatedActionPayload
+import com.terraformation.backend.eventlog.api.CreatedFieldPayload
 import com.terraformation.backend.eventlog.api.DeletedActionPayload
 import com.terraformation.backend.eventlog.api.EventActionPayload
 import com.terraformation.backend.eventlog.api.EventLogEntryPayload
@@ -154,7 +155,16 @@ class EventLogPayloadTransformer(
           }
 
       // Create and delete actions don't need any event-type-specific arguments because the details
-      // are already in the subject.
+      // are already in the subject. Events that implement FieldsCreatedPersistentEvent also include
+      // initial field values in the payload.
+      is FieldsCreatedPersistentEvent ->
+          listOf(
+              CreatedActionPayload(
+                  event.listInitialFields(messages).map {
+                    CreatedFieldPayload(it.fieldName, it.value)
+                  }
+              )
+          )
       is EntityCreatedPersistentEvent -> listOf(CreatedActionPayload())
       is EntityDeletedPersistentEvent -> listOf(DeletedActionPayload())
 

--- a/src/main/kotlin/com/terraformation/backend/eventlog/FieldsCreatedPersistentEvent.kt
+++ b/src/main/kotlin/com/terraformation/backend/eventlog/FieldsCreatedPersistentEvent.kt
@@ -1,0 +1,79 @@
+package com.terraformation.backend.eventlog
+
+import com.terraformation.backend.i18n.Messages
+
+/**
+ * Common interface for events that represent an entity being created with specific initial field
+ * values. This is used to render [PersistentEvent]s into API payloads for event log queries.
+ * Creation events that implement this interface will produce a
+ * [CreatedActionPayload][com.terraformation.backend.eventlog.api.CreatedActionPayload] that
+ * includes the initial field values; those that don't will produce a plain
+ * [CreatedActionPayload][com.terraformation.backend.eventlog.api.CreatedActionPayload] with no
+ * field data.
+ *
+ * The typical pattern is to define a nested class (usually called `Values`) with a nullable
+ * property for each field whose initial value should be surfaced. Implementing [listInitialFields]
+ * is then a matter of scanning those properties and returning an [InitialField] for each non-null
+ * one. Use [createInitialField] as a helper to skip null values cleanly inside `listOfNotNull`.
+ *
+ * Fields that don't need to appear in the event log can simply be omitted from `Values` or left
+ * null, and they won't show up in the payload.
+ *
+ * For example:
+ * ```kotlin
+ * data class ExampleCreatedEventV1(
+ *   val values: Values,
+ *   val exampleId: ExampleID
+ * ) : FieldsCreatedPersistentEvent {
+ *   data class Values(
+ *     val quantity: Int?,
+ *   )
+ *
+ *   override fun listInitialFields(messages: Messages): List<InitialField> {
+ *     return listOfNotNull(
+ *       createInitialField("quantity", values.quantity?.toString()),
+ *     )
+ *   }
+ * }
+ * ```
+ */
+interface FieldsCreatedPersistentEvent : EntityCreatedPersistentEvent {
+  /**
+   * Returns a list of the fields whose initial values should be included in the event log payload.
+   * Fields that don't need to be surfaced can be omitted.
+   */
+  fun listInitialFields(messages: Messages): List<InitialField>
+
+  /** Represents the initial value of a single field at entity creation time. */
+  data class InitialField(
+      /**
+       * Canonical name of the field. This will generally be the same as the name of the Kotlin
+       * property of the entity's model class. Do not use localized names here; localization of
+       * field names is handled elsewhere.
+       */
+      val fieldName: String,
+      /**
+       * Initial value of the field, or null if the field had no value at creation time. For scalar
+       * fields this list will have one element, but it can have multiple elements if the field is,
+       * e.g., a set of enum values. This value should be localized if applicable.
+       */
+      val value: List<String>?,
+  )
+
+  /**
+   * Returns an [InitialField] if [value] is non-null, null otherwise. This would typically be
+   * called in `listOfNotNull` in the [listInitialFields] implementation.
+   */
+  fun createInitialField(fieldName: String, value: List<String>?): InitialField? {
+    return if (value != null) InitialField(fieldName, value) else null
+  }
+
+  /**
+   * Returns an [InitialField] with [value] wrapped in a single-element list if [value] is non-null,
+   * null otherwise. This would typically be called in `listOfNotNull` in the [listInitialFields]
+   * implementation.
+   */
+  fun createInitialField(fieldName: String, value: String?): InitialField? {
+    return createInitialField(fieldName, value?.let { listOf(it) })
+  }
+}

--- a/src/main/kotlin/com/terraformation/backend/eventlog/FieldsCreatedPersistentEvent.kt
+++ b/src/main/kotlin/com/terraformation/backend/eventlog/FieldsCreatedPersistentEvent.kt
@@ -1,14 +1,13 @@
 package com.terraformation.backend.eventlog
 
+import com.terraformation.backend.eventlog.api.CreatedActionPayload
 import com.terraformation.backend.i18n.Messages
 
 /**
  * Common interface for events that represent an entity being created with specific initial field
  * values. This is used to render [PersistentEvent]s into API payloads for event log queries.
- * Creation events that implement this interface will produce a
- * [CreatedActionPayload][com.terraformation.backend.eventlog.api.CreatedActionPayload] that
- * includes the initial field values; those that don't will produce a plain
- * [CreatedActionPayload][com.terraformation.backend.eventlog.api.CreatedActionPayload] with no
+ * Creation events that implement this interface will produce a [CreatedActionPayload] that includes
+ * the initial field values; those that don't will produce a plain [CreatedActionPayload] with no
  * field data.
  *
  * The typical pattern is to define a nested class (usually called `Values`) with a nullable
@@ -64,8 +63,8 @@ interface FieldsCreatedPersistentEvent : EntityCreatedPersistentEvent {
    * Returns an [InitialField] if [value] is non-null, null otherwise. This would typically be
    * called in `listOfNotNull` in the [listInitialFields] implementation.
    */
-  fun createInitialField(fieldName: String, value: List<String>?): InitialField? {
-    return if (value != null) InitialField(fieldName, value) else null
+  fun createInitialField(fieldName: String, value: List<String>?): InitialField? = value?.let {
+    InitialField(fieldName, it)
   }
 
   /**
@@ -73,7 +72,6 @@ interface FieldsCreatedPersistentEvent : EntityCreatedPersistentEvent {
    * null otherwise. This would typically be called in `listOfNotNull` in the [listInitialFields]
    * implementation.
    */
-  fun createInitialField(fieldName: String, value: String?): InitialField? {
-    return createInitialField(fieldName, value?.let { listOf(it) })
-  }
+  fun createInitialField(fieldName: String, value: String?): InitialField? =
+      createInitialField(fieldName, value?.let { listOf(it) })
 }

--- a/src/main/kotlin/com/terraformation/backend/eventlog/api/EventActionPayload.kt
+++ b/src/main/kotlin/com/terraformation/backend/eventlog/api/EventActionPayload.kt
@@ -1,17 +1,21 @@
 package com.terraformation.backend.eventlog.api
 
+import com.fasterxml.jackson.annotation.JsonInclude
 import com.fasterxml.jackson.annotation.JsonTypeInfo
 import com.fasterxml.jackson.annotation.JsonTypeName
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "type")
 sealed interface EventActionPayload
 
-@JsonTypeName("Created")
-class CreatedActionPayload : EventActionPayload {
-  override fun equals(other: Any?) = other is CreatedActionPayload
+data class CreatedFieldPayload(
+    val fieldName: String,
+    val value: List<String>?,
+)
 
-  override fun hashCode() = javaClass.hashCode() xor 1
-}
+@JsonTypeName("Created")
+data class CreatedActionPayload(
+    @JsonInclude(JsonInclude.Include.NON_EMPTY) val fields: List<CreatedFieldPayload> = emptyList(),
+) : EventActionPayload
 
 @JsonTypeName("Deleted")
 class DeletedActionPayload : EventActionPayload {


### PR DESCRIPTION
We already include fields that can be updated in `FieldsUpdatedPersistentEvent`, allowing the `action` of the payload to contain the `changedFrom` and `changedTo` values. Product has started to request that some event log events be displayed in the FE with their initial values. Create a new `CreatedFieldPayload` to return this and `FieldsCreatedPersistentEvent` to allow for events to specify these fields. If a Created event has none of these, it will behave the same as before.

Co-authored-by: Claude Opus 4.8 <noreply@anthropic.com>