### PR TITLE
SW-8430 Add "Explanation" monitoring plot media type

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/accelerator/ObservationActivityService.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/ObservationActivityService.kt
@@ -145,11 +145,13 @@ class ObservationActivityService(
                 plotResult.media
                     .sortedBy { it.fileId }
                     .sortedBy { file ->
-                      // Corner photos first, then quadrat photos, then everything else.
+                      // Corner / explanation photos first, then quadrat photos, then the rest.
                       when (file.type) {
                         ObservationMediaType.Plot if file.position != null -> 0
+                        ObservationMediaType.Explanation -> 0
                         ObservationMediaType.Quadrat -> 1
-                        else -> 2
+                        ObservationMediaType.Plot,
+                        ObservationMediaType.Soil -> 2
                       }
                     }
 

--- a/src/main/kotlin/com/terraformation/backend/tracking/ObservationService.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/ObservationService.kt
@@ -332,6 +332,12 @@ class ObservationService(
     val initialRow = fetchMediaFilesRow(observationId, monitoringPlotId, fileId)
     val updatedRow = updateFunc(initialRow)
 
+    if (
+        initialRow.typeId == ObservationMediaType.Explanation && updatedRow.caption.isNullOrBlank()
+    ) {
+      throw IllegalArgumentException("Cannot remove caption from Explanation photo")
+    }
+
     if (initialRow != updatedRow) {
       observationMediaFilesDao.update(initialRow.copy(caption = updatedRow.caption))
       fileService.touchFile(fileId)

--- a/src/main/kotlin/com/terraformation/backend/tracking/ObservationService.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/ObservationService.kt
@@ -260,10 +260,18 @@ class ObservationService(
     if (metadata.geolocation == null && isOriginal) {
       throw IllegalArgumentException("Geolocation is required for original observation photos")
     }
+
+    if (type == ObservationMediaType.Explanation) {
+      if (caption.isNullOrBlank()) {
+        throw IllegalArgumentException("Caption is required for explanation media file")
+      }
+      if (position == null) {
+        throw IllegalArgumentException("Position is required for explanation media file")
+      }
+    }
     if (type == ObservationMediaType.Quadrat && position == null) {
       throw IllegalArgumentException("Position is required for quadrat media file")
     }
-
     if (type == ObservationMediaType.Soil && position != null) {
       throw IllegalArgumentException("Position must be null for a soil media file")
     }

--- a/src/main/resources/db/migration/R__TypeCodes.sql
+++ b/src/main/resources/db/migration/R__TypeCodes.sql
@@ -389,7 +389,8 @@ ON CONFLICT (id) DO UPDATE SET name = excluded.name;
 INSERT INTO tracking.observation_media_types (id, name)
 VALUES (1, 'Plot'),
        (2, 'Quadrat'),
-       (3, 'Soil')
+       (3, 'Soil'),
+       (4, 'Explanation')
 ON CONFLICT (id) DO UPDATE SET name = excluded.name;
 
 INSERT INTO tracking.observation_plot_positions (id, name)

--- a/src/test/kotlin/com/terraformation/backend/accelerator/ObservationActivityServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/ObservationActivityServiceTest.kt
@@ -270,6 +270,12 @@ class ObservationActivityServiceTest : DatabaseTest(), RunsAsDatabaseUser {
       )
       val plot2File3Id = insertFile(contentType = "video/mp4")
       insertObservationMediaFile(position = null)
+      val plot2File4Id = insertFile()
+      insertObservationMediaFile(
+          caption = "Explanation",
+          position = ObservationPlotPosition.NortheastCorner,
+          type = ObservationMediaType.Explanation,
+      )
 
       // Second observation shouldn't be included.
       insertObservation()
@@ -331,11 +337,20 @@ class ObservationActivityServiceTest : DatabaseTest(), RunsAsDatabaseUser {
               ActivityMediaFilesRecord(
                   activityId = activityId,
                   activityMediaTypeId = ActivityMediaType.Photo,
+                  caption = "Explanation",
+                  fileId = plot2File4Id,
+                  isCoverPhoto = false,
+                  isHiddenOnMap = false,
+                  listPosition = 4,
+              ),
+              ActivityMediaFilesRecord(
+                  activityId = activityId,
+                  activityMediaTypeId = ActivityMediaType.Photo,
                   caption = "Quadrat",
                   fileId = plot2File1Id,
                   isCoverPhoto = false,
                   isHiddenOnMap = false,
-                  listPosition = 4,
+                  listPosition = 5,
               ),
               ActivityMediaFilesRecord(
                   activityId = activityId,
@@ -344,7 +359,7 @@ class ObservationActivityServiceTest : DatabaseTest(), RunsAsDatabaseUser {
                   fileId = plot2File3Id,
                   isCoverPhoto = false,
                   isHiddenOnMap = false,
-                  listPosition = 5,
+                  listPosition = 6,
               ),
           )
       )

--- a/src/test/kotlin/com/terraformation/backend/tracking/ObservationServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/ObservationServiceTest.kt
@@ -1121,6 +1121,25 @@ class ObservationServiceTest : DatabaseTest(), RunsAsDatabaseUser {
       }
 
       @Test
+      fun `throws exception if removing caption from Explanation photo`() {
+        val fileId =
+            service.storeMediaFile(
+                observationId = observationId,
+                monitoringPlotId = plotId,
+                position = ObservationPlotPosition.NortheastCorner,
+                data = byteArrayOf(1).inputStream(),
+                metadata = metadata,
+                caption = "caption",
+                isOriginal = true,
+                type = ObservationMediaType.Explanation,
+            )
+
+        assertThrows<IllegalArgumentException> {
+          service.updateMediaFile(observationId, plotId, fileId) { it.copy(caption = null) }
+        }
+      }
+
+      @Test
       fun `throws exception if no permission to update observation`() {
         val fileId =
             service.storeMediaFile(

--- a/src/test/kotlin/com/terraformation/backend/tracking/ObservationServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/ObservationServiceTest.kt
@@ -917,6 +917,38 @@ class ObservationServiceTest : DatabaseTest(), RunsAsDatabaseUser {
       }
 
       @Test
+      fun `throws exception for missing caption for Explanation photos`() {
+        assertThrows<IllegalArgumentException> {
+          service.storeMediaFile(
+              observationId = observationId,
+              monitoringPlotId = plotId,
+              position = ObservationPlotPosition.SouthwestCorner,
+              data = byteArrayOf(1).inputStream(),
+              metadata = metadata,
+              caption = "",
+              isOriginal = true,
+              type = ObservationMediaType.Explanation,
+          )
+        }
+      }
+
+      @Test
+      fun `throws exception for missing photo position for Explanation photos`() {
+        assertThrows<IllegalArgumentException> {
+          service.storeMediaFile(
+              observationId = observationId,
+              monitoringPlotId = plotId,
+              position = null,
+              data = byteArrayOf(1).inputStream(),
+              metadata = metadata,
+              caption = "Explanation",
+              isOriginal = true,
+              type = ObservationMediaType.Explanation,
+          )
+        }
+      }
+
+      @Test
       fun `throws exception for missing photo position for Quadrat photos`() {
         assertThrows<IllegalArgumentException> {
           service.storeMediaFile(


### PR DESCRIPTION
We want users to be able to upload additional plot corner photos with captions
explaining why they're placing a corner more than a certain distance from the
system-generated location. Add a new media type for these photos, `Explanation`,
which is sorted along with the other plot corner photos in the activity log
and, like quadrat photos, requires a position (corner) to be set.