### PR TITLE
SW-8594 Add country/botanical country to search API

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/search/table/CountriesTable.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/table/CountriesTable.kt
@@ -1,6 +1,7 @@
 package com.terraformation.backend.search.table
 
 import com.terraformation.backend.db.default_schema.tables.references.COUNTRIES
+import com.terraformation.backend.db.default_schema.tables.references.COUNTRY_BOTANICAL_COUNTRIES
 import com.terraformation.backend.db.default_schema.tables.references.COUNTRY_SUBDIVISIONS
 import com.terraformation.backend.db.default_schema.tables.references.ORGANIZATIONS
 import com.terraformation.backend.search.SearchTable
@@ -16,6 +17,10 @@ class CountriesTable(tables: SearchTables) : SearchTable() {
   override val sublists: List<SublistField> by lazy {
     with(tables) {
       listOf(
+          countryBotanicalCountries.asMultiValueSublist(
+              "botanicalCountries",
+              COUNTRIES.CODE.eq(COUNTRY_BOTANICAL_COUNTRIES.COUNTRY_CODE),
+          ),
           organizations.asMultiValueSublist(
               "organizations",
               COUNTRIES.CODE.eq(ORGANIZATIONS.COUNTRY_CODE),

--- a/src/main/kotlin/com/terraformation/backend/search/table/CountryBotanicalCountriesTable.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/table/CountryBotanicalCountriesTable.kt
@@ -1,6 +1,7 @@
 package com.terraformation.backend.search.table
 
 import com.terraformation.backend.db.default_schema.tables.references.BOTANICAL_COUNTRIES
+import com.terraformation.backend.db.default_schema.tables.references.COUNTRIES
 import com.terraformation.backend.db.default_schema.tables.references.COUNTRY_BOTANICAL_COUNTRIES
 import com.terraformation.backend.search.SearchTable
 import com.terraformation.backend.search.SublistField
@@ -8,24 +9,24 @@ import com.terraformation.backend.search.field.SearchField
 import org.jooq.Record
 import org.jooq.TableField
 
-class BotanicalCountriesTable(private val tables: SearchTables) : SearchTable() {
+class CountryBotanicalCountriesTable(private val tables: SearchTables) : SearchTable() {
   override val primaryKey: TableField<out Record, out Any?>
-    get() = BOTANICAL_COUNTRIES.ID
+    get() = COUNTRY_BOTANICAL_COUNTRIES.COUNTRY_BOTANICAL_COUNTRY_ID
 
   override val sublists: List<SublistField> by lazy {
     with(tables) {
       listOf(
-          countryBotanicalCountries.asMultiValueSublist(
-              "countries",
-              BOTANICAL_COUNTRIES.ID.eq(COUNTRY_BOTANICAL_COUNTRIES.BOTANICAL_COUNTRY_ID),
+          botanicalCountries.asSingleValueSublist(
+              "botanicalCountry",
+              COUNTRY_BOTANICAL_COUNTRIES.BOTANICAL_COUNTRY_ID.eq(BOTANICAL_COUNTRIES.ID),
+          ),
+          countries.asSingleValueSublist(
+              "country",
+              COUNTRY_BOTANICAL_COUNTRIES.COUNTRY_CODE.eq(COUNTRIES.CODE),
           ),
       )
     }
   }
 
-  override val fields: List<SearchField> =
-      listOf(
-          textField("level3Code", BOTANICAL_COUNTRIES.LEVEL3_CODE),
-          localizedTextField("name", BOTANICAL_COUNTRIES.LEVEL3_CODE, "i18n.BotanicalCountries"),
-      )
+  override val fields: List<SearchField> = emptyList()
 }

--- a/src/main/kotlin/com/terraformation/backend/search/table/SearchTables.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/table/SearchTables.kt
@@ -34,6 +34,7 @@ class SearchTables(clock: Clock) {
   val batchWithdrawals = BatchWithdrawalsTable(this)
   val botanicalCountries = BotanicalCountriesTable(this)
   val countries = CountriesTable(this)
+  val countryBotanicalCountries = CountryBotanicalCountriesTable(this)
   val countrySubdivisions = CountrySubdivisionsTable(this)
   val deliverables = DeliverablesTable(this)
   val deliveries = DeliveriesTable(this)


### PR DESCRIPTION
Expose the new mapping between countries and botanical countries in the search
API. This will allow clients to show a list of possible botanical countries for
whichever country the user selects for a project.