### PR TITLE
Add fileBatchId to upload file endpoints

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/customer/event/OrganizationVideoUploadedEvent.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/event/OrganizationVideoUploadedEvent.kt
@@ -1,5 +1,6 @@
 package com.terraformation.backend.customer.event
 
+import com.terraformation.backend.db.default_schema.FileBatchId
 import com.terraformation.backend.db.default_schema.FileId
 import com.terraformation.backend.db.default_schema.OrganizationId
 
@@ -7,4 +8,5 @@ import com.terraformation.backend.db.default_schema.OrganizationId
 data class OrganizationVideoUploadedEvent(
     val fileId: FileId,
     val organizationId: OrganizationId,
+    val fileBatchId: FileBatchId? = null,
 )

--- a/src/main/kotlin/com/terraformation/backend/db/Exceptions.kt
+++ b/src/main/kotlin/com/terraformation/backend/db/Exceptions.kt
@@ -11,6 +11,7 @@ import com.terraformation.backend.db.default_schema.DeviceManagerId
 import com.terraformation.backend.db.default_schema.DisclaimerId
 import com.terraformation.backend.db.default_schema.FacilityId
 import com.terraformation.backend.db.default_schema.FacilityType
+import com.terraformation.backend.db.default_schema.FileBatchId
 import com.terraformation.backend.db.default_schema.FileId
 import com.terraformation.backend.db.default_schema.InternalTagId
 import com.terraformation.backend.db.default_schema.NotificationId
@@ -115,6 +116,9 @@ class FacilityNotFoundException(val facilityId: FacilityId) :
 
 class FacilityTypeMismatchException(val facilityId: FacilityId, val requiredType: FacilityType) :
     MismatchedStateException("Facility $facilityId is not of type ${requiredType.jsonValue}")
+
+class FileBatchNotFoundException(val fileBatchId: FileBatchId) :
+    EntityNotFoundException("File batch $fileBatchId not found")
 
 class FileNotFoundException(val fileId: FileId) : EntityNotFoundException("File $fileId not found")
 

--- a/src/main/kotlin/com/terraformation/backend/file/FileService.kt
+++ b/src/main/kotlin/com/terraformation/backend/file/FileService.kt
@@ -93,6 +93,7 @@ class FileService(
       data: InputStream,
       newFileMetadata: NewFileMetadata,
       populateMetadata: ((NewFileMetadata) -> NewFileMetadata)? = null,
+      fileBatchId: FileBatchId? = null,
       insertChildRows: (StoredFile) -> Unit,
   ): FileId {
     val copier = InputStreamCopier(data)
@@ -168,6 +169,7 @@ class FileService(
                 contentType = fullMetadata.contentType,
                 createdTime = clock.instant(),
                 createdBy = currentUser().userId,
+                fileBatchId = fileBatchId,
                 fileName = fullMetadata.filename,
                 geolocation = fullMetadata.geolocation,
                 modifiedBy = currentUser().userId,

--- a/src/main/kotlin/com/terraformation/backend/file/FileService.kt
+++ b/src/main/kotlin/com/terraformation/backend/file/FileService.kt
@@ -7,6 +7,7 @@ import com.drew.metadata.Metadata
 import com.terraformation.backend.auth.currentUser
 import com.terraformation.backend.daily.DailyTaskTimeArrivedEvent
 import com.terraformation.backend.db.DefaultCatalog
+import com.terraformation.backend.db.FileBatchNotFoundException
 import com.terraformation.backend.db.FileNotFoundException
 import com.terraformation.backend.db.TokenNotFoundException
 import com.terraformation.backend.db.default_schema.FileBatchId
@@ -96,6 +97,13 @@ class FileService(
       fileBatchId: FileBatchId? = null,
       insertChildRows: (StoredFile) -> Unit,
   ): FileId {
+    if (
+        fileBatchId != null &&
+            !dslContext.fetchExists(FILE_BATCHES, FILE_BATCHES.ID.eq(fileBatchId))
+    ) {
+      throw FileBatchNotFoundException(fileBatchId)
+    }
+
     val copier = InputStreamCopier(data)
     val fileTypeStream = copier.getCopy()
     val exifStream = copier.getCopy()

--- a/src/main/kotlin/com/terraformation/backend/splat/SplatService.kt
+++ b/src/main/kotlin/com/terraformation/backend/splat/SplatService.kt
@@ -5,12 +5,15 @@ import com.terraformation.backend.config.TerrawareServerConfig
 import com.terraformation.backend.customer.db.ParentStore
 import com.terraformation.backend.customer.event.OrganizationVideoUploadedEvent
 import com.terraformation.backend.customer.model.requirePermissions
+import com.terraformation.backend.db.FileBatchNotFoundException
 import com.terraformation.backend.db.FileNotFoundException
 import com.terraformation.backend.db.default_schema.AssetStatus
+import com.terraformation.backend.db.default_schema.FileBatchType
 import com.terraformation.backend.db.default_schema.FileId
 import com.terraformation.backend.db.default_schema.OrganizationId
 import com.terraformation.backend.db.default_schema.tables.references.BIRDNET_RESULTS
 import com.terraformation.backend.db.default_schema.tables.references.FILES
+import com.terraformation.backend.db.default_schema.tables.references.FILE_BATCHES
 import com.terraformation.backend.db.default_schema.tables.references.ORGANIZATION_MEDIA_FILES
 import com.terraformation.backend.db.default_schema.tables.references.SPLATS
 import com.terraformation.backend.db.default_schema.tables.references.SPLAT_ANNOTATIONS
@@ -537,8 +540,13 @@ class SplatService(
   @EventListener
   fun on(event: OrganizationVideoUploadedEvent) {
     if (event.fileBatchId != null) {
-      // Video was part of a batch; don't auto-generate splat.
-      return
+      val batchType =
+          dslContext.fetchValue(FILE_BATCHES.BATCH_TYPE_ID, FILE_BATCHES.ID.eq(event.fileBatchId))
+              ?: throw FileBatchNotFoundException(event.fileBatchId)
+      if (batchType == FileBatchType.Splats) {
+        // Video was part of a splat batch; don't auto-generate splat (wait until batch is complete)
+        return
+      }
     }
     try {
       generateOrganizationMediaSplat(event.organizationId, event.fileId)

--- a/src/main/kotlin/com/terraformation/backend/splat/SplatService.kt
+++ b/src/main/kotlin/com/terraformation/backend/splat/SplatService.kt
@@ -543,7 +543,7 @@ class SplatService(
       val batchType =
           dslContext.fetchValue(FILE_BATCHES.BATCH_TYPE_ID, FILE_BATCHES.ID.eq(event.fileBatchId))
               ?: throw FileBatchNotFoundException(event.fileBatchId)
-      if (batchType == FileBatchType.Splats) {
+      if (batchType == FileBatchType.Splat) {
         // Video was part of a splat batch; don't auto-generate splat (wait until batch is complete)
         return
       }

--- a/src/main/kotlin/com/terraformation/backend/splat/SplatService.kt
+++ b/src/main/kotlin/com/terraformation/backend/splat/SplatService.kt
@@ -8,7 +8,6 @@ import com.terraformation.backend.customer.model.requirePermissions
 import com.terraformation.backend.db.FileBatchNotFoundException
 import com.terraformation.backend.db.FileNotFoundException
 import com.terraformation.backend.db.default_schema.AssetStatus
-import com.terraformation.backend.db.default_schema.FileBatchType
 import com.terraformation.backend.db.default_schema.FileId
 import com.terraformation.backend.db.default_schema.OrganizationId
 import com.terraformation.backend.db.default_schema.tables.references.BIRDNET_RESULTS
@@ -540,14 +539,14 @@ class SplatService(
   @EventListener
   fun on(event: OrganizationVideoUploadedEvent) {
     if (event.fileBatchId != null) {
-      val batchType =
-          dslContext.fetchValue(FILE_BATCHES.BATCH_TYPE_ID, FILE_BATCHES.ID.eq(event.fileBatchId))
-              ?: throw FileBatchNotFoundException(event.fileBatchId)
-      if (batchType == FileBatchType.Splat) {
-        // Video was part of a splat batch; don't auto-generate splat (wait until batch is complete)
+      if (dslContext.fetchExists(FILE_BATCHES, FILE_BATCHES.ID.eq(event.fileBatchId))) {
+        // Video was part of a batch; don't auto-generate splat
         return
+      } else {
+        throw FileBatchNotFoundException(event.fileBatchId)
       }
     }
+
     try {
       generateOrganizationMediaSplat(event.organizationId, event.fileId)
     } catch (e: Exception) {

--- a/src/main/kotlin/com/terraformation/backend/splat/SplatService.kt
+++ b/src/main/kotlin/com/terraformation/backend/splat/SplatService.kt
@@ -536,6 +536,10 @@ class SplatService(
 
   @EventListener
   fun on(event: OrganizationVideoUploadedEvent) {
+    if (event.fileBatchId != null) {
+      // Video was part of a batch; don't auto-generate splat.
+      return
+    }
     try {
       generateOrganizationMediaSplat(event.organizationId, event.fileId)
     } catch (e: Exception) {

--- a/src/main/kotlin/com/terraformation/backend/tracking/ObservationService.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/ObservationService.kt
@@ -6,6 +6,7 @@ import com.terraformation.backend.customer.model.SystemUser
 import com.terraformation.backend.customer.model.requirePermissions
 import com.terraformation.backend.db.FileNotFoundException
 import com.terraformation.backend.db.asNonNullable
+import com.terraformation.backend.db.default_schema.FileBatchId
 import com.terraformation.backend.db.default_schema.FileId
 import com.terraformation.backend.db.default_schema.SpeciesId
 import com.terraformation.backend.db.tracking.MonitoringPlotId
@@ -247,6 +248,7 @@ class ObservationService(
       caption: String?,
       isOriginal: Boolean,
       type: ObservationMediaType = ObservationMediaType.Plot,
+      fileBatchId: FileBatchId? = null,
   ): FileId {
     requirePermissions { updateObservation(observationId) }
 
@@ -277,7 +279,8 @@ class ObservationService(
     }
 
     val fileId =
-        fileService.storeFile("observation", data, metadata) { (fileId, fullMetadata) ->
+        fileService.storeFile("observation", data, metadata, fileBatchId = fileBatchId) {
+            (fileId, fullMetadata) ->
           observationMediaFilesDao.insert(
               ObservationMediaFilesRow(
                   caption = caption,

--- a/src/main/kotlin/com/terraformation/backend/tracking/OrganizationMediaService.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/OrganizationMediaService.kt
@@ -7,6 +7,7 @@ import com.terraformation.backend.customer.event.OrganizationVideoUploadedEvent
 import com.terraformation.backend.customer.model.requirePermissions
 import com.terraformation.backend.db.FileNotFoundException
 import com.terraformation.backend.db.asNonNullable
+import com.terraformation.backend.db.default_schema.FileBatchId
 import com.terraformation.backend.db.default_schema.FileId
 import com.terraformation.backend.db.default_schema.OrganizationId
 import com.terraformation.backend.db.default_schema.tables.references.FILES
@@ -41,6 +42,7 @@ class OrganizationMediaService(
       organizationId: OrganizationId,
       file: MultipartFile,
       caption: String?,
+      fileBatchId: FileBatchId? = null,
   ): FileId {
     requirePermissions { createOrganizationMedia(organizationId) }
 
@@ -52,6 +54,7 @@ class OrganizationMediaService(
             "organizationMedia",
             file.inputStream,
             FileMetadata.of(contentType, filename, file.size),
+            fileBatchId = fileBatchId,
         ) { (fileId, _) ->
           dslContext
               .insertInto(ORGANIZATION_MEDIA_FILES)
@@ -64,7 +67,9 @@ class OrganizationMediaService(
     log.info("Stored media file $fileId for organization $organizationId")
 
     if (contentType.startsWith("video/")) {
-      eventPublisher.publishEvent(OrganizationVideoUploadedEvent(fileId, organizationId))
+      eventPublisher.publishEvent(
+          OrganizationVideoUploadedEvent(fileId, organizationId, fileBatchId)
+      )
     }
 
     return fileId

--- a/src/main/kotlin/com/terraformation/backend/tracking/api/ObservationsController.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/api/ObservationsController.kt
@@ -18,6 +18,7 @@ import com.terraformation.backend.api.getPlainContentType
 import com.terraformation.backend.api.gpxResponse
 import com.terraformation.backend.api.toResponseEntity
 import com.terraformation.backend.db.SRID
+import com.terraformation.backend.db.default_schema.FileBatchId
 import com.terraformation.backend.db.default_schema.FileId
 import com.terraformation.backend.db.default_schema.OrganizationId
 import com.terraformation.backend.db.default_schema.SpeciesId
@@ -574,6 +575,7 @@ class ObservationsController(
       @RequestPart("file") file: MultipartFile,
       @RequestPart("payload") payload: UploadPlotMediaRequestPayload?,
       @RequestParam caption: String?,
+      @RequestParam fileBatchId: FileBatchId?,
       @RequestParam position: ObservationPlotPosition?,
       @RequestParam type: ObservationMediaType?,
   ): UploadPlotMediaResponsePayload {
@@ -590,6 +592,7 @@ class ObservationsController(
             caption = payload?.caption ?: caption,
             isOriginal = false,
             type = payload?.type ?: type ?: ObservationMediaType.Plot,
+            fileBatchId = payload?.fileBatchId ?: fileBatchId,
         )
     return UploadPlotMediaResponsePayload(fileId)
   }
@@ -1068,6 +1071,7 @@ data class UploadPlotMediaRequestPayload(
     val position: ObservationPlotPosition?,
     @Schema(description = "Type of subject the uploaded file depicts.", defaultValue = "Plot")
     val type: ObservationMediaType?,
+    val fileBatchId: FileBatchId? = null,
 )
 
 data class UploadPlotPhotoRequestPayload(

--- a/src/main/kotlin/com/terraformation/backend/tracking/api/OrganizationMediaController.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/api/OrganizationMediaController.kt
@@ -9,6 +9,7 @@ import com.terraformation.backend.api.RequestBodyPhotoFile
 import com.terraformation.backend.api.SimpleSuccessResponsePayload
 import com.terraformation.backend.api.SuccessResponsePayload
 import com.terraformation.backend.api.toResponseEntity
+import com.terraformation.backend.db.default_schema.FileBatchId
 import com.terraformation.backend.db.default_schema.FileId
 import com.terraformation.backend.db.default_schema.OrganizationId
 import com.terraformation.backend.file.mux.MuxStreamModel
@@ -50,6 +51,7 @@ class OrganizationMediaController(
             organizationId = organizationId,
             file = file,
             caption = payload?.caption,
+            fileBatchId = payload?.fileBatchId,
         )
     return UploadOrganizationMediaResponsePayload(fileId)
   }
@@ -129,6 +131,7 @@ class OrganizationMediaController(
 
 data class UploadOrganizationMediaRequestPayload(
     val caption: String? = null,
+    val fileBatchId: FileBatchId? = null,
 )
 
 data class UploadOrganizationMediaResponsePayload(

--- a/src/test/kotlin/com/terraformation/backend/accelerator/ReportServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/ReportServiceTest.kt
@@ -104,9 +104,9 @@ class ReportServiceTest : DatabaseTest(), RunsAsDatabaseUser {
             financialSummaries = "financial summaries",
         )
 
-    every { fileService.storeFile(any(), any(), any(), any(), any()) } answers
+    every { fileService.storeFile(any(), any(), any(), any(), any(), any()) } answers
         {
-          val func = arg<((storedFile: FileService.StoredFile) -> Unit)?>(4)
+          val func = arg<((storedFile: FileService.StoredFile) -> Unit)?>(5)
           val fileId = insertFile()
           func?.let { it(FileService.StoredFile(fileId, arg(2))) }
           fileId
@@ -327,7 +327,9 @@ class ReportServiceTest : DatabaseTest(), RunsAsDatabaseUser {
               metadata = metadata,
               reportId = reportId,
           )
-      verify(exactly = 1) { fileService.storeFile(any(), inputStream, metadata, any(), any()) }
+      verify(exactly = 1) {
+        fileService.storeFile(any(), inputStream, metadata, any(), any(), any())
+      }
 
       assertTableEquals(
           listOf(

--- a/src/test/kotlin/com/terraformation/backend/db/DatabaseBackedTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/db/DatabaseBackedTest.kt
@@ -144,6 +144,7 @@ import com.terraformation.backend.db.default_schema.FacilityConnectionState
 import com.terraformation.backend.db.default_schema.FacilityId
 import com.terraformation.backend.db.default_schema.FacilityType
 import com.terraformation.backend.db.default_schema.FileBatchId
+import com.terraformation.backend.db.default_schema.FileBatchType
 import com.terraformation.backend.db.default_schema.FileId
 import com.terraformation.backend.db.default_schema.GlobalRole
 import com.terraformation.backend.db.default_schema.GriisResourceId
@@ -1920,12 +1921,14 @@ abstract class DatabaseBackedTest {
   fun insertFileBatch(
       row: FileBatchesRow = FileBatchesRow(),
       assetStatus: AssetStatus = row.assetStatusId ?: AssetStatus.Preparing,
+      batchType: FileBatchType = row.batchTypeId ?: FileBatchType.Splats,
       createdBy: UserId = row.createdBy ?: inserted.userId,
       createdTime: Instant = row.createdTime ?: Instant.EPOCH,
   ): FileBatchId {
     val rowWithDefaults =
         row.copy(
             assetStatusId = assetStatus,
+            batchTypeId = batchType,
             createdBy = createdBy,
             createdTime = createdTime,
         )

--- a/src/test/kotlin/com/terraformation/backend/db/DatabaseBackedTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/db/DatabaseBackedTest.kt
@@ -1919,11 +1919,13 @@ abstract class DatabaseBackedTest {
 
   fun insertFileBatch(
       row: FileBatchesRow = FileBatchesRow(),
+      assetStatus: AssetStatus = row.assetStatusId ?: AssetStatus.Preparing,
       createdBy: UserId = row.createdBy ?: inserted.userId,
       createdTime: Instant = row.createdTime ?: Instant.EPOCH,
   ): FileBatchId {
     val rowWithDefaults =
         row.copy(
+            assetStatusId = assetStatus,
             createdBy = createdBy,
             createdTime = createdTime,
         )

--- a/src/test/kotlin/com/terraformation/backend/db/DatabaseBackedTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/db/DatabaseBackedTest.kt
@@ -144,6 +144,7 @@ import com.terraformation.backend.db.default_schema.FacilityConnectionState
 import com.terraformation.backend.db.default_schema.FacilityId
 import com.terraformation.backend.db.default_schema.FacilityType
 import com.terraformation.backend.db.default_schema.FileBatchId
+import com.terraformation.backend.db.default_schema.FileBatchStatus
 import com.terraformation.backend.db.default_schema.FileBatchType
 import com.terraformation.backend.db.default_schema.FileId
 import com.terraformation.backend.db.default_schema.GlobalRole
@@ -1920,14 +1921,14 @@ abstract class DatabaseBackedTest {
 
   fun insertFileBatch(
       row: FileBatchesRow = FileBatchesRow(),
-      assetStatus: AssetStatus = row.assetStatusId ?: AssetStatus.Preparing,
-      batchType: FileBatchType = row.batchTypeId ?: FileBatchType.Splats,
+      batchStatus: FileBatchStatus = row.batchStatusId ?: FileBatchStatus.Uploading,
+      batchType: FileBatchType = row.batchTypeId ?: FileBatchType.Splat,
       createdBy: UserId = row.createdBy ?: inserted.userId,
       createdTime: Instant = row.createdTime ?: Instant.EPOCH,
   ): FileBatchId {
     val rowWithDefaults =
         row.copy(
-            assetStatusId = assetStatus,
+            batchStatusId = batchStatus,
             batchTypeId = batchType,
             createdBy = createdBy,
             createdTime = createdTime,

--- a/src/test/kotlin/com/terraformation/backend/db/DatabaseBackedTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/db/DatabaseBackedTest.kt
@@ -143,6 +143,7 @@ import com.terraformation.backend.db.default_schema.ExternalDatasetType
 import com.terraformation.backend.db.default_schema.FacilityConnectionState
 import com.terraformation.backend.db.default_schema.FacilityId
 import com.terraformation.backend.db.default_schema.FacilityType
+import com.terraformation.backend.db.default_schema.FileBatchId
 import com.terraformation.backend.db.default_schema.FileId
 import com.terraformation.backend.db.default_schema.GlobalRole
 import com.terraformation.backend.db.default_schema.GriisResourceId
@@ -185,6 +186,7 @@ import com.terraformation.backend.db.default_schema.tables.daos.DeviceTemplatesD
 import com.terraformation.backend.db.default_schema.tables.daos.DevicesDao
 import com.terraformation.backend.db.default_schema.tables.daos.DisclaimersDao
 import com.terraformation.backend.db.default_schema.tables.daos.FacilitiesDao
+import com.terraformation.backend.db.default_schema.tables.daos.FileBatchesDao
 import com.terraformation.backend.db.default_schema.tables.daos.FilesDao
 import com.terraformation.backend.db.default_schema.tables.daos.IdentifierSequencesDao
 import com.terraformation.backend.db.default_schema.tables.daos.InternalTagsDao
@@ -223,6 +225,7 @@ import com.terraformation.backend.db.default_schema.tables.pojos.BirdnetResultsR
 import com.terraformation.backend.db.default_schema.tables.pojos.DeviceManagersRow
 import com.terraformation.backend.db.default_schema.tables.pojos.DisclaimersRow
 import com.terraformation.backend.db.default_schema.tables.pojos.FacilitiesRow
+import com.terraformation.backend.db.default_schema.tables.pojos.FileBatchesRow
 import com.terraformation.backend.db.default_schema.tables.pojos.FilesRow
 import com.terraformation.backend.db.default_schema.tables.pojos.InternalTagsRow
 import com.terraformation.backend.db.default_schema.tables.pojos.OrganizationInternalTagsRow
@@ -726,6 +729,7 @@ abstract class DatabaseBackedTest {
   protected val eventProjectsDao: EventProjectsDao by lazyDao()
   protected val eventsDao: EventsDao by lazyDao()
   protected val facilitiesDao: FacilitiesDao by lazyDao()
+  protected val fileBatchesDao: FileBatchesDao by lazyDao()
   protected val filesDao: FilesDao by lazyDao()
   protected val fundingEntitiesDao: FundingEntitiesDao by lazyDao()
   protected val fundingEntityProjectsDao: FundingEntityProjectsDao by lazyDao()
@@ -1887,6 +1891,7 @@ abstract class DatabaseBackedTest {
       capturedLocalTime: LocalDateTime? = row.capturedLocalTime,
       createdBy: UserId = row.createdBy ?: inserted.userId,
       createdTime: Instant = row.createdTime ?: Instant.EPOCH,
+      fileBatchId: FileBatchId? = row.fileBatchId,
       geolocation: Point? = row.geolocation?.centroid,
       modifiedBy: UserId = row.modifiedBy ?: createdBy,
       modifiedTime: Instant = row.modifiedTime ?: createdTime,
@@ -1898,6 +1903,7 @@ abstract class DatabaseBackedTest {
             contentType = contentType,
             createdBy = createdBy,
             createdTime = createdTime,
+            fileBatchId = fileBatchId,
             fileName = fileName,
             geolocation = geolocation,
             modifiedBy = modifiedBy,
@@ -1909,6 +1915,22 @@ abstract class DatabaseBackedTest {
     filesDao.insert(rowWithDefaults)
 
     return rowWithDefaults.id!!.also { inserted.fileIds.add(it) }
+  }
+
+  fun insertFileBatch(
+      row: FileBatchesRow = FileBatchesRow(),
+      createdBy: UserId = row.createdBy ?: inserted.userId,
+      createdTime: Instant = row.createdTime ?: Instant.EPOCH,
+  ): FileBatchId {
+    val rowWithDefaults =
+        row.copy(
+            createdBy = createdBy,
+            createdTime = createdTime,
+        )
+
+    fileBatchesDao.insert(rowWithDefaults)
+
+    return rowWithDefaults.id!!.also { inserted.fileBatchIds.add(it) }
   }
 
   private var nextUploadNumber = 1

--- a/src/test/kotlin/com/terraformation/backend/db/InsertedDatabaseIds.kt
+++ b/src/test/kotlin/com/terraformation/backend/db/InsertedDatabaseIds.kt
@@ -18,6 +18,7 @@ import com.terraformation.backend.db.default_schema.AutomationId
 import com.terraformation.backend.db.default_schema.DeviceId
 import com.terraformation.backend.db.default_schema.DisclaimerId
 import com.terraformation.backend.db.default_schema.FacilityId
+import com.terraformation.backend.db.default_schema.FileBatchId
 import com.terraformation.backend.db.default_schema.FileId
 import com.terraformation.backend.db.default_schema.GriisResourceId
 import com.terraformation.backend.db.default_schema.InternalTagId
@@ -84,6 +85,7 @@ class InsertedDatabaseIds {
   val draftPlantingSiteIds = mutableListOf<DraftPlantingSiteId>()
   val eventIds = mutableListOf<EventId>()
   val facilityIds = mutableListOf<FacilityId>()
+  val fileBatchIds = mutableListOf<FileBatchId>()
   val fileIds = mutableListOf<FileId>()
   val fundingEntityIds = mutableListOf<FundingEntityId>()
   val griisResourceIds = mutableListOf<GriisResourceId>()
@@ -193,6 +195,9 @@ class InsertedDatabaseIds {
 
   val facilityId
     get() = facilityIds.last()
+
+  val fileBatchId
+    get() = fileBatchIds.last()
 
   val fileId
     get() = fileIds.last()

--- a/src/test/kotlin/com/terraformation/backend/file/FileServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/file/FileServiceTest.kt
@@ -12,8 +12,10 @@ import com.terraformation.backend.config.TerrawareServerConfig
 import com.terraformation.backend.customer.model.TerrawareUser
 import com.terraformation.backend.daily.DailyTaskTimeArrivedEvent
 import com.terraformation.backend.db.DatabaseTest
+import com.terraformation.backend.db.FileBatchNotFoundException
 import com.terraformation.backend.db.FileNotFoundException
 import com.terraformation.backend.db.TokenNotFoundException
+import com.terraformation.backend.db.default_schema.FileBatchId
 import com.terraformation.backend.db.default_schema.FileBatchStatus
 import com.terraformation.backend.db.default_schema.FileBatchType
 import com.terraformation.backend.db.default_schema.FileId
@@ -349,6 +351,18 @@ class FileServiceTest : DatabaseTest(), RunsAsUser {
           ) {}
 
       assertEquals(fileBatchId, filesDao.fetchOneById(fileId)!!.fileBatchId, "File Batch ID")
+    }
+
+    @Test
+    fun `throws exception if file batch ID is invalid`() {
+      assertThrows<FileBatchNotFoundException> {
+        fileService.storeFile(
+            "category",
+            Random.nextBytes(10).inputStream(),
+            metadata,
+            fileBatchId = FileBatchId(-1),
+        ) {}
+      }
     }
   }
 

--- a/src/test/kotlin/com/terraformation/backend/file/FileServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/file/FileServiceTest.kt
@@ -334,6 +334,22 @@ class FileServiceTest : DatabaseTest(), RunsAsUser {
         fileService.storeFile("category", ByteArray(0).inputStream(), metadata) {}
       }
     }
+
+    @Test
+    fun `stores file batch ID when provided`() {
+      val fileBatchId = insertFileBatch()
+      val data = Random.nextBytes(10)
+
+      val fileId =
+          fileService.storeFile(
+              "category",
+              data.inputStream(),
+              metadata.copy(size = data.size.toLong()),
+              fileBatchId = fileBatchId,
+          ) {}
+
+      assertEquals(fileBatchId, filesDao.fetchOneById(fileId)!!.fileBatchId, "File Batch ID")
+    }
   }
 
   @Test

--- a/src/test/kotlin/com/terraformation/backend/splat/SplatServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/splat/SplatServiceTest.kt
@@ -1908,7 +1908,7 @@ class SplatServiceTest : DatabaseTest(), RunsAsDatabaseUser {
 
     @Test
     fun `does not generate splat when upload is part of a file batch`() {
-      val fileBatchId = insertFileBatch(batchType = FileBatchType.Splats)
+      val fileBatchId = insertFileBatch(batchType = FileBatchType.Splat)
       service.on(OrganizationVideoUploadedEvent(orgFileId, organizationId, fileBatchId))
 
       assertTableEmpty(SPLATS)

--- a/src/test/kotlin/com/terraformation/backend/splat/SplatServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/splat/SplatServiceTest.kt
@@ -1904,5 +1904,14 @@ class SplatServiceTest : DatabaseTest(), RunsAsDatabaseUser {
 
       assertTableEmpty(SPLATS)
     }
+
+    @Test
+    fun `does not generate splat when upload is part of a file batch`() {
+      val fileBatchId = insertFileBatch()
+      service.on(OrganizationVideoUploadedEvent(orgFileId, organizationId, fileBatchId))
+
+      assertTableEmpty(SPLATS)
+      verify(exactly = 0) { sqsTemplate.send(any<String>(), any<SplatterRequestMessage>()) }
+    }
   }
 }

--- a/src/test/kotlin/com/terraformation/backend/splat/SplatServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/splat/SplatServiceTest.kt
@@ -11,6 +11,7 @@ import com.terraformation.backend.db.DatabaseTest
 import com.terraformation.backend.db.FileNotFoundException
 import com.terraformation.backend.db.OrganizationNotFoundException
 import com.terraformation.backend.db.default_schema.AssetStatus
+import com.terraformation.backend.db.default_schema.FileBatchType
 import com.terraformation.backend.db.default_schema.FileId
 import com.terraformation.backend.db.default_schema.OrganizationId
 import com.terraformation.backend.db.default_schema.Role
@@ -1907,7 +1908,7 @@ class SplatServiceTest : DatabaseTest(), RunsAsDatabaseUser {
 
     @Test
     fun `does not generate splat when upload is part of a file batch`() {
-      val fileBatchId = insertFileBatch()
+      val fileBatchId = insertFileBatch(batchType = FileBatchType.Splats)
       service.on(OrganizationVideoUploadedEvent(orgFileId, organizationId, fileBatchId))
 
       assertTableEmpty(SPLATS)

--- a/src/test/kotlin/com/terraformation/backend/tracking/ObservationServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/ObservationServiceTest.kt
@@ -949,6 +949,25 @@ class ObservationServiceTest : DatabaseTest(), RunsAsDatabaseUser {
       }
 
       @Test
+      fun `stores file batch ID on the file row`() {
+        val fileBatchId = insertFileBatch()
+
+        val fileId =
+            service.storeMediaFile(
+                observationId = observationId,
+                monitoringPlotId = plotId,
+                position = null,
+                data = byteArrayOf(1).inputStream(),
+                metadata = metadata,
+                caption = "caption",
+                isOriginal = false,
+                fileBatchId = fileBatchId,
+            )
+
+        assertEquals(fileBatchId, filesDao.fetchOneById(fileId)!!.fileBatchId, "File Batch ID")
+      }
+
+      @Test
       fun `throws exception for missing photo position for Quadrat photos`() {
         assertThrows<IllegalArgumentException> {
           service.storeMediaFile(

--- a/src/test/kotlin/com/terraformation/backend/tracking/OrganizationMediaServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/OrganizationMediaServiceTest.kt
@@ -106,6 +106,19 @@ internal class OrganizationMediaServiceTest : DatabaseTest(), RunsAsUser {
 
       eventPublisher.assertEventNotPublished<OrganizationVideoUploadedEvent>()
     }
+
+    @Test
+    fun `stores file batch ID on the file row and includes on batch ID on the event`() {
+      val fileBatchId = insertFileBatch()
+      val multipartFile = MockMultipartFile("file", "video/mp4", "video/mp4", ByteArray(1024))
+
+      val fileId = service.upload(organizationId, multipartFile, "caption", fileBatchId)
+
+      assertEquals(fileBatchId, filesDao.fetchOneById(fileId)!!.fileBatchId)
+      eventPublisher.assertEventPublished(
+          OrganizationVideoUploadedEvent(fileId, organizationId, fileBatchId)
+      )
+    }
   }
 
   @Nested

--- a/src/test/kotlin/com/terraformation/backend/tracking/OrganizationMediaServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/OrganizationMediaServiceTest.kt
@@ -108,7 +108,7 @@ internal class OrganizationMediaServiceTest : DatabaseTest(), RunsAsUser {
     }
 
     @Test
-    fun `stores file batch ID on the file row and includes on batch ID on the event`() {
+    fun `stores file batch ID on the file row and includes batch ID on the event`() {
       val fileBatchId = insertFileBatch()
       val multipartFile = MockMultipartFile("file", "video/mp4", "video/mp4", ByteArray(1024))
 


### PR DESCRIPTION
Add optional `fileBatchId` param to upload file endpoints for Organization Media and Observation Media. Throws `FileBatchNotFoundException` if batch doesn't exist.

If batch id is specified and batch is of type "Splat", don't autogenerate a splat when an organization video is uploaded. The next PR includes the ability to finish a batch upload.

Co-authored-by: Claude Opus 4.8 [noreply@anthropic.com](mailto:noreply@anthropic.com)