### PR TITLE
Add endpoint to finish a file batch upload

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/customer/db/ParentStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/db/ParentStore.kt
@@ -27,6 +27,7 @@ import com.terraformation.backend.db.default_schema.DeviceManagerId
 import com.terraformation.backend.db.default_schema.FacilityConnectionState
 import com.terraformation.backend.db.default_schema.FacilityId
 import com.terraformation.backend.db.default_schema.FacilityType
+import com.terraformation.backend.db.default_schema.FileBatchId
 import com.terraformation.backend.db.default_schema.NotificationId
 import com.terraformation.backend.db.default_schema.OrganizationId
 import com.terraformation.backend.db.default_schema.ProjectId
@@ -39,6 +40,7 @@ import com.terraformation.backend.db.default_schema.tables.references.AUTOMATION
 import com.terraformation.backend.db.default_schema.tables.references.DEVICES
 import com.terraformation.backend.db.default_schema.tables.references.DEVICE_MANAGERS
 import com.terraformation.backend.db.default_schema.tables.references.FACILITIES
+import com.terraformation.backend.db.default_schema.tables.references.FILE_BATCHES
 import com.terraformation.backend.db.default_schema.tables.references.NOTIFICATIONS
 import com.terraformation.backend.db.default_schema.tables.references.ORGANIZATION_USERS
 import com.terraformation.backend.db.default_schema.tables.references.PROJECTS
@@ -407,6 +409,9 @@ class ParentStore(private val dslContext: DSLContext) {
 
   fun getUserId(draftPlantingSiteId: DraftPlantingSiteId): UserId? =
       fetchFieldById(draftPlantingSiteId, DRAFT_PLANTING_SITES.ID, DRAFT_PLANTING_SITES.CREATED_BY)
+
+  fun getUserId(fileBatchId: FileBatchId): UserId? =
+      fetchFieldById(fileBatchId, FILE_BATCHES.ID, FILE_BATCHES.CREATED_BY)
 
   fun getUserId(notificationId: NotificationId): UserId? =
       fetchFieldById(notificationId, NOTIFICATIONS.ID, NOTIFICATIONS.USER_ID)

--- a/src/main/kotlin/com/terraformation/backend/customer/model/IndividualUser.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/IndividualUser.kt
@@ -17,6 +17,7 @@ import com.terraformation.backend.db.default_schema.AutomationId
 import com.terraformation.backend.db.default_schema.DeviceId
 import com.terraformation.backend.db.default_schema.DeviceManagerId
 import com.terraformation.backend.db.default_schema.FacilityId
+import com.terraformation.backend.db.default_schema.FileBatchId
 import com.terraformation.backend.db.default_schema.GlobalRole
 import com.terraformation.backend.db.default_schema.NotificationId
 import com.terraformation.backend.db.default_schema.OrganizationId
@@ -272,6 +273,9 @@ data class IndividualUser(
   override fun canDeleteUpload(uploadId: UploadId) = canReadUpload(uploadId)
 
   override fun canDeleteUsers(): Boolean = isSuperAdmin()
+
+  override fun canFinishUploadingFileBatch(fileBatchId: FileBatchId): Boolean =
+      parentStore.getUserId(fileBatchId) == userId || isSuperAdmin()
 
   override fun canImportGlobalSpeciesData() = isSuperAdmin()
 

--- a/src/main/kotlin/com/terraformation/backend/customer/model/PermissionRequirements.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/PermissionRequirements.kt
@@ -13,6 +13,7 @@ import com.terraformation.backend.db.DeviceNotFoundException
 import com.terraformation.backend.db.EntityNotFoundException
 import com.terraformation.backend.db.EventNotFoundException
 import com.terraformation.backend.db.FacilityNotFoundException
+import com.terraformation.backend.db.FileBatchNotFoundException
 import com.terraformation.backend.db.NotificationNotFoundException
 import com.terraformation.backend.db.OrganizationNotFoundException
 import com.terraformation.backend.db.ProjectNotFoundException
@@ -614,7 +615,7 @@ class PermissionRequirements(private val user: TerrawareUser) {
   fun finishUploadingFileBatch(fileBatchId: FileBatchId) {
     user.recordPermissionChecks {
       if (!user.canFinishUploadingFileBatch(fileBatchId)) {
-        throw AccessDeniedException("No permission to finish uploading file batch $fileBatchId")
+        throw FileBatchNotFoundException(fileBatchId)
       }
     }
   }

--- a/src/main/kotlin/com/terraformation/backend/customer/model/PermissionRequirements.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/PermissionRequirements.kt
@@ -37,6 +37,7 @@ import com.terraformation.backend.db.default_schema.AutomationId
 import com.terraformation.backend.db.default_schema.DeviceId
 import com.terraformation.backend.db.default_schema.DeviceManagerId
 import com.terraformation.backend.db.default_schema.FacilityId
+import com.terraformation.backend.db.default_schema.FileBatchId
 import com.terraformation.backend.db.default_schema.GlobalRole
 import com.terraformation.backend.db.default_schema.NotificationId
 import com.terraformation.backend.db.default_schema.OrganizationId
@@ -606,6 +607,14 @@ class PermissionRequirements(private val user: TerrawareUser) {
     user.recordPermissionChecks {
       if (!user.canDeleteUsers()) {
         throw AccessDeniedException("No permission to delete users")
+      }
+    }
+  }
+
+  fun finishUploadingFileBatch(fileBatchId: FileBatchId) {
+    user.recordPermissionChecks {
+      if (!user.canFinishUploadingFileBatch(fileBatchId)) {
+        throw AccessDeniedException("No permission to finish uploading file batch $fileBatchId")
       }
     }
   }

--- a/src/main/kotlin/com/terraformation/backend/customer/model/TerrawareUser.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/TerrawareUser.kt
@@ -15,6 +15,7 @@ import com.terraformation.backend.db.default_schema.AutomationId
 import com.terraformation.backend.db.default_schema.DeviceId
 import com.terraformation.backend.db.default_schema.DeviceManagerId
 import com.terraformation.backend.db.default_schema.FacilityId
+import com.terraformation.backend.db.default_schema.FileBatchId
 import com.terraformation.backend.db.default_schema.GlobalRole
 import com.terraformation.backend.db.default_schema.NotificationId
 import com.terraformation.backend.db.default_schema.OrganizationId
@@ -328,6 +329,8 @@ interface TerrawareUser : Principal, UserDetails {
   fun canDeleteUpload(uploadId: UploadId): Boolean = defaultPermission
 
   fun canDeleteUsers(): Boolean = defaultPermission
+
+  fun canFinishUploadingFileBatch(fileBatchId: FileBatchId): Boolean = defaultPermission
 
   fun canImportGlobalSpeciesData(): Boolean = defaultPermission
 

--- a/src/main/kotlin/com/terraformation/backend/file/FileService.kt
+++ b/src/main/kotlin/com/terraformation/backend/file/FileService.kt
@@ -224,15 +224,15 @@ class FileService(
   }
 
   /**
-   * Marks a file batch as finished uploading. This sets the batch's asset status to
-   * [AssetStatus.Ready] and publishes a [FileBatchFinishedUploadingEvent].
+   * Marks a file batch as finished uploading. This sets the batch's asset status
+   * to[FileBatchStatus.UploadComplete] and publishes a [FileBatchFinishedUploadingEvent].
    */
   fun finishUploadingFileBatch(fileBatchId: FileBatchId) {
     val rowsUpdated =
         with(FILE_BATCHES) {
           dslContext
               .update(FILE_BATCHES)
-              .set(ASSET_STATUS_ID, AssetStatus.Ready)
+              .set(BATCH_STATUS_ID, FileBatchStatus.UploadComplete)
               .where(ID.eq(fileBatchId))
               .execute()
         }

--- a/src/main/kotlin/com/terraformation/backend/file/FileService.kt
+++ b/src/main/kotlin/com/terraformation/backend/file/FileService.kt
@@ -5,6 +5,7 @@ import com.drew.imaging.FileTypeDetector
 import com.drew.imaging.ImageMetadataReader
 import com.drew.metadata.Metadata
 import com.terraformation.backend.auth.currentUser
+import com.terraformation.backend.customer.model.requirePermissions
 import com.terraformation.backend.daily.DailyTaskTimeArrivedEvent
 import com.terraformation.backend.db.DefaultCatalog
 import com.terraformation.backend.db.FileBatchNotFoundException
@@ -224,10 +225,12 @@ class FileService(
   }
 
   /**
-   * Marks a file batch as finished uploading. This sets the batch's asset status
-   * to[FileBatchStatus.UploadComplete] and publishes a [FileBatchFinishedUploadingEvent].
+   * Marks a file batch as finished uploading. This sets the batch's asset status to
+   * [FileBatchStatus.UploadComplete] and publishes a [FileBatchFinishedUploadingEvent].
    */
   fun finishUploadingFileBatch(fileBatchId: FileBatchId) {
+    requirePermissions { finishUploadingFileBatch(fileBatchId) }
+
     val rowsUpdated =
         with(FILE_BATCHES) {
           dslContext

--- a/src/main/kotlin/com/terraformation/backend/file/FileService.kt
+++ b/src/main/kotlin/com/terraformation/backend/file/FileService.kt
@@ -22,6 +22,7 @@ import com.terraformation.backend.db.default_schema.tables.references.FILE_BATCH
 import com.terraformation.backend.db.default_schema.tables.references.MUX_ASSETS
 import com.terraformation.backend.db.default_schema.tables.references.SPLATS
 import com.terraformation.backend.db.default_schema.tables.references.THUMBNAILS
+import com.terraformation.backend.file.event.FileBatchFinishedUploadingEvent
 import com.terraformation.backend.file.event.FileDeletionStartedEvent
 import com.terraformation.backend.file.event.FileReferenceDeletedEvent
 import com.terraformation.backend.file.event.VideoFileUploadedEvent
@@ -220,6 +221,27 @@ class FileService(
           .returning(ID)
           .fetchOne(ID)!!
     }
+  }
+
+  /**
+   * Marks a file batch as finished uploading. This sets the batch's asset status to
+   * [AssetStatus.Ready] and publishes a [FileBatchFinishedUploadingEvent].
+   */
+  fun finishUploadingFileBatch(fileBatchId: FileBatchId) {
+    val rowsUpdated =
+        with(FILE_BATCHES) {
+          dslContext
+              .update(FILE_BATCHES)
+              .set(ASSET_STATUS_ID, AssetStatus.Ready)
+              .where(ID.eq(fileBatchId))
+              .execute()
+        }
+
+    if (rowsUpdated != 1) {
+      throw FileBatchNotFoundException(fileBatchId)
+    }
+
+    eventPublisher.publishEvent(FileBatchFinishedUploadingEvent(fileBatchId))
   }
 
   @Throws(IOException::class)

--- a/src/main/kotlin/com/terraformation/backend/file/api/FilesController.kt
+++ b/src/main/kotlin/com/terraformation/backend/file/api/FilesController.kt
@@ -2,6 +2,7 @@ package com.terraformation.backend.file.api
 
 import com.terraformation.backend.api.ApiResponse200
 import com.terraformation.backend.api.InternalEndpoint
+import com.terraformation.backend.api.SimpleSuccessResponsePayload
 import com.terraformation.backend.api.SuccessResponsePayload
 import com.terraformation.backend.api.toResponseEntity
 import com.terraformation.backend.db.default_schema.FileBatchId
@@ -38,6 +39,21 @@ class FilesController(
   ): CreateFileBatchResponsePayload {
     val fileBatchId = fileService.createFileBatch(payload.type)
     return CreateFileBatchResponsePayload(fileBatchId)
+  }
+
+  @ApiResponse200
+  @Operation(
+      summary = "Marks a file batch as finished uploading.",
+      description =
+          "Indicates that all the files in the batch have been uploaded and the batch is ready to " +
+              "be processed.",
+  )
+  @PostMapping("/batches/{fileBatchId}/finish")
+  fun finishUploadingFileBatch(
+      @PathVariable fileBatchId: FileBatchId
+  ): SimpleSuccessResponsePayload {
+    fileService.finishUploadingFileBatch(fileBatchId)
+    return SimpleSuccessResponsePayload()
   }
 
   // If you change this path, update the path in MuxService too.

--- a/src/main/kotlin/com/terraformation/backend/file/event/FileBatchFinishedUploadingEvent.kt
+++ b/src/main/kotlin/com/terraformation/backend/file/event/FileBatchFinishedUploadingEvent.kt
@@ -1,0 +1,5 @@
+package com.terraformation.backend.file.event
+
+import com.terraformation.backend.db.default_schema.FileBatchId
+
+data class FileBatchFinishedUploadingEvent(val fileBatchId: FileBatchId)

--- a/src/test/kotlin/com/terraformation/backend/customer/model/PermissionRequirementsTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/model/PermissionRequirementsTest.kt
@@ -35,6 +35,7 @@ import com.terraformation.backend.db.default_schema.AutomationId
 import com.terraformation.backend.db.default_schema.DeviceId
 import com.terraformation.backend.db.default_schema.DeviceManagerId
 import com.terraformation.backend.db.default_schema.FacilityId
+import com.terraformation.backend.db.default_schema.FileBatchId
 import com.terraformation.backend.db.default_schema.NotificationId
 import com.terraformation.backend.db.default_schema.OrganizationId
 import com.terraformation.backend.db.default_schema.ProjectId
@@ -142,6 +143,7 @@ internal class PermissionRequirementsTest : RunsAsUser {
       readableId(EventNotFoundException::class) { canReadModuleEvent(it) }
   private val facilityId: FacilityId by
       readableId(FacilityNotFoundException::class) { canReadFacility(it) }
+  private val fileBatchId = FileBatchId(1)
   private val funderId: UserId by readableId(AccessDeniedException::class) { canReadUser(it) }
   private val fundingEntityId: FundingEntityId by
       readableId(FundingEntityNotFoundException::class) { canReadFundingEntity(it) }
@@ -513,6 +515,13 @@ internal class PermissionRequirementsTest : RunsAsUser {
   @Test fun deleteUpload() = allow { deleteUpload(uploadId) } ifUser { canDeleteUpload(uploadId) }
 
   @Test fun deleteUsers() = allow { deleteUsers() } ifUser { canDeleteUsers() }
+
+  @Test
+  fun finishUploadingFileBatch() =
+      allow { finishUploadingFileBatch(fileBatchId) } ifUser
+          {
+            canFinishUploadingFileBatch(fileBatchId)
+          }
 
   @Test
   fun importGlobalSpeciesData() =

--- a/src/test/kotlin/com/terraformation/backend/customer/model/PermissionRequirementsTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/model/PermissionRequirementsTest.kt
@@ -13,6 +13,7 @@ import com.terraformation.backend.db.DeviceNotFoundException
 import com.terraformation.backend.db.EntityNotFoundException
 import com.terraformation.backend.db.EventNotFoundException
 import com.terraformation.backend.db.FacilityNotFoundException
+import com.terraformation.backend.db.FileBatchNotFoundException
 import com.terraformation.backend.db.NotificationNotFoundException
 import com.terraformation.backend.db.OrganizationNotFoundException
 import com.terraformation.backend.db.ProjectNotFoundException
@@ -143,7 +144,8 @@ internal class PermissionRequirementsTest : RunsAsUser {
       readableId(EventNotFoundException::class) { canReadModuleEvent(it) }
   private val facilityId: FacilityId by
       readableId(FacilityNotFoundException::class) { canReadFacility(it) }
-  private val fileBatchId = FileBatchId(1)
+  private val fileBatchId: FileBatchId by
+      readableId(FileBatchNotFoundException::class) { canFinishUploadingFileBatch(it) }
   private val funderId: UserId by readableId(AccessDeniedException::class) { canReadUser(it) }
   private val fundingEntityId: FundingEntityId by
       readableId(FundingEntityNotFoundException::class) { canReadFundingEntity(it) }
@@ -516,12 +518,11 @@ internal class PermissionRequirementsTest : RunsAsUser {
 
   @Test fun deleteUsers() = allow { deleteUsers() } ifUser { canDeleteUsers() }
 
-  @Test
-  fun finishUploadingFileBatch() =
-      allow { finishUploadingFileBatch(fileBatchId) } ifUser
-          {
-            canFinishUploadingFileBatch(fileBatchId)
-          }
+  @Test fun finishUploadingFileBatch() = testRead { finishUploadingFileBatch(fileBatchId) }
+
+  //          {
+  //            canFinishUploadingFileBatch(fileBatchId)
+  //          }
 
   @Test
   fun importGlobalSpeciesData() =

--- a/src/test/kotlin/com/terraformation/backend/customer/model/PermissionTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/model/PermissionTest.kt
@@ -3086,6 +3086,28 @@ internal class PermissionTest : DatabaseTest() {
   }
 
   @Test
+  fun `user can finish uploading their own file batch`() {
+    val fileBatchId = insertFileBatch(createdBy = userId)
+
+    assertTrue(user.canFinishUploadingFileBatch(fileBatchId), "Can finish uploading file batch")
+  }
+
+  @Test
+  fun `user cannot finish uploading file batch of other users`() {
+    val fileBatchId = insertFileBatch(createdBy = sameOrgUserId)
+
+    assertFalse(user.canFinishUploadingFileBatch(fileBatchId), "Can finish uploading file batch")
+  }
+
+  @Test
+  fun `super admin can finish uploading file batch of other users`() {
+    insertUserGlobalRole(userId, GlobalRole.SuperAdmin)
+    val fileBatchId = insertFileBatch(createdBy = sameOrgUserId)
+
+    assertTrue(user.canFinishUploadingFileBatch(fileBatchId), "Can finish uploading file batch")
+  }
+
+  @Test
   fun `admin user can read but not write draft planting sites of other users in same org`() {
     val otherUserDraftSiteId =
         insertDraftPlantingSite(createdBy = sameOrgUserId, organizationId = getDatabaseId(org1Id))

--- a/src/test/kotlin/com/terraformation/backend/file/FileServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/file/FileServiceTest.kt
@@ -62,6 +62,7 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.springframework.dao.DuplicateKeyException
 import org.springframework.http.MediaType
+import org.springframework.security.access.AccessDeniedException
 
 class FileServiceTest : DatabaseTest(), RunsAsUser {
   private val clock = TestClock()
@@ -498,20 +499,36 @@ class FileServiceTest : DatabaseTest(), RunsAsUser {
     @Test
     fun `sets batch status to Upload Complete and publishes event`() {
       val fileBatchId = insertFileBatch()
+      every { user.canFinishUploadingFileBatch(fileBatchId) } returns true
 
       fileService.finishUploadingFileBatch(fileBatchId)
 
       assertEquals(
           FileBatchStatus.UploadComplete,
           fileBatchesDao.fetchOneById(fileBatchId)!!.batchStatusId,
-          "Batch status",
+          "Batch status should complete",
       )
       eventPublisher.assertEventPublished(FileBatchFinishedUploadingEvent(fileBatchId))
     }
 
     @Test
+    fun `throws exception if no permission to finish uploading file batch`() {
+      val fileBatchId = insertFileBatch()
+      every { user.canFinishUploadingFileBatch(fileBatchId) } returns false
+
+      assertThrows<AccessDeniedException> { fileService.finishUploadingFileBatch(fileBatchId) }
+
+      assertEquals(
+          FileBatchStatus.Uploading,
+          fileBatchesDao.fetchOneById(fileBatchId)!!.batchStatusId,
+          "Batch status should stay uploading",
+      )
+      eventPublisher.assertEventNotPublished<FileBatchFinishedUploadingEvent>()
+    }
+
+    @Test
     fun `throws exception if file batch does not exist`() {
-      assertThrows<FileBatchNotFoundException> {
+      assertThrows<AccessDeniedException> {
         fileService.finishUploadingFileBatch(FileBatchId(-1))
       }
     }

--- a/src/test/kotlin/com/terraformation/backend/file/FileServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/file/FileServiceTest.kt
@@ -62,7 +62,6 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.springframework.dao.DuplicateKeyException
 import org.springframework.http.MediaType
-import org.springframework.security.access.AccessDeniedException
 
 class FileServiceTest : DatabaseTest(), RunsAsUser {
   private val clock = TestClock()
@@ -516,7 +515,7 @@ class FileServiceTest : DatabaseTest(), RunsAsUser {
       val fileBatchId = insertFileBatch()
       every { user.canFinishUploadingFileBatch(fileBatchId) } returns false
 
-      assertThrows<AccessDeniedException> { fileService.finishUploadingFileBatch(fileBatchId) }
+      assertThrows<FileBatchNotFoundException> { fileService.finishUploadingFileBatch(fileBatchId) }
 
       assertEquals(
           FileBatchStatus.Uploading,
@@ -528,7 +527,7 @@ class FileServiceTest : DatabaseTest(), RunsAsUser {
 
     @Test
     fun `throws exception if file batch does not exist`() {
-      assertThrows<AccessDeniedException> {
+      assertThrows<FileBatchNotFoundException> {
         fileService.finishUploadingFileBatch(FileBatchId(-1))
       }
     }

--- a/src/test/kotlin/com/terraformation/backend/file/FileServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/file/FileServiceTest.kt
@@ -25,6 +25,7 @@ import com.terraformation.backend.db.default_schema.tables.records.FileBatchesRe
 import com.terraformation.backend.db.default_schema.tables.records.FilesRecord
 import com.terraformation.backend.db.default_schema.tables.references.FILES
 import com.terraformation.backend.db.default_schema.tables.references.FILE_ACCESS_TOKENS
+import com.terraformation.backend.file.event.FileBatchFinishedUploadingEvent
 import com.terraformation.backend.file.event.FileDeletionStartedEvent
 import com.terraformation.backend.file.event.FileReferenceDeletedEvent
 import com.terraformation.backend.file.event.VideoFileUploadedEvent
@@ -489,6 +490,30 @@ class FileServiceTest : DatabaseTest(), RunsAsUser {
               createdTime = clock.instant,
           )
       )
+    }
+  }
+
+  @Nested
+  inner class FinishUploadingFileBatch {
+    @Test
+    fun `sets asset status to Ready and publishes event`() {
+      val fileBatchId = insertFileBatch()
+
+      fileService.finishUploadingFileBatch(fileBatchId)
+
+      assertEquals(
+          AssetStatus.Ready,
+          fileBatchesDao.fetchOneById(fileBatchId)!!.assetStatusId,
+          "Asset status",
+      )
+      eventPublisher.assertEventPublished(FileBatchFinishedUploadingEvent(fileBatchId))
+    }
+
+    @Test
+    fun `throws exception if file batch does not exist`() {
+      assertThrows<FileBatchNotFoundException> {
+        fileService.finishUploadingFileBatch(FileBatchId(-1))
+      }
     }
   }
 

--- a/src/test/kotlin/com/terraformation/backend/file/FileServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/file/FileServiceTest.kt
@@ -496,15 +496,15 @@ class FileServiceTest : DatabaseTest(), RunsAsUser {
   @Nested
   inner class FinishUploadingFileBatch {
     @Test
-    fun `sets asset status to Ready and publishes event`() {
+    fun `sets batch status to Upload Complete and publishes event`() {
       val fileBatchId = insertFileBatch()
 
       fileService.finishUploadingFileBatch(fileBatchId)
 
       assertEquals(
-          AssetStatus.Ready,
-          fileBatchesDao.fetchOneById(fileBatchId)!!.assetStatusId,
-          "Asset status",
+          FileBatchStatus.UploadComplete,
+          fileBatchesDao.fetchOneById(fileBatchId)!!.batchStatusId,
+          "Batch status",
       )
       eventPublisher.assertEventPublished(FileBatchFinishedUploadingEvent(fileBatchId))
     }


### PR DESCRIPTION
We need a way to finish a batch upload and tell the system that it is ready for processing. Add a new endpoint and event for this.

A later PR will consume this event.

Co-authored-by: Claude Opus 4.8 [noreply@anthropic.com](mailto:noreply@anthropic.com)