### PR TITLE
Update organization and observation media endpoints to support json files

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/file/MediaTypes.kt
+++ b/src/main/kotlin/com/terraformation/backend/file/MediaTypes.kt
@@ -14,3 +14,9 @@ val SUPPORTED_PHOTO_TYPES =
  * supports all the widely-used video formats.
  */
 val SUPPORTED_MEDIA_TYPES = SUPPORTED_PHOTO_TYPES + setOf(MediaType.valueOf("video/*"))
+
+/**
+ * List of supported content types for additional media associated with an organization or an
+ * observation.
+ */
+val SUPPORTED_ADDITIONAL_MEDIA_TYPES = SUPPORTED_MEDIA_TYPES + setOf(MediaType.APPLICATION_JSON)

--- a/src/main/kotlin/com/terraformation/backend/tracking/OrganizationMediaService.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/OrganizationMediaService.kt
@@ -13,7 +13,7 @@ import com.terraformation.backend.db.default_schema.OrganizationId
 import com.terraformation.backend.db.default_schema.tables.references.FILES
 import com.terraformation.backend.db.default_schema.tables.references.ORGANIZATION_MEDIA_FILES
 import com.terraformation.backend.file.FileService
-import com.terraformation.backend.file.SUPPORTED_MEDIA_TYPES
+import com.terraformation.backend.file.SUPPORTED_ADDITIONAL_MEDIA_TYPES
 import com.terraformation.backend.file.SizedInputStream
 import com.terraformation.backend.file.ThumbnailService
 import com.terraformation.backend.file.event.FileReferenceDeletedEvent
@@ -46,7 +46,7 @@ class OrganizationMediaService(
   ): FileId {
     requirePermissions { createOrganizationMedia(organizationId) }
 
-    val contentType = file.getPlainContentType(SUPPORTED_MEDIA_TYPES)
+    val contentType = file.getPlainContentType(SUPPORTED_ADDITIONAL_MEDIA_TYPES)
     val filename = file.getFilename("media")
 
     val fileId =

--- a/src/main/kotlin/com/terraformation/backend/tracking/api/ObservationsController.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/api/ObservationsController.kt
@@ -38,7 +38,7 @@ import com.terraformation.backend.db.tracking.RecordedSpeciesCertainty
 import com.terraformation.backend.db.tracking.SubstratumId
 import com.terraformation.backend.db.tracking.tables.pojos.ObservationMediaFilesRow
 import com.terraformation.backend.db.tracking.tables.pojos.RecordedPlantsRow
-import com.terraformation.backend.file.SUPPORTED_MEDIA_TYPES
+import com.terraformation.backend.file.SUPPORTED_ADDITIONAL_MEDIA_TYPES
 import com.terraformation.backend.file.SUPPORTED_PHOTO_TYPES
 import com.terraformation.backend.file.api.GetMuxStreamResponsePayload
 import com.terraformation.backend.file.model.FileMetadata
@@ -563,7 +563,10 @@ class ObservationsController(
     return UploadPlotMediaResponsePayload(fileId)
   }
 
-  @Operation(summary = "Adds a photo/video of a monitoring plot after an observation is complete.")
+  @Operation(
+      summary =
+          "Adds a photo, video, or data file of a monitoring plot after an observation is complete."
+  )
   @PostMapping(
       "/{observationId}/plots/{plotId}/otherMedia",
       consumes = [MediaType.MULTIPART_FORM_DATA_VALUE],
@@ -579,7 +582,7 @@ class ObservationsController(
       @RequestParam position: ObservationPlotPosition?,
       @RequestParam type: ObservationMediaType?,
   ): UploadPlotMediaResponsePayload {
-    val contentType = file.getPlainContentType(SUPPORTED_MEDIA_TYPES)
+    val contentType = file.getPlainContentType(SUPPORTED_ADDITIONAL_MEDIA_TYPES)
     val filename = file.getFilename("photo")
 
     val fileId =

--- a/src/main/kotlin/com/terraformation/backend/tracking/api/OrganizationMediaController.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/api/OrganizationMediaController.kt
@@ -38,7 +38,7 @@ class OrganizationMediaController(
     private val organizationMediaService: OrganizationMediaService,
 ) {
   @ApiResponse200
-  @Operation(summary = "Uploads a photo or video associated with an organization.")
+  @Operation(summary = "Uploads a photo, video, or data file associated with an organization.")
   @PostMapping(consumes = [MediaType.MULTIPART_FORM_DATA_VALUE])
   @RequestBodyPhotoFile
   fun uploadOrganizationMediaFile(

--- a/src/test/kotlin/com/terraformation/backend/tracking/OrganizationMediaServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/OrganizationMediaServiceTest.kt
@@ -108,6 +108,18 @@ internal class OrganizationMediaServiceTest : DatabaseTest(), RunsAsUser {
     }
 
     @Test
+    fun `accepts JSON data files without publishing a video event`() {
+      val multipartFile = MockMultipartFile("file", "data.json", "application/json", ByteArray(1))
+
+      val insertedFileId = service.upload(organizationId, multipartFile, "Test caption")
+
+      assertTableEquals(
+          OrganizationMediaFilesRecord(insertedFileId, organizationId, "Test caption")
+      )
+      eventPublisher.assertEventNotPublished<OrganizationVideoUploadedEvent>()
+    }
+
+    @Test
     fun `stores file batch ID on the file row and includes batch ID on the event`() {
       val fileBatchId = insertFileBatch()
       val multipartFile = MockMultipartFile("file", "video/mp4", "video/mp4", ByteArray(1024))


### PR DESCRIPTION
Now that videos can be part of a batch, add support for uploading json files so that the mobile app can upload data json files with sensor data from the capture. For now this is only added to Organization media and Observation media endpoints.

Co-authored-by: Claude Opus 4.8 [noreply@anthropic.com](mailto:noreply@anthropic.com)