### PR TITLE
SW-8608 Update planting date request status whenever request is updated

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/plantingmanagement/db/PlantingDateRequestsStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/plantingmanagement/db/PlantingDateRequestsStore.kt
@@ -164,6 +164,8 @@ class PlantingDateRequestsStore(
 
       insertRequestSpecies(scheduledPlantingDateId)
 
+      updateRequestStatus(scheduledPlantingDateId)
+
       val newDate =
           dslContext
               .select(PLANTING_DATE_REQUESTS.DATE)

--- a/src/test/kotlin/com/terraformation/backend/plantingmanagement/db/PlantingDateRequestsStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/plantingmanagement/db/PlantingDateRequestsStoreTest.kt
@@ -271,6 +271,37 @@ internal class PlantingDateRequestsStoreTest : DatabaseTest(), RunsAsDatabaseUse
     }
 
     @Test
+    fun `changes status back to Partial when a species is added to the date`() {
+      val scheduledPlantingDateId = insertPlantingSeasonScheduledDate()
+      insertScheduledPlantingDateSpecies(quantity = 5)
+      insertPlantingDateRequest(status = PlantingDateRequestStatus.Fulfilled)
+      insertFacility()
+      insertBatch()
+      insertNurseryWithdrawal(
+          plantingSeasonId = plantingSeasonId,
+          scheduledPlantingDateRequestId = scheduledPlantingDateId,
+          purpose = WithdrawalPurpose.OutPlant,
+      )
+      insertBatchWithdrawal(readyQuantityWithdrawn = 5)
+
+      val species2 = insertSpecies()
+      insertScheduledPlantingDateSpecies(speciesId = species2, quantity = 10)
+
+      store.update(scheduledPlantingDateId, plantingSeasonId)
+      assertTableEquals(
+          PlantingDateRequestsRecord(
+              date = LocalDate.EPOCH,
+              createdBy = user.userId,
+              createdTime = Instant.EPOCH,
+              modifiedBy = user.userId,
+              modifiedTime = clock.instant,
+              scheduledPlantingDateId = scheduledPlantingDateId,
+              statusId = PlantingDateRequestStatus.Partial,
+          )
+      )
+    }
+
+    @Test
     fun `deletes species no longer in scheduled planting date`() {
       val scheduledPlantingDateId = insertPlantingSeasonScheduledDate()
       insertPlantingDateRequest()


### PR DESCRIPTION
When a planting date request is updated, update its status based on the current state of the scheduled planting date. Previously this only happened when a withdrawal occurred against the request.