### PR TITLE
SW-8594 Add project botanical country to API

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/accelerator/migration/ProjectSetUpImporter.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/migration/ProjectSetUpImporter.kt
@@ -112,6 +112,7 @@ class ProjectSetUpImporter(
                     val projectId =
                         projectStore.create(
                             NewProjectModel(
+                                botanicalCountryCode = null,
                                 id = null,
                                 name = projectName,
                                 organizationId = organization.id,

--- a/src/main/kotlin/com/terraformation/backend/customer/api/ProjectsController.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/api/ProjectsController.kt
@@ -77,6 +77,7 @@ class ProjectsController(
     val projectId =
         projectStore.create(
             NewProjectModel(
+                botanicalCountryCode = payload.botanicalCountryCode,
                 countryCode = payload.countryCode,
                 description = payload.description,
                 id = null,
@@ -157,6 +158,7 @@ class ProjectsController(
 
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
 data class ProjectPayload(
+    val botanicalCountryCode: String?,
     val countryCode: String?,
     val createdBy: UserId?,
     val createdTime: Instant?,
@@ -171,6 +173,7 @@ data class ProjectPayload(
   constructor(
       model: ExistingProjectModel
   ) : this(
+      botanicalCountryCode = model.botanicalCountryCode,
       countryCode = model.countryCode,
       createdBy = model.createdBy,
       createdTime = model.createdTime,
@@ -201,6 +204,7 @@ data class InternalUserPayload(
 data class UpdateProjectInternalUserRequestPayload(val internalUsers: List<InternalUserPayload>)
 
 data class CreateProjectRequestPayload(
+    val botanicalCountryCode: String?,
     val countryCode: String?,
     val description: String?,
     val name: String,
@@ -210,6 +214,9 @@ data class CreateProjectRequestPayload(
 data class CreateProjectResponsePayload(val id: ProjectId) : SuccessResponsePayload
 
 data class UpdateProjectRequestPayload(
+    // TEMPORARY: Treat missing codes as "don't edit"; this can change to plain String? type once
+    // clients are updated to know about this field.
+    val botanicalCountryCode: Optional<String>?,
     // TEMPORARY: Treat missing country codes as "don't edit"; this can change to plain String? type
     // once clients are updated to know about this field.
     val countryCode: Optional<String>?,
@@ -218,6 +225,7 @@ data class UpdateProjectRequestPayload(
 ) {
   fun applyTo(model: ExistingProjectModel) =
       model.copy(
+          botanicalCountryCode = botanicalCountryCode.patchNullable(model.botanicalCountryCode),
           countryCode = countryCode.patchNullable(model.countryCode),
           description = description,
           name = name,

--- a/src/main/kotlin/com/terraformation/backend/customer/db/ProjectStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/db/ProjectStore.kt
@@ -25,6 +25,7 @@ import com.terraformation.backend.db.default_schema.UserId
 import com.terraformation.backend.db.default_schema.tables.daos.ProjectsDao
 import com.terraformation.backend.db.default_schema.tables.pojos.ProjectInternalUsersRow
 import com.terraformation.backend.db.default_schema.tables.pojos.ProjectsRow
+import com.terraformation.backend.db.default_schema.tables.references.BOTANICAL_COUNTRIES
 import com.terraformation.backend.db.default_schema.tables.references.PROJECTS
 import com.terraformation.backend.db.default_schema.tables.references.PROJECT_INTERNAL_USERS
 import com.terraformation.backend.util.nullIfEquals
@@ -73,8 +74,11 @@ class ProjectStore(
   fun create(model: NewProjectModel): ProjectId {
     requirePermissions { createProject(model.organizationId) }
 
+    validateBotanicalCountryCode(model.botanicalCountryCode)
+
     val row =
         ProjectsRow(
+            botanicalCountryCode = model.botanicalCountryCode,
             countryCode = model.countryCode,
             createdBy = currentUser().userId,
             createdTime = clock.instant(),
@@ -95,6 +99,7 @@ class ProjectStore(
 
     eventPublisher.publishEvent(
         ProjectCreatedEvent(
+            botanicalCountryCode = model.botanicalCountryCode,
             countryCode = model.countryCode,
             name = model.name,
             organizationId = model.organizationId,
@@ -128,10 +133,13 @@ class ProjectStore(
     val existing = fetchOneById(projectId)
     val updated = updateFunc(existing)
 
+    validateBotanicalCountryCode(updated.botanicalCountryCode)
+
     dslContext.transaction { _ ->
       try {
         dslContext
             .update(PROJECTS)
+            .set(PROJECTS.BOTANICAL_COUNTRY_CODE, updated.botanicalCountryCode)
             .set(PROJECTS.COUNTRY_CODE, updated.countryCode)
             .set(PROJECTS.DESCRIPTION, updated.description)
             .set(PROJECTS.MODIFIED_BY, currentUser().userId)
@@ -155,17 +163,27 @@ class ProjectStore(
       }
 
       if (
-          existing.countryCode != updated.countryCode || existing.description != updated.description
+          existing.botanicalCountryCode != updated.botanicalCountryCode ||
+              existing.countryCode != updated.countryCode ||
+              existing.description != updated.description
       ) {
         eventPublisher.publishEvent(
             ProjectUpdatedEvent(
                 changedFrom =
                     ProjectUpdatedEventValues(
+                        botanicalCountryCode =
+                            existing.botanicalCountryCode.nullIfEquals(
+                                updated.botanicalCountryCode
+                            ),
                         countryCode = existing.countryCode.nullIfEquals(updated.countryCode),
                         description = existing.description.nullIfEquals(updated.description),
                     ),
                 changedTo =
                     ProjectUpdatedEventValues(
+                        botanicalCountryCode =
+                            updated.botanicalCountryCode.nullIfEquals(
+                                existing.botanicalCountryCode
+                            ),
                         countryCode = updated.countryCode.nullIfEquals(existing.countryCode),
                         description = updated.description.nullIfEquals(existing.description),
                     ),
@@ -276,5 +294,18 @@ class ProjectStore(
         .selectFrom(PROJECT_INTERNAL_USERS)
         .where(conditions)
         .fetchInto(ProjectInternalUsersRow::class.java)
+  }
+
+  /** Throws [IllegalArgumentException] if a botanical country code is invalid. */
+  private fun validateBotanicalCountryCode(botanicalCountryCode: String?) {
+    if (
+        botanicalCountryCode != null &&
+            !dslContext.fetchExists(
+                BOTANICAL_COUNTRIES,
+                BOTANICAL_COUNTRIES.LEVEL3_CODE.eq(botanicalCountryCode),
+            )
+    ) {
+      throw IllegalArgumentException("Botanical country code not recognized")
+    }
   }
 }

--- a/src/main/kotlin/com/terraformation/backend/customer/db/ProjectStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/db/ProjectStore.kt
@@ -296,7 +296,6 @@ class ProjectStore(
         .fetchInto(ProjectInternalUsersRow::class.java)
   }
 
-  /** Throws [IllegalArgumentException] if a botanical country code is invalid. */
   private fun validateBotanicalCountryCode(botanicalCountryCode: String?) {
     if (
         botanicalCountryCode != null &&

--- a/src/main/kotlin/com/terraformation/backend/customer/event/ProjectCreatedEvent.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/event/ProjectCreatedEvent.kt
@@ -5,6 +5,7 @@ import com.terraformation.backend.db.default_schema.ProjectId
 import com.terraformation.backend.eventlog.EntityCreatedPersistentEvent
 
 data class ProjectCreatedEventV1(
+    val botanicalCountryCode: String? = null,
     val countryCode: String?,
     val name: String,
     override val organizationId: OrganizationId,

--- a/src/main/kotlin/com/terraformation/backend/customer/event/ProjectUpdatedEvent.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/event/ProjectUpdatedEvent.kt
@@ -16,12 +16,18 @@ data class ProjectUpdatedEventV1(
     override val projectId: ProjectId,
 ) : FieldsUpdatedPersistentEvent, ProjectPersistentEvent {
   data class Values(
+      val botanicalCountryCode: String? = null,
       val countryCode: String? = null,
       val description: String? = null,
   )
 
   override fun listUpdatedFields(messages: Messages) =
       listOfNotNull(
+          createUpdatedField(
+              "botanicalCountryCode",
+              messages.botanicalCountryName(changedFrom.botanicalCountryCode),
+              messages.botanicalCountryName(changedTo.botanicalCountryCode),
+          ),
           createUpdatedField("countryCode", changedFrom.countryCode, changedTo.countryCode),
           createUpdatedField("description", changedFrom.description, changedTo.description),
       )

--- a/src/main/kotlin/com/terraformation/backend/customer/model/ProjectModel.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/ProjectModel.kt
@@ -10,6 +10,7 @@ import java.time.Instant
 import org.jooq.Record
 
 data class ProjectModel<ID : ProjectId?>(
+    val botanicalCountryCode: String? = null,
     val countryCode: String? = null,
     val createdBy: UserId? = null,
     val createdTime: Instant? = null,
@@ -24,6 +25,7 @@ data class ProjectModel<ID : ProjectId?>(
   companion object {
     fun of(row: ProjectsRow): ExistingProjectModel {
       return ExistingProjectModel(
+          row.botanicalCountryCode,
           row.countryCode,
           row.createdBy,
           row.createdTime,
@@ -39,6 +41,7 @@ data class ProjectModel<ID : ProjectId?>(
 
     fun of(record: Record): ExistingProjectModel {
       return ExistingProjectModel(
+          botanicalCountryCode = record[PROJECTS.BOTANICAL_COUNTRY_CODE],
           countryCode = record[PROJECTS.COUNTRY_CODE],
           createdBy = record[PROJECTS.CREATED_BY]!!,
           createdTime = record[PROJECTS.CREATED_TIME]!!,

--- a/src/main/kotlin/com/terraformation/backend/i18n/Messages.kt
+++ b/src/main/kotlin/com/terraformation/backend/i18n/Messages.kt
@@ -103,6 +103,10 @@ class Messages {
 
   fun booleanOrNull(value: Boolean?): String? = value?.let { getMessage("boolean.$it") }
 
+  fun botanicalCountryName(value: String?): String? = value?.let {
+    getMessageSource("i18n.BotanicalCountries").getMessage(it)
+  }
+
   fun csvBadHeader() = getMessage("csvBadHeader")
 
   fun csvRequiredFieldMissing() = getMessage("csvRequiredFieldMissing")

--- a/src/main/kotlin/com/terraformation/backend/search/table/ProjectsTable.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/table/ProjectsTable.kt
@@ -10,6 +10,7 @@ import com.terraformation.backend.db.accelerator.tables.references.PROJECT_DELIV
 import com.terraformation.backend.db.accelerator.tables.references.PROJECT_MODULES
 import com.terraformation.backend.db.accelerator.tables.references.PROJECT_VARIABLES
 import com.terraformation.backend.db.default_schema.ProjectId
+import com.terraformation.backend.db.default_schema.tables.references.BOTANICAL_COUNTRIES
 import com.terraformation.backend.db.default_schema.tables.references.COUNTRIES
 import com.terraformation.backend.db.default_schema.tables.references.ORGANIZATIONS
 import com.terraformation.backend.db.default_schema.tables.references.PROJECTS
@@ -39,6 +40,10 @@ class ProjectsTable(tables: SearchTables) : SearchTable() {
           accessions.asMultiValueSublist("accessions", PROJECTS.ID.eq(ACCESSIONS.PROJECT_ID)),
           applications.asSingleValueSublist("application", PROJECTS.ID.eq(APPLICATIONS.PROJECT_ID)),
           batches.asMultiValueSublist("batches", PROJECTS.ID.eq(BATCHES.PROJECT_ID)),
+          botanicalCountries.asSingleValueSublist(
+              "botanicalCountry",
+              PROJECTS.BOTANICAL_COUNTRY_CODE.eq(BOTANICAL_COUNTRIES.LEVEL3_CODE),
+          ),
           countries.asSingleValueSublist("country", PROJECTS.COUNTRY_CODE.eq(COUNTRIES.CODE)),
           documents.asMultiValueSublist("documents", PROJECTS.ID.eq(DOCUMENTS.PROJECT_ID)),
           draftPlantingSites.asMultiValueSublist(

--- a/src/main/resources/i18n/Messages_en.properties
+++ b/src/main/resources/i18n/Messages_en.properties
@@ -154,6 +154,7 @@ eventSubject.PlantingSeasonSpeciesTarget.full=Species {0} ({1} / {2})
 eventSubject.PlantingSeasonSpeciesTarget.short=Species
 eventSubject.PlantingSeasonWithdrawal.full=Planting Season Withdrawal on {0}
 eventSubject.PlantingSeasonWithdrawal.short=Planting Season Withdrawal
+eventSubject.Project.field.botanicalCountryCode=botanical country
 eventSubject.Project.field.countryCode=country code
 eventSubject.Project.field.description=description
 eventSubject.Project.field.name=name

--- a/src/main/resources/i18n/Messages_es.properties
+++ b/src/main/resources/i18n/Messages_es.properties
@@ -271,6 +271,8 @@ eventSubject.PlantingSeasonSpeciesTarget.short=Especie
 eventSubject.PlantingSeasonWithdrawal.full=Retiro de la temporada de plantación el {0}
 # 067e0333
 eventSubject.PlantingSeasonWithdrawal.short=Retiro de la temporada de plantación
+# 31141c4d
+eventSubject.Project.field.botanicalCountryCode=país botánico
 # 7d01988a
 eventSubject.Project.field.countryCode=código de país
 # e119fcaa

--- a/src/main/resources/i18n/Messages_fr.properties
+++ b/src/main/resources/i18n/Messages_fr.properties
@@ -271,6 +271,8 @@ eventSubject.PlantingSeasonSpeciesTarget.short=Espèce
 eventSubject.PlantingSeasonWithdrawal.full=Retrait de la saison de plantation le {0}
 # 067e0333
 eventSubject.PlantingSeasonWithdrawal.short=Retrait de la saison de plantation
+# 31141c4d
+eventSubject.Project.field.botanicalCountryCode=pays botanique
 # 7d01988a
 eventSubject.Project.field.countryCode=code du pays
 # e119fcaa

--- a/src/test/kotlin/com/terraformation/backend/customer/db/ProjectStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/db/ProjectStoreTest.kt
@@ -71,10 +71,13 @@ class ProjectStoreTest : DatabaseTest(), RunsAsDatabaseUser {
   inner class Create {
     @Test
     fun `creates project`() {
+      val botanicalCountryCode = insertBotanicalCountry()
       clock.instant = Instant.ofEpochSecond(123)
+
       val newProjectId =
           store.create(
               NewProjectModel(
+                  botanicalCountryCode = botanicalCountryCode,
                   countryCode = "US",
                   description = "Project description",
                   id = null,
@@ -85,6 +88,7 @@ class ProjectStoreTest : DatabaseTest(), RunsAsDatabaseUser {
 
       val expected =
           ProjectsRow(
+              botanicalCountryCode = botanicalCountryCode,
               countryCode = "US",
               createdBy = user.userId,
               createdTime = clock.instant,
@@ -101,6 +105,7 @@ class ProjectStoreTest : DatabaseTest(), RunsAsDatabaseUser {
 
       eventPublisher.assertEventPublished(
           ProjectCreatedEvent(
+              botanicalCountryCode = botanicalCountryCode,
               countryCode = "US",
               name = "Project name",
               organizationId = organizationId,
@@ -125,6 +130,20 @@ class ProjectStoreTest : DatabaseTest(), RunsAsDatabaseUser {
       assertThrows<ProjectNameInUseException> {
         store.create(
             NewProjectModel(id = null, name = "Project 1", organizationId = organizationId)
+        )
+      }
+    }
+
+    @Test
+    fun `throws exception on bad botanical country code`() {
+      assertThrows<IllegalArgumentException> {
+        store.create(
+            NewProjectModel(
+                botanicalCountryCode = "XXX",
+                id = null,
+                name = "Project 1",
+                organizationId = organizationId,
+            )
         )
       }
     }
@@ -211,6 +230,7 @@ class ProjectStoreTest : DatabaseTest(), RunsAsDatabaseUser {
     @Test
     fun `fetches projects across organizations`() {
       val currentUserId = user.userId
+      val botanicalCountryCode = insertBotanicalCountry()
       val otherUserOrganizationId = insertOrganization()
       val nonMemberOrganizationId = insertOrganization()
 
@@ -221,6 +241,7 @@ class ProjectStoreTest : DatabaseTest(), RunsAsDatabaseUser {
       val projectId2 = insertProject(name = "Project 2", organizationId = organizationId)
       val projectId3 =
           insertProject(
+              botanicalCountryCode = botanicalCountryCode,
               name = "Project 3",
               organizationId = otherUserOrganizationId,
           )
@@ -247,6 +268,7 @@ class ProjectStoreTest : DatabaseTest(), RunsAsDatabaseUser {
                   organizationId = organizationId,
               ),
               ExistingProjectModel(
+                  botanicalCountryCode = botanicalCountryCode,
                   createdBy = currentUserId,
                   createdTime = Instant.EPOCH,
                   id = projectId3,
@@ -267,6 +289,7 @@ class ProjectStoreTest : DatabaseTest(), RunsAsDatabaseUser {
   inner class Update {
     @Test
     fun `updates editable fields`() {
+      val botanicalCountryCode = insertBotanicalCountry()
       clock.instant = Instant.ofEpochSecond(123)
       val currentUserId = user.userId
 
@@ -274,6 +297,7 @@ class ProjectStoreTest : DatabaseTest(), RunsAsDatabaseUser {
 
       store.update(projectId) {
         ExistingProjectModel(
+            botanicalCountryCode = botanicalCountryCode,
             countryCode = "AU",
             description = "New description",
             id = ProjectId(-1),
@@ -284,6 +308,7 @@ class ProjectStoreTest : DatabaseTest(), RunsAsDatabaseUser {
 
       val expected =
           before.copy(
+              botanicalCountryCode = botanicalCountryCode,
               countryCode = "AU",
               createdBy = currentUserId,
               createdTime = Instant.EPOCH,
@@ -310,6 +335,7 @@ class ProjectStoreTest : DatabaseTest(), RunsAsDatabaseUser {
               changedFrom = ProjectUpdatedEventValues(description = "Description 1"),
               changedTo =
                   ProjectUpdatedEventValues(
+                      botanicalCountryCode = botanicalCountryCode,
                       countryCode = "AU",
                       description = "New description",
                   ),
@@ -347,6 +373,15 @@ class ProjectStoreTest : DatabaseTest(), RunsAsDatabaseUser {
 
       assertThrows<ProjectNameInUseException> {
         store.update(projectId2) { it.copy(name = "Existing name") }
+      }
+    }
+
+    @Test
+    fun `throws exception on bad botanical country code`() {
+      val projectId = insertProject()
+
+      assertThrows<IllegalArgumentException> {
+        store.update(projectId) { it.copy(botanicalCountryCode = "XXX") }
       }
     }
   }


### PR DESCRIPTION
Return the botanical country code as part of the project data, and in the
search API. Allow clients to set the code at creation or update time.

For now, updates use PATCH-style behavior to avoid older clients clearing
the code inadvertently.