### PR TITLE
Make OrganizationStore.update use an update function

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/customer/api/OrganizationsController.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/api/OrganizationsController.kt
@@ -112,7 +112,7 @@ class OrganizationsController(
       @PathVariable organizationId: OrganizationId,
       @RequestBody @Valid payload: UpdateOrganizationRequestPayload,
   ): SimpleSuccessResponsePayload {
-    organizationStore.update(payload.toRow().copy(id = organizationId))
+    organizationStore.update(organizationId, payload::applyTo)
     return SimpleSuccessResponsePayload()
   }
 
@@ -326,18 +326,17 @@ data class UpdateOrganizationRequestPayload(
     val timeZone: ZoneId?,
     val website: String?,
 ) {
-  fun toRow(): OrganizationsRow {
-    return OrganizationsRow(
-        countryCode = countryCode,
-        countrySubdivisionCode = countrySubdivisionCode,
-        description = description,
-        name = name,
-        organizationTypeId = organizationType,
-        organizationTypeDetails = organizationTypeDetails,
-        timeZone = timeZone,
-        website = website,
-    )
-  }
+  fun applyTo(row: OrganizationsRow) =
+      row.copy(
+          countryCode = countryCode,
+          countrySubdivisionCode = countrySubdivisionCode,
+          description = description,
+          name = name,
+          organizationTypeId = organizationType,
+          organizationTypeDetails = organizationTypeDetails,
+          timeZone = timeZone,
+          website = website,
+      )
 }
 
 @JsonInclude(JsonInclude.Include.NON_NULL)

--- a/src/main/kotlin/com/terraformation/backend/customer/db/OrganizationStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/db/OrganizationStore.kt
@@ -196,17 +196,16 @@ class OrganizationStore(
     }
   }
 
-  fun update(row: OrganizationsRow) {
-    val organizationId = row.id ?: throw IllegalArgumentException("Organization ID must be set")
-
+  fun update(organizationId: OrganizationId, updateFunc: (OrganizationsRow) -> OrganizationsRow) {
     requirePermissions { updateOrganization(organizationId) }
-
-    validateCountryCode(row.countryCode, row.countrySubdivisionCode)
-    validateOrganizationType(row.organizationTypeId, row.organizationTypeDetails)
 
     val existingRow =
         organizationsDao.fetchOneById(organizationId)
             ?: throw OrganizationNotFoundException(organizationId)
+    val row = updateFunc(existingRow)
+
+    validateCountryCode(row.countryCode, row.countrySubdivisionCode)
+    validateOrganizationType(row.organizationTypeId, row.organizationTypeDetails)
 
     with(ORGANIZATIONS) {
       dslContext

--- a/src/test/kotlin/com/terraformation/backend/customer/db/OrganizationStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/db/OrganizationStoreTest.kt
@@ -402,7 +402,7 @@ internal class OrganizationStoreTest : DatabaseTest(), RunsAsUser {
 
     every { user.userId } returns newUserId
 
-    store.update(updates)
+    store.update(organizationId) { updates }
 
     val actual = organizationsDao.fetchOneById(organizationId)!!
 
@@ -419,13 +419,12 @@ internal class OrganizationStoreTest : DatabaseTest(), RunsAsUser {
 
   @Test
   fun `update publishes event if time zone is changed`() {
-    val existing = organizationsDao.fetchOneById(organizationId)!!
     val newTimeZone = ZoneId.of("Europe/London")
 
-    store.update(existing)
+    store.update(organizationId) { it }
     publisher.assertEventNotPublished<OrganizationTimeZoneChangedEvent>()
 
-    store.update(existing.copy(timeZone = newTimeZone))
+    store.update(organizationId) { it.copy(timeZone = newTimeZone) }
     publisher.assertEventPublished(
         OrganizationTimeZoneChangedEvent(organizationId, null, newTimeZone)
     )
@@ -436,14 +435,14 @@ internal class OrganizationStoreTest : DatabaseTest(), RunsAsUser {
     every { user.canUpdateOrganization(organizationId) } returns false
 
     assertThrows<AccessDeniedException> {
-      store.update(OrganizationsRow(id = organizationId, name = "New Name"))
+      store.update(organizationId) { it }
     }
   }
 
   @Test
   fun `update rejects invalid country codes`() {
     assertThrows<IllegalArgumentException> {
-      store.update(OrganizationsRow(id = organizationId, name = "X", countryCode = "XX"))
+      store.update(organizationId) { it.copy(name = "X", countryCode = "XX") }
     }
   }
 


### PR DESCRIPTION
In preparation for adding an optional field to the organization update API
payload, change the organization update code to take a callback that modifies
the current organization data.