### PR TITLE
SW-8594 Add organization botanical country to API

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/customer/api/OrganizationsController.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/api/OrganizationsController.kt
@@ -28,6 +28,7 @@ import com.terraformation.backend.db.default_schema.ProjectId
 import com.terraformation.backend.db.default_schema.Role
 import com.terraformation.backend.db.default_schema.UserId
 import com.terraformation.backend.db.default_schema.tables.pojos.OrganizationsRow
+import com.terraformation.backend.util.patchNullable
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.media.ArraySchema
 import io.swagger.v3.oas.annotations.media.Schema
@@ -41,6 +42,7 @@ import jakarta.ws.rs.core.Response
 import java.time.Instant
 import java.time.ZoneId
 import java.time.temporal.ChronoUnit
+import java.util.Optional
 import org.apache.commons.validator.routines.EmailValidator
 import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
@@ -265,6 +267,8 @@ data class UpdateOrganizationUserRequestPayload(
 )
 
 data class CreateOrganizationRequestPayload(
+    @Schema(description = "TDWG Level 3 region code of organization's botanical country.")
+    val botanicalCountryCode: String?,
     @Schema(description = "ISO 3166 alpha-2 code of organization's country.", example = "AU")
     @field:Size(min = 2, max = 2)
     val countryCode: String?,
@@ -292,6 +296,7 @@ data class CreateOrganizationRequestPayload(
 ) {
   fun toRow(): OrganizationsRow {
     return OrganizationsRow(
+        botanicalCountryCode = botanicalCountryCode,
         countryCode = countryCode,
         countrySubdivisionCode = countrySubdivisionCode,
         description = description,
@@ -305,6 +310,10 @@ data class CreateOrganizationRequestPayload(
 }
 
 data class UpdateOrganizationRequestPayload(
+    // TEMPORARY: Treat missing codes as "don't edit"; this can change to plain String? type once
+    // clients are updated to know about this field.
+    @Schema(description = "TDWG Level 3 region code of organization's botanical country.")
+    val botanicalCountryCode: Optional<String>?,
     @Schema(description = "ISO 3166 alpha-2 code of organization's country.", example = "AU")
     @field:Size(min = 2, max = 2)
     val countryCode: String?,
@@ -328,6 +337,7 @@ data class UpdateOrganizationRequestPayload(
 ) {
   fun applyTo(row: OrganizationsRow) =
       row.copy(
+          botanicalCountryCode = botanicalCountryCode.patchNullable(row.botanicalCountryCode),
           countryCode = countryCode,
           countrySubdivisionCode = countrySubdivisionCode,
           description = description,
@@ -341,6 +351,8 @@ data class UpdateOrganizationRequestPayload(
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
 data class OrganizationPayload(
+    @Schema(description = "TDWG Level 3 region code of organization's botanical country.")
+    val botanicalCountryCode: String?,
     @Schema(description = "Whether this organization can submit reports to Terraformation.")
     val canSubmitReports: Boolean,
     @Schema(description = "ISO 3166 alpha-2 code of organization's country.", example = "AU")
@@ -388,21 +400,22 @@ data class OrganizationPayload(
       role: Role?,
       tfContactUser: IndividualUser? = null,
   ) : this(
+      botanicalCountryCode = model.botanicalCountryCode,
       canSubmitReports = InternalTagIds.Reporter in model.internalTags,
-      model.countryCode,
-      model.countrySubdivisionCode,
-      model.createdTime.truncatedTo(ChronoUnit.SECONDS),
-      model.description,
-      model.facilities?.map { FacilityPayload(it) },
-      model.id,
-      model.name,
-      model.organizationType,
-      model.organizationTypeDetails,
-      role,
+      countryCode = model.countryCode,
+      countrySubdivisionCode = model.countrySubdivisionCode,
+      createdTime = model.createdTime.truncatedTo(ChronoUnit.SECONDS),
+      description = model.description,
+      facilities = model.facilities?.map { FacilityPayload(it) },
+      id = model.id,
+      name = model.name,
+      organizationType = model.organizationType,
+      organizationTypeDetails = model.organizationTypeDetails,
+      role = role,
       tfContactUser = tfContactUser?.let { TerraformationContactUserPayload(it) },
-      model.timeZone,
-      model.totalUsers,
-      model.website,
+      timeZone = model.timeZone,
+      totalUsers = model.totalUsers,
+      website = model.website,
   )
 }
 

--- a/src/main/kotlin/com/terraformation/backend/customer/db/OrganizationStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/db/OrganizationStore.kt
@@ -620,7 +620,6 @@ class OrganizationStore(
     }
   }
 
-  /** Throws [IllegalArgumentException] if a botanical country code is invalid. */
   private fun validateBotanicalCountryCode(botanicalCountryCode: String?) {
     if (
         botanicalCountryCode != null &&
@@ -633,7 +632,6 @@ class OrganizationStore(
     }
   }
 
-  /** Throws [IllegalArgumentException] if country and/or subdivision codes are invalid. */
   private fun validateCountryCode(countryCode: String?, countrySubdivisionCode: String?) {
     if (countryCode != null) {
       if (countryCode.length != 2) {

--- a/src/main/kotlin/com/terraformation/backend/customer/db/OrganizationStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/db/OrganizationStore.kt
@@ -27,6 +27,7 @@ import com.terraformation.backend.db.default_schema.UserId
 import com.terraformation.backend.db.default_schema.UserType
 import com.terraformation.backend.db.default_schema.tables.daos.OrganizationsDao
 import com.terraformation.backend.db.default_schema.tables.pojos.OrganizationsRow
+import com.terraformation.backend.db.default_schema.tables.references.BOTANICAL_COUNTRIES
 import com.terraformation.backend.db.default_schema.tables.references.COUNTRIES
 import com.terraformation.backend.db.default_schema.tables.references.COUNTRY_SUBDIVISIONS
 import com.terraformation.backend.db.default_schema.tables.references.FACILITIES
@@ -141,11 +142,13 @@ class OrganizationStore(
   ): OrganizationModel {
     requirePermissions { createEntityWithOwner(ownerUserId) }
 
+    validateBotanicalCountryCode(row.botanicalCountryCode)
     validateCountryCode(row.countryCode, row.countrySubdivisionCode)
     validateOrganizationType(row.organizationTypeId, row.organizationTypeDetails)
 
     val fullRow =
         OrganizationsRow(
+            botanicalCountryCode = row.botanicalCountryCode,
             countryCode = row.countryCode?.uppercase(),
             countrySubdivisionCode = row.countrySubdivisionCode?.uppercase(),
             createdBy = currentUser().userId,
@@ -204,12 +207,14 @@ class OrganizationStore(
             ?: throw OrganizationNotFoundException(organizationId)
     val row = updateFunc(existingRow)
 
+    validateBotanicalCountryCode(row.botanicalCountryCode)
     validateCountryCode(row.countryCode, row.countrySubdivisionCode)
     validateOrganizationType(row.organizationTypeId, row.organizationTypeDetails)
 
     with(ORGANIZATIONS) {
       dslContext
           .update(ORGANIZATIONS)
+          .set(BOTANICAL_COUNTRY_CODE, row.botanicalCountryCode)
           .set(COUNTRY_CODE, row.countryCode)
           .set(COUNTRY_SUBDIVISION_CODE, row.countrySubdivisionCode)
           .set(DESCRIPTION, row.description)
@@ -612,6 +617,19 @@ class OrganizationStore(
       if (numOwners < 2) {
         throw CannotRemoveLastOwnerException(organizationId)
       }
+    }
+  }
+
+  /** Throws [IllegalArgumentException] if a botanical country code is invalid. */
+  private fun validateBotanicalCountryCode(botanicalCountryCode: String?) {
+    if (
+        botanicalCountryCode != null &&
+            !dslContext.fetchExists(
+                BOTANICAL_COUNTRIES,
+                BOTANICAL_COUNTRIES.LEVEL3_CODE.eq(botanicalCountryCode),
+            )
+    ) {
+      throw IllegalArgumentException("Botanical country code not recognized")
     }
   }
 

--- a/src/main/kotlin/com/terraformation/backend/customer/db/ParentStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/db/ParentStore.kt
@@ -36,6 +36,7 @@ import com.terraformation.backend.db.default_schema.SubLocationId
 import com.terraformation.backend.db.default_schema.UploadId
 import com.terraformation.backend.db.default_schema.UserId
 import com.terraformation.backend.db.default_schema.tables.references.AUTOMATIONS
+import com.terraformation.backend.db.default_schema.tables.references.BOTANICAL_COUNTRIES
 import com.terraformation.backend.db.default_schema.tables.references.DEVICES
 import com.terraformation.backend.db.default_schema.tables.references.DEVICE_MANAGERS
 import com.terraformation.backend.db.default_schema.tables.references.FACILITIES
@@ -347,6 +348,12 @@ class ParentStore(private val dslContext: DSLContext) {
           PLANTING_SITES.ID,
           DSL.coalesce(PLANTING_SITES.TIME_ZONE, PLANTING_SITES.organizations.TIME_ZONE),
       ) ?: ZoneOffset.UTC
+
+  fun botanicalCountryExists(botanicalCountryCode: String): Boolean =
+      dslContext.fetchExists(
+          BOTANICAL_COUNTRIES,
+          BOTANICAL_COUNTRIES.LEVEL3_CODE.eq(botanicalCountryCode),
+      )
 
   fun exists(deviceManagerId: DeviceManagerId): Boolean =
       fetchFieldById(deviceManagerId, DEVICE_MANAGERS.ID, DSL.one()) != null

--- a/src/main/kotlin/com/terraformation/backend/customer/model/OrganizationModel.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/OrganizationModel.kt
@@ -15,6 +15,7 @@ data class OrganizationModel(
     val id: OrganizationId,
     val name: String,
     val description: String? = null,
+    val botanicalCountryCode: String? = null,
     val countryCode: String? = null,
     val countrySubdivisionCode: String? = null,
     val createdTime: Instant,
@@ -36,6 +37,7 @@ data class OrganizationModel(
       id = record[ORGANIZATIONS.ID] ?: throw IllegalArgumentException("ID is required"),
       name = record[ORGANIZATIONS.NAME] ?: throw IllegalArgumentException("Name is required"),
       description = record[ORGANIZATIONS.DESCRIPTION],
+      botanicalCountryCode = record[ORGANIZATIONS.BOTANICAL_COUNTRY_CODE],
       countryCode = record[ORGANIZATIONS.COUNTRY_CODE],
       countrySubdivisionCode = record[ORGANIZATIONS.COUNTRY_SUBDIVISION_CODE],
       createdTime =
@@ -57,6 +59,7 @@ fun OrganizationsRow.toModel(totalUsers: Int): OrganizationModel =
         id = id ?: throw IllegalArgumentException("ID is required"),
         name = name ?: throw IllegalArgumentException("Name is required"),
         description = description,
+        botanicalCountryCode = botanicalCountryCode,
         countryCode = countryCode,
         countrySubdivisionCode = countrySubdivisionCode,
         createdTime = createdTime ?: throw IllegalArgumentException("Created time is required"),

--- a/src/main/kotlin/com/terraformation/backend/search/table/OrganizationsTable.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/table/OrganizationsTable.kt
@@ -3,6 +3,7 @@ package com.terraformation.backend.search.table
 import com.terraformation.backend.auth.currentUser
 import com.terraformation.backend.db.accelerator.tables.references.APPLICATIONS
 import com.terraformation.backend.db.default_schema.OrganizationId
+import com.terraformation.backend.db.default_schema.tables.references.BOTANICAL_COUNTRIES
 import com.terraformation.backend.db.default_schema.tables.references.COUNTRIES
 import com.terraformation.backend.db.default_schema.tables.references.COUNTRY_SUBDIVISIONS
 import com.terraformation.backend.db.default_schema.tables.references.FACILITIES
@@ -33,6 +34,10 @@ class OrganizationsTable(tables: SearchTables) : SearchTable() {
     with(tables) {
       listOf(
           batches.asMultiValueSublist("batches", ORGANIZATIONS.ID.eq(BATCHES.ORGANIZATION_ID)),
+          botanicalCountries.asSingleValueSublist(
+              "botanicalCountry",
+              ORGANIZATIONS.BOTANICAL_COUNTRY_CODE.eq(BOTANICAL_COUNTRIES.LEVEL3_CODE),
+          ),
           countries.asSingleValueSublist(
               "country",
               ORGANIZATIONS.COUNTRY_CODE.eq(COUNTRIES.CODE),

--- a/src/test/kotlin/com/terraformation/backend/customer/db/OrganizationStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/db/OrganizationStoreTest.kt
@@ -76,6 +76,7 @@ internal class OrganizationStoreTest : DatabaseTest(), RunsAsUser {
     OrganizationModel(
         id = organizationId,
         name = "Organization 1",
+        botanicalCountryCode = null,
         countryCode = "US",
         countrySubdivisionCode = "US-HI",
         createdTime = Instant.EPOCH,
@@ -205,8 +206,10 @@ internal class OrganizationStoreTest : DatabaseTest(), RunsAsUser {
 
   @Test
   fun `createWithAdmin populates organization details`() {
+    val botanicalCountryCode = insertBotanicalCountry()
     val row =
         OrganizationsRow(
+            botanicalCountryCode = botanicalCountryCode,
             countryCode = "US",
             countrySubdivisionCode = "US-HI",
             description = "Test description",
@@ -245,6 +248,13 @@ internal class OrganizationStoreTest : DatabaseTest(), RunsAsUser {
 
     assertEquals("US", row.countryCode, "Country code")
     assertEquals("US-HI", row.countrySubdivisionCode, "Subdivision code")
+  }
+
+  @Test
+  fun `createWithAdmin rejects invalid botanical country codes`() {
+    assertThrows<IllegalArgumentException> {
+      store.createWithAdmin(OrganizationsRow(botanicalCountryCode = "XXX", name = "Test Org"))
+    }
   }
 
   @Test
@@ -377,6 +387,7 @@ internal class OrganizationStoreTest : DatabaseTest(), RunsAsUser {
 
   @Test
   fun `update populates organization details`() {
+    val botanicalCountryCode = insertBotanicalCountry()
     val newTime = clock.instant().plusSeconds(1000)
     clock.instant = newTime
 
@@ -387,6 +398,7 @@ internal class OrganizationStoreTest : DatabaseTest(), RunsAsUser {
             id = organizationId,
             name = "New Name",
             description = "New Description",
+            botanicalCountryCode = botanicalCountryCode,
             countryCode = "ZA",
             organizationTypeId = OrganizationType.Academia,
             timeZone = timeZone,
@@ -436,6 +448,13 @@ internal class OrganizationStoreTest : DatabaseTest(), RunsAsUser {
 
     assertThrows<AccessDeniedException> {
       store.update(organizationId) { it }
+    }
+  }
+
+  @Test
+  fun `update rejects invalid botanical country codes`() {
+    assertThrows<IllegalArgumentException> {
+      store.update(organizationId) { it.copy(name = "X", botanicalCountryCode = "XXX") }
     }
   }
 


### PR DESCRIPTION
Return the botanical country code as part of the organization data, and in
the search API. Allow clients to set the code at creation or update time.

For now, updates use PATCH-style behavior to avoid older clients clearing
the code inadvertently.