### PR TITLE
Reduce unnecessary Buildkite cache updates

### DIFF
--- a/.buildkite/README.md
+++ b/.buildkite/README.md
@@ -63,8 +63,10 @@ for downloaded dependencies. We use our own S3 bucket to store the caches.
 Caches have a concept of a level hierarchy, documented here:
 https://buildkite.com/resources/plugins/buildkite-plugins/cache-buildkite-plugin/#caching-levels
 In this pipeline, all builds read dependencies from the pipeline level and write dependencies
-to the branch and file levels. Then, after a successful build, if we're building on the "main"
-branch, we "promote" the caches to the pipeline level so they'll be available in other branches.
+to the file level. Then, after a successful build, if we're building on the "main" branch, we
+"promote" the file-level cache to the pipeline level, such that next time the dependencies change,
+the pipeline-level cache serves as a starting point and we only have to download the dependencies
+that actually changes.
 
 Artifacts are per-job; we use them to pass data between steps. For example, the "build" directory
 gets bundled up in a compressed tarfile so it can be downloaded by later steps.

--- a/.buildkite/README.md
+++ b/.buildkite/README.md
@@ -23,7 +23,11 @@ steps:
           # from which the current branch was forked, but small enough to keep the clone
           # operation reasonably fast.
           depth: 200
-    command: "buildkite-agent pipeline upload"
+    command: |
+      if [[ "$$BUILDKITE_BRANCH" == "$$BUILDKITE_PIPELINE_DEFAULT_BRANCH" ]]; then
+        export BUILDKITE_GIT_DIFF_BASE="HEAD~1"
+      fi
+      buildkite-agent pipeline upload
 ```
 
 ## YAML anchors
@@ -67,6 +71,11 @@ to the file level. Then, after a successful build, if we're building on the "mai
 "promote" the file-level cache to the pipeline level, such that next time the dependencies change,
 the pipeline-level cache serves as a starting point and we only have to download the dependencies
 that actually changes.
+
+Each promotion step is guarded by an `if_changed` directive so it only runs when the relevant
+manifest files changed. Note that `if_changed` needs the `BUILDKITE_GIT_DIFF_BASE` override set
+in the upload step (see above) to work correctly on main; without it, the diff on a main build
+would compare main against itself and the promotion steps would never fire.
 
 Artifacts are per-job; we use them to pass data between steps. For example, the "build" directory
 gets bundled up in a compressed tarfile so it can be downloaded by later steps.

--- a/.buildkite/README.md
+++ b/.buildkite/README.md
@@ -70,7 +70,7 @@ In this pipeline, all builds read dependencies from the pipeline level and write
 to the file level. Then, after a successful build, if we're building on the "main" branch, we
 "promote" the file-level cache to the pipeline level, such that next time the dependencies change,
 the pipeline-level cache serves as a starting point and we only have to download the dependencies
-that actually changes.
+that actually changed.
 
 Each promotion step is guarded by an `if_changed` directive so it only runs when the relevant
 manifest files changed. Note that `if_changed` needs the `BUILDKITE_GIT_DIFF_BASE` override set

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -6,22 +6,27 @@ common:
     compression: tgz
     restore: pipeline
 
-  - &cache-gradle-home-args
-    <<: *cache-common-args
-    path: ".gradle-home"
-    manifest:
+  - _: &cache-gradle-home-manifest
       - "build.gradle.kts"
       - "gradle.properties"
       - "settings.gradle.kts"
+
+  - &cache-gradle-home-args
+    <<: *cache-common-args
+    path: ".gradle-home"
+    manifest: *cache-gradle-home-manifest
 
   - &cache-gradle-home
     cache#v1.11.1:
       <<: *cache-gradle-home-args
 
+  - _: &cache-node-modules-manifest
+      - "yarn.lock"
+
   - &cache-node-modules-args
     <<: *cache-common-args
     path: "node_modules"
-    manifest: "yarn.lock"
+    manifest: *cache-node-modules-manifest
 
   - &cache-node-modules
     cache#v1.11.1:
@@ -33,6 +38,14 @@ common:
     manifest:
       - "scripts/requirements.txt"
       - ".buildkite/scripts/check-scripts.sh"
+
+  - _: &cache-buildx-manifest
+      - "docker/Dockerfile"
+      - "docker/Makefile"
+      - "docker/start.sh"
+      - "build.gradle.kts"
+      - "gradle.properties"
+      - "settings.gradle.kts"
 
   - &load-secrets
     seek-oss/aws-sm#v2.4.1:
@@ -83,12 +96,10 @@ steps:
           <<: *cache-gradle-home-args
           save:
             - file
-            - branch
       - cache#v1.11.1:
           <<: *cache-node-modules-args
           save:
             - file
-            - branch
       - artifacts#v1.9.4:
           upload: "build"
           compressed: "build.tgz"
@@ -138,7 +149,6 @@ steps:
           <<: *cache-pip-args
           save:
             - "file"
-            - "branch"
     command: .buildkite/scripts/check-scripts.sh
 
   - label: ":junit: Annotate build with test results"
@@ -166,34 +176,48 @@ steps:
       - cache#v1.11.1:
           <<: *cache-common-args
           path: ".buildx-cache"
+          manifest: *cache-buildx-manifest
           save:
-            - branch
-          force: true
+            - file
       - *restore-build-cache
       - *restore-build
       - *restore-dot-gradle
     command: .buildkite/scripts/docker-build-push.sh
 
-  - label: ":buildkite: Promote branch-level caches to pipeline-level"
-    key: "promote-caches"
+  - label: ":buildkite: Promote Gradle home cache to pipeline-level"
+    key: "promote-gradle-cache"
     depends_on: "docker"
     branches: "main"
+    if_changed: *cache-gradle-home-manifest
     plugins:
       - *shallow-clone
-      - cache#v1.11.1: &promote-cache
+      - cache#v1.11.1:
           <<: *cache-gradle-home-args
           save: "pipeline"
+          force: true
+    command: "rm -rf .gradle-home/caches/build-cache-1"
+
+  - label: ":buildkite: Promote Node modules cache to pipeline-level"
+    key: "promote-node-cache"
+    depends_on:
+      - "docker"
+      - "promote-gradle-cache"
+    branches: "main"
+    if_changed: *cache-node-modules-manifest
+    plugins:
+      - *shallow-clone
       - cache#v1.11.1:
           <<: *cache-node-modules-args
           save: "pipeline"
-      - cache#v1.11.1:
-          <<: *promote-cache
-          path: ".buildx-cache"
-    command: "rm -rf .gradle-home/caches/build-cache-1"
+          force: true
+    command: "true"
 
   - label: ":buildkite: Promote branch-level script cache to pipeline-level"
     key: "promote-script-cache"
-    depends_on: "promote-caches"
+    depends_on:
+      - "docker"
+      - "promote-gradle-cache"
+      - "promote-node-cache"
     branches: "main"
     if_changed: "scripts/**"
     plugins:
@@ -201,7 +225,27 @@ steps:
       - cache#v1.11.1:
           <<: *cache-pip-args
           save: "pipeline"
-    command: "echo --- :buildkite: Loaded branch-level script cache"
+          force: true
+    command: "true"
+
+  - label: ":buildkite: Promote Docker build cache to pipeline-level"
+    key: "promote-buildx-cache"
+    depends_on:
+      - "docker"
+      - "promote-gradle-cache"
+      - "promote-node-cache"
+      - "promote-script-cache"
+    branches: "main"
+    if_changed: *cache-buildx-manifest
+    plugins:
+      - *shallow-clone
+      - cache#v1.11.1:
+          <<: *cache-common-args
+          manifest: *cache-buildx-manifest
+          path: ".buildx-cache"
+          save: "pipeline"
+          force: true
+    command: "true"
 
   - label: ":amazon-ecs: Deploy to ECS"
     key: "deploy"
@@ -209,7 +253,9 @@ steps:
     concurrency_group: "terraware-server/deploy"
     depends_on:
       - "docker"
-      - "promote-caches"
+      - "promote-buildx-cache"
+      - "promote-gradle-cache"
+      - "promote-node-cache"
       - "promote-script-cache"
     if: "build.branch == 'main' || build.tag =~ /^v2[0-9]+\\.[0-9]+/"
     plugins:


### PR DESCRIPTION
We were telling Buildkite to save a copy of the Gradle home directory at both
the "file" level (which is keyed based on a checksum of build.gradle.kts and
related files so the existing cache is retained if none of the build files
actually changed) and at the "branch" level (which uses the current branch
name as the cache key), then, if the build was on main, attempting to promote
the branch-level cache to the "pipeline" level at the end so it could be
shared across branches.

This was wrong in a couple ways. First, saving branch-level caches meant that
every PR's initial build had to tar/gzip the Gradle home directory, which is
not tiny; the tar/gzip step often took over 2 minutes. That happened even if
no dependencies had changed, because there wasn't an existing cache entry
with the branch name in its key.

Second, the promotion logic wasn't actually promoting the branch-level caches
because (a) the file-level cache takes precedence, and (b) we didn't have
the "force" option enabled, meaning the update was skipped because the
pipeline-level cache entry already existed..

Stop writing branch-level caches altogether, relying on the file-level ones.
And split the promotion logic out into separate steps, each of which only
runs if a related manifest file changed.