### PR TITLE
Improve CountryDetector large geometry handling

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/gis/CountryDetector.kt
+++ b/src/main/kotlin/com/terraformation/backend/gis/CountryDetector.kt
@@ -78,6 +78,10 @@ class CountryDetector {
     result
   }
 
+  val countryAreas: Map<String, Double> by lazy {
+    countryBorders.mapValues { (_, border) -> border.area }
+  }
+
   /** Returns the country border geometry given the 2-letter country code */
   fun getCountryBorder(countryCode: String): Geometry? {
     return countryBorders[countryCode]
@@ -87,14 +91,18 @@ class CountryDetector {
    * Returns the 2-letter country codes for the countries that contain a geometry. If the geometry
    * falls outside any country, returns an empty set.
    *
-   * @param minCoveragePercent A country must cover at least this percentage of [geometry] to be
-   *   included in the result.
+   * @param minCoveragePercent Minimum percentage of the smaller geometry that must be covered by
+   *   the larger geometry to be included in the result. For geometries such as planting sites that
+   *   are much smaller than countries, this means at least this percentage of [geometry] must be
+   *   covered by a country for that country to be included. For large geometries like botanical
+   *   countries that can span multiple countries, at least this percentage of a country's area must
+   *   be covered by [geometry] for the country to be included.
    */
   fun getCountries(
       geometry: Geometry,
       minCoveragePercent: Double = MIN_COVERAGE_PERCENT,
   ): Set<String> {
-    val minCoverageArea = geometry.area * minCoveragePercent / 100.0
+    val geometryArea = geometry.area
 
     // For complex MultiPolygons, intersection calculations can be expensive. We only care
     // about exceeding the minimum coverage area, so do the calculation one polygon at a time
@@ -108,6 +116,8 @@ class CountryDetector {
 
     return countryBorders
         .mapNotNull { (countryCode, countryBorder) ->
+          val countryArea = countryAreas[countryCode] ?: geometryArea
+          val minCoverageArea = minOf(geometryArea, countryArea) * minCoveragePercent / 100.0
           val hasMinCoverage =
               geometries
                   .asSequence()

--- a/src/test/kotlin/com/terraformation/backend/gis/CountryDetectorTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/gis/CountryDetectorTest.kt
@@ -3,6 +3,7 @@ package com.terraformation.backend.gis
 import com.terraformation.backend.TestSingletons
 import com.terraformation.backend.assertSetEquals
 import com.terraformation.backend.point
+import com.terraformation.backend.polygon
 import com.terraformation.backend.util.Turtle
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
@@ -38,10 +39,18 @@ class CountryDetectorTest {
         detector.intersectionArea("NL", geometry) / geometry.area * 100.0
 
     assertThat(netherlandsIntersectionPercent)
+        .describedAs("Geometry intersects NL a little bit")
         .isGreaterThan(0.0)
         .isLessThan(CountryDetector.MIN_COVERAGE_PERCENT)
-        .describedAs("Geometry intersects NL a little bit")
 
     assertSetEquals(setOf("BE", "FR"), detector.getCountries(geometry))
+  }
+
+  @Test
+  fun `counts a country as covered even if it is a small percent of a geometry`() {
+    val geometry = polygon(1, 20, 24, 50)
+    val countries = detector.getCountries(geometry)
+
+    assertThat(countries).describedAs("Big geometry should cover Vatican City").contains("VA")
   }
 }


### PR DESCRIPTION
Previously, if we ran CountryDetector on a very large geometry such as one of
the bigger ecoregions, it was theoretically possible for it to leave out a
covered country if the country was too small to account for a minimum
percentage of the geometry's area (3% by default). Change the minimum coverage
percentage to use the country's area rather than the geometry's area in cases
where the country is smaller than the geometry. For sub-country-sized geometries,
it continues to work the same as before.