### PR TITLE
SW-8616 Add table to track dataset import times

### DIFF
--- a/jooq/src/main/kotlin/com/terraformation/backend/jooq/Config.kt
+++ b/jooq/src/main/kotlin/com/terraformation/backend/jooq/Config.kt
@@ -183,6 +183,11 @@ val ENUM_TABLES =
                     isLocalizable = false,
                 ),
                 EnumTable("ecosystem_types"),
+                EnumTable(
+                    "external_dataset_types",
+                    listOf("external_dataset_types\\.id", ".*\\.external_dataset_type_id"),
+                    isLocalizable = false,
+                ),
                 EnumTable("facility_connection_states", listOf("facilities\\.connection_state_id")),
                 EnumTable("facility_types", listOf("facilities\\.type_id")),
                 EnumTable("global_roles", isLocalizable = false),

--- a/src/main/resources/db/migration/0500/V525__ExternalDatasetVersions.sql
+++ b/src/main/resources/db/migration/0500/V525__ExternalDatasetVersions.sql
@@ -1,0 +1,10 @@
+CREATE TABLE external_dataset_types (
+    id INTEGER PRIMARY KEY,
+    name TEXT NOT NULL
+);
+
+CREATE TABLE external_dataset_imports (
+    external_dataset_type_id INTEGER PRIMARY KEY REFERENCES external_dataset_types,
+    imported_time TIMESTAMP WITH TIME ZONE NOT NULL,
+    last_publication_date DATE
+);

--- a/src/main/resources/db/migration/R__Comments.sql
+++ b/src/main/resources/db/migration/R__Comments.sql
@@ -94,6 +94,10 @@ COMMENT ON COLUMN event_log.payload IS 'JSON-serialized contents of the event ob
 
 COMMENT ON PROCEDURE event_log_create_id_index IS 'Creates an index on the event_log table for a top-level field in the event payload. The field is treated as a BIGINT. Only rows that have a non-null value for the field are indexed. The event class is included as a secondary key to support "all events of type X for entity Y" queries.';
 
+COMMENT ON TABLE external_dataset_imports IS 'The most recently imported versions of external data sets.';
+
+COMMENT ON TABLE external_dataset_types IS 'Types of external data sets that the system can pull information from.';
+
 COMMENT ON TABLE facilities IS 'Physical locations at a site. For example, each seed bank and each nursery is a facility.';
 COMMENT ON COLUMN facilities.idle_after_time IS 'Time at which the facility will be considered idle if no timeseries data is received. Null if the timeseries has already been marked as idle or if no timeseries data has ever been received from the facility.';
 COMMENT ON COLUMN facilities.idle_since_time IS 'Time at which the facility became idle. Null if the facility is not currently considered idle.';

--- a/src/main/resources/db/migration/R__TypeCodes.sql
+++ b/src/main/resources/db/migration/R__TypeCodes.sql
@@ -249,6 +249,14 @@ VALUES (1, 'One-on-One Session'),
        (4, 'Recorded Session')
 ON CONFLICT (id) DO UPDATE SET name = excluded.name;
 
+INSERT INTO external_dataset_types (id, name)
+VALUES (1, 'GBIF'),
+       (2, 'WCVP'),
+       (3, 'GRIIS'),
+       (4, 'RESOLVE'),
+       (5, 'NaturalEarth')
+ON CONFLICT (id) DO UPDATE SET name = excluded.name;
+
 INSERT INTO facility_connection_states (id, name)
 VALUES (1, 'Not Connected'),
        (2, 'Connected'),
@@ -818,6 +826,12 @@ FROM (
 ON CONFLICT (id) DO UPDATE SET name = excluded.name,
                                description = excluded.description;
 
+-- Depends on external_dataset_types
+INSERT INTO external_dataset_imports (external_dataset_type_id, imported_time, last_publication_date)
+VALUES (5, '2024-07-12T16:22:22Z', '2022-06-02')
+ON CONFLICT (external_dataset_type_id) DO UPDATE
+    SET imported_time = excluded.imported_time,
+        last_publication_date = excluded.last_publication_date;
 
 -- When adding new tables, put them in alphabetical (ASCII) order unless they depend on other
 -- tables with alphabetically-greater names.

--- a/src/test/kotlin/com/terraformation/backend/db/SchemaDocsGenerator.kt
+++ b/src/test/kotlin/com/terraformation/backend/db/SchemaDocsGenerator.kt
@@ -297,6 +297,8 @@ class SchemaDocsGenerator : DatabaseTest() {
                   "disclaimers" to setOf(ALL, CUSTOMER),
                   "ecosystem_types" to setOf(ALL, SPECIES),
                   "event_log" to setOf(ALL),
+                  "external_dataset_imports" to setOf(ALL, SPECIES),
+                  "external_dataset_types" to setOf(ALL, SPECIES),
                   "facilities" to setOf(ALL, CUSTOMER, DEVICE, SEEDBANK),
                   "facility_connection_states" to setOf(ALL, CUSTOMER, DEVICE),
                   "facility_types" to setOf(ALL, CUSTOMER),


### PR DESCRIPTION
We'll need to attribute species data to specific versions of specific datasets;
add a table to track when we import each dataset.

We include the Natural Earth country borders dataset in the code rather than
importing it explicitly. Populate the import information for that dataset based
on when we added it to the repo.