### PR TITLE
SW-8616 Track GRIIS import times

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/species/db/GriisImporter.kt
+++ b/src/main/kotlin/com/terraformation/backend/species/db/GriisImporter.kt
@@ -4,7 +4,9 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
 import com.opencsv.CSVParser
+import com.terraformation.backend.db.default_schema.ExternalDatasetType
 import com.terraformation.backend.db.default_schema.tables.records.GriisTaxaRecord
+import com.terraformation.backend.db.default_schema.tables.references.EXTERNAL_DATASET_IMPORTS
 import com.terraformation.backend.db.default_schema.tables.references.GRIIS_RESOURCES
 import com.terraformation.backend.db.default_schema.tables.references.GRIIS_TAXA
 import com.terraformation.backend.log.perClassLogger
@@ -18,6 +20,7 @@ import java.net.URI
 import java.nio.file.Files.copy
 import java.nio.file.StandardCopyOption
 import java.time.Instant
+import java.time.InstantSource
 import java.time.ZoneOffset
 import java.time.ZonedDateTime
 import java.time.format.DateTimeFormatter
@@ -41,6 +44,7 @@ import org.jooq.impl.DSL
  */
 @Named
 class GriisImporter(
+    private val clock: InstantSource,
     private val dslContext: DSLContext,
     private val objectMapper: ObjectMapper,
     private val uriFetcher: UriFetcher,
@@ -239,6 +243,26 @@ class GriisImporter(
 
         log.info("Imported ${taxaRecords.size} GRIIS taxa from resource $resourceName")
       }
+
+      updateImportTime()
+    }
+  }
+
+  private fun updateImportTime() {
+    with(EXTERNAL_DATASET_IMPORTS) {
+      dslContext
+          .insertInto(EXTERNAL_DATASET_IMPORTS)
+          .set(EXTERNAL_DATASET_TYPE_ID, ExternalDatasetType.GRIIS)
+          .set(IMPORTED_TIME, clock.instant())
+          .set(
+              LAST_PUBLICATION_DATE,
+              DSL.select(DSL.max(GRIIS_RESOURCES.PUBLICATION_DATE)).from(GRIIS_RESOURCES),
+          )
+          .onConflict(EXTERNAL_DATASET_TYPE_ID)
+          .doUpdate()
+          .set(IMPORTED_TIME, DSL.excluded(IMPORTED_TIME))
+          .set(LAST_PUBLICATION_DATE, DSL.excluded(LAST_PUBLICATION_DATE))
+          .execute()
     }
   }
 

--- a/src/test/kotlin/com/terraformation/backend/species/db/GriisImporterTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/species/db/GriisImporterTest.kt
@@ -1,9 +1,13 @@
 package com.terraformation.backend.species.db
 
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.terraformation.backend.TestClock
 import com.terraformation.backend.db.DatabaseTest
+import com.terraformation.backend.db.default_schema.ExternalDatasetType
+import com.terraformation.backend.db.default_schema.tables.records.ExternalDatasetImportsRecord
 import com.terraformation.backend.db.default_schema.tables.records.GriisResourcesRecord
 import com.terraformation.backend.db.default_schema.tables.records.GriisTaxaRecord
+import com.terraformation.backend.db.default_schema.tables.references.EXTERNAL_DATASET_IMPORTS
 import com.terraformation.backend.db.default_schema.tables.references.GRIIS_RESOURCES
 import com.terraformation.backend.db.default_schema.tables.references.GRIIS_TAXA
 import com.terraformation.backend.species.db.GriisImporter.GriisResource
@@ -21,9 +25,10 @@ import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 
 class GriisImporterTest : DatabaseTest() {
+  private val clock = TestClock()
   private val uriFetcher: UriFetcher = mockk()
   private val importer: GriisImporter by lazy {
-    GriisImporter(dslContext, jacksonObjectMapper(), uriFetcher)
+    GriisImporter(clock, dslContext, jacksonObjectMapper(), uriFetcher)
   }
 
   @Nested
@@ -31,6 +36,7 @@ class GriisImporterTest : DatabaseTest() {
     @Test
     fun `imports plant species from archive`() {
       val updatedTime = Instant.ofEpochSecond(123)
+      clock.instant = Instant.ofEpochSecond(456)
       mockResource("test", javaClass.getResourceAsStream("/species/griis/griis.zip")!!)
 
       importer.importResource(GriisResource("test", updatedTime))
@@ -59,6 +65,17 @@ class GriisImporterTest : DatabaseTest() {
               taxonomicStatus = "accepted",
               taxonRank = "species",
           )
+      )
+
+      assertTableEquals(
+          listOf(
+              ExternalDatasetImportsRecord(
+                  externalDatasetTypeId = ExternalDatasetType.GRIIS,
+                  importedTime = clock.instant,
+                  lastPublicationDate = LocalDate.of(2026, 6, 22),
+              )
+          ),
+          where = EXTERNAL_DATASET_IMPORTS.EXTERNAL_DATASET_TYPE_ID.eq(ExternalDatasetType.GRIIS),
       )
     }
 


### PR DESCRIPTION
Keep a record of when we imported GRIIS data. Since GRIIS datasets are
independently updated, there isn't a single "publication date" for GRIIS
as a whole; use the most recent publication data across all the datasets.