### PR TITLE
SW-8623 Normalize GRIIS, WCVP scientific names

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/species/WcvpImporter.kt
+++ b/src/main/kotlin/com/terraformation/backend/species/WcvpImporter.kt
@@ -12,6 +12,7 @@ import com.terraformation.backend.db.default_schema.tables.references.WCVP_DISTR
 import com.terraformation.backend.db.default_schema.tables.references.WCVP_TAXA
 import com.terraformation.backend.log.perClassLogger
 import com.terraformation.backend.species.event.WcvpImportedEvent
+import com.terraformation.backend.species.model.normalizeScientificName
 import com.terraformation.backend.util.ParsedCsvReader
 import com.terraformation.backend.util.onChunk
 import jakarta.inject.Named
@@ -170,10 +171,11 @@ class WcvpImporter(
         setOf("Illegitimate", "Invalid", "Misapplied", "Synonym")
 
     override fun parseRow(row: Array<String?>): WcvpTaxaRecord? {
+      val scientificName = row["scientificName"] ?: return null
       val taxonRank = row["taxonRank"] ?: return null
       val taxonomicStatus = row["taxonomicStatus"]
 
-      if (taxonomicStatus in excludedTaxonomicStatuses) {
+      if (taxonomicStatus in excludedTaxonomicStatuses || taxonRank == "Genus") {
         return null
       }
 
@@ -185,7 +187,7 @@ class WcvpImporter(
           nomenclaturalStatus = row["nomenclaturalStatus"],
           originalNameUsageId = row["originalNameUsageID"]?.let { WcvpTaxonId(it) },
           parentNameUsageId = row["parentNameUsageID"]?.let { WcvpTaxonId(it) },
-          scientificName = row["scientificName"],
+          scientificName = normalizeScientificName(scientificName),
           specificEpithet = row["specificEpithet"],
           taxonId = row["id"]?.let { WcvpTaxonId(it) },
           taxonomicStatus = taxonomicStatus,

--- a/src/main/kotlin/com/terraformation/backend/species/db/GriisImporter.kt
+++ b/src/main/kotlin/com/terraformation/backend/species/db/GriisImporter.kt
@@ -12,6 +12,7 @@ import com.terraformation.backend.db.default_schema.tables.references.GRIIS_RESO
 import com.terraformation.backend.db.default_schema.tables.references.GRIIS_TAXA
 import com.terraformation.backend.log.perClassLogger
 import com.terraformation.backend.species.DarwinCoreReader
+import com.terraformation.backend.species.model.normalizeScientificName
 import com.terraformation.backend.util.ParsedCsvReader
 import com.terraformation.backend.util.UriFetcher
 import jakarta.inject.Named
@@ -244,7 +245,7 @@ class GriisImporter(
               habitat = profile.habitat,
               isInvasive = profile.isInvasive,
               occurrenceStatus = distribution.occurrenceStatus,
-              scientificName = taxon.scientificName,
+              scientificName = normalizeScientificName(taxon.scientificName),
               speciesNativityId = nativity,
               taxonId = taxon.taxonId,
               taxonomicStatus = taxon.taxonomicStatus,
@@ -357,6 +358,7 @@ class GriisImporter(
       if (
           row["kingdom"] != "Plantae" ||
               taxonRank == "synonym" ||
+              taxonRank == "genus" ||
               !taxonomicStatus.startsWith("accepted")
       ) {
         return null

--- a/src/main/kotlin/com/terraformation/backend/species/model/Validation.kt
+++ b/src/main/kotlin/com/terraformation/backend/species/model/Validation.kt
@@ -1,6 +1,9 @@
 package com.terraformation.backend.species.model
 
+private val emEnDashRegex = Regex("[—–]")
 private val invalidScientificNameChars = Regex("[^A-Za-z. -]")
+private val rankMarkers = setOf("f.", "subsp.", "var.")
+private val whitespaceRegex = Regex("\\s+")
 
 /**
  * Validates the syntax of a scientific name. This does not check for higher-level conditions such
@@ -28,10 +31,24 @@ fun validateScientificNameSyntax(
 }
 
 /**
- * Normalizes the scientific name for a species. Normalizations performed include:
- * - replace en- and em-dashes with hyphens
+ * Transforms a full species scientific name to a normalized form.
+ *
+ * Normalized species names are either two words (genus and specific epithet) or four words (genus,
+ * specific epithet, infraspecific rank abbreviation, infraspecific epithet). For example, "Aloe
+ * vera" or "Euphorbia milii var. splendens".
+ *
+ * Authorship, hybrid markers, and other elements are removed, and em- and en-dashes are turned to
+ * hyphens.
  */
 fun normalizeScientificName(value: String): String {
-  // normalize dashes
-  return value.replace(Regex("[—–]"), "-")
+  val words = value.replace("×", "").replace(emEnDashRegex, "-").trim().split(whitespaceRegex)
+
+  val numSignificantWords =
+      when {
+        words.size < 2 -> throw IllegalArgumentException("$value is not a valid species name")
+        words.size >= 4 && words[2] in rankMarkers -> 4
+        else -> 2
+      }
+
+  return words.subList(0, numSignificantWords).joinToString(" ")
 }

--- a/src/main/kotlin/com/terraformation/backend/species/model/Validation.kt
+++ b/src/main/kotlin/com/terraformation/backend/species/model/Validation.kt
@@ -45,7 +45,9 @@ fun normalizeScientificName(value: String): String {
 
   val numSignificantWords =
       when {
-        words.size < 2 -> throw IllegalArgumentException("$value is not a valid species name")
+        words.isEmpty() || words.size == 1 && words[0].isEmpty() ->
+            throw IllegalArgumentException("No species name to normalize")
+        words.size == 1 -> 1
         words.size >= 4 && words[2] in rankMarkers -> 4
         else -> 2
       }

--- a/src/main/kotlin/com/terraformation/backend/species/model/Validation.kt
+++ b/src/main/kotlin/com/terraformation/backend/species/model/Validation.kt
@@ -22,7 +22,7 @@ fun validateScientificNameSyntax(
     onInvalidCharacter(invalidChar)
   }
 
-  val wordCount = normalizedValue.split(' ').size
+  val wordCount = value.split(' ').size
   if (wordCount < 2) {
     onTooShort()
   } else if (wordCount > 4) {

--- a/src/main/resources/db/migration/0500/V527__SpeciesNameIndexes.sql
+++ b/src/main/resources/db/migration/0500/V527__SpeciesNameIndexes.sql
@@ -1,0 +1,3 @@
+CREATE INDEX ON griis_taxa (scientific_name);
+
+CREATE INDEX ON wcvp_taxa (scientific_name);

--- a/src/test/kotlin/com/terraformation/backend/species/db/GriisImporterTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/species/db/GriisImporterTest.kt
@@ -61,7 +61,7 @@ class GriisImporterTest : DatabaseTest() {
               habitat = "Mangrove",
               isInvasive = true,
               occurrenceStatus = "present",
-              scientificName = "Cenchrus echinatus L.",
+              scientificName = "Cenchrus echinatus",
               speciesNativityId = SpeciesNativity.Invasive,
               taxonId = 100001L,
               taxonomicStatus = "accepted",

--- a/src/test/kotlin/com/terraformation/backend/species/db/SpeciesCsvValidatorTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/species/db/SpeciesCsvValidatorTest.kt
@@ -97,7 +97,7 @@ internal class SpeciesCsvValidatorTest {
 
     @Test
     fun `may not contain punctuation other than periods or dashes`() {
-      assertError("Name name var: x", MalformedValue, messages.csvScientificNameInvalidChar(":"))
+      assertError("Name: name var. x", MalformedValue, messages.csvScientificNameInvalidChar(":"))
     }
 
     @ParameterizedTest

--- a/src/test/kotlin/com/terraformation/backend/species/model/NormalizeScientificNameTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/species/model/NormalizeScientificNameTest.kt
@@ -18,6 +18,7 @@ class NormalizeScientificNameTest {
             "Aloe vera (L.) Burm. f." to "Aloe vera",
             "Costus woodsonii Maas" to "Costus woodsonii",
             " Allium   porrum " to "Allium porrum",
+            "Allium" to "Allium",
         )
 
     val actual = expected.mapValues { (name, _) -> normalizeScientificName(name) }
@@ -28,10 +29,5 @@ class NormalizeScientificNameTest {
   @Test
   fun `throws IllegalArgumentException on empty name`() {
     assertThrows<IllegalArgumentException> { normalizeScientificName("") }
-  }
-
-  @Test
-  fun `throws IllegalArgumentException on single-word name`() {
-    assertThrows<IllegalArgumentException> { normalizeScientificName("Foo") }
   }
 }

--- a/src/test/kotlin/com/terraformation/backend/species/model/NormalizeScientificNameTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/species/model/NormalizeScientificNameTest.kt
@@ -1,0 +1,37 @@
+package com.terraformation.backend.species.model
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+class NormalizeScientificNameTest {
+  @Test
+  fun `removes unwanted notations from scientific names`() {
+    val expected =
+        mapOf(
+            "Pelargonium ×orphanum Hoffmanns. ex F.Dietr." to "Pelargonium orphanum",
+            "Musa × paradisiaca L." to "Musa paradisiaca",
+            "Abelmoschus manihot subsp. tetraphyllus (Roxb. ex Hornem.) Borss.Waalk." to
+                "Abelmoschus manihot subsp. tetraphyllus",
+            "Prosopis glandulosa var. glandulosa" to "Prosopis glandulosa var. glandulosa",
+            "Pinus nigra f. nigra" to "Pinus nigra f. nigra",
+            "Aloe vera (L.) Burm. f." to "Aloe vera",
+            "Costus woodsonii Maas" to "Costus woodsonii",
+            " Allium   porrum " to "Allium porrum",
+        )
+
+    val actual = expected.mapValues { (name, _) -> normalizeScientificName(name) }
+
+    assertEquals(expected, actual)
+  }
+
+  @Test
+  fun `throws IllegalArgumentException on empty name`() {
+    assertThrows<IllegalArgumentException> { normalizeScientificName("") }
+  }
+
+  @Test
+  fun `throws IllegalArgumentException on single-word name`() {
+    assertThrows<IllegalArgumentException> { normalizeScientificName("Foo") }
+  }
+}


### PR DESCRIPTION
In preparation for looking up nativity status based on species scientific names,
update the GRIIS and WCVP importers so that they normalize scientific names to
the same format that's used in the `gbif_names` table.

Add indexes to the scientific name columns in the GRIIS and WCVP taxon tables
to support efficiently searching for the normalized names.