### PR TITLE
SW-8623 Calculate species nativities

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/species/db/SpeciesNativityCalculator.kt
+++ b/src/main/kotlin/com/terraformation/backend/species/db/SpeciesNativityCalculator.kt
@@ -1,0 +1,85 @@
+package com.terraformation.backend.species.db
+
+import com.terraformation.backend.db.default_schema.ExternalDatasetType
+import com.terraformation.backend.db.default_schema.SpeciesNativity
+import com.terraformation.backend.db.default_schema.tables.references.EXTERNAL_DATASET_IMPORTS
+import com.terraformation.backend.db.default_schema.tables.references.GRIIS_RESOURCES
+import com.terraformation.backend.db.default_schema.tables.references.GRIIS_TAXA
+import com.terraformation.backend.db.default_schema.tables.references.WCVP_DISTRIBUTIONS
+import com.terraformation.backend.db.default_schema.tables.references.WCVP_TAXA
+import com.terraformation.backend.species.model.SourcedSpeciesNativity
+import jakarta.inject.Named
+import org.jooq.DSLContext
+
+@Named
+class SpeciesNativityCalculator(
+    private val dslContext: DSLContext,
+) {
+  fun calculateNativities(
+      botanicalCountryCode: String,
+      countryCode: String,
+      scientificNames: Collection<String>,
+  ): Map<String, SourcedSpeciesNativity> {
+    // Species nativities are defined in descending order of precedence, so if we sort by them,
+    // we get the highest-precedence nativity for a given species first.
+    val griisRecords =
+        dslContext
+            .select(
+                GRIIS_TAXA.SCIENTIFIC_NAME,
+                GRIIS_TAXA.SPECIES_NATIVITY_ID,
+                EXTERNAL_DATASET_IMPORTS.LAST_PUBLICATION_DATE,
+            )
+            .from(GRIIS_TAXA)
+            .join(GRIIS_RESOURCES)
+            .on(GRIIS_TAXA.GRIIS_RESOURCE_ID.eq(GRIIS_RESOURCES.ID))
+            .join(EXTERNAL_DATASET_IMPORTS)
+            .on(EXTERNAL_DATASET_IMPORTS.EXTERNAL_DATASET_TYPE_ID.eq(ExternalDatasetType.GRIIS))
+            .where(GRIIS_TAXA.SCIENTIFIC_NAME.`in`(scientificNames))
+            .and(GRIIS_RESOURCES.COUNTRY_CODE.eq(countryCode))
+            .orderBy(GRIIS_TAXA.SPECIES_NATIVITY_ID)
+            .fetchGroups(GRIIS_TAXA.SCIENTIFIC_NAME)
+            .mapValues { (_, records) -> records.first() }
+    val wcvpRecords =
+        dslContext
+            .select(
+                WCVP_TAXA.SCIENTIFIC_NAME,
+                WCVP_DISTRIBUTIONS.SPECIES_NATIVITY_ID,
+                EXTERNAL_DATASET_IMPORTS.LAST_PUBLICATION_DATE,
+            )
+            .from(WCVP_DISTRIBUTIONS)
+            .join(WCVP_TAXA)
+            .on(WCVP_DISTRIBUTIONS.TAXON_ID.eq(WCVP_TAXA.TAXON_ID))
+            .join(EXTERNAL_DATASET_IMPORTS)
+            .on(EXTERNAL_DATASET_IMPORTS.EXTERNAL_DATASET_TYPE_ID.eq(ExternalDatasetType.WCVP))
+            .where(WCVP_DISTRIBUTIONS.BOTANICAL_COUNTRY_CODE.eq(botanicalCountryCode))
+            .and(WCVP_TAXA.SCIENTIFIC_NAME.`in`(scientificNames))
+            .orderBy(WCVP_DISTRIBUTIONS.SPECIES_NATIVITY_ID)
+            .fetchGroups(WCVP_TAXA.SCIENTIFIC_NAME)
+            .mapValues { (_, records) -> records.first() }
+
+    return scientificNames.associateWith { scientificName ->
+      val griisRecord = griisRecords[scientificName]
+      val wcvpRecord = wcvpRecords[scientificName]
+      val griisNativity = griisRecord?.get(GRIIS_TAXA.SPECIES_NATIVITY_ID)
+      val wcvpNativity = wcvpRecord?.get(WCVP_DISTRIBUTIONS.SPECIES_NATIVITY_ID)
+
+      when {
+        griisNativity == SpeciesNativity.Invasive || griisNativity == SpeciesNativity.Introduced ->
+            SourcedSpeciesNativity(
+                griisNativity,
+                ExternalDatasetType.GRIIS,
+                griisRecord[EXTERNAL_DATASET_IMPORTS.LAST_PUBLICATION_DATE],
+            )
+
+        wcvpNativity == SpeciesNativity.Native || wcvpNativity == SpeciesNativity.Introduced ->
+            SourcedSpeciesNativity(
+                wcvpNativity,
+                ExternalDatasetType.WCVP,
+                wcvpRecord[EXTERNAL_DATASET_IMPORTS.LAST_PUBLICATION_DATE],
+            )
+
+        else -> SourcedSpeciesNativity(SpeciesNativity.Unknown, null, null)
+      }
+    }
+  }
+}

--- a/src/main/kotlin/com/terraformation/backend/species/model/SourcedSpeciesNativity.kt
+++ b/src/main/kotlin/com/terraformation/backend/species/model/SourcedSpeciesNativity.kt
@@ -1,0 +1,11 @@
+package com.terraformation.backend.species.model
+
+import com.terraformation.backend.db.default_schema.ExternalDatasetType
+import com.terraformation.backend.db.default_schema.SpeciesNativity
+import java.time.LocalDate
+
+data class SourcedSpeciesNativity(
+    val speciesNativity: SpeciesNativity,
+    val datasetType: ExternalDatasetType?,
+    val datasetDate: LocalDate?,
+)

--- a/src/main/resources/db/migration/R__TypeCodes.sql
+++ b/src/main/resources/db/migration/R__TypeCodes.sql
@@ -644,6 +644,7 @@ VALUES (1, 'Native'),
        (2, 'Non-native')
 ON CONFLICT (id) DO UPDATE SET name = excluded.name;
 
+-- These need to be in descending order of precedence.
 INSERT INTO species_nativities (id, name)
 VALUES (1, 'Invasive'),
        (2, 'Introduced'),

--- a/src/test/kotlin/com/terraformation/backend/db/DatabaseBackedTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/db/DatabaseBackedTest.kt
@@ -139,6 +139,7 @@ import com.terraformation.backend.db.default_schema.DeviceId
 import com.terraformation.backend.db.default_schema.DisclaimerId
 import com.terraformation.backend.db.default_schema.EcosystemType
 import com.terraformation.backend.db.default_schema.EventLogId
+import com.terraformation.backend.db.default_schema.ExternalDatasetType
 import com.terraformation.backend.db.default_schema.FacilityConnectionState
 import com.terraformation.backend.db.default_schema.FacilityId
 import com.terraformation.backend.db.default_schema.FacilityType
@@ -161,6 +162,7 @@ import com.terraformation.backend.db.default_schema.SeedStorageBehavior
 import com.terraformation.backend.db.default_schema.SeedTreatment
 import com.terraformation.backend.db.default_schema.SpeciesId
 import com.terraformation.backend.db.default_schema.SpeciesNativeCategory
+import com.terraformation.backend.db.default_schema.SpeciesNativity
 import com.terraformation.backend.db.default_schema.SplatAnnotationId
 import com.terraformation.backend.db.default_schema.SubLocationId
 import com.terraformation.backend.db.default_schema.SuccessionalGroup
@@ -238,6 +240,7 @@ import com.terraformation.backend.db.default_schema.tables.pojos.UserDisclaimers
 import com.terraformation.backend.db.default_schema.tables.pojos.UserGlobalRolesRow
 import com.terraformation.backend.db.default_schema.tables.records.BotanicalCountriesRecord
 import com.terraformation.backend.db.default_schema.tables.records.CountryBotanicalCountriesRecord
+import com.terraformation.backend.db.default_schema.tables.records.ExternalDatasetImportsRecord
 import com.terraformation.backend.db.default_schema.tables.records.GriisResourcesRecord
 import com.terraformation.backend.db.default_schema.tables.records.GriisTaxaRecord
 import com.terraformation.backend.db.default_schema.tables.records.WcvpDistributionsRecord
@@ -5911,9 +5914,11 @@ abstract class DatabaseBackedTest {
       establishmentMeans: String? = null,
       griisResourceId: GriisResourceId = inserted.griisResourceId,
       habitat: String? = null,
-      isInvasive: Boolean = true,
+      isInvasive: Boolean = false,
       occurrenceStatus: String? = "present",
       scientificName: String = "Species name",
+      speciesNativity: SpeciesNativity =
+          if (isInvasive) SpeciesNativity.Invasive else SpeciesNativity.Unknown,
       taxonId: Long = nextGriisTaxonId++,
       taxonomicStatus: String = "accepted",
       taxonRank: String = "species",
@@ -5926,6 +5931,7 @@ abstract class DatabaseBackedTest {
             isInvasive = isInvasive,
             occurrenceStatus = occurrenceStatus,
             scientificName = scientificName,
+            speciesNativityId = speciesNativity,
             taxonId = taxonId,
             taxonomicStatus = taxonomicStatus,
             taxonRank = taxonRank,
@@ -5975,6 +5981,7 @@ abstract class DatabaseBackedTest {
       establishmentMeans: String? = null,
       level3Code: String = "COD",
       occurrenceStatus: String? = null,
+      speciesNativity: SpeciesNativity = SpeciesNativity.Introduced,
       taxonId: WcvpTaxonId = inserted.wcvpTaxonId,
       threatStatus: String? = null,
   ) {
@@ -5983,8 +5990,23 @@ abstract class DatabaseBackedTest {
             establishmentMeans = establishmentMeans,
             level3Code = level3Code,
             occurrenceStatus = occurrenceStatus,
+            speciesNativityId = speciesNativity,
             taxonId = taxonId,
             threatStatus = threatStatus,
+        )
+        .attach(dslContext)
+        .insert()
+  }
+
+  fun insertExternalDatasetImport(
+      type: ExternalDatasetType = ExternalDatasetType.GRIIS,
+      importedTime: Instant = Instant.EPOCH,
+      lastPublicationDate: LocalDate = LocalDate.of(2026, 1, 1),
+  ) {
+    ExternalDatasetImportsRecord(
+            externalDatasetTypeId = type,
+            importedTime = importedTime,
+            lastPublicationDate = lastPublicationDate,
         )
         .attach(dslContext)
         .insert()

--- a/src/test/kotlin/com/terraformation/backend/gis/RegionMetadataServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/gis/RegionMetadataServiceTest.kt
@@ -2,6 +2,7 @@ package com.terraformation.backend.gis
 
 import com.terraformation.backend.assertIsEventListener
 import com.terraformation.backend.db.DatabaseTest
+import com.terraformation.backend.db.default_schema.SpeciesNativity
 import com.terraformation.backend.db.default_schema.tables.records.CountryBotanicalCountriesRecord
 import com.terraformation.backend.db.default_schema.tables.records.WcvpDistributionsRecord
 import com.terraformation.backend.gis.event.BotanicalCountriesImportedEvent
@@ -69,20 +70,24 @@ class RegionMetadataServiceTest : DatabaseTest() {
               WcvpDistributionsRecord(
                   botanicalCountryCode = "AAA",
                   level3Code = "AAA",
+                  speciesNativityId = SpeciesNativity.Introduced,
                   taxonId = taxonId1,
               ),
               WcvpDistributionsRecord(
                   botanicalCountryCode = "AAA",
                   level3Code = "AAA",
+                  speciesNativityId = SpeciesNativity.Introduced,
                   taxonId = taxonId2,
               ),
               WcvpDistributionsRecord(
                   botanicalCountryCode = "BBB",
                   level3Code = "BBB",
+                  speciesNativityId = SpeciesNativity.Introduced,
                   taxonId = taxonId2,
               ),
               WcvpDistributionsRecord(
                   level3Code = "XXX",
+                  speciesNativityId = SpeciesNativity.Introduced,
                   taxonId = taxonId3,
               ),
           )

--- a/src/test/kotlin/com/terraformation/backend/species/db/GriisImporterTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/species/db/GriisImporterTest.kt
@@ -87,7 +87,7 @@ class GriisImporterTest : DatabaseTest() {
       mockResource("test", javaClass.getResourceAsStream("/species/griis/griis.zip")!!)
 
       insertGriisResource(resourceName = "test", updatedTime = updatedTime)
-      insertGriisTaxon()
+      insertGriisTaxon(isInvasive = true)
 
       val expectedResources = dslContext.fetch(GRIIS_RESOURCES)
       val expectedTaxa = dslContext.fetch(GRIIS_TAXA)

--- a/src/test/kotlin/com/terraformation/backend/species/db/SpeciesNativityCalculatorTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/species/db/SpeciesNativityCalculatorTest.kt
@@ -1,0 +1,115 @@
+package com.terraformation.backend.species.db
+
+import com.terraformation.backend.db.DatabaseTest
+import com.terraformation.backend.db.default_schema.ExternalDatasetType
+import com.terraformation.backend.db.default_schema.SpeciesNativity
+import com.terraformation.backend.species.model.SourcedSpeciesNativity
+import java.time.LocalDate
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class SpeciesNativityCalculatorTest : DatabaseTest() {
+  private val calculator: SpeciesNativityCalculator by lazy {
+    SpeciesNativityCalculator(dslContext)
+  }
+
+  @Test
+  fun `calculates nativity from GRIIS and WCVP data`() {
+    // Species is listed in two GRIIS resources, one with Invasive and one with Introduced;
+    // Invasive should take precedence.
+    val invasiveName = "Acceleratti incredibilis"
+
+    // Species is listed in GRIIS (as Introduced) but not WCVP.
+    val introducedName = "Birdibus zippibus"
+
+    // Species is listed in GRIIS (as Unknown) and WCVP (as Native).
+    val nativeName = "Cantus stopus"
+
+    // Species is not listed in either GRIIS or WCVP for the target country, but is listed for
+    // a different country.
+    val unknownName = "Dogius ignoramii"
+
+    val botanicalCountryCode = insertBotanicalCountry()
+    val otherBotanicalCountryCode = insertBotanicalCountry()
+    val countryCode = "KE"
+    val otherCountryCode = "TZ"
+    val griisPublicationDate = LocalDate.of(2026, 1, 1)
+    val wcvpPublicationDate = LocalDate.of(2026, 2, 2)
+
+    insertExternalDatasetImport(
+        type = ExternalDatasetType.GRIIS,
+        lastPublicationDate = griisPublicationDate,
+    )
+    insertExternalDatasetImport(
+        type = ExternalDatasetType.WCVP,
+        lastPublicationDate = wcvpPublicationDate,
+    )
+
+    insertGriisResource(publicationDate = griisPublicationDate, countryCode = countryCode)
+    insertGriisTaxon(scientificName = invasiveName, speciesNativity = SpeciesNativity.Introduced)
+    insertGriisTaxon(scientificName = introducedName, speciesNativity = SpeciesNativity.Introduced)
+    insertGriisTaxon(scientificName = nativeName, speciesNativity = SpeciesNativity.Unknown)
+
+    val otherGriisPublicationDate = LocalDate.of(2020, 3, 3)
+    insertGriisResource(countryCode = countryCode, publicationDate = otherGriisPublicationDate)
+    insertGriisTaxon(scientificName = invasiveName, isInvasive = true)
+
+    insertWcvpTaxon(scientificName = invasiveName)
+    insertWcvpDistribution(
+        botanicalCountryCode = botanicalCountryCode,
+        speciesNativity = SpeciesNativity.Introduced,
+    )
+    insertWcvpTaxon(scientificName = nativeName)
+    insertWcvpDistribution(
+        botanicalCountryCode = botanicalCountryCode,
+        speciesNativity = SpeciesNativity.Native,
+    )
+
+    insertGriisResource(countryCode = otherCountryCode)
+    insertGriisTaxon(scientificName = unknownName, isInvasive = true)
+    insertWcvpTaxon(scientificName = unknownName)
+    insertWcvpDistribution(
+        botanicalCountryCode = otherBotanicalCountryCode,
+        speciesNativity = SpeciesNativity.Introduced,
+    )
+
+    assertEquals(
+        mapOf(
+            introducedName to
+                SourcedSpeciesNativity(
+                    SpeciesNativity.Introduced,
+                    ExternalDatasetType.GRIIS,
+                    griisPublicationDate,
+                ),
+            invasiveName to
+                SourcedSpeciesNativity(
+                    SpeciesNativity.Invasive,
+                    ExternalDatasetType.GRIIS,
+                    griisPublicationDate,
+                ),
+            nativeName to
+                SourcedSpeciesNativity(
+                    SpeciesNativity.Native,
+                    ExternalDatasetType.WCVP,
+                    wcvpPublicationDate,
+                ),
+            unknownName to
+                SourcedSpeciesNativity(
+                    SpeciesNativity.Unknown,
+                    null,
+                    null,
+                ),
+        ),
+        calculator.calculateNativities(
+            botanicalCountryCode,
+            countryCode,
+            listOf(
+                introducedName,
+                invasiveName,
+                nativeName,
+                unknownName,
+            ),
+        ),
+    )
+  }
+}


### PR DESCRIPTION
Add logic to collate nativity data from GRIIS and WCVP to calculate an overall
nativity for a list of species.

Nothing calls this yet, but it will be used by the "check species" feature.