### PR TITLE
Move species admin to a separate page

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/admin/AdminController.kt
+++ b/src/main/kotlin/com/terraformation/backend/admin/AdminController.kt
@@ -8,8 +8,6 @@ import com.terraformation.backend.db.default_schema.GlobalRole
 import com.terraformation.backend.db.default_schema.Role
 import com.terraformation.backend.db.default_schema.tables.daos.OrganizationsDao
 import com.terraformation.backend.file.GoogleDriveWriter
-import com.terraformation.backend.gis.BotanicalCountryImporter
-import com.terraformation.backend.species.WcvpImporter
 import java.net.URI
 import java.util.Locale
 import org.springframework.stereotype.Controller
@@ -111,11 +109,6 @@ class AdminController(
     model.addAttribute("canUpdateDefaultVoters", currentUser().canUpdateDefaultVoters())
     model.addAttribute("canUpdateDeviceTemplates", currentUser().canUpdateDeviceTemplates())
     model.addAttribute("canUpdateGlobalRoles", currentUser().canUpdateGlobalRoles())
-    model.addAttribute(
-        "defaultBotanicalCountriesUrl",
-        BotanicalCountryImporter.defaultGeoJsonUrl.toString(),
-    )
-    model.addAttribute("defaultWcvpSpeciesListUrl", WcvpImporter.defaultZipFileUrl.toString())
     model.addAttribute("organizations", organizations)
     model.addAttribute("roles", Role.entries.map { it to it.getDisplayName(Locale.ENGLISH) })
     model.addAttribute("splatterEnabled", config.splatter.enabled)

--- a/src/main/kotlin/com/terraformation/backend/admin/AdminSpeciesController.kt
+++ b/src/main/kotlin/com/terraformation/backend/admin/AdminSpeciesController.kt
@@ -1,6 +1,7 @@
 package com.terraformation.backend.admin
 
 import com.terraformation.backend.api.RequireGlobalRole
+import com.terraformation.backend.auth.currentUser
 import com.terraformation.backend.db.default_schema.GlobalRole
 import com.terraformation.backend.gis.BotanicalCountryImporter
 import com.terraformation.backend.log.perClassLogger
@@ -15,7 +16,9 @@ import java.util.zip.ZipFile
 import kotlin.io.path.deleteIfExists
 import kotlin.io.path.inputStream
 import org.springframework.stereotype.Controller
+import org.springframework.ui.Model
 import org.springframework.validation.annotation.Validated
+import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
@@ -23,7 +26,9 @@ import org.springframework.web.servlet.mvc.support.RedirectAttributes
 
 @Controller
 @RequestMapping("/admin")
-@RequireGlobalRole([GlobalRole.SuperAdmin])
+@RequireGlobalRole(
+    [GlobalRole.SuperAdmin, GlobalRole.AcceleratorAdmin, GlobalRole.TFExpert, GlobalRole.ReadOnly]
+)
 @Validated
 class AdminSpeciesController(
     private val botanicalCountryImporter: BotanicalCountryImporter,
@@ -33,7 +38,20 @@ class AdminSpeciesController(
 ) {
   private val log = perClassLogger()
 
+  @GetMapping("/species")
+  fun getSpeciesAdminHome(model: Model): String {
+    model.addAttribute("canImportGlobalSpeciesData", currentUser().canImportGlobalSpeciesData())
+    model.addAttribute(
+        "defaultBotanicalCountriesUrl",
+        BotanicalCountryImporter.defaultGeoJsonUrl.toString(),
+    )
+    model.addAttribute("defaultWcvpSpeciesListUrl", WcvpImporter.defaultZipFileUrl.toString())
+
+    return "/admin/species"
+  }
+
   @PostMapping("/importGbif")
+  @RequireGlobalRole([GlobalRole.SuperAdmin])
   fun importGbif(
       @RequestParam url: URI,
       redirectAttributes: RedirectAttributes,
@@ -48,10 +66,11 @@ class AdminSpeciesController(
       redirectAttributes.failureMessage = "Import failed: ${e.message}"
     }
 
-    return redirectToAdminHome()
+    return redirectToSpeciesHome()
   }
 
   @PostMapping("/importBotanicalCountries")
+  @RequireGlobalRole([GlobalRole.SuperAdmin])
   fun importBotanicalCountries(
       @RequestParam url: URI,
       redirectAttributes: RedirectAttributes,
@@ -69,10 +88,11 @@ class AdminSpeciesController(
       redirectAttributes.failureMessage = "Import failed: ${e.message}"
     }
 
-    return redirectToAdminHome()
+    return redirectToSpeciesHome()
   }
 
   @PostMapping("/importGriisResources")
+  @RequireGlobalRole([GlobalRole.SuperAdmin])
   fun importGriisResources(
       @RequestParam resourceName: String? = null,
       @RequestParam forceUpdate: Boolean,
@@ -97,10 +117,11 @@ class AdminSpeciesController(
       redirectAttributes.failureMessage = "Import failed: ${e.message}"
     }
 
-    return redirectToAdminHome()
+    return redirectToSpeciesHome()
   }
 
   @PostMapping("/importWcvpSpeciesList")
+  @RequireGlobalRole([GlobalRole.SuperAdmin])
   fun importWcvpSpeciesList(
       @RequestParam url: URI,
       redirectAttributes: RedirectAttributes,
@@ -115,7 +136,7 @@ class AdminSpeciesController(
       redirectAttributes.failureMessage = "Import failed: ${e.message}"
     }
 
-    return redirectToAdminHome()
+    return redirectToSpeciesHome()
   }
 
   private fun <T> withDownloadedFile(url: URI, suffix: String = ".zip", func: (Path) -> T): T {
@@ -134,5 +155,5 @@ class AdminSpeciesController(
     }
   }
 
-  private fun redirectToAdminHome() = "redirect:/admin/"
+  private fun redirectToSpeciesHome() = "redirect:/admin/species"
 }

--- a/src/main/resources/templates/admin/index.html
+++ b/src/main/resources/templates/admin/index.html
@@ -79,6 +79,13 @@
             <a href="/admin/hubSpot">Manage HubSpot integration</a>
         </p>
     </th:block>
+
+    <h3>Species Management</h3>
+
+    <p>
+        <a href="/admin/species">Manage species configuration</a>
+    </p>
+
 </details>
 
 <details id="testing" class="section" th:if="${canSetTestClock}">
@@ -175,87 +182,6 @@
             <input type="submit" value="Delete User"/>
         </form>
     </th:block>
-</details>
-
-<details id="species" class="section">
-    <summary>Species Management</summary>
-
-    <div th:if="${canImportGlobalSpeciesData}">
-        <h3>Import GBIF species data</h3>
-
-        <p>You can download the data
-            <a href="https://hosted-datasets.gbif.org/datasets/backbone/current/backbone.zip">here</a>.
-            Use a <code>file://</code> URL to load the data from a file on the server's local
-            filesystem.
-        </p>
-
-        <form method="POST" enctype="multipart/form-data" action="importGbif">
-            <label for="gbifUrl">URL of backbone.zip</label>
-            <input id="gbifUrl" type="url" name="url" required/>
-            <input type="submit" value="Import"/>
-            (can take several minutes)
-        </form>
-    </div>
-
-    <div th:if="${canImportGlobalSpeciesData}">
-        <h3>Import GRIIS resources</h3>
-
-        <p>
-            The list of resources is available
-            <a href="https://cloud.gbif.org/griis/">here</a>.
-        </p>
-
-        <form method="POST" action="importGriisResources">
-            <label>
-                Single resource name to import (leave blank to import all)
-                <input type="text" name="resourceName"/>
-            </label>
-            <label>
-                Force import?
-                <select name="forceUpdate">
-                    <option value="false" selected>No (only import updated resources)</option>
-                    <option value="true">Yes (import all resources)</option>
-                </select>
-            </label>
-            <input type="submit" value="Import">
-            (can take several minutes)
-        </form>
-    </div>
-
-    <div th:if="${canImportGlobalSpeciesData}">
-        <h3>Import TDWG Level 3 botanical countries</h3>
-
-        <p>
-            You can download the data from
-            <a href="https://github.com/tdwg/wgsrpd/blob/master/geojson/level3.geojson">here</a>.
-        </p>
-
-        <form method="POST" action="importBotanicalCountries">
-            <label>URL of GeoJSON file
-                <input id="botanicalCountriesUrl" name="url" required th:value="${defaultBotanicalCountriesUrl}"/>
-            </label>
-            <input type="submit" value="Import">
-            (can take several minutes)
-        </form>
-    </div>
-
-    <div th:if="${canImportGlobalSpeciesData}">
-        <h3>Import WCVP species list</h3>
-
-        <p>
-            You can download the data from
-            <a href="https://www.gbif.org/dataset/f382f0ce-323a-4091-bb9f-add557f3a9a2">here</a>.
-        </p>
-
-        <form method="POST" action="importWcvpSpeciesList">
-            <label>URL of zipfile
-                <input name="url" required th:value="${defaultWcvpSpeciesListUrl}"/>
-            </label>
-            <input type="submit" value="Import">
-            (can take several minutes)
-        </form>
-    </div>
-
 </details>
 
 <details id="tracking" class="section" th:if="${canManageTracking}">

--- a/src/main/resources/templates/admin/species.html
+++ b/src/main/resources/templates/admin/species.html
@@ -1,0 +1,89 @@
+<!DOCTYPE HTML>
+<html xmlns:th="http://www.thymeleaf.org">
+<head th:replace="~{/admin/header :: head}">
+    <style th:fragment="additionalStyle">
+        form {
+            padding-bottom: 1em;
+        }
+    </style>
+</head>
+<body>
+
+<span th:replace="~{/admin/header :: top}"/>
+
+<a href="/admin/">Home</a>
+
+<h2>Species Management</h2>
+
+<div th:if="${canImportGlobalSpeciesData}">
+    <h3>Import GBIF species data</h3>
+
+    <p>You can download the data
+        <a href="https://hosted-datasets.gbif.org/datasets/backbone/current/backbone.zip">here</a>.
+        Use a <code>file://</code> URL to load the data from a file on the server's local
+        filesystem.
+    </p>
+
+    <form method="POST" enctype="multipart/form-data" action="importGbif">
+        <label for="gbifUrl">URL of backbone.zip</label>
+        <input id="gbifUrl" type="url" name="url" required/>
+        <input type="submit" value="Import"/>
+        (can take several minutes)
+    </form>
+
+    <h3>Import GRIIS resources</h3>
+
+    <p>
+        The list of resources is available
+        <a href="https://cloud.gbif.org/griis/">here</a>.
+    </p>
+
+    <form method="POST" action="importGriisResources">
+        <label>
+            Single resource name to import (leave blank to import all)
+            <input type="text" name="resourceName"/>
+        </label>
+        <label>
+            Force import?
+            <select name="forceUpdate">
+                <option value="false" selected>No (only import updated resources)</option>
+                <option value="true">Yes (import all resources)</option>
+            </select>
+        </label>
+        <input type="submit" value="Import">
+        (can take several minutes)
+    </form>
+
+    <h3>Import TDWG Level 3 botanical countries</h3>
+
+    <p>
+        You can download the data from
+        <a href="https://github.com/tdwg/wgsrpd/blob/master/geojson/level3.geojson">here</a>.
+    </p>
+
+    <form method="POST" action="importBotanicalCountries">
+        <label>URL of GeoJSON file
+            <input id="botanicalCountriesUrl" name="url" required th:value="${defaultBotanicalCountriesUrl}"/>
+        </label>
+        <input type="submit" value="Import">
+        (can take several minutes)
+    </form>
+
+    <h3>Import WCVP species list</h3>
+
+    <p>
+        You can download the data from
+        <a href="https://www.gbif.org/dataset/f382f0ce-323a-4091-bb9f-add557f3a9a2">here</a>.
+    </p>
+
+    <form method="POST" action="importWcvpSpeciesList">
+        <label>URL of zipfile
+            <input name="url" required th:value="${defaultWcvpSpeciesListUrl}"/>
+        </label>
+        <input type="submit" value="Import">
+        (can take several minutes)
+    </form>
+</div>
+
+</body>
+</html>


### PR DESCRIPTION
In preparation for adding some more admin tools related to species data, move the
species configuration management features to a separate admin UI page.