### PR TITLE
Update PermissionRequirements to correct the exceptions thrown

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/customer/model/PermissionRequirements.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/PermissionRequirements.kt
@@ -297,8 +297,11 @@ class PermissionRequirements(private val user: TerrawareUser) {
   }
 
   fun createNotification(userId: UserId) {
-    if (!user.canCreateNotification(userId)) {
-      throw AccessDeniedException("No permission to create notification")
+    user.recordPermissionChecks {
+      if (!user.canCreateNotification(userId)) {
+        readUser(userId)
+        throw AccessDeniedException("No permission to create notification")
+      }
     }
   }
 
@@ -323,6 +326,7 @@ class PermissionRequirements(private val user: TerrawareUser) {
   fun createParticipantProjectSpecies(projectId: ProjectId) {
     user.recordPermissionChecks {
       if (!user.canCreateParticipantProjectSpecies(projectId)) {
+        readProject(projectId)
         throw AccessDeniedException("No permission to create participant project species")
       }
     }
@@ -364,6 +368,7 @@ class PermissionRequirements(private val user: TerrawareUser) {
   fun createSavedVersion(documentId: DocumentId) {
     user.recordPermissionChecks {
       if (!user.canCreateSavedVersion(documentId)) {
+        readDocument(documentId)
         throw AccessDeniedException("No permission to create saved versions")
       }
     }
@@ -483,6 +488,7 @@ class PermissionRequirements(private val user: TerrawareUser) {
   fun deleteFunder(userId: UserId) {
     user.recordPermissionChecks {
       if (!user.canDeleteFunder(userId)) {
+        readUser(userId)
         throw AccessDeniedException("No permission to delete funder $userId")
       }
     }
@@ -1629,6 +1635,7 @@ class PermissionRequirements(private val user: TerrawareUser) {
   fun updateDocument(documentId: DocumentId) {
     user.recordPermissionChecks {
       if (!user.canUpdateDocument(documentId)) {
+        readDocument(documentId)
         throw AccessDeniedException("No permission to update document")
       }
     }
@@ -1673,6 +1680,7 @@ class PermissionRequirements(private val user: TerrawareUser) {
   fun updateFundingEntityUsers(fundingEntityId: FundingEntityId) {
     user.recordPermissionChecks {
       if (!user.canUpdateFundingEntityUsers(fundingEntityId)) {
+        readFundingEntity(fundingEntityId)
         throw AccessDeniedException("No permission to update funding entity users")
       }
     }

--- a/src/test/kotlin/com/terraformation/backend/customer/db/UserStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/db/UserStoreTest.kt
@@ -19,6 +19,7 @@ import com.terraformation.backend.db.DatabaseTest
 import com.terraformation.backend.db.KeycloakRequestFailedException
 import com.terraformation.backend.db.KeycloakUserNotFoundException
 import com.terraformation.backend.db.OrganizationNotFoundException
+import com.terraformation.backend.db.UserNotFoundException
 import com.terraformation.backend.db.default_schema.GlobalRole
 import com.terraformation.backend.db.default_schema.OrganizationId
 import com.terraformation.backend.db.default_schema.Role
@@ -886,15 +887,28 @@ internal class UserStoreTest : DatabaseTest(), RunsAsUser {
 
     @Test
     fun `throws exception if no permission to delete funders`() {
+      every { user.canReadUser(inserted.userId) } returns true
       every { user.canDeleteFunder(inserted.userId) } returns false
 
       assertThrows<AccessDeniedException> { userStore.deleteFunderById(inserted.userId) }
     }
 
     @Test
+    fun `throws not-found exception if funder is not readable`() {
+      every { user.canReadUser(inserted.userId) } returns false
+      every { user.canDeleteFunder(inserted.userId) } returns false
+
+      assertThrows<UserNotFoundException> { userStore.deleteFunderById(inserted.userId) }
+    }
+
+    @Test
     fun `throws exception if attempting to delete non-funder users`() {
       val deviceManagerUser = insertUser(type = UserType.DeviceManager)
       val systemUser = insertUser(type = UserType.System)
+
+      every { user.canReadUser(any()) } returns true
+      every { user.canDeleteFunder(deviceManagerUser) } returns true
+      every { user.canDeleteFunder(systemUser) } returns true
 
       assertThrows<AccessDeniedException> { userStore.deleteFunderById(deviceManagerUser) }
       assertThrows<AccessDeniedException> { userStore.deleteFunderById(systemUser) }

--- a/src/test/kotlin/com/terraformation/backend/customer/model/PermissionRequirementsTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/model/PermissionRequirementsTest.kt
@@ -46,6 +46,7 @@ import com.terraformation.backend.db.default_schema.SpeciesId
 import com.terraformation.backend.db.default_schema.SubLocationId
 import com.terraformation.backend.db.default_schema.UploadId
 import com.terraformation.backend.db.default_schema.UserId
+import com.terraformation.backend.db.docprod.DocumentId
 import com.terraformation.backend.db.funder.FundingEntityId
 import com.terraformation.backend.db.nursery.BatchId
 import com.terraformation.backend.db.nursery.WithdrawalId
@@ -60,6 +61,7 @@ import com.terraformation.backend.db.tracking.PlantingSeasonId
 import com.terraformation.backend.db.tracking.PlantingSiteId
 import com.terraformation.backend.db.tracking.StratumId
 import com.terraformation.backend.db.tracking.SubstratumId
+import com.terraformation.backend.documentproducer.db.DocumentNotFoundException
 import com.terraformation.backend.funder.db.FundingEntityNotFoundException
 import com.terraformation.backend.nursery.db.BatchNotFoundException
 import com.terraformation.backend.nursery.db.WithdrawalNotFoundException
@@ -138,6 +140,8 @@ internal class PermissionRequirementsTest : RunsAsUser {
   private val deviceId: DeviceId by readableId(DeviceNotFoundException::class) { canReadDevice(it) }
   private val deviceManagerId: DeviceManagerId by
       readableId(DeviceManagerNotFoundException::class) { canReadDeviceManager(it) }
+  private val documentId: DocumentId by
+      readableId(DocumentNotFoundException::class) { canReadDocument(it) }
   private val draftPlantingSiteId: DraftPlantingSiteId by
       readableId(DraftPlantingSiteNotFoundException::class) { canReadDraftPlantingSite(it) }
   private val eventId: EventId by
@@ -146,13 +150,14 @@ internal class PermissionRequirementsTest : RunsAsUser {
       readableId(FacilityNotFoundException::class) { canReadFacility(it) }
   private val fileBatchId: FileBatchId by
       readableId(FileBatchNotFoundException::class) { canFinishUploadingFileBatch(it) }
-  private val funderId: UserId by readableId(AccessDeniedException::class) { canReadUser(it) }
+  private val funderId: UserId by readableId(UserNotFoundException::class) { canReadUser(it) }
   private val fundingEntityId: FundingEntityId by
       readableId(FundingEntityNotFoundException::class) { canReadFundingEntity(it) }
   private val moduleId: ModuleId by readableId(ModuleNotFoundException::class) { canReadModule(it) }
   private val monitoringPlotId: MonitoringPlotId by
       readableId(PlotNotFoundException::class) { canReadMonitoringPlot(it) }
-  private val notificationUserId = UserId(2)
+  private val notificationUserId: UserId by
+      readableId(UserNotFoundException::class) { canReadUser(it) }
   private val notificationId: NotificationId by
       readableId(NotificationNotFoundException::class) { canReadNotification(it) }
   private val observationId: ObservationId by
@@ -385,12 +390,11 @@ internal class PermissionRequirementsTest : RunsAsUser {
           }
 
   @Test
-  fun createParticipantProjectSpecies() {
-    assertThrows<AccessDeniedException> { requirements.createParticipantProjectSpecies(projectId) }
-
-    grant { user.canCreateParticipantProjectSpecies(projectId) }
-    requirements.createParticipantProjectSpecies(projectId)
-  }
+  fun createParticipantProjectSpecies() =
+      allow { createParticipantProjectSpecies(projectId) } ifUser
+          {
+            canCreateParticipantProjectSpecies(projectId)
+          }
 
   @Test
   fun createPlantingSeason() =
@@ -413,6 +417,10 @@ internal class PermissionRequirementsTest : RunsAsUser {
           {
             canCreateSeedFundReport(organizationId)
           }
+
+  @Test
+  fun createSavedVersion() =
+      allow { createSavedVersion(documentId) } ifUser { canCreateSavedVersion(documentId) }
 
   @Test
   fun createSpecies() =
@@ -1051,6 +1059,10 @@ internal class PermissionRequirementsTest : RunsAsUser {
       allow { updateDeviceTemplates() } ifUser { canUpdateDeviceTemplates() }
 
   @Test
+  fun updateDocument() =
+      allow { updateDocument(documentId) } ifUser { canUpdateDocument(documentId) }
+
+  @Test
   fun updateDraftPlantingSite() =
       allow { updateDraftPlantingSite(draftPlantingSiteId) } ifUser
           {
@@ -1071,6 +1083,11 @@ internal class PermissionRequirementsTest : RunsAsUser {
 
   @Test
   fun updateFundingEntityUsers() {
+    assertThrows<FundingEntityNotFoundException> {
+      requirements.updateFundingEntityUsers(fundingEntityId)
+    }
+
+    grant { user.canReadFundingEntity(fundingEntityId) }
     assertThrows<AccessDeniedException> { requirements.updateFundingEntityUsers(fundingEntityId) }
 
     grant { user.canUpdateFundingEntityUsers(fundingEntityId) }


### PR DESCRIPTION
The KDocs for `PermissionRequirements` specified that users without the ability to read something should receive an `EntityNotFoundException` and without the ability to create/write/delete should receive an `AccessDeniedException`. Some of the methods didn't quite follow this; update them to match.

There's a small chance that this could cause an issue in the FE if anything is expecting a 403 and receives a 404 instead, though I think this is very unlikely.

Co-authored-by: Claude Opus 4.8 [noreply@anthropic.com](mailto:noreply@anthropic.com)