### PR TITLE
SW-8597 Update queries used for public stats

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/statistics/db/PublicStatisticsStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/statistics/db/PublicStatisticsStore.kt
@@ -7,9 +7,8 @@ import com.terraformation.backend.db.default_schema.tables.references.ORGANIZATI
 import com.terraformation.backend.db.default_schema.tables.references.PROJECTS
 import com.terraformation.backend.db.nursery.tables.references.BATCHES
 import com.terraformation.backend.db.seedbank.AccessionState
-import com.terraformation.backend.db.seedbank.SeedQuantityUnits
 import com.terraformation.backend.db.seedbank.tables.references.ACCESSIONS
-import com.terraformation.backend.db.tracking.tables.references.DELIVERIES
+import com.terraformation.backend.db.tracking.tables.references.PLANTINGS
 import com.terraformation.backend.db.tracking.tables.references.PLANTING_SITES
 import com.terraformation.backend.statistics.PublicStatisticsModel
 import jakarta.inject.Named
@@ -34,6 +33,12 @@ import org.jooq.impl.DSL
 class PublicStatisticsStore(
     private val dslContext: DSLContext,
 ) {
+  /**
+   * Maximum area of a planting site that we consider. Larger than this is probably just for
+   * testing.
+   */
+  private val MAX_SITE_AREA = BigDecimal("100000")
+
   /** Subquery selecting the IDs of organizations that are tagged as internal to Terraformation. */
   private val internalOrganizationIds =
       DSL.select(ORGANIZATION_INTERNAL_TAGS.ORGANIZATION_ID)
@@ -89,37 +94,18 @@ class PublicStatisticsStore(
         .select(DSL.sum(PLANTING_SITES.AREA_HA))
         .from(PLANTING_SITES)
         .where(PLANTING_SITES.ORGANIZATION_ID.notIn(internalOrganizationIds))
+        .and(PLANTING_SITES.AREA_HA.le(MAX_SITE_AREA))
         .fetchOne(0, BigDecimal::class.java) ?: BigDecimal.ZERO
   }
 
   private fun sumSeedsInStorage(): Long {
-    val totalSeeds =
-        DSL.sum(
-            DSL.case_()
-                .`when`(
-                    ACCESSIONS.REMAINING_UNITS_ID.eq(SeedQuantityUnits.Seeds),
-                    ACCESSIONS.REMAINING_QUANTITY,
-                )
-                .`when`(
-                    ACCESSIONS.REMAINING_UNITS_ID.ne(SeedQuantityUnits.Seeds)
-                        .and(ACCESSIONS.SUBSET_COUNT.isNotNull)
-                        .and(ACCESSIONS.SUBSET_WEIGHT_GRAMS.isNotNull)
-                        .and(ACCESSIONS.REMAINING_GRAMS.isNotNull),
-                    ACCESSIONS.REMAINING_GRAMS.div(ACCESSIONS.SUBSET_WEIGHT_GRAMS)
-                        .mul(ACCESSIONS.SUBSET_COUNT),
-                )
-                .else_(BigDecimal.ZERO)
-        )
-
-    val activeStates = AccessionState.entries.filter { it.active }
-
     return dslContext
-        .select(totalSeeds)
+        .select(DSL.sum(ACCESSIONS.EST_SEED_COUNT))
         .from(ACCESSIONS)
         .join(FACILITIES)
         .on(ACCESSIONS.FACILITY_ID.eq(FACILITIES.ID))
         .where(FACILITIES.ORGANIZATION_ID.notIn(internalOrganizationIds))
-        .and(ACCESSIONS.STATE_ID.`in`(activeStates))
+        .and(ACCESSIONS.STATE_ID.`in`(AccessionState.entries.filter { it.active }))
         .fetchOne { (total) -> (total ?: BigDecimal.ZERO).toLong() } ?: 0L
   }
 
@@ -139,10 +125,10 @@ class PublicStatisticsStore(
 
   private fun countPlantings(): Int {
     return dslContext
-        .selectCount()
-        .from(DELIVERIES)
+        .select(DSL.sum(PLANTINGS.NUM_PLANTS))
+        .from(PLANTINGS)
         .join(PLANTING_SITES)
-        .on(DELIVERIES.PLANTING_SITE_ID.eq(PLANTING_SITES.ID))
+        .on(PLANTINGS.PLANTING_SITE_ID.eq(PLANTING_SITES.ID))
         .where(PLANTING_SITES.ORGANIZATION_ID.notIn(internalOrganizationIds))
         .fetchOne(0, Int::class.java) ?: 0
   }

--- a/src/main/kotlin/com/terraformation/backend/statistics/db/PublicStatisticsStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/statistics/db/PublicStatisticsStore.kt
@@ -37,7 +37,7 @@ class PublicStatisticsStore(
    * Maximum area of a planting site that we consider. Larger than this is probably just for
    * testing.
    */
-  private val MAX_SITE_AREA = BigDecimal("100000")
+  private val MAX_SITE_AREA_HA = BigDecimal("100000")
 
   /** Subquery selecting the IDs of organizations that are tagged as internal to Terraformation. */
   private val internalOrganizationIds =
@@ -94,7 +94,7 @@ class PublicStatisticsStore(
         .select(DSL.sum(PLANTING_SITES.AREA_HA))
         .from(PLANTING_SITES)
         .where(PLANTING_SITES.ORGANIZATION_ID.notIn(internalOrganizationIds))
-        .and(PLANTING_SITES.AREA_HA.le(MAX_SITE_AREA))
+        .and(PLANTING_SITES.AREA_HA.le(MAX_SITE_AREA_HA))
         .fetchOne(0, BigDecimal::class.java) ?: BigDecimal.ZERO
   }
 

--- a/src/test/kotlin/com/terraformation/backend/statistics/db/PublicStatisticsStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/statistics/db/PublicStatisticsStoreTest.kt
@@ -6,7 +6,6 @@ import com.terraformation.backend.customer.model.TerrawareUser
 import com.terraformation.backend.db.DatabaseTest
 import com.terraformation.backend.db.default_schema.FacilityType
 import com.terraformation.backend.db.seedbank.AccessionState
-import com.terraformation.backend.db.seedbank.SeedQuantityUnits
 import com.terraformation.backend.db.seedbank.tables.pojos.AccessionsRow
 import com.terraformation.backend.statistics.PublicStatisticsModel
 import java.math.BigDecimal
@@ -105,24 +104,16 @@ internal class PublicStatisticsStoreTest : DatabaseTest(), RunsAsDatabaseUser {
   }
 
   @Test
-  fun `sums seeds in storage using seed count units`() {
+  fun `sums seeds in storage using estimated seed count`() {
     val organizationId = insertOrganization()
     val facilityId = insertFacility(organizationId = organizationId, type = FacilityType.SeedBank)
     insertAccession(
-        row =
-            AccessionsRow(
-                remainingQuantity = BigDecimal(100),
-                remainingUnitsId = SeedQuantityUnits.Seeds,
-            ),
+        row = AccessionsRow(estSeedCount = 100),
         facilityId = facilityId,
         stateId = AccessionState.InStorage,
     )
     insertAccession(
-        row =
-            AccessionsRow(
-                remainingQuantity = BigDecimal(50),
-                remainingUnitsId = SeedQuantityUnits.Seeds,
-            ),
+        row = AccessionsRow(estSeedCount = 50),
         facilityId = facilityId,
         stateId = AccessionState.Drying,
     )
@@ -131,37 +122,12 @@ internal class PublicStatisticsStoreTest : DatabaseTest(), RunsAsDatabaseUser {
   }
 
   @Test
-  fun `estimates seeds in storage from weight when no seed count available`() {
-    val organizationId = insertOrganization()
-    val facilityId = insertFacility(organizationId = organizationId, type = FacilityType.SeedBank)
-    // 10g remaining / 2g per subset * 100 seeds per subset = 500 estimated seeds
-    insertAccession(
-        row =
-            AccessionsRow(
-                remainingGrams = BigDecimal(10),
-                remainingQuantity = BigDecimal(10),
-                remainingUnitsId = SeedQuantityUnits.Grams,
-                subsetWeightGrams = BigDecimal(2),
-                subsetCount = 100,
-            ),
-        facilityId = facilityId,
-        stateId = AccessionState.InStorage,
-    )
-
-    assertEquals(500L, store.fetchStatistics().totalSeedsInStorage)
-  }
-
-  @Test
   fun `excludes seeds in inactive accession states from storage count`() {
     val organizationId = insertOrganization()
     val facilityId = insertFacility(organizationId = organizationId, type = FacilityType.SeedBank)
     for (state in listOf(AccessionState.Withdrawn, AccessionState.UsedUp, AccessionState.Nursery)) {
       insertAccession(
-          row =
-              AccessionsRow(
-                  remainingQuantity = BigDecimal(100),
-                  remainingUnitsId = SeedQuantityUnits.Seeds,
-              ),
+          row = AccessionsRow(estSeedCount = 100),
           facilityId = facilityId,
           stateId = state,
       )
@@ -176,11 +142,7 @@ internal class PublicStatisticsStoreTest : DatabaseTest(), RunsAsDatabaseUser {
     insertOrganizationInternalTag(internalOrgId, InternalTagIds.Internal)
     val facilityId = insertFacility(organizationId = internalOrgId, type = FacilityType.SeedBank)
     insertAccession(
-        row =
-            AccessionsRow(
-                remainingQuantity = BigDecimal(100),
-                remainingUnitsId = SeedQuantityUnits.Seeds,
-            ),
+        row = AccessionsRow(estSeedCount = 100),
         facilityId = facilityId,
         stateId = AccessionState.InStorage,
     )
@@ -217,14 +179,14 @@ internal class PublicStatisticsStoreTest : DatabaseTest(), RunsAsDatabaseUser {
   }
 
   @Test
-  fun `counts deliveries excluding internal organizations`() {
+  fun `counts plantings excluding internal organizations`() {
     val organizationId = insertOrganization()
+    insertSpecies()
     val facilityId = insertFacility(organizationId = organizationId, type = FacilityType.Nursery)
     val plantingSiteId = insertPlantingSite(organizationId = organizationId)
     val withdrawalId1 = insertNurseryWithdrawal(facilityId = facilityId)
-    val withdrawalId2 = insertNurseryWithdrawal(facilityId = facilityId)
     insertDelivery(plantingSiteId = plantingSiteId, withdrawalId = withdrawalId1)
-    insertDelivery(plantingSiteId = plantingSiteId, withdrawalId = withdrawalId2)
+    insertPlanting(numPlants = 10)
 
     val internalOrgId = insertOrganization()
     insertOrganizationInternalTag(internalOrgId, InternalTagIds.Internal)
@@ -233,7 +195,8 @@ internal class PublicStatisticsStoreTest : DatabaseTest(), RunsAsDatabaseUser {
     val internalPlantingSiteId = insertPlantingSite(organizationId = internalOrgId)
     val internalWithdrawalId = insertNurseryWithdrawal(facilityId = internalFacilityId)
     insertDelivery(plantingSiteId = internalPlantingSiteId, withdrawalId = internalWithdrawalId)
+    insertPlanting(numPlants = 5)
 
-    assertEquals(2, store.fetchStatistics().totalPlantings)
+    assertEquals(10, store.fetchStatistics().totalPlantings)
   }
 }


### PR DESCRIPTION
We want to update our public stats queries to basically match what's used in grafana. 

A later PR will change the definition of internal orgs, for now this is just focused on updating the rest of the parts of the queries.