### PR TITLE
SW-8597 Update excluded org definition

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/statistics/db/PublicStatisticsStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/statistics/db/PublicStatisticsStore.kt
@@ -1,6 +1,7 @@
 package com.terraformation.backend.statistics.db
 
 import com.terraformation.backend.customer.model.InternalTagIds
+import com.terraformation.backend.db.default_schema.InternalTagId
 import com.terraformation.backend.db.default_schema.Role
 import com.terraformation.backend.db.default_schema.tables.references.FACILITIES
 import com.terraformation.backend.db.default_schema.tables.references.ORGANIZATIONS
@@ -44,20 +45,17 @@ class PublicStatisticsStore(
    */
   private val MAX_SITE_AREA_HA = BigDecimal("100000")
 
-  /** Subquery selecting the IDs of organizations tagged with [InternalTagIds.Internal]. */
-  private val internalTaggedOrganizationIds =
+  private fun taggedOrganizationIds(internalTagId: InternalTagId) =
       DSL.select(ORGANIZATION_INTERNAL_TAGS.ORGANIZATION_ID)
           .from(ORGANIZATION_INTERNAL_TAGS)
-          .where(ORGANIZATION_INTERNAL_TAGS.INTERNAL_TAG_ID.eq(InternalTagIds.Internal))
+          .where(ORGANIZATION_INTERNAL_TAGS.INTERNAL_TAG_ID.eq(internalTagId))
 
   /**
    * Subquery selecting the IDs of organizations that are excluded from public statistics because
-   * they belong to Terraformation. See the class documentation for the exclusion rules.
+   * they belong to Terraformation.
    */
   private val excludedOrganizationIds =
-      DSL.select(ORGANIZATION_INTERNAL_TAGS.ORGANIZATION_ID)
-          .from(ORGANIZATION_INTERNAL_TAGS)
-          .where(ORGANIZATION_INTERNAL_TAGS.INTERNAL_TAG_ID.eq(InternalTagIds.Testing))
+      taggedOrganizationIds(InternalTagIds.Testing)
           .union(
               DSL.select(ORGANIZATION_USERS.ORGANIZATION_ID)
                   .from(ORGANIZATION_USERS)
@@ -65,7 +63,11 @@ class PublicStatisticsStore(
                   .on(ORGANIZATION_USERS.USER_ID.eq(USERS.ID))
                   .where(ORGANIZATION_USERS.ROLE_ID.eq(Role.Owner))
                   .and(USERS.EMAIL.likeIgnoreCase("%@terraformation.com"))
-                  .and(ORGANIZATION_USERS.ORGANIZATION_ID.notIn(internalTaggedOrganizationIds))
+                  .and(
+                      ORGANIZATION_USERS.ORGANIZATION_ID.notIn(
+                          taggedOrganizationIds(InternalTagIds.Internal)
+                      )
+                  )
           )
 
   private val cachedStatistics: PublicStatisticsModel by lazy { computeStatistics() }

--- a/src/main/kotlin/com/terraformation/backend/statistics/db/PublicStatisticsStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/statistics/db/PublicStatisticsStore.kt
@@ -1,10 +1,13 @@
 package com.terraformation.backend.statistics.db
 
 import com.terraformation.backend.customer.model.InternalTagIds
+import com.terraformation.backend.db.default_schema.Role
 import com.terraformation.backend.db.default_schema.tables.references.FACILITIES
 import com.terraformation.backend.db.default_schema.tables.references.ORGANIZATIONS
 import com.terraformation.backend.db.default_schema.tables.references.ORGANIZATION_INTERNAL_TAGS
+import com.terraformation.backend.db.default_schema.tables.references.ORGANIZATION_USERS
 import com.terraformation.backend.db.default_schema.tables.references.PROJECTS
+import com.terraformation.backend.db.default_schema.tables.references.USERS
 import com.terraformation.backend.db.nursery.tables.references.BATCHES
 import com.terraformation.backend.db.seedbank.AccessionState
 import com.terraformation.backend.db.seedbank.tables.references.ACCESSIONS
@@ -25,9 +28,11 @@ import org.jooq.impl.DSL
  * platform-wide aggregate values that don't reveal anything about a specific organization should be
  * returned from here.
  *
- * Organizations tagged with either [InternalTagIds.Internal] or [InternalTagIds.Testing], along
- * with their projects and planting sites, are excluded from every statistic so that
- * Terraformation's own internal organizations don't inflate the numbers.
+ * Organizations that are excluded from every statistic (along with their projects and planting
+ * sites) so that Terraformation's own organizations don't inflate the numbers are:
+ * - Organizations tagged with [InternalTagIds.Testing].
+ * - Organizations that have an [Role.Owner] whose email address ends in "@terraformation.com"
+ *   (case-insensitive), unless the organization is tagged with [InternalTagIds.Internal].
  */
 @Named
 class PublicStatisticsStore(
@@ -39,15 +44,28 @@ class PublicStatisticsStore(
    */
   private val MAX_SITE_AREA_HA = BigDecimal("100000")
 
-  /** Subquery selecting the IDs of organizations that are tagged as internal to Terraformation. */
-  private val internalOrganizationIds =
+  /** Subquery selecting the IDs of organizations tagged with [InternalTagIds.Internal]. */
+  private val internalTaggedOrganizationIds =
       DSL.select(ORGANIZATION_INTERNAL_TAGS.ORGANIZATION_ID)
           .from(ORGANIZATION_INTERNAL_TAGS)
-          .where(
-              ORGANIZATION_INTERNAL_TAGS.INTERNAL_TAG_ID.`in`(
-                  InternalTagIds.Internal,
-                  InternalTagIds.Testing,
-              )
+          .where(ORGANIZATION_INTERNAL_TAGS.INTERNAL_TAG_ID.eq(InternalTagIds.Internal))
+
+  /**
+   * Subquery selecting the IDs of organizations that are excluded from public statistics because
+   * they belong to Terraformation. See the class documentation for the exclusion rules.
+   */
+  private val excludedOrganizationIds =
+      DSL.select(ORGANIZATION_INTERNAL_TAGS.ORGANIZATION_ID)
+          .from(ORGANIZATION_INTERNAL_TAGS)
+          .where(ORGANIZATION_INTERNAL_TAGS.INTERNAL_TAG_ID.eq(InternalTagIds.Testing))
+          .union(
+              DSL.select(ORGANIZATION_USERS.ORGANIZATION_ID)
+                  .from(ORGANIZATION_USERS)
+                  .join(USERS)
+                  .on(ORGANIZATION_USERS.USER_ID.eq(USERS.ID))
+                  .where(ORGANIZATION_USERS.ROLE_ID.eq(Role.Owner))
+                  .and(USERS.EMAIL.likeIgnoreCase("%@terraformation.com"))
+                  .and(ORGANIZATION_USERS.ORGANIZATION_ID.notIn(internalTaggedOrganizationIds))
           )
 
   private val cachedStatistics: PublicStatisticsModel by lazy { computeStatistics() }
@@ -69,7 +87,7 @@ class PublicStatisticsStore(
     return dslContext
         .selectCount()
         .from(ORGANIZATIONS)
-        .where(ORGANIZATIONS.ID.notIn(internalOrganizationIds))
+        .where(ORGANIZATIONS.ID.notIn(excludedOrganizationIds))
         .fetchOne(0, Int::class.java) ?: 0
   }
 
@@ -78,13 +96,13 @@ class PublicStatisticsStore(
         DSL.select(ORGANIZATIONS.COUNTRY_CODE)
             .from(ORGANIZATIONS)
             .where(ORGANIZATIONS.COUNTRY_CODE.isNotNull)
-            .and(ORGANIZATIONS.ID.notIn(internalOrganizationIds))
+            .and(ORGANIZATIONS.ID.notIn(excludedOrganizationIds))
 
     val projectCountries =
         DSL.select(PROJECTS.COUNTRY_CODE)
             .from(PROJECTS)
             .where(PROJECTS.COUNTRY_CODE.isNotNull)
-            .and(PROJECTS.ORGANIZATION_ID.notIn(internalOrganizationIds))
+            .and(PROJECTS.ORGANIZATION_ID.notIn(excludedOrganizationIds))
 
     return dslContext.fetchCount(organizationCountries.union(projectCountries))
   }
@@ -93,7 +111,7 @@ class PublicStatisticsStore(
     return dslContext
         .select(DSL.sum(PLANTING_SITES.AREA_HA))
         .from(PLANTING_SITES)
-        .where(PLANTING_SITES.ORGANIZATION_ID.notIn(internalOrganizationIds))
+        .where(PLANTING_SITES.ORGANIZATION_ID.notIn(excludedOrganizationIds))
         .and(PLANTING_SITES.AREA_HA.le(MAX_SITE_AREA_HA))
         .fetchOne(0, BigDecimal::class.java) ?: BigDecimal.ZERO
   }
@@ -104,7 +122,7 @@ class PublicStatisticsStore(
         .from(ACCESSIONS)
         .join(FACILITIES)
         .on(ACCESSIONS.FACILITY_ID.eq(FACILITIES.ID))
-        .where(FACILITIES.ORGANIZATION_ID.notIn(internalOrganizationIds))
+        .where(FACILITIES.ORGANIZATION_ID.notIn(excludedOrganizationIds))
         .and(ACCESSIONS.STATE_ID.`in`(AccessionState.entries.filter { it.active }))
         .fetchOne { (total) -> (total ?: BigDecimal.ZERO).toLong() } ?: 0L
   }
@@ -119,7 +137,7 @@ class PublicStatisticsStore(
             )
         )
         .from(BATCHES)
-        .where(BATCHES.ORGANIZATION_ID.notIn(internalOrganizationIds))
+        .where(BATCHES.ORGANIZATION_ID.notIn(excludedOrganizationIds))
         .fetchOne(0, Long::class.java) ?: 0L
   }
 
@@ -129,7 +147,7 @@ class PublicStatisticsStore(
         .from(PLANTINGS)
         .join(PLANTING_SITES)
         .on(PLANTINGS.PLANTING_SITE_ID.eq(PLANTING_SITES.ID))
-        .where(PLANTING_SITES.ORGANIZATION_ID.notIn(internalOrganizationIds))
+        .where(PLANTING_SITES.ORGANIZATION_ID.notIn(excludedOrganizationIds))
         .fetchOne(0, Int::class.java) ?: 0
   }
 }

--- a/src/test/kotlin/com/terraformation/backend/statistics/db/PublicStatisticsStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/statistics/db/PublicStatisticsStoreTest.kt
@@ -5,6 +5,8 @@ import com.terraformation.backend.customer.model.InternalTagIds
 import com.terraformation.backend.customer.model.TerrawareUser
 import com.terraformation.backend.db.DatabaseTest
 import com.terraformation.backend.db.default_schema.FacilityType
+import com.terraformation.backend.db.default_schema.OrganizationId
+import com.terraformation.backend.db.default_schema.Role
 import com.terraformation.backend.db.seedbank.AccessionState
 import com.terraformation.backend.db.seedbank.tables.pojos.AccessionsRow
 import com.terraformation.backend.statistics.PublicStatisticsModel
@@ -36,13 +38,83 @@ internal class PublicStatisticsStoreTest : DatabaseTest(), RunsAsDatabaseUser {
   }
 
   @Test
-  fun `counts organizations excluding ones tagged as internal or testing`() {
+  fun `excludes organizations tagged as testing`() {
     insertOrganization()
+    val testingOrganizationId = insertOrganization()
+    insertOrganizationInternalTag(testingOrganizationId, InternalTagIds.Testing)
+
+    assertEquals(1, store.fetchStatistics().totalOrganizations)
+  }
+
+  @Test
+  fun `excludes organizations with a terraformation owner`() {
+    insertOrganization()
+    val terraformationOrganizationId = insertOrganization()
+    addTerraformationOwner(terraformationOrganizationId)
+
+    assertEquals(1, store.fetchStatistics().totalOrganizations)
+  }
+
+  @Test
+  fun `matches terraformation owner email case-insensitively`() {
+    insertOrganization()
+    val terraformationOrganizationId = insertOrganization()
+    val userId = insertUser(email = "Owner@Terraformation.COM")
+    insertOrganizationUser(
+        userId = userId,
+        organizationId = terraformationOrganizationId,
+        role = Role.Owner,
+    )
+
+    assertEquals(1, store.fetchStatistics().totalOrganizations)
+  }
+
+  @Test
+  fun `excludes orgs that have terraformation owner and are tagged as both internal and testing`() {
+    insertOrganization()
+    val organizationId = insertOrganization()
+    addTerraformationOwner(organizationId)
+    insertOrganizationInternalTag(organizationId, InternalTagIds.Testing)
+    insertOrganizationInternalTag(organizationId, InternalTagIds.Internal)
+
+    assertEquals(1, store.fetchStatistics().totalOrganizations)
+  }
+
+  @Test
+  fun `does not exclude terraformation-owned organizations tagged as internal`() {
     insertOrganization()
     val internalOrganizationId = insertOrganization()
-    val testingOrganizationId = insertOrganization()
+    addTerraformationOwner(internalOrganizationId)
     insertOrganizationInternalTag(internalOrganizationId, InternalTagIds.Internal)
-    insertOrganizationInternalTag(testingOrganizationId, InternalTagIds.Testing)
+
+    assertEquals(2, store.fetchStatistics().totalOrganizations)
+  }
+
+  @Test
+  fun `does not exclude organizations tagged as internal without a terraformation owner`() {
+    insertOrganization()
+    val internalOrganizationId = insertOrganization()
+    insertOrganizationInternalTag(internalOrganizationId, InternalTagIds.Internal)
+
+    assertEquals(2, store.fetchStatistics().totalOrganizations)
+  }
+
+  @Test
+  fun `does not exclude organizations whose terraformation user is not an owner`() {
+    insertOrganization()
+    val organizationId = insertOrganization()
+    val userId = insertUser(email = "admin@terraformation.com")
+    insertOrganizationUser(userId = userId, organizationId = organizationId, role = Role.Admin)
+
+    assertEquals(2, store.fetchStatistics().totalOrganizations)
+  }
+
+  @Test
+  fun `does not exclude organizations whose owner has a non-terraformation email`() {
+    insertOrganization()
+    val organizationId = insertOrganization()
+    val userId = insertUser(email = "owner@example.com")
+    insertOrganizationUser(userId = userId, organizationId = organizationId, role = Role.Owner)
 
     assertEquals(2, store.fetchStatistics().totalOrganizations)
   }
@@ -57,7 +129,7 @@ internal class PublicStatisticsStoreTest : DatabaseTest(), RunsAsDatabaseUser {
   }
 
   @Test
-  fun `sums distinct countries, excluding internal organizations`() {
+  fun `sums distinct countries, excluding excluded organizations`() {
     insertOrganization(countryCode = "US")
     val kenyaOrganizationId = insertOrganization(countryCode = "KE")
 
@@ -67,11 +139,11 @@ internal class PublicStatisticsStoreTest : DatabaseTest(), RunsAsDatabaseUser {
 
     insertOrganization(countryCode = null)
 
-    insertOrganization(countryCode = "MX")
-    insertOrganizationInternalTag(tagId = InternalTagIds.Internal)
+    val terraformationOrganizationId = insertOrganization(countryCode = "MX")
+    addTerraformationOwner(terraformationOrganizationId)
 
-    insertOrganization(countryCode = "SE")
-    insertOrganizationInternalTag(tagId = InternalTagIds.Testing)
+    val testingOrganizationId = insertOrganization(countryCode = "SE")
+    insertOrganizationInternalTag(testingOrganizationId, InternalTagIds.Testing)
 
     assertEquals(3, store.fetchStatistics().totalCountries)
   }
@@ -88,14 +160,14 @@ internal class PublicStatisticsStoreTest : DatabaseTest(), RunsAsDatabaseUser {
   }
 
   @Test
-  fun `sums planting site area excluding internal organizations`() {
+  fun `sums planting site area excluding excluded organizations`() {
     val organizationId = insertOrganization()
     insertPlantingSite(organizationId = organizationId, areaHa = BigDecimal(10))
     insertPlantingSite(organizationId = organizationId, areaHa = BigDecimal(5))
 
-    val internalOrganizationId = insertOrganization()
-    insertOrganizationInternalTag(internalOrganizationId, InternalTagIds.Internal)
-    insertPlantingSite(organizationId = internalOrganizationId, areaHa = BigDecimal(100))
+    val excludedOrganizationId = insertOrganization()
+    addTerraformationOwner(excludedOrganizationId)
+    insertPlantingSite(organizationId = excludedOrganizationId, areaHa = BigDecimal(100))
 
     assertEquals(
         0,
@@ -137,10 +209,10 @@ internal class PublicStatisticsStoreTest : DatabaseTest(), RunsAsDatabaseUser {
   }
 
   @Test
-  fun `excludes seeds from internal organizations`() {
-    val internalOrgId = insertOrganization()
-    insertOrganizationInternalTag(internalOrgId, InternalTagIds.Internal)
-    val facilityId = insertFacility(organizationId = internalOrgId, type = FacilityType.SeedBank)
+  fun `excludes seeds from excluded organizations`() {
+    val excludedOrgId = insertOrganization()
+    addTerraformationOwner(excludedOrgId)
+    val facilityId = insertFacility(organizationId = excludedOrgId, type = FacilityType.SeedBank)
     insertAccession(
         row = AccessionsRow(estSeedCount = 100),
         facilityId = facilityId,
@@ -151,7 +223,7 @@ internal class PublicStatisticsStoreTest : DatabaseTest(), RunsAsDatabaseUser {
   }
 
   @Test
-  fun `sums all seedling quantities excluding internal organizations`() {
+  fun `sums all seedling quantities excluding excluded organizations`() {
     val organizationId = insertOrganization()
     insertFacility(organizationId = organizationId, type = FacilityType.Nursery)
     insertSpecies(organizationId = organizationId)
@@ -163,12 +235,12 @@ internal class PublicStatisticsStoreTest : DatabaseTest(), RunsAsDatabaseUser {
         hardeningOffQuantity = 5,
     )
 
-    val internalOrgId = insertOrganization()
-    insertOrganizationInternalTag(internalOrgId, InternalTagIds.Internal)
-    insertFacility(organizationId = internalOrgId, type = FacilityType.Nursery)
-    insertSpecies(organizationId = internalOrgId)
+    val excludedOrgId = insertOrganization()
+    addTerraformationOwner(excludedOrgId)
+    insertFacility(organizationId = excludedOrgId, type = FacilityType.Nursery)
+    insertSpecies(organizationId = excludedOrgId)
     insertBatch(
-        organizationId = internalOrgId,
+        organizationId = excludedOrgId,
         germinatingQuantity = 100,
         activeGrowthQuantity = 100,
         readyQuantity = 100,
@@ -179,7 +251,7 @@ internal class PublicStatisticsStoreTest : DatabaseTest(), RunsAsDatabaseUser {
   }
 
   @Test
-  fun `counts plantings excluding internal organizations`() {
+  fun `counts plantings excluding excluded organizations`() {
     val organizationId = insertOrganization()
     insertSpecies()
     val facilityId = insertFacility(organizationId = organizationId, type = FacilityType.Nursery)
@@ -188,15 +260,24 @@ internal class PublicStatisticsStoreTest : DatabaseTest(), RunsAsDatabaseUser {
     insertDelivery(plantingSiteId = plantingSiteId, withdrawalId = withdrawalId1)
     insertPlanting(numPlants = 10)
 
-    val internalOrgId = insertOrganization()
-    insertOrganizationInternalTag(internalOrgId, InternalTagIds.Internal)
-    val internalFacilityId =
-        insertFacility(organizationId = internalOrgId, type = FacilityType.Nursery)
-    val internalPlantingSiteId = insertPlantingSite(organizationId = internalOrgId)
-    val internalWithdrawalId = insertNurseryWithdrawal(facilityId = internalFacilityId)
-    insertDelivery(plantingSiteId = internalPlantingSiteId, withdrawalId = internalWithdrawalId)
+    val excludedOrgId = insertOrganization()
+    addTerraformationOwner(excludedOrgId)
+    val excludedFacilityId =
+        insertFacility(organizationId = excludedOrgId, type = FacilityType.Nursery)
+    val excludedPlantingSiteId = insertPlantingSite(organizationId = excludedOrgId)
+    val excludedWithdrawalId = insertNurseryWithdrawal(facilityId = excludedFacilityId)
+    insertDelivery(plantingSiteId = excludedPlantingSiteId, withdrawalId = excludedWithdrawalId)
     insertPlanting(numPlants = 5)
 
     assertEquals(10, store.fetchStatistics().totalPlantings)
+  }
+
+  /**
+   * Marks an organization as excluded from public statistics by giving it an owner whose email
+   * address is in the terraformation.com domain.
+   */
+  private fun addTerraformationOwner(organizationId: OrganizationId) {
+    val userId = insertUser()
+    insertOrganizationUser(userId = userId, organizationId = organizationId, role = Role.Owner)
   }
 }


### PR DESCRIPTION
Change the definition of excluded orgs to be one of the following:

- has `Testing` internal tag
- has an owner with an `@terraformation.com` email address and does _not_ have the `Internal` internal tag

This excludes all tf created orgs while still allowing us to whitelist some orgs (unless they have the `Testing` tag).

Co-authored-by: Claude Opus 4.8 [noreply@anthropic.com](mailto:noreply@anthropic.com)