### PR TITLE
Wrap facility location for multiset

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/customer/db/OrganizationStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/db/OrganizationStore.kt
@@ -37,6 +37,7 @@ import com.terraformation.backend.db.default_schema.tables.references.ORGANIZATI
 import com.terraformation.backend.db.default_schema.tables.references.ORGANIZATION_USERS
 import com.terraformation.backend.db.default_schema.tables.references.USERS
 import com.terraformation.backend.db.default_schema.tables.references.USER_PREFERENCES
+import com.terraformation.backend.db.forMultiset
 import com.terraformation.backend.log.perClassLogger
 import jakarta.inject.Named
 import java.time.Clock
@@ -53,6 +54,7 @@ class OrganizationStore(
     private val organizationsDao: OrganizationsDao,
     private val publisher: ApplicationEventPublisher,
 ) {
+  private val facilitiesLocationField = FACILITIES.LOCATION.forMultiset()
   private val log = perClassLogger()
 
   /** Returns all the organizations the user is a member of. */
@@ -101,13 +103,36 @@ class OrganizationStore(
                 DSL.falseCondition()
               }
 
-          DSL.multiset(
-                  DSL.selectFrom(FACILITIES)
-                      .where(FACILITIES.ORGANIZATION_ID.eq(ORGANIZATIONS.ID))
-                      .and(facilitiesCondition)
-                      .orderBy(FACILITIES.ID)
-              )
-              .convertFrom { result -> result.map { FacilityModel(it) } }
+          with(FACILITIES) {
+            DSL.multiset(
+                    DSL.select(
+                            BUILD_COMPLETED_DATE,
+                            BUILD_STARTED_DATE,
+                            CAPACITY,
+                            CONNECTION_STATE_ID,
+                            CREATED_TIME,
+                            DESCRIPTION,
+                            facilitiesLocationField,
+                            FACILITY_NUMBER,
+                            ID,
+                            LAST_NOTIFICATION_DATE,
+                            LAST_TIMESERIES_TIME,
+                            MAX_IDLE_MINUTES,
+                            MODIFIED_TIME,
+                            NAME,
+                            NEXT_NOTIFICATION_TIME,
+                            OPERATION_STARTED_DATE,
+                            ORGANIZATION_ID,
+                            TIME_ZONE,
+                            TYPE_ID,
+                        )
+                        .from(FACILITIES)
+                        .where(ORGANIZATION_ID.eq(ORGANIZATIONS.ID))
+                        .and(facilitiesCondition)
+                        .orderBy(ID),
+                )
+                .convertFrom { result -> result.map { FacilityModel(it, facilitiesLocationField) } }
+          }
         } else {
           DSL.value(null as List<FacilityModel>?)
         }

--- a/src/main/kotlin/com/terraformation/backend/customer/model/FacilityModel.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/FacilityModel.kt
@@ -10,7 +10,9 @@ import com.terraformation.backend.db.default_schema.tables.references.FACILITIES
 import java.time.Instant
 import java.time.LocalDate
 import java.time.ZoneId
+import org.jooq.Field
 import org.jooq.Record
+import org.locationtech.jts.geom.Geometry
 import org.locationtech.jts.geom.Point
 
 /** Maximum device manager idle time, in minutes, to assign to new facilities by default. */
@@ -53,7 +55,8 @@ data class FacilityModel(
     val type: FacilityType,
 ) {
   constructor(
-      record: Record
+      record: Record,
+      locationField: Field<Geometry?> = FACILITIES.LOCATION,
   ) : this(
       buildCompletedDate = record[FACILITIES.BUILD_COMPLETED_DATE],
       buildStartedDate = record[FACILITIES.BUILD_STARTED_DATE],
@@ -71,7 +74,7 @@ data class FacilityModel(
       id = record[FACILITIES.ID] ?: throw IllegalArgumentException("ID is required"),
       lastNotificationDate = record[FACILITIES.LAST_NOTIFICATION_DATE],
       lastTimeseriesTime = record[FACILITIES.LAST_TIMESERIES_TIME],
-      location = record[FACILITIES.LOCATION] as? Point,
+      location = record[locationField] as? Point,
       maxIdleMinutes =
           record[FACILITIES.MAX_IDLE_MINUTES]
               ?: throw IllegalArgumentException("Max idle minutes is required"),

--- a/src/test/kotlin/com/terraformation/backend/customer/db/OrganizationStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/db/OrganizationStoreTest.kt
@@ -33,6 +33,7 @@ import com.terraformation.backend.db.default_schema.tables.pojos.UserPreferences
 import com.terraformation.backend.db.default_schema.tables.records.OrganizationManagedLocationTypesRecord
 import com.terraformation.backend.db.default_schema.tables.references.USER_PREFERENCES
 import com.terraformation.backend.mockUser
+import com.terraformation.backend.point
 import io.mockk.every
 import java.time.Instant
 import java.time.ZoneId
@@ -62,6 +63,7 @@ internal class OrganizationStoreTest : DatabaseTest(), RunsAsUser {
         description = "Description 1",
         facilityNumber = 1,
         id = facilityId,
+        location = point(1),
         modifiedTime = Instant.EPOCH,
         name = "Facility 1",
         organizationId = organizationId,
@@ -97,7 +99,7 @@ internal class OrganizationStoreTest : DatabaseTest(), RunsAsUser {
 
     organizationId = insertOrganization(countryCode = "US", countrySubdivisionCode = "US-HI")
     insertOrganizationInternalTag(organizationId, InternalTagIds.Reporter)
-    facilityId = insertFacility()
+    facilityId = insertFacility(location = point(1))
 
     every { user.canCreateEntityWithOwner(any()) } returns true
     every { user.canReadOrganization(any()) } returns true


### PR DESCRIPTION
When querying organizations with facilities, we were extracting the new
`facilities.location` column in a multiset, which requires wrapping it in a
conversion function.