### PR TITLE
Run CI builds on ARM hosts

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -74,7 +74,7 @@ common:
 
 agents:
   # Run all steps on the same kind of runner.
-  queue: "x86-8core"
+  queue: "arm-8core"
 
 env:
   BUILDKITE_ARTIFACT_UPLOAD_DESTINATION: "s3://$BUILDKITE_PLUGIN_S3_CACHE_BUCKET/artifacts/$BUILDKITE_PIPELINE_SLUG/$BUILDKITE_BUILD_ID"


### PR DESCRIPTION
Switch from x86 to ARM for our CI builds; the ARM hosts are slightly cheaper.
We continue to build Docker images for both x86 and ARM; now the build will
use CPU emulation for the x86 build rather than the ARM one.