### PR TITLE
SW-8651 Fall back to English for common names

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/species/db/GbifStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/species/db/GbifStore.kt
@@ -109,7 +109,8 @@ class GbifStore(private val dslContext: DSLContext) {
    *
    * @param [vernacularNameLanguage] ISO 639-1 two-letter language code. If non-null, filter
    *   vernacular names to exclude names in languages other than this. Vernacular names without
-   *   langauge tags are always included.
+   *   langauge tags are always included. If no vernacular names exist in the requested language,
+   *   English names are returned.
    */
   fun fetchOneByScientificName(
       scientificName: String,
@@ -117,9 +118,9 @@ class GbifStore(private val dslContext: DSLContext) {
   ): GbifTaxonModel? {
     val languageCondition =
         if (vernacularNameLanguage != null) {
-          GBIF_VERNACULAR_NAMES.LANGUAGE.isNull.or(
-              GBIF_VERNACULAR_NAMES.LANGUAGE.eq(vernacularNameLanguage)
-          )
+          GBIF_VERNACULAR_NAMES.LANGUAGE.isNull
+              .or(GBIF_VERNACULAR_NAMES.LANGUAGE.eq(vernacularNameLanguage))
+              .or(GBIF_VERNACULAR_NAMES.LANGUAGE.eq("en"))
         } else {
           null
         }
@@ -164,6 +165,21 @@ class GbifStore(private val dslContext: DSLContext) {
         )
         .limit(1)
         .fetchOne { record ->
+          val vernacularNames = record[vernacularNamesMultiset]
+
+          val filteredVernacularNames =
+              if (vernacularNameLanguage != null) {
+                val filterLanguage =
+                    if (vernacularNames.any { it.language == vernacularNameLanguage }) {
+                      vernacularNameLanguage
+                    } else {
+                      "en"
+                    }
+                vernacularNames.filter { it.language == filterLanguage || it.language == null }
+              } else {
+                vernacularNames
+              }
+
           GbifTaxonModel(
               taxonId =
                   record[GBIF_TAXA.TAXON_ID]
@@ -174,7 +190,7 @@ class GbifStore(private val dslContext: DSLContext) {
               familyName =
                   record[GBIF_TAXA.FAMILY]
                       ?: throw IllegalArgumentException("Family name must be non-null"),
-              vernacularNames = record[vernacularNamesMultiset],
+              vernacularNames = filteredVernacularNames,
               threatStatus = record[GBIF_DISTRIBUTIONS.THREAT_STATUS],
           )
         }

--- a/src/test/kotlin/com/terraformation/backend/species/db/GbifStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/species/db/GbifStoreTest.kt
@@ -197,7 +197,40 @@ internal class GbifStoreTest : DatabaseTest() {
       val taxonId =
           insertTaxon(
               "Scientific name",
-              listOf("Common en" to "en", "Common xx" to "xx", "Common unknown" to null),
+              listOf(
+                  "Common es" to "es",
+                  "Common xx" to "xx",
+                  "Common unknown" to null,
+              ),
+              "Family",
+          )
+
+      val expected =
+          GbifTaxonModel(
+              taxonId,
+              "Scientific name",
+              "Family",
+              listOf(
+                  GbifVernacularNameModel("Common es", "es"),
+                  GbifVernacularNameModel("Common unknown", null),
+              ),
+              null,
+          )
+
+      val actual = store.fetchOneByScientificName("Scientific name", "es")
+      assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `falls back to English if no vernacular names exist in requested language`() {
+      val taxonId =
+          insertTaxon(
+              "Scientific name",
+              listOf(
+                  "Common en" to "en",
+                  "Common xx" to "xx",
+                  "Common unknown" to null,
+              ),
               "Family",
           )
 
@@ -213,7 +246,7 @@ internal class GbifStoreTest : DatabaseTest() {
               null,
           )
 
-      val actual = store.fetchOneByScientificName("Scientific name", "en")
+      val actual = store.fetchOneByScientificName("Scientific name", "fr")
       assertEquals(expected, actual)
     }
 


### PR DESCRIPTION
Currently, if the client looks up information about a species and specifies a
language, we return names from the GBIF dataset that are either tagged with
the requested language or have no language tag. However, the list of English
vernacular names in the GBIF dataset dwarfs the list in any other language,
and we want to start autofilling English names if there aren't any non-English
ones available.

Update the species lookup logic to fall back to English if there are no
names in the requested language.