### PR TITLE
SW-8597 Add max values to public stats queries

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/statistics/db/PublicStatisticsStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/statistics/db/PublicStatisticsStore.kt
@@ -43,7 +43,10 @@ class PublicStatisticsStore(
    * Maximum area of a planting site that we consider. Larger than this is probably just for
    * testing.
    */
-  private val MAX_SITE_AREA_HA = BigDecimal("100000")
+  private val MAX_SITE_AREA_HA = BigDecimal("10000")
+  private val MAX_SEEDS_IN_ACCESSION = 1_000_000
+  private val MAX_SEEDLINGS_IN_BATCH = 1_000_000
+  private val MAX_PLANTS_IN_PLANTING = 500_000
 
   private fun taggedOrganizationIds(internalTagId: InternalTagId) =
       DSL.select(ORGANIZATION_INTERNAL_TAGS.ORGANIZATION_ID)
@@ -110,46 +113,62 @@ class PublicStatisticsStore(
   }
 
   private fun sumPlantingSiteArea(): BigDecimal {
-    return dslContext
-        .select(DSL.sum(PLANTING_SITES.AREA_HA))
-        .from(PLANTING_SITES)
-        .where(PLANTING_SITES.ORGANIZATION_ID.notIn(excludedOrganizationIds))
-        .and(PLANTING_SITES.AREA_HA.le(MAX_SITE_AREA_HA))
-        .fetchOne(0, BigDecimal::class.java) ?: BigDecimal.ZERO
+    with(PLANTING_SITES) {
+      return dslContext
+          .select(DSL.sum(AREA_HA))
+          .from(PLANTING_SITES)
+          .where(ORGANIZATION_ID.notIn(excludedOrganizationIds))
+          .and(AREA_HA.le(MAX_SITE_AREA_HA))
+          .fetchOne(0, BigDecimal::class.java) ?: BigDecimal.ZERO
+    }
   }
 
   private fun sumSeedsInStorage(): Long {
-    return dslContext
-        .select(DSL.sum(ACCESSIONS.EST_SEED_COUNT))
-        .from(ACCESSIONS)
-        .join(FACILITIES)
-        .on(ACCESSIONS.FACILITY_ID.eq(FACILITIES.ID))
-        .where(FACILITIES.ORGANIZATION_ID.notIn(excludedOrganizationIds))
-        .and(ACCESSIONS.STATE_ID.`in`(AccessionState.entries.filter { it.active }))
-        .fetchOne { (total) -> (total ?: BigDecimal.ZERO).toLong() } ?: 0L
+    with(ACCESSIONS) {
+      return dslContext
+          .select(DSL.sum(EST_SEED_COUNT))
+          .from(ACCESSIONS)
+          .join(FACILITIES)
+          .on(FACILITY_ID.eq(FACILITIES.ID))
+          .where(FACILITIES.ORGANIZATION_ID.notIn(excludedOrganizationIds))
+          .and(STATE_ID.`in`(AccessionState.entries.filter { it.active }))
+          .and(EST_SEED_COUNT.le(MAX_SEEDS_IN_ACCESSION))
+          .fetchOne { (total) -> (total ?: BigDecimal.ZERO).toLong() } ?: 0L
+    }
   }
 
   private fun sumSeedlingsInNurseries(): Long {
-    return dslContext
-        .select(
-            DSL.sum(
-                BATCHES.GERMINATING_QUANTITY.plus(BATCHES.ACTIVE_GROWTH_QUANTITY)
-                    .plus(BATCHES.READY_QUANTITY)
-                    .plus(BATCHES.HARDENING_OFF_QUANTITY)
-            )
-        )
-        .from(BATCHES)
-        .where(BATCHES.ORGANIZATION_ID.notIn(excludedOrganizationIds))
-        .fetchOne(0, Long::class.java) ?: 0L
+    with(BATCHES) {
+      return dslContext
+          .select(
+              DSL.sum(
+                  GERMINATING_QUANTITY.plus(ACTIVE_GROWTH_QUANTITY)
+                      .plus(READY_QUANTITY)
+                      .plus(HARDENING_OFF_QUANTITY)
+              )
+          )
+          .from(BATCHES)
+          .where(ORGANIZATION_ID.notIn(excludedOrganizationIds))
+          .and(
+              (GERMINATING_QUANTITY.plus(ACTIVE_GROWTH_QUANTITY)
+                      .plus(READY_QUANTITY)
+                      .plus(HARDENING_OFF_QUANTITY))
+                  .le(MAX_SEEDLINGS_IN_BATCH)
+          )
+          .fetchOne(0, Long::class.java) ?: 0L
+    }
   }
 
   private fun countPlantings(): Int {
-    return dslContext
-        .select(DSL.sum(PLANTINGS.NUM_PLANTS))
-        .from(PLANTINGS)
-        .join(PLANTING_SITES)
-        .on(PLANTINGS.PLANTING_SITE_ID.eq(PLANTING_SITES.ID))
-        .where(PLANTING_SITES.ORGANIZATION_ID.notIn(excludedOrganizationIds))
-        .fetchOne(0, Int::class.java) ?: 0
+    with(PLANTINGS) {
+      return dslContext
+          .select(DSL.sum(NUM_PLANTS))
+          .from(PLANTINGS)
+          .join(PLANTING_SITES)
+          .on(PLANTING_SITE_ID.eq(PLANTING_SITES.ID))
+          .where(PLANTING_SITES.ORGANIZATION_ID.notIn(excludedOrganizationIds))
+          .and(NUM_PLANTS.le(MAX_PLANTS_IN_PLANTING))
+          .fetchOne(0, Int::class.java) ?: 0
+    }
   }
 }

--- a/src/test/kotlin/com/terraformation/backend/statistics/db/PublicStatisticsStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/statistics/db/PublicStatisticsStoreTest.kt
@@ -160,10 +160,11 @@ internal class PublicStatisticsStoreTest : DatabaseTest(), RunsAsDatabaseUser {
   }
 
   @Test
-  fun `sums planting site area excluding excluded organizations`() {
+  fun `sums planting site area excluding excluded organizations and large areas`() {
     val organizationId = insertOrganization()
     insertPlantingSite(organizationId = organizationId, areaHa = BigDecimal(10))
     insertPlantingSite(organizationId = organizationId, areaHa = BigDecimal(5))
+    insertPlantingSite(organizationId = organizationId, areaHa = BigDecimal("10001"))
 
     val excludedOrganizationId = insertOrganization()
     addTerraformationOwner(excludedOrganizationId)
@@ -209,7 +210,7 @@ internal class PublicStatisticsStoreTest : DatabaseTest(), RunsAsDatabaseUser {
   }
 
   @Test
-  fun `excludes seeds from excluded organizations`() {
+  fun `excludes seeds from excluded organizations and test accessions`() {
     val excludedOrgId = insertOrganization()
     addTerraformationOwner(excludedOrgId)
     val facilityId = insertFacility(organizationId = excludedOrgId, type = FacilityType.SeedBank)
@@ -218,12 +219,17 @@ internal class PublicStatisticsStoreTest : DatabaseTest(), RunsAsDatabaseUser {
         facilityId = facilityId,
         stateId = AccessionState.InStorage,
     )
+    insertAccession(
+        row = AccessionsRow(estSeedCount = 1_000_001),
+        facilityId = facilityId,
+        stateId = AccessionState.InStorage,
+    )
 
     assertEquals(0L, store.fetchStatistics().totalSeedsInStorage)
   }
 
   @Test
-  fun `sums all seedling quantities excluding excluded organizations`() {
+  fun `sums all seedling quantities excluding excluded organizations and test batches`() {
     val organizationId = insertOrganization()
     insertFacility(organizationId = organizationId, type = FacilityType.Nursery)
     insertSpecies(organizationId = organizationId)
@@ -233,6 +239,13 @@ internal class PublicStatisticsStoreTest : DatabaseTest(), RunsAsDatabaseUser {
         activeGrowthQuantity = 20,
         readyQuantity = 30,
         hardeningOffQuantity = 5,
+    )
+    insertBatch(
+        organizationId = organizationId,
+        germinatingQuantity = 1,
+        activeGrowthQuantity = 2,
+        readyQuantity = 3,
+        hardeningOffQuantity = 1_000_000,
     )
 
     val excludedOrgId = insertOrganization()
@@ -251,7 +264,7 @@ internal class PublicStatisticsStoreTest : DatabaseTest(), RunsAsDatabaseUser {
   }
 
   @Test
-  fun `counts plantings excluding excluded organizations`() {
+  fun `counts plantings excluding excluded organizations and test plantings`() {
     val organizationId = insertOrganization()
     insertSpecies()
     val facilityId = insertFacility(organizationId = organizationId, type = FacilityType.Nursery)
@@ -259,6 +272,9 @@ internal class PublicStatisticsStoreTest : DatabaseTest(), RunsAsDatabaseUser {
     val withdrawalId1 = insertNurseryWithdrawal(facilityId = facilityId)
     insertDelivery(plantingSiteId = plantingSiteId, withdrawalId = withdrawalId1)
     insertPlanting(numPlants = 10)
+    val withdrawalId2 = insertNurseryWithdrawal(facilityId = facilityId)
+    insertDelivery(plantingSiteId = plantingSiteId, withdrawalId = withdrawalId2)
+    insertPlanting(numPlants = 500_001)
 
     val excludedOrgId = insertOrganization()
     addTerraformationOwner(excludedOrgId)


### PR DESCRIPTION
Some users put test data into Terraware in production. Because we can't figure out every value that is invalid data, put max values for accessions, batches, and plantings, and adjust the max for site area. 