### PR TITLE
SW-8654 Fix delete seasons with withdrawals for request

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/plantingmanagement/db/PlantingSeasonStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/plantingmanagement/db/PlantingSeasonStore.kt
@@ -9,6 +9,7 @@ import com.terraformation.backend.db.default_schema.OrganizationId
 import com.terraformation.backend.db.tracking.PlantingSeasonId
 import com.terraformation.backend.db.tracking.PlantingSeasonStatus
 import com.terraformation.backend.db.tracking.PlantingSiteId
+import com.terraformation.backend.db.tracking.tables.references.PLANTING_DATE_REQUESTS
 import com.terraformation.backend.db.tracking.tables.references.PLANTING_SEASONS
 import com.terraformation.backend.db.tracking.tables.references.PLANTING_SEASON_SPECIES_TARGETS
 import com.terraformation.backend.db.tracking.tables.references.PLANTING_SITES
@@ -256,6 +257,12 @@ class PlantingSeasonStore(
         parentStore.getPlantingSiteId(id) ?: throw PlantingSeasonNotFoundException(id)
     val organizationId =
         parentStore.getOrganizationId(id) ?: throw PlantingSeasonNotFoundException(id)
+
+    // Delete requests related to the season before the season to meet check constraint requirements
+    dslContext
+        .deleteFrom(PLANTING_DATE_REQUESTS)
+        .where(PLANTING_DATE_REQUESTS.scheduledPlantingDates.PLANTING_SEASON_ID.eq(id))
+        .execute()
 
     val rowsDeleted =
         dslContext.deleteFrom(PLANTING_SEASONS).where(PLANTING_SEASONS.ID.eq(id)).execute()

--- a/src/test/kotlin/com/terraformation/backend/plantingmanagement/db/PlantingSeasonStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/plantingmanagement/db/PlantingSeasonStoreTest.kt
@@ -9,6 +9,7 @@ import com.terraformation.backend.db.DatabaseTest
 import com.terraformation.backend.db.OrganizationNotFoundException
 import com.terraformation.backend.db.default_schema.OrganizationId
 import com.terraformation.backend.db.default_schema.Role
+import com.terraformation.backend.db.nursery.WithdrawalPurpose
 import com.terraformation.backend.db.tracking.PlantingSeasonId
 import com.terraformation.backend.db.tracking.PlantingSeasonStatus
 import com.terraformation.backend.db.tracking.PlantingSiteId
@@ -744,7 +745,19 @@ internal class PlantingSeasonStoreTest : DatabaseTest(), RunsAsDatabaseUser {
   inner class Delete {
     @Test
     fun `deletes the planting season row`() {
+      insertStratum()
+      insertSubstratum()
+      insertSpecies()
+      insertFacility()
       val id = insertPlantingSeason()
+      val scheduledDateId = insertPlantingSeasonScheduledDate()
+      insertScheduledPlantingDateSpecies()
+      insertPlantingDateRequest()
+      insertNurseryWithdrawal(
+          purpose = WithdrawalPurpose.OutPlant,
+          plantingSeasonId = id,
+          scheduledPlantingDateRequestId = scheduledDateId,
+      )
 
       store.delete(id)
 


### PR DESCRIPTION
The check constraint on `nursery.withdrawals` - `withdrawals_planting_date_request_season` - checks that `scheduled_planting_date_request_id IS NULL OR planting_season_id IS NOT NULL`, which is throwing an error when deleting a planting season that has a withdrawal tied to a scheduled planting date request because the check constraint is violated by the season delete before the cascade deletes the request. Delete the planting date requests (which use `on delete set null`) before deleting the season to fix this issue. 