### PR TITLE
Add nested test classes to species tests

### DIFF
--- a/src/test/kotlin/com/terraformation/backend/species/SpeciesServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/species/SpeciesServiceTest.kt
@@ -22,6 +22,7 @@ import io.mockk.verify
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 
@@ -60,94 +61,103 @@ internal class SpeciesServiceTest : DatabaseTest(), RunsAsUser {
     every { user.canDeleteSpecies(any()) } returns true
   }
 
-  @Test
-  fun `createSpecies checks for problems with species data`() {
-    val speciesId =
-        service.createSpecies(
-            NewSpeciesModel(organizationId = organizationId, scientificName = "Scientific name")
-        )
+  @Nested
+  inner class CreateSpecies {
+    @Test
+    fun `checks for problems with species data`() {
+      val speciesId =
+          service.createSpecies(
+              NewSpeciesModel(organizationId = organizationId, scientificName = "Scientific name")
+          )
 
-    verify { speciesChecker.checkSpecies(speciesId) }
+      verify { speciesChecker.checkSpecies(speciesId) }
+    }
   }
 
-  @Test
-  fun `updateSpecies checks for problems with species data`() {
-    val speciesId = insertSpecies("Old name")
-    val originalModel = speciesStore.fetchSpeciesById(speciesId)
+  @Nested
+  inner class UpdateSpecies {
+    @Test
+    fun `checks for problems with species data`() {
+      val speciesId = insertSpecies("Old name")
+      val originalModel = speciesStore.fetchSpeciesById(speciesId)
 
-    val updatedModel = service.updateSpecies(originalModel.copy(scientificName = "New name"))
+      val updatedModel = service.updateSpecies(originalModel.copy(scientificName = "New name"))
 
-    assertEquals("New name", updatedModel.scientificName)
+      assertEquals("New name", updatedModel.scientificName)
 
-    verify {
-      speciesChecker.recheckSpecies(
-          match { it.scientificName == "Old name" },
-          match { it.scientificName == "New name" },
+      verify {
+        speciesChecker.recheckSpecies(
+            match { it.scientificName == "Old name" },
+            match { it.scientificName == "New name" },
+        )
+      }
+
+      eventPublisher.assertEventPublished(
+          SpeciesEditedEvent(
+              species =
+                  ExistingSpeciesModel(
+                      averageWoodDensity = null,
+                      checkedTime = null,
+                      commonName = null,
+                      conservationCategory = null,
+                      createdTime = originalModel.createdTime,
+                      dbhSource = null,
+                      dbhValue = null,
+                      deletedTime = null,
+                      ecologicalRoleKnown = null,
+                      familyName = null,
+                      id = inserted.speciesId,
+                      initialScientificName = "Old name",
+                      modifiedTime = clock.instant(),
+                      organizationId = inserted.organizationId,
+                      scientificName = "New name",
+                  )
+          )
       )
     }
-
-    eventPublisher.assertEventPublished(
-        SpeciesEditedEvent(
-            species =
-                ExistingSpeciesModel(
-                    averageWoodDensity = null,
-                    checkedTime = null,
-                    commonName = null,
-                    conservationCategory = null,
-                    createdTime = originalModel.createdTime,
-                    dbhSource = null,
-                    dbhValue = null,
-                    deletedTime = null,
-                    ecologicalRoleKnown = null,
-                    familyName = null,
-                    id = inserted.speciesId,
-                    initialScientificName = "Old name",
-                    modifiedTime = clock.instant(),
-                    organizationId = inserted.organizationId,
-                    scientificName = "New name",
-                )
-        )
-    )
   }
 
-  @Test
-  fun `deleteSpecies throws exception if species is in use in accession`() {
-    val speciesId = insertSpecies("species name")
-    insertFacility()
-    insertAccession(speciesId = speciesId)
+  @Nested
+  inner class DeleteSpecies {
+    @Test
+    fun `throws exception if species is in use in accession`() {
+      val speciesId = insertSpecies("species name")
+      insertFacility()
+      insertAccession(speciesId = speciesId)
 
-    assertThrows<SpeciesInUseException> { service.deleteSpecies(speciesId) }
-  }
+      assertThrows<SpeciesInUseException> { service.deleteSpecies(speciesId) }
+    }
 
-  @Test
-  fun `deleteSpecies throws exception if species is in use in batch`() {
-    val speciesId = insertSpecies("species name")
-    insertFacility()
-    insertBatch(speciesId = speciesId)
+    @Test
+    fun `throws exception if species is in use in batch`() {
+      val speciesId = insertSpecies("species name")
+      insertFacility()
+      insertBatch(speciesId = speciesId)
 
-    assertThrows<SpeciesInUseException> { service.deleteSpecies(speciesId) }
-  }
+      assertThrows<SpeciesInUseException> { service.deleteSpecies(speciesId) }
+    }
 
-  @Test
-  fun `deleteSpecies throws exception if species is in use in observation`() {
-    val speciesId = insertSpecies("species name")
-    insertPlantingSite()
-    insertStratum()
-    insertSubstratum()
-    insertMonitoringPlot()
-    insertObservation()
-    insertObservationPlot()
-    insertRecordedPlant(speciesId = speciesId)
+    @Test
+    fun `throws exception if species is in use in observation`() {
+      val speciesId = insertSpecies("species name")
+      insertPlantingSite()
+      insertStratum()
+      insertSubstratum()
+      insertMonitoringPlot()
+      insertObservation()
+      insertObservationPlot()
+      insertRecordedPlant(speciesId = speciesId)
 
-    assertThrows<SpeciesInUseException> { service.deleteSpecies(speciesId) }
-  }
+      assertThrows<SpeciesInUseException> { service.deleteSpecies(speciesId) }
+    }
 
-  @Test
-  fun `deleteSpecies deletes species when not in use`() {
-    val speciesId = insertSpecies("species name")
-    assertNotNull(speciesStore.fetchSpeciesById(speciesId))
+    @Test
+    fun `deletes species when not in use`() {
+      val speciesId = insertSpecies("species name")
+      assertNotNull(speciesStore.fetchSpeciesById(speciesId))
 
-    service.deleteSpecies(speciesId)
-    assertThrows<SpeciesNotFoundException> { speciesStore.fetchSpeciesById(speciesId) }
+      service.deleteSpecies(speciesId)
+      assertThrows<SpeciesNotFoundException> { speciesStore.fetchSpeciesById(speciesId) }
+    }
   }
 }

--- a/src/test/kotlin/com/terraformation/backend/species/db/SpeciesStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/species/db/SpeciesStoreTest.kt
@@ -75,459 +75,489 @@ internal class SpeciesStoreTest : DatabaseTest(), RunsAsUser {
     organizationId = insertOrganization()
   }
 
-  @Test
-  fun `createSpecies inserts species`() {
-    val model =
-        NewSpeciesModel(
-            averageWoodDensity = BigDecimal(1.1),
-            commonName = "common",
-            conservationCategory = ConservationCategory.Endangered,
-            dbhSource = "dbh source",
-            dbhValue = BigDecimal(2.1),
-            deletedTime = Instant.EPOCH,
-            ecologicalRoleKnown = "role",
-            familyName = "family",
-            growthForms = setOf(GrowthForm.Shrub),
-            heightAtMaturitySource = "height source",
-            heightAtMaturityValue = BigDecimal(3.1),
-            localUsesKnown = "uses",
-            nativeEcosystem = "ecosystem",
-            organizationId = organizationId,
-            otherFacts = "facts",
-            rare = false,
-            scientificName = "test",
-            seedStorageBehavior = SeedStorageBehavior.Recalcitrant,
-            woodDensityLevel = WoodDensityLevel.Family,
+  @Nested
+  inner class CreateSpecies {
+    @Test
+    fun `inserts species`() {
+      val model =
+          NewSpeciesModel(
+              averageWoodDensity = BigDecimal(1.1),
+              commonName = "common",
+              conservationCategory = ConservationCategory.Endangered,
+              dbhSource = "dbh source",
+              dbhValue = BigDecimal(2.1),
+              deletedTime = Instant.EPOCH,
+              ecologicalRoleKnown = "role",
+              familyName = "family",
+              growthForms = setOf(GrowthForm.Shrub),
+              heightAtMaturitySource = "height source",
+              heightAtMaturityValue = BigDecimal(3.1),
+              localUsesKnown = "uses",
+              nativeEcosystem = "ecosystem",
+              organizationId = organizationId,
+              otherFacts = "facts",
+              rare = false,
+              scientificName = "test",
+              seedStorageBehavior = SeedStorageBehavior.Recalcitrant,
+              woodDensityLevel = WoodDensityLevel.Family,
+          )
+
+      val speciesId = store.createSpecies(model)
+      assertNotNull(speciesId, "Should have returned ID")
+
+      val expected =
+          listOf(
+              SpeciesRow(
+                  averageWoodDensity = BigDecimal(1.1),
+                  commonName = "common",
+                  conservationCategoryId = ConservationCategory.Endangered,
+                  createdBy = user.userId,
+                  createdTime = Instant.EPOCH,
+                  dbhSource = "dbh source",
+                  dbhValue = BigDecimal(2.1),
+                  deletedBy = null,
+                  deletedTime = null,
+                  ecologicalRoleKnown = "role",
+                  familyName = "family",
+                  id = speciesId,
+                  heightAtMaturitySource = "height source",
+                  heightAtMaturityValue = BigDecimal(3.1),
+                  initialScientificName = "test",
+                  modifiedBy = user.userId,
+                  modifiedTime = Instant.EPOCH,
+                  localUsesKnown = "uses",
+                  nativeEcosystem = "ecosystem",
+                  organizationId = organizationId,
+                  otherFacts = "facts",
+                  rare = false,
+                  scientificName = "test",
+                  seedStorageBehaviorId = SeedStorageBehavior.Recalcitrant,
+                  woodDensityLevelId = WoodDensityLevel.Family,
+              )
+          )
+
+      val actual = speciesDao.findAll()
+      assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `allows the same name to be used in different organizations`() {
+      val otherOrgId = insertOrganization()
+
+      val model = NewSpeciesModel(organizationId = organizationId, scientificName = "test")
+      store.createSpecies(model)
+
+      assertDoesNotThrow { store.createSpecies(model.copy(organizationId = otherOrgId)) }
+    }
+
+    @Test
+    fun `reuses previously deleted species if one exists`() {
+      val originalSpeciesId =
+          store.createSpecies(
+              NewSpeciesModel(
+                  averageWoodDensity = BigDecimal(1.1),
+                  commonName = "original common",
+                  conservationCategory = ConservationCategory.LeastConcern,
+                  dbhSource = "original dbh source",
+                  dbhValue = BigDecimal(2.1),
+                  ecologicalRoleKnown = "original role",
+                  ecosystemTypes = setOf(EcosystemType.Mangroves),
+                  familyName = "original family",
+                  growthForms = setOf(GrowthForm.Fern),
+                  heightAtMaturitySource = "original height source",
+                  heightAtMaturityValue = BigDecimal(3.1),
+                  localUsesKnown = "original uses",
+                  nativeEcosystem = "original ecosystem",
+                  organizationId = organizationId,
+                  otherFacts = "original facts",
+                  plantMaterialSourcingMethods =
+                      setOf(PlantMaterialSourcingMethod.SeedlingPurchase),
+                  rare = false,
+                  scientificName = "test",
+                  seedStorageBehavior = SeedStorageBehavior.Orthodox,
+                  successionalGroups = setOf(SuccessionalGroup.Pioneer),
+                  woodDensityLevel = WoodDensityLevel.Family,
+              )
+          )
+      val originalRow = speciesDao.fetchOneById(originalSpeciesId)!!
+
+      store.deleteSpecies(originalSpeciesId)
+
+      val editedModel =
+          NewSpeciesModel(
+              averageWoodDensity = BigDecimal(1.99),
+              commonName = "edited common",
+              conservationCategory = ConservationCategory.NearThreatened,
+              dbhSource = "edit db source",
+              dbhValue = BigDecimal(2.99),
+              ecologicalRoleKnown = "edited role",
+              ecosystemTypes = setOf(EcosystemType.Tundra),
+              familyName = "edited family",
+              growthForms = setOf(GrowthForm.Shrub),
+              heightAtMaturitySource = "edited height source",
+              heightAtMaturityValue = BigDecimal(3.99),
+              localUsesKnown = "edited uses",
+              nativeEcosystem = "edited ecosystem",
+              organizationId = organizationId,
+              otherFacts = "edited facts",
+              plantMaterialSourcingMethods = setOf(PlantMaterialSourcingMethod.WildlingHarvest),
+              rare = true,
+              scientificName = "test",
+              seedStorageBehavior = SeedStorageBehavior.Recalcitrant,
+              successionalGroups = setOf(SuccessionalGroup.Mature),
+              woodDensityLevel = WoodDensityLevel.Species,
+          )
+
+      val newInstant = Instant.ofEpochSecond(500)
+      clock.instant = newInstant
+
+      val reusedSpeciesId = store.createSpecies(editedModel)
+
+      val expectedSpecies =
+          SpeciesRow(
+              averageWoodDensity = BigDecimal(1.99),
+              commonName = "edited common",
+              conservationCategoryId = ConservationCategory.NearThreatened,
+              createdBy = originalRow.createdBy,
+              createdTime = originalRow.createdTime,
+              dbhSource = "edit db source",
+              dbhValue = BigDecimal(2.99),
+              ecologicalRoleKnown = "edited role",
+              familyName = "edited family",
+              heightAtMaturitySource = "edited height source",
+              heightAtMaturityValue = BigDecimal(3.99),
+              id = originalSpeciesId,
+              initialScientificName = "test",
+              localUsesKnown = "edited uses",
+              nativeEcosystem = "edited ecosystem",
+              organizationId = organizationId,
+              otherFacts = "edited facts",
+              modifiedBy = user.userId,
+              modifiedTime = clock.instant(),
+              rare = true,
+              scientificName = "test",
+              seedStorageBehaviorId = SeedStorageBehavior.Recalcitrant,
+              woodDensityLevelId = WoodDensityLevel.Species,
+          )
+
+      val actualSpecies = speciesDao.fetchOneById(reusedSpeciesId)
+      assertEquals(expectedSpecies, actualSpecies)
+
+      val expectedEcosystemTypes =
+          listOf(SpeciesEcosystemTypesRow(originalSpeciesId, EcosystemType.Tundra))
+      val actualEcosystemTypes = speciesEcosystemTypesDao.fetchBySpeciesId(originalSpeciesId)
+      assertEquals(expectedEcosystemTypes, actualEcosystemTypes)
+
+      val expectedGrowthForms = listOf(SpeciesGrowthFormsRow(originalSpeciesId, GrowthForm.Shrub))
+      val actualGrowthForms = speciesGrowthFormsDao.fetchBySpeciesId(originalSpeciesId)
+      assertEquals(expectedGrowthForms, actualGrowthForms)
+
+      val expectedPlantMaterialSourcingMethods =
+          listOf(
+              SpeciesPlantMaterialSourcingMethodsRow(
+                  originalSpeciesId,
+                  PlantMaterialSourcingMethod.WildlingHarvest,
+              )
+          )
+      val actualPlantMaterialSourcingMethods =
+          speciesPlantMaterialSourcingMethodsDao.fetchBySpeciesId(originalSpeciesId)
+      assertEquals(expectedPlantMaterialSourcingMethods, actualPlantMaterialSourcingMethods)
+
+      val expectedSuccessionalGroups =
+          listOf(SpeciesSuccessionalGroupsRow(originalSpeciesId, SuccessionalGroup.Mature))
+      val actualSuccessionalGroups =
+          speciesSuccessionalGroupsDao.fetchBySpeciesId(originalSpeciesId)
+      assertEquals(expectedSuccessionalGroups, actualSuccessionalGroups)
+    }
+
+    @Test
+    fun `throws exception if name already exists for organization`() {
+      val model = NewSpeciesModel(organizationId = organizationId, scientificName = "test")
+      store.createSpecies(model)
+
+      assertThrows<DuplicateKeyException> { store.createSpecies(model) }
+    }
+
+    @Test
+    fun `throws exception if user has no permission to create species`() {
+      every { user.canCreateSpecies(organizationId) } returns false
+      assertThrows<AccessDeniedException> {
+        store.createSpecies(
+            NewSpeciesModel(organizationId = organizationId, scientificName = "dummy")
         )
+      }
+    }
+  }
 
-    val speciesId = store.createSpecies(model)
-    assertNotNull(speciesId, "Should have returned ID")
+  @Nested
+  inner class UpdateSpecies {
+    @Test
+    fun `updates all modifiable fields`() {
+      val initial =
+          NewSpeciesModel(
+              averageWoodDensity = BigDecimal(1.1),
+              commonName = "original common",
+              conservationCategory = ConservationCategory.Extinct,
+              dbhSource = "original db source",
+              dbhValue = BigDecimal(2.1),
+              ecologicalRoleKnown = "original role",
+              ecosystemTypes = setOf(EcosystemType.Mangroves, EcosystemType.Tundra),
+              familyName = "original family",
+              growthForms = setOf(GrowthForm.Shrub),
+              heightAtMaturitySource = "original height source",
+              heightAtMaturityValue = BigDecimal(3.1),
+              localUsesKnown = "original uses",
+              nativeEcosystem = "original ecosystem",
+              organizationId = organizationId,
+              otherFacts = "original facts",
+              plantMaterialSourcingMethods = setOf(PlantMaterialSourcingMethod.SeedlingPurchase),
+              rare = true,
+              scientificName = "original scientific",
+              seedStorageBehavior = SeedStorageBehavior.Unknown,
+              successionalGroups = setOf(SuccessionalGroup.Pioneer),
+              woodDensityLevel = WoodDensityLevel.Family,
+          )
+      val speciesId = store.createSpecies(initial)
 
-    val expected =
-        listOf(
-            SpeciesRow(
-                averageWoodDensity = BigDecimal(1.1),
-                commonName = "common",
-                conservationCategoryId = ConservationCategory.Endangered,
-                createdBy = user.userId,
+      val bogusOrganizationId = OrganizationId(-1)
+      val bogusInstant = Instant.ofEpochSecond(1000)
+
+      val newInstant = Instant.ofEpochSecond(500)
+      clock.instant = newInstant
+
+      val update =
+          ExistingSpeciesModel(
+              averageWoodDensity = BigDecimal(1.99),
+              commonName = "new common",
+              conservationCategory = ConservationCategory.ExtinctInTheWild,
+              createdTime = Instant.EPOCH,
+              dbhSource = "new db source",
+              dbhValue = BigDecimal(2.99),
+              deletedTime = bogusInstant,
+              ecologicalRoleKnown = "new role",
+              ecosystemTypes = setOf(EcosystemType.BorealForestsTaiga, EcosystemType.Tundra),
+              familyName = "new family",
+              growthForms = setOf(GrowthForm.Fern),
+              heightAtMaturitySource = "new height source",
+              heightAtMaturityValue = BigDecimal(3.99),
+              id = speciesId,
+              initialScientificName = "new initial",
+              localUsesKnown = "new uses",
+              modifiedTime = Instant.EPOCH,
+              nativeEcosystem = "new ecosystem",
+              organizationId = bogusOrganizationId,
+              otherFacts = "new facts",
+              plantMaterialSourcingMethods = setOf(PlantMaterialSourcingMethod.WildlingHarvest),
+              rare = false,
+              scientificName = "new scientific",
+              seedStorageBehavior = SeedStorageBehavior.Orthodox,
+              successionalGroups = setOf(SuccessionalGroup.Mature),
+              woodDensityLevel = WoodDensityLevel.Species,
+          )
+
+      val expectedSpecies =
+          SpeciesRow(
+              averageWoodDensity = BigDecimal(1.99),
+              commonName = "new common",
+              conservationCategoryId = ConservationCategory.ExtinctInTheWild,
+              createdBy = user.userId,
+              createdTime = Instant.EPOCH,
+              dbhSource = "new db source",
+              dbhValue = BigDecimal(2.99),
+              deletedBy = null,
+              deletedTime = null,
+              ecologicalRoleKnown = "new role",
+              familyName = "new family",
+              heightAtMaturitySource = "new height source",
+              heightAtMaturityValue = BigDecimal(3.99),
+              id = speciesId,
+              initialScientificName = "original scientific",
+              localUsesKnown = "new uses",
+              nativeEcosystem = "new ecosystem",
+              modifiedBy = user.userId,
+              modifiedTime = newInstant,
+              organizationId = organizationId,
+              otherFacts = "new facts",
+              rare = false,
+              scientificName = "new scientific",
+              seedStorageBehaviorId = SeedStorageBehavior.Orthodox,
+              woodDensityLevelId = WoodDensityLevel.Species,
+          )
+
+      store.updateSpecies(update)
+
+      val actualSpecies = speciesDao.fetchOneById(speciesId)!!
+      assertEquals(expectedSpecies, actualSpecies)
+
+      val expectedEcosystemTypes =
+          setOf(
+              SpeciesEcosystemTypesRow(speciesId, EcosystemType.BorealForestsTaiga),
+              SpeciesEcosystemTypesRow(speciesId, EcosystemType.Tundra),
+          )
+      val actualEcosystemTypes = speciesEcosystemTypesDao.fetchBySpeciesId(speciesId).toSet()
+      assertEquals(expectedEcosystemTypes, actualEcosystemTypes)
+
+      val expectedGrowthForms = setOf(SpeciesGrowthFormsRow(speciesId, GrowthForm.Fern))
+      val actualGrowthForms = speciesGrowthFormsDao.fetchBySpeciesId(speciesId).toSet()
+      assertEquals(expectedGrowthForms, actualGrowthForms)
+
+      val expectedPlantMaterialSourcingMethods =
+          listOf(
+              SpeciesPlantMaterialSourcingMethodsRow(
+                  speciesId,
+                  PlantMaterialSourcingMethod.WildlingHarvest,
+              )
+          )
+      val actualPlantMaterialSourcingMethods =
+          speciesPlantMaterialSourcingMethodsDao.fetchBySpeciesId(speciesId)
+      assertEquals(expectedPlantMaterialSourcingMethods, actualPlantMaterialSourcingMethods)
+
+      val expectedSuccessionalGroups =
+          listOf(SpeciesSuccessionalGroupsRow(speciesId, SuccessionalGroup.Mature))
+      val actualSuccessionalGroups = speciesSuccessionalGroupsDao.fetchBySpeciesId(speciesId)
+      assertEquals(expectedSuccessionalGroups, actualSuccessionalGroups)
+    }
+
+    @Test
+    fun `throws exception if scientific name exists in organization`() {
+      insertSpecies(scientificName = "Test 1")
+      val speciesId = insertSpecies(scientificName = "Test 2")
+
+      assertThrows<ScientificNameExistsException> {
+        store.updateSpecies(
+            ExistingSpeciesModel(
                 createdTime = Instant.EPOCH,
-                dbhSource = "dbh source",
-                dbhValue = BigDecimal(2.1),
-                deletedBy = null,
-                deletedTime = null,
-                ecologicalRoleKnown = "role",
-                familyName = "family",
                 id = speciesId,
-                heightAtMaturitySource = "height source",
-                heightAtMaturityValue = BigDecimal(3.1),
-                initialScientificName = "test",
-                modifiedBy = user.userId,
                 modifiedTime = Instant.EPOCH,
-                localUsesKnown = "uses",
-                nativeEcosystem = "ecosystem",
                 organizationId = organizationId,
-                otherFacts = "facts",
-                rare = false,
-                scientificName = "test",
-                seedStorageBehaviorId = SeedStorageBehavior.Recalcitrant,
-                woodDensityLevelId = WoodDensityLevel.Family,
+                scientificName = "Test 1",
             )
         )
+      }
+    }
 
-    val actual = speciesDao.findAll()
-    assertEquals(expected, actual)
-  }
+    @Test
+    fun `throws exception if user has no permission to update species`() {
+      every { user.canUpdateSpecies(any()) } returns false
 
-  @Test
-  fun `createSpecies allows the same name to be used in different organizations`() {
-    val otherOrgId = insertOrganization()
+      val speciesId =
+          store.createSpecies(
+              NewSpeciesModel(organizationId = organizationId, scientificName = "dummy")
+          )
 
-    val model = NewSpeciesModel(organizationId = organizationId, scientificName = "test")
-    store.createSpecies(model)
-
-    assertDoesNotThrow { store.createSpecies(model.copy(organizationId = otherOrgId)) }
-  }
-
-  @Test
-  fun `createSpecies reuses previously deleted species if one exists`() {
-    val originalSpeciesId =
-        store.createSpecies(
-            NewSpeciesModel(
-                averageWoodDensity = BigDecimal(1.1),
-                commonName = "original common",
-                conservationCategory = ConservationCategory.LeastConcern,
-                dbhSource = "original dbh source",
-                dbhValue = BigDecimal(2.1),
-                ecologicalRoleKnown = "original role",
-                ecosystemTypes = setOf(EcosystemType.Mangroves),
-                familyName = "original family",
-                growthForms = setOf(GrowthForm.Fern),
-                heightAtMaturitySource = "original height source",
-                heightAtMaturityValue = BigDecimal(3.1),
-                localUsesKnown = "original uses",
-                nativeEcosystem = "original ecosystem",
+      assertThrows<AccessDeniedException> {
+        store.updateSpecies(
+            ExistingSpeciesModel(
+                createdTime = Instant.EPOCH,
+                id = speciesId,
+                modifiedTime = Instant.EPOCH,
                 organizationId = organizationId,
-                otherFacts = "original facts",
-                plantMaterialSourcingMethods = setOf(PlantMaterialSourcingMethod.SeedlingPurchase),
-                rare = false,
-                scientificName = "test",
-                seedStorageBehavior = SeedStorageBehavior.Orthodox,
-                successionalGroups = setOf(SuccessionalGroup.Pioneer),
-                woodDensityLevel = WoodDensityLevel.Family,
+                scientificName = "other",
             )
         )
-    val originalRow = speciesDao.fetchOneById(originalSpeciesId)!!
-
-    store.deleteSpecies(originalSpeciesId)
-
-    val editedModel =
-        NewSpeciesModel(
-            averageWoodDensity = BigDecimal(1.99),
-            commonName = "edited common",
-            conservationCategory = ConservationCategory.NearThreatened,
-            dbhSource = "edit db source",
-            dbhValue = BigDecimal(2.99),
-            ecologicalRoleKnown = "edited role",
-            ecosystemTypes = setOf(EcosystemType.Tundra),
-            familyName = "edited family",
-            growthForms = setOf(GrowthForm.Shrub),
-            heightAtMaturitySource = "edited height source",
-            heightAtMaturityValue = BigDecimal(3.99),
-            localUsesKnown = "edited uses",
-            nativeEcosystem = "edited ecosystem",
-            organizationId = organizationId,
-            otherFacts = "edited facts",
-            plantMaterialSourcingMethods = setOf(PlantMaterialSourcingMethod.WildlingHarvest),
-            rare = true,
-            scientificName = "test",
-            seedStorageBehavior = SeedStorageBehavior.Recalcitrant,
-            successionalGroups = setOf(SuccessionalGroup.Mature),
-            woodDensityLevel = WoodDensityLevel.Species,
-        )
-
-    val newInstant = Instant.ofEpochSecond(500)
-    clock.instant = newInstant
-
-    val reusedSpeciesId = store.createSpecies(editedModel)
-
-    val expectedSpecies =
-        SpeciesRow(
-            averageWoodDensity = BigDecimal(1.99),
-            commonName = "edited common",
-            conservationCategoryId = ConservationCategory.NearThreatened,
-            createdBy = originalRow.createdBy,
-            createdTime = originalRow.createdTime,
-            dbhSource = "edit db source",
-            dbhValue = BigDecimal(2.99),
-            ecologicalRoleKnown = "edited role",
-            familyName = "edited family",
-            heightAtMaturitySource = "edited height source",
-            heightAtMaturityValue = BigDecimal(3.99),
-            id = originalSpeciesId,
-            initialScientificName = "test",
-            localUsesKnown = "edited uses",
-            nativeEcosystem = "edited ecosystem",
-            organizationId = organizationId,
-            otherFacts = "edited facts",
-            modifiedBy = user.userId,
-            modifiedTime = clock.instant(),
-            rare = true,
-            scientificName = "test",
-            seedStorageBehaviorId = SeedStorageBehavior.Recalcitrant,
-            woodDensityLevelId = WoodDensityLevel.Species,
-        )
-
-    val actualSpecies = speciesDao.fetchOneById(reusedSpeciesId)
-    assertEquals(expectedSpecies, actualSpecies)
-
-    val expectedEcosystemTypes =
-        listOf(SpeciesEcosystemTypesRow(originalSpeciesId, EcosystemType.Tundra))
-    val actualEcosystemTypes = speciesEcosystemTypesDao.fetchBySpeciesId(originalSpeciesId)
-    assertEquals(expectedEcosystemTypes, actualEcosystemTypes)
-
-    val expectedGrowthForms = listOf(SpeciesGrowthFormsRow(originalSpeciesId, GrowthForm.Shrub))
-    val actualGrowthForms = speciesGrowthFormsDao.fetchBySpeciesId(originalSpeciesId)
-    assertEquals(expectedGrowthForms, actualGrowthForms)
-
-    val expectedPlantMaterialSourcingMethods =
-        listOf(
-            SpeciesPlantMaterialSourcingMethodsRow(
-                originalSpeciesId,
-                PlantMaterialSourcingMethod.WildlingHarvest,
-            )
-        )
-    val actualPlantMaterialSourcingMethods =
-        speciesPlantMaterialSourcingMethodsDao.fetchBySpeciesId(originalSpeciesId)
-    assertEquals(expectedPlantMaterialSourcingMethods, actualPlantMaterialSourcingMethods)
-
-    val expectedSuccessionalGroups =
-        listOf(SpeciesSuccessionalGroupsRow(originalSpeciesId, SuccessionalGroup.Mature))
-    val actualSuccessionalGroups = speciesSuccessionalGroupsDao.fetchBySpeciesId(originalSpeciesId)
-    assertEquals(expectedSuccessionalGroups, actualSuccessionalGroups)
+      }
+    }
   }
 
-  @Test
-  fun `createSpecies throws exception if name already exists for organization`() {
-    val model = NewSpeciesModel(organizationId = organizationId, scientificName = "test")
-    store.createSpecies(model)
-
-    assertThrows<DuplicateKeyException> { store.createSpecies(model) }
-  }
-
-  @Test
-  fun `createSpecies throws exception if user has no permission to create species`() {
-    every { user.canCreateSpecies(organizationId) } returns false
-    assertThrows<AccessDeniedException> {
+  @Nested
+  inner class DeleteSpecies {
+    @Test
+    fun `marks species as deleted`() {
+      // Make sure it only deletes the species in question, not the whole table
       store.createSpecies(
-          NewSpeciesModel(organizationId = organizationId, scientificName = "dummy")
+          NewSpeciesModel(organizationId = organizationId, scientificName = "other")
       )
+      val expected = store.findAllSpecies(organizationId)
+
+      val speciesId =
+          store.createSpecies(
+              NewSpeciesModel(organizationId = organizationId, scientificName = "to delete")
+          )
+
+      store.deleteSpecies(speciesId)
+
+      val actual = store.findAllSpecies(organizationId)
+      assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `throws exception if user has no permission to delete species`() {
+      every { user.canDeleteSpecies(any()) } returns false
+
+      val speciesId =
+          store.createSpecies(
+              NewSpeciesModel(organizationId = organizationId, scientificName = "dummy")
+          )
+
+      assertThrows<AccessDeniedException> { store.deleteSpecies(speciesId) }
+    }
+
+    @Test
+    fun `throws exception if species does not exist at all`() {
+      assertThrows<SpeciesNotFoundException> { store.deleteSpecies(SpeciesId(1)) }
     }
   }
 
-  @Test
-  fun `updateSpecies updates all modifiable fields`() {
-    val initial =
-        NewSpeciesModel(
-            averageWoodDensity = BigDecimal(1.1),
-            commonName = "original common",
-            conservationCategory = ConservationCategory.Extinct,
-            dbhSource = "original db source",
-            dbhValue = BigDecimal(2.1),
-            ecologicalRoleKnown = "original role",
-            ecosystemTypes = setOf(EcosystemType.Mangroves, EcosystemType.Tundra),
-            familyName = "original family",
-            growthForms = setOf(GrowthForm.Shrub),
-            heightAtMaturitySource = "original height source",
-            heightAtMaturityValue = BigDecimal(3.1),
-            localUsesKnown = "original uses",
-            nativeEcosystem = "original ecosystem",
-            organizationId = organizationId,
-            otherFacts = "original facts",
-            plantMaterialSourcingMethods = setOf(PlantMaterialSourcingMethod.SeedlingPurchase),
-            rare = true,
-            scientificName = "original scientific",
-            seedStorageBehavior = SeedStorageBehavior.Unknown,
-            successionalGroups = setOf(SuccessionalGroup.Pioneer),
-            woodDensityLevel = WoodDensityLevel.Family,
-        )
-    val speciesId = store.createSpecies(initial)
+  @Nested
+  inner class FetchSpeciesById {
+    @Test
+    fun `returns species if it is not deleted`() {
+      val speciesId =
+          store.createSpecies(
+              NewSpeciesModel(
+                  ecosystemTypes = setOf(EcosystemType.Mangroves, EcosystemType.Tundra),
+                  organizationId = organizationId,
+                  scientificName = "test",
+              )
+          )
 
-    val bogusOrganizationId = OrganizationId(-1)
-    val bogusInstant = Instant.ofEpochSecond(1000)
-
-    val newInstant = Instant.ofEpochSecond(500)
-    clock.instant = newInstant
-
-    val update =
-        ExistingSpeciesModel(
-            averageWoodDensity = BigDecimal(1.99),
-            commonName = "new common",
-            conservationCategory = ConservationCategory.ExtinctInTheWild,
-            createdTime = Instant.EPOCH,
-            dbhSource = "new db source",
-            dbhValue = BigDecimal(2.99),
-            deletedTime = bogusInstant,
-            ecologicalRoleKnown = "new role",
-            ecosystemTypes = setOf(EcosystemType.BorealForestsTaiga, EcosystemType.Tundra),
-            familyName = "new family",
-            growthForms = setOf(GrowthForm.Fern),
-            heightAtMaturitySource = "new height source",
-            heightAtMaturityValue = BigDecimal(3.99),
-            id = speciesId,
-            initialScientificName = "new initial",
-            localUsesKnown = "new uses",
-            modifiedTime = Instant.EPOCH,
-            nativeEcosystem = "new ecosystem",
-            organizationId = bogusOrganizationId,
-            otherFacts = "new facts",
-            plantMaterialSourcingMethods = setOf(PlantMaterialSourcingMethod.WildlingHarvest),
-            rare = false,
-            scientificName = "new scientific",
-            seedStorageBehavior = SeedStorageBehavior.Orthodox,
-            successionalGroups = setOf(SuccessionalGroup.Mature),
-            woodDensityLevel = WoodDensityLevel.Species,
-        )
-
-    val expectedSpecies =
-        SpeciesRow(
-            averageWoodDensity = BigDecimal(1.99),
-            commonName = "new common",
-            conservationCategoryId = ConservationCategory.ExtinctInTheWild,
-            createdBy = user.userId,
-            createdTime = Instant.EPOCH,
-            dbhSource = "new db source",
-            dbhValue = BigDecimal(2.99),
-            deletedBy = null,
-            deletedTime = null,
-            ecologicalRoleKnown = "new role",
-            familyName = "new family",
-            heightAtMaturitySource = "new height source",
-            heightAtMaturityValue = BigDecimal(3.99),
-            id = speciesId,
-            initialScientificName = "original scientific",
-            localUsesKnown = "new uses",
-            nativeEcosystem = "new ecosystem",
-            modifiedBy = user.userId,
-            modifiedTime = newInstant,
-            organizationId = organizationId,
-            otherFacts = "new facts",
-            rare = false,
-            scientificName = "new scientific",
-            seedStorageBehaviorId = SeedStorageBehavior.Orthodox,
-            woodDensityLevelId = WoodDensityLevel.Species,
-        )
-
-    store.updateSpecies(update)
-
-    val actualSpecies = speciesDao.fetchOneById(speciesId)!!
-    assertEquals(expectedSpecies, actualSpecies)
-
-    val expectedEcosystemTypes =
-        setOf(
-            SpeciesEcosystemTypesRow(speciesId, EcosystemType.BorealForestsTaiga),
-            SpeciesEcosystemTypesRow(speciesId, EcosystemType.Tundra),
-        )
-    val actualEcosystemTypes = speciesEcosystemTypesDao.fetchBySpeciesId(speciesId).toSet()
-    assertEquals(expectedEcosystemTypes, actualEcosystemTypes)
-
-    val expectedGrowthForms = setOf(SpeciesGrowthFormsRow(speciesId, GrowthForm.Fern))
-    val actualGrowthForms = speciesGrowthFormsDao.fetchBySpeciesId(speciesId).toSet()
-    assertEquals(expectedGrowthForms, actualGrowthForms)
-
-    val expectedPlantMaterialSourcingMethods =
-        listOf(
-            SpeciesPlantMaterialSourcingMethodsRow(
-                speciesId,
-                PlantMaterialSourcingMethod.WildlingHarvest,
-            )
-        )
-    val actualPlantMaterialSourcingMethods =
-        speciesPlantMaterialSourcingMethodsDao.fetchBySpeciesId(speciesId)
-    assertEquals(expectedPlantMaterialSourcingMethods, actualPlantMaterialSourcingMethods)
-
-    val expectedSuccessionalGroups =
-        listOf(SpeciesSuccessionalGroupsRow(speciesId, SuccessionalGroup.Mature))
-    val actualSuccessionalGroups = speciesSuccessionalGroupsDao.fetchBySpeciesId(speciesId)
-    assertEquals(expectedSuccessionalGroups, actualSuccessionalGroups)
-  }
-
-  @Test
-  fun `updateSpecies throws exception if scientific name exists in organization`() {
-    insertSpecies(scientificName = "Test 1")
-    val speciesId = insertSpecies(scientificName = "Test 2")
-
-    assertThrows<ScientificNameExistsException> {
-      store.updateSpecies(
+      val expected =
           ExistingSpeciesModel(
               createdTime = Instant.EPOCH,
+              ecosystemTypes = setOf(EcosystemType.Mangroves, EcosystemType.Tundra),
               id = speciesId,
+              initialScientificName = "test",
               modifiedTime = Instant.EPOCH,
               organizationId = organizationId,
-              scientificName = "Test 1",
+              scientificName = "test",
           )
-      )
+
+      val actual = store.fetchSpeciesById(speciesId)
+      assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `throws exception if species is deleted`() {
+      val speciesId =
+          store.createSpecies(
+              NewSpeciesModel(organizationId = organizationId, scientificName = "test")
+          )
+      store.deleteSpecies(speciesId)
+
+      assertThrows<SpeciesNotFoundException> { store.fetchSpeciesById(speciesId) }
     }
   }
 
-  @Test
-  fun `updateSpecies throws exception if user has no permission to update species`() {
-    every { user.canUpdateSpecies(any()) } returns false
+  @Nested
+  inner class FetchAllUncheckedSpeciesIds {
+    @Test
+    fun `only returns unchecked species`() {
+      val uncheckedSpeciesId = insertSpecies()
+      insertSpecies(checkedTime = Instant.EPOCH)
 
-    val speciesId =
-        store.createSpecies(
-            NewSpeciesModel(organizationId = organizationId, scientificName = "dummy")
-        )
-
-    assertThrows<AccessDeniedException> {
-      store.updateSpecies(
-          ExistingSpeciesModel(
-              createdTime = Instant.EPOCH,
-              id = speciesId,
-              modifiedTime = Instant.EPOCH,
-              organizationId = organizationId,
-              scientificName = "other",
-          )
-      )
+      assertEquals(listOf(uncheckedSpeciesId), store.fetchUncheckedSpeciesIds(organizationId))
     }
-  }
 
-  @Test
-  fun `deleteSpecies marks species as deleted`() {
-    // Make sure it only deletes the species in question, not the whole table
-    store.createSpecies(NewSpeciesModel(organizationId = organizationId, scientificName = "other"))
-    val expected = store.findAllSpecies(organizationId)
+    @Test
+    fun `does not return deleted species`() {
+      val speciesId =
+          store.createSpecies(
+              NewSpeciesModel(organizationId = organizationId, scientificName = "dummy")
+          )
+      store.deleteSpecies(speciesId)
 
-    val speciesId =
-        store.createSpecies(
-            NewSpeciesModel(organizationId = organizationId, scientificName = "to delete")
-        )
-
-    store.deleteSpecies(speciesId)
-
-    val actual = store.findAllSpecies(organizationId)
-    assertEquals(expected, actual)
-  }
-
-  @Test
-  fun `deleteSpecies throws exception if user has no permission to delete species`() {
-    every { user.canDeleteSpecies(any()) } returns false
-
-    val speciesId =
-        store.createSpecies(
-            NewSpeciesModel(organizationId = organizationId, scientificName = "dummy")
-        )
-
-    assertThrows<AccessDeniedException> { store.deleteSpecies(speciesId) }
-  }
-
-  @Test
-  fun `deleteSpecies throws exception if species does not exist at all`() {
-    assertThrows<SpeciesNotFoundException> { store.deleteSpecies(SpeciesId(1)) }
-  }
-
-  @Test
-  fun `fetchSpeciesById returns species if it is not deleted`() {
-    val speciesId =
-        store.createSpecies(
-            NewSpeciesModel(
-                ecosystemTypes = setOf(EcosystemType.Mangroves, EcosystemType.Tundra),
-                organizationId = organizationId,
-                scientificName = "test",
-            )
-        )
-
-    val expected =
-        ExistingSpeciesModel(
-            createdTime = Instant.EPOCH,
-            ecosystemTypes = setOf(EcosystemType.Mangroves, EcosystemType.Tundra),
-            id = speciesId,
-            initialScientificName = "test",
-            modifiedTime = Instant.EPOCH,
-            organizationId = organizationId,
-            scientificName = "test",
-        )
-
-    val actual = store.fetchSpeciesById(speciesId)
-    assertEquals(expected, actual)
-  }
-
-  @Test
-  fun `fetchSpeciesById throws exception if species is deleted`() {
-    val speciesId =
-        store.createSpecies(
-            NewSpeciesModel(organizationId = organizationId, scientificName = "test")
-        )
-    store.deleteSpecies(speciesId)
-
-    assertThrows<SpeciesNotFoundException> { store.fetchSpeciesById(speciesId) }
-  }
-
-  @Test
-  fun `fetchAllUncheckedSpeciesIds only returns unchecked species`() {
-    val uncheckedSpeciesId = insertSpecies()
-    insertSpecies(checkedTime = Instant.EPOCH)
-
-    assertEquals(listOf(uncheckedSpeciesId), store.fetchUncheckedSpeciesIds(organizationId))
+      assertEquals(emptyList<SpeciesId>(), store.fetchUncheckedSpeciesIds(organizationId))
+    }
   }
 
   @Nested
@@ -691,37 +721,191 @@ internal class SpeciesStoreTest : DatabaseTest(), RunsAsUser {
     }
   }
 
-  @Test
-  fun `fetchAllUncheckedSpeciesIds does not return deleted species`() {
-    val speciesId =
-        store.createSpecies(
-            NewSpeciesModel(organizationId = organizationId, scientificName = "dummy")
-        )
-    store.deleteSpecies(speciesId)
+  @Nested
+  inner class FindAllProblems {
+    @Test
+    fun `does not return problems with deleted species`() {
+      val speciesId =
+          store.createSpecies(
+              NewSpeciesModel(organizationId = organizationId, scientificName = "dummy")
+          )
+      speciesProblemsDao.insert(
+          SpeciesProblemsRow(
+              createdTime = Instant.EPOCH,
+              fieldId = SpeciesProblemField.ScientificName,
+              speciesId = speciesId,
+              typeId = SpeciesProblemType.NameNotFound,
+          )
+      )
+      store.deleteSpecies(speciesId)
 
-    assertEquals(emptyList<SpeciesId>(), store.fetchUncheckedSpeciesIds(organizationId))
+      assertEquals(
+          emptyMap<SpeciesId, List<SpeciesProblemsRow>>(),
+          store.findAllProblems(organizationId),
+      )
+    }
   }
 
-  @Test
-  fun `findAllProblems does not return problems with deleted species`() {
-    val speciesId =
-        store.createSpecies(
-            NewSpeciesModel(organizationId = organizationId, scientificName = "dummy")
-        )
-    speciesProblemsDao.insert(
-        SpeciesProblemsRow(
-            createdTime = Instant.EPOCH,
-            fieldId = SpeciesProblemField.ScientificName,
-            speciesId = speciesId,
-            typeId = SpeciesProblemType.NameNotFound,
-        )
-    )
-    store.deleteSpecies(speciesId)
+  @Nested
+  inner class AcceptProblemSuggestion {
+    @Test
+    fun `throws exception if suggested scientific name is already in use`() {
+      store.createSpecies(
+          NewSpeciesModel(organizationId = organizationId, scientificName = "Correct name")
+      )
+      val speciesIdWithOutdatedName =
+          store.createSpecies(
+              NewSpeciesModel(organizationId = organizationId, scientificName = "Outdated name")
+          )
+      val problemsRow =
+          SpeciesProblemsRow(
+              createdTime = Instant.EPOCH,
+              fieldId = SpeciesProblemField.ScientificName,
+              speciesId = speciesIdWithOutdatedName,
+              suggestedValue = "Correct name",
+              typeId = SpeciesProblemType.NameIsSynonym,
+          )
+      speciesProblemsDao.insert(problemsRow)
 
-    assertEquals(
-        emptyMap<SpeciesId, List<SpeciesProblemsRow>>(),
-        store.findAllProblems(organizationId),
-    )
+      assertThrows<ScientificNameExistsException> {
+        store.acceptProblemSuggestion(problemsRow.id!!)
+      }
+    }
+  }
+
+  @Nested
+  inner class FindAllSpeciesInUse {
+    @Test
+    fun `returns no species when none in use`() {
+      store.createSpecies(
+          NewSpeciesModel(organizationId = organizationId, scientificName = "other")
+      )
+
+      val actual = store.findAllSpecies(organizationId, true)
+
+      assertEquals(emptyList<ExistingSpeciesModel>(), actual)
+    }
+
+    @Test
+    fun `returns species used in batches`() {
+      val created =
+          store.createSpecies(
+              NewSpeciesModel(organizationId = organizationId, scientificName = "batch")
+          )
+      store.createSpecies(
+          NewSpeciesModel(organizationId = organizationId, scientificName = "unused")
+      )
+
+      // create a batch with 'other' species
+      insertFacility()
+      insertBatch(speciesId = created)
+
+      // create another org batch
+      val otherOrgId = insertOrganization()
+      val other =
+          store.createSpecies(
+              NewSpeciesModel(organizationId = otherOrgId, scientificName = "other")
+          )
+      insertFacility()
+      insertBatch(speciesId = other)
+
+      val expected = listOf(store.fetchSpeciesById(created))
+      val actual = store.findAllSpecies(organizationId, true)
+
+      assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `returns species used in accessions`() {
+      val created =
+          store.createSpecies(
+              NewSpeciesModel(organizationId = organizationId, scientificName = "batch")
+          )
+      store.createSpecies(
+          NewSpeciesModel(organizationId = organizationId, scientificName = "unused")
+      )
+
+      // create an accession with 'other' species
+      insertFacility()
+      insertAccession(speciesId = created)
+
+      // create another org accession
+      val otherOrgId = insertOrganization()
+      val other =
+          store.createSpecies(
+              NewSpeciesModel(organizationId = otherOrgId, scientificName = "other")
+          )
+      insertFacility()
+      insertAccession(row = AccessionsRow(speciesId = other))
+
+      val expected = listOf(store.fetchSpeciesById(created))
+      val actual = store.findAllSpecies(organizationId, true)
+
+      assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `returns species used in observations`() {
+      val inUseSpeciesId =
+          store.createSpecies(
+              NewSpeciesModel(organizationId = organizationId, scientificName = "observed")
+          )
+      store.createSpecies(
+          NewSpeciesModel(organizationId = organizationId, scientificName = "unused")
+      )
+
+      insertPlantingSite()
+      insertStratum()
+      insertSubstratum()
+      insertMonitoringPlot()
+      insertObservation()
+      insertObservationPlot()
+      insertRecordedPlant(speciesId = inUseSpeciesId)
+
+      val expected = listOf(store.fetchSpeciesById(inUseSpeciesId))
+      val actual = store.findAllSpecies(organizationId, inUse = true)
+
+      assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `returns species used in plantings`() {
+      val created =
+          store.createSpecies(
+              NewSpeciesModel(organizationId = organizationId, scientificName = "batch")
+          )
+      store.createSpecies(
+          NewSpeciesModel(organizationId = organizationId, scientificName = "unused")
+      )
+
+      // create plantings with 'other' species
+      insertFacility()
+      insertPlantingSite()
+      insertStratum()
+      insertSubstratum()
+      insertNurseryWithdrawal()
+      insertDelivery()
+      insertPlanting(speciesId = created)
+
+      // create another org planting
+      val otherOrgId = insertOrganization()
+      val other =
+          store.createSpecies(
+              NewSpeciesModel(organizationId = otherOrgId, scientificName = "other")
+          )
+      insertFacility()
+      insertPlantingSite()
+      insertStratum()
+      insertSubstratum()
+      insertNurseryWithdrawal()
+      insertDelivery()
+      insertPlanting(speciesId = other)
+
+      val expected = listOf(store.fetchSpeciesById(created))
+      val actual = store.findAllSpecies(organizationId, true)
+
+      assertEquals(expected, actual)
+    }
   }
 
   @Test
@@ -740,143 +924,5 @@ internal class SpeciesStoreTest : DatabaseTest(), RunsAsUser {
     assertThrows<SpeciesNotFoundException> { store.fetchSpeciesById(speciesId) }
 
     assertThrows<OrganizationNotFoundException> { store.findAllSpecies(organizationId) }
-  }
-
-  @Test
-  fun `acceptProblemSuggestion throws exception if suggested scientific name is already in use`() {
-    store.createSpecies(
-        NewSpeciesModel(organizationId = organizationId, scientificName = "Correct name")
-    )
-    val speciesIdWithOutdatedName =
-        store.createSpecies(
-            NewSpeciesModel(organizationId = organizationId, scientificName = "Outdated name")
-        )
-    val problemsRow =
-        SpeciesProblemsRow(
-            createdTime = Instant.EPOCH,
-            fieldId = SpeciesProblemField.ScientificName,
-            speciesId = speciesIdWithOutdatedName,
-            suggestedValue = "Correct name",
-            typeId = SpeciesProblemType.NameIsSynonym,
-        )
-    speciesProblemsDao.insert(problemsRow)
-
-    assertThrows<ScientificNameExistsException> { store.acceptProblemSuggestion(problemsRow.id!!) }
-  }
-
-  @Test
-  fun `find all species in use returns no species when none in use`() {
-    store.createSpecies(NewSpeciesModel(organizationId = organizationId, scientificName = "other"))
-
-    val actual = store.findAllSpecies(organizationId, true)
-
-    assertEquals(emptyList<ExistingSpeciesModel>(), actual)
-  }
-
-  @Test
-  fun `find all species in use returns species used in batches`() {
-    val created =
-        store.createSpecies(
-            NewSpeciesModel(organizationId = organizationId, scientificName = "batch")
-        )
-    store.createSpecies(NewSpeciesModel(organizationId = organizationId, scientificName = "unused"))
-
-    // create a batch with 'other' species
-    insertFacility()
-    insertBatch(speciesId = created)
-
-    // create another org batch
-    val otherOrgId = insertOrganization()
-    val other =
-        store.createSpecies(NewSpeciesModel(organizationId = otherOrgId, scientificName = "other"))
-    insertFacility()
-    insertBatch(speciesId = other)
-
-    val expected = listOf(store.fetchSpeciesById(created))
-    val actual = store.findAllSpecies(organizationId, true)
-
-    assertEquals(expected, actual)
-  }
-
-  @Test
-  fun `find all species in use returns species used in accessions`() {
-    val created =
-        store.createSpecies(
-            NewSpeciesModel(organizationId = organizationId, scientificName = "batch")
-        )
-    store.createSpecies(NewSpeciesModel(organizationId = organizationId, scientificName = "unused"))
-
-    // create an accession with 'other' species
-    insertFacility()
-    insertAccession(speciesId = created)
-
-    // create another org accession
-    val otherOrgId = insertOrganization()
-    val other =
-        store.createSpecies(NewSpeciesModel(organizationId = otherOrgId, scientificName = "other"))
-    insertFacility()
-    insertAccession(row = AccessionsRow(speciesId = other))
-
-    val expected = listOf(store.fetchSpeciesById(created))
-    val actual = store.findAllSpecies(organizationId, true)
-
-    assertEquals(expected, actual)
-  }
-
-  @Test
-  fun `find all species in use returns species used in observations`() {
-    val inUseSpeciesId =
-        store.createSpecies(
-            NewSpeciesModel(organizationId = organizationId, scientificName = "observed")
-        )
-    store.createSpecies(NewSpeciesModel(organizationId = organizationId, scientificName = "unused"))
-
-    insertPlantingSite()
-    insertStratum()
-    insertSubstratum()
-    insertMonitoringPlot()
-    insertObservation()
-    insertObservationPlot()
-    insertRecordedPlant(speciesId = inUseSpeciesId)
-
-    val expected = listOf(store.fetchSpeciesById(inUseSpeciesId))
-    val actual = store.findAllSpecies(organizationId, inUse = true)
-
-    assertEquals(expected, actual)
-  }
-
-  @Test
-  fun `find all species in use returns species used in plantings`() {
-    val created =
-        store.createSpecies(
-            NewSpeciesModel(organizationId = organizationId, scientificName = "batch")
-        )
-    store.createSpecies(NewSpeciesModel(organizationId = organizationId, scientificName = "unused"))
-
-    // create plantings with 'other' species
-    insertFacility()
-    insertPlantingSite()
-    insertStratum()
-    insertSubstratum()
-    insertNurseryWithdrawal()
-    insertDelivery()
-    insertPlanting(speciesId = created)
-
-    // create another org planting
-    val otherOrgId = insertOrganization()
-    val other =
-        store.createSpecies(NewSpeciesModel(organizationId = otherOrgId, scientificName = "other"))
-    insertFacility()
-    insertPlantingSite()
-    insertStratum()
-    insertSubstratum()
-    insertNurseryWithdrawal()
-    insertDelivery()
-    insertPlanting(speciesId = other)
-
-    val expected = listOf(store.fetchSpeciesById(created))
-    val actual = store.findAllSpecies(organizationId, true)
-
-    assertEquals(expected, actual)
   }
 }


### PR DESCRIPTION
In preparation for adding more test cases to SpeciesServiceTest and
SpeciesStoreTest, introduce inner classes to break up the tests for specific
service methods.

No change to the test logic here, just moving the test methods to inner
classes. SpeciesStoreTest already had an inner class for some of its tests.