### PR TITLE
Move GBIF insert function to DatabaseBackedTest

### DIFF
--- a/src/test/kotlin/com/terraformation/backend/db/DatabaseBackedTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/db/DatabaseBackedTest.kt
@@ -147,6 +147,7 @@ import com.terraformation.backend.db.default_schema.FileBatchId
 import com.terraformation.backend.db.default_schema.FileBatchStatus
 import com.terraformation.backend.db.default_schema.FileBatchType
 import com.terraformation.backend.db.default_schema.FileId
+import com.terraformation.backend.db.default_schema.GbifTaxonId
 import com.terraformation.backend.db.default_schema.GlobalRole
 import com.terraformation.backend.db.default_schema.GriisResourceId
 import com.terraformation.backend.db.default_schema.GrowthForm
@@ -253,6 +254,11 @@ import com.terraformation.backend.db.default_schema.tables.records.WcvpTaxaRecor
 import com.terraformation.backend.db.default_schema.tables.references.AUTOMATIONS
 import com.terraformation.backend.db.default_schema.tables.references.DEVICES
 import com.terraformation.backend.db.default_schema.tables.references.FACILITIES
+import com.terraformation.backend.db.default_schema.tables.references.GBIF_DISTRIBUTIONS
+import com.terraformation.backend.db.default_schema.tables.references.GBIF_NAMES
+import com.terraformation.backend.db.default_schema.tables.references.GBIF_NAME_WORDS
+import com.terraformation.backend.db.default_schema.tables.references.GBIF_TAXA
+import com.terraformation.backend.db.default_schema.tables.references.GBIF_VERNACULAR_NAMES
 import com.terraformation.backend.db.default_schema.tables.references.NOTIFICATIONS
 import com.terraformation.backend.db.default_schema.tables.references.ORGANIZATIONS
 import com.terraformation.backend.db.default_schema.tables.references.ORGANIZATION_MEDIA_FILES
@@ -574,6 +580,8 @@ import com.terraformation.backend.documentproducer.model.StableIds
 import com.terraformation.backend.point
 import com.terraformation.backend.rectangle
 import com.terraformation.backend.rectanglePolygon
+import com.terraformation.backend.species.db.GbifImporterTest
+import com.terraformation.backend.species.db.GbifStore
 import com.terraformation.backend.splat.CoordinateModel
 import com.terraformation.backend.splat.toMultiPointField
 import com.terraformation.backend.splat.toPointField
@@ -581,6 +589,7 @@ import com.terraformation.backend.toBigDecimal
 import com.terraformation.backend.tracking.model.MONITORING_PLOT_SIZE
 import com.terraformation.backend.tracking.model.MONITORING_PLOT_SIZE_INT
 import com.terraformation.backend.tracking.model.StratumModel
+import com.terraformation.backend.util.removeDiacritics
 import jakarta.ws.rs.NotFoundException
 import java.math.BigDecimal
 import java.net.URI
@@ -5914,6 +5923,70 @@ abstract class DatabaseBackedTest {
     CountryBotanicalCountriesRecord(countryCode, botanicalCountryCode).attach(dslContext).insert()
   }
 
+  fun insertGbifTaxon(
+      scientificName: String,
+      commonNames: Collection<Pair<String, String?>> = emptyList(),
+      familyName: String = scientificName.substringBefore(' '),
+      threatStatus: String? = null,
+      fullScientificName: String = scientificName,
+      acceptedNameUsageId: GbifTaxonId? = null,
+      taxonomicStatus: String = GbifStore.TAXONOMIC_STATUS_ACCEPTED,
+  ): GbifTaxonId {
+    val taxonId = GbifTaxonId(nextGbifTaxonId.getAndIncrement())
+
+    fun insertName(name: String, isScientific: Boolean) {
+      val nameId =
+          dslContext
+              .insertInto(GBIF_NAMES)
+              .set(GBIF_NAMES.TAXON_ID, taxonId)
+              .set(GBIF_NAMES.NAME, name)
+              .set(GBIF_NAMES.IS_SCIENTIFIC, isScientific)
+              .returning(GBIF_NAMES.ID)
+              .fetchOne(GBIF_NAMES.ID)!!
+
+      name.split(' ').forEach { word ->
+        dslContext
+            .insertInto(GBIF_NAME_WORDS)
+            .set(GBIF_NAME_WORDS.GBIF_NAME_ID, nameId)
+            .set(GBIF_NAME_WORDS.WORD, word.removeDiacritics().lowercase())
+            .execute()
+      }
+    }
+
+    dslContext
+        .insertInto(GBIF_TAXA)
+        .set(GBIF_TAXA.TAXON_ID, taxonId)
+        .set(GBIF_TAXA.SCIENTIFIC_NAME, fullScientificName)
+        .set(GBIF_TAXA.FAMILY, familyName)
+        .set(GBIF_TAXA.TAXON_RANK, "species")
+        .set(GBIF_TAXA.TAXONOMIC_STATUS, taxonomicStatus)
+        .set(GBIF_TAXA.ACCEPTED_NAME_USAGE_ID, acceptedNameUsageId)
+        .execute()
+
+    insertName(scientificName, true)
+
+    commonNames.forEach { (name, language) ->
+      dslContext
+          .insertInto(GBIF_VERNACULAR_NAMES)
+          .set(GBIF_VERNACULAR_NAMES.TAXON_ID, taxonId)
+          .set(GBIF_VERNACULAR_NAMES.VERNACULAR_NAME, name)
+          .set(GBIF_VERNACULAR_NAMES.LANGUAGE, language)
+          .execute()
+
+      insertName(name, false)
+    }
+
+    if (threatStatus != null) {
+      dslContext
+          .insertInto(GBIF_DISTRIBUTIONS)
+          .set(GBIF_DISTRIBUTIONS.TAXON_ID, taxonId)
+          .set(GBIF_DISTRIBUTIONS.THREAT_STATUS, threatStatus)
+          .execute()
+    }
+
+    return taxonId
+  }
+
   private var nextGriisResourceSuffix: Int = 1
 
   fun insertGriisResource(
@@ -6273,6 +6346,16 @@ abstract class DatabaseBackedTest {
      * tests here run concurrently.
      */
     @JvmStatic protected val nextBalenaId = AtomicLong(1L)
+
+    /**
+     * Taxon IDs are defined in the GBIF dataset, not allocated locally by the database, but they
+     * are required to be unique in our data model. Use taxon IDs that are unique across threads to
+     * avoid database deadlocks if multiple of these tests are running concurrently and try to
+     * insert the same taxon ID at the same time.
+     *
+     * This starts at a high number to avoid colliding with the taxon IDs in [GbifImporterTest].
+     */
+    val nextGbifTaxonId = AtomicLong(1000000)
 
     private val imageName: DockerImageName =
         DockerImageName.parse("$POSTGRES_DOCKER_REPOSITORY:$POSTGRES_DOCKER_TAG")

--- a/src/test/kotlin/com/terraformation/backend/species/db/GbifStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/species/db/GbifStoreTest.kt
@@ -6,15 +6,8 @@ import com.terraformation.backend.db.default_schema.SpeciesProblemField
 import com.terraformation.backend.db.default_schema.SpeciesProblemType
 import com.terraformation.backend.db.default_schema.tables.pojos.GbifNamesRow
 import com.terraformation.backend.db.default_schema.tables.pojos.SpeciesProblemsRow
-import com.terraformation.backend.db.default_schema.tables.references.GBIF_DISTRIBUTIONS
-import com.terraformation.backend.db.default_schema.tables.references.GBIF_NAMES
-import com.terraformation.backend.db.default_schema.tables.references.GBIF_NAME_WORDS
-import com.terraformation.backend.db.default_schema.tables.references.GBIF_TAXA
-import com.terraformation.backend.db.default_schema.tables.references.GBIF_VERNACULAR_NAMES
 import com.terraformation.backend.species.model.GbifTaxonModel
 import com.terraformation.backend.species.model.GbifVernacularNameModel
-import com.terraformation.backend.util.removeDiacritics
-import java.util.concurrent.atomic.AtomicLong
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Nested
@@ -28,8 +21,8 @@ internal class GbifStoreTest : DatabaseTest() {
   inner class FindNamesByWordPrefixes {
     @Test
     fun `matches prefixes but not non-prefix substrings`() {
-      val taxonId1 = insertTaxon("Scientific name")
-      insertTaxon("Unscientific name")
+      val taxonId1 = insertGbifTaxon("Scientific name")
+      insertGbifTaxon("Unscientific name")
 
       val expected = listOf(namesRow(taxonId1, "Scientific name"))
 
@@ -39,9 +32,9 @@ internal class GbifStoreTest : DatabaseTest() {
 
     @Test
     fun `only returns names that match all the prefixes`() {
-      insertTaxon("Real name")
-      insertTaxon("Fake identity")
-      val taxonId3 = insertTaxon("Some fake kind of name")
+      insertGbifTaxon("Real name")
+      insertGbifTaxon("Fake identity")
+      val taxonId3 = insertGbifTaxon("Some fake kind of name")
 
       val expected = listOf(namesRow(taxonId3, "Some fake kind of name"))
 
@@ -51,9 +44,9 @@ internal class GbifStoreTest : DatabaseTest() {
 
     @Test
     fun `does case-insensitive prefix matching of scientific names`() {
-      val taxonId1 = insertTaxon("Scientific name")
-      insertTaxon("Unscientific name", listOf("Scientific name but it is common" to null))
-      insertTaxon("Scientific balderdash")
+      val taxonId1 = insertGbifTaxon("Scientific name")
+      insertGbifTaxon("Unscientific name", listOf("Scientific name but it is common" to null))
+      insertGbifTaxon("Scientific balderdash")
 
       val expected = listOf(namesRow(taxonId1, "Scientific name"))
 
@@ -63,7 +56,7 @@ internal class GbifStoreTest : DatabaseTest() {
 
     @Test
     fun `ignores non-alphabetic characters in prefixes`() {
-      val taxonId = insertTaxon("Matching result")
+      val taxonId = insertGbifTaxon("Matching result")
 
       val expected = listOf(namesRow(taxonId, "Matching result"))
 
@@ -73,8 +66,8 @@ internal class GbifStoreTest : DatabaseTest() {
 
     @Test
     fun `can search common names`() {
-      val taxonId1 = insertTaxon("Scientific name", listOf("Common name" to null))
-      insertTaxon("Somewhat common name", listOf("No match" to null))
+      val taxonId1 = insertGbifTaxon("Scientific name", listOf("Common name" to null))
+      insertGbifTaxon("Somewhat common name", listOf("No match" to null))
 
       val expected = listOf(namesRow(taxonId1, "Common name", isScientific = false))
 
@@ -84,8 +77,8 @@ internal class GbifStoreTest : DatabaseTest() {
 
     @Test
     fun `is sensitive to order of prefixes`() {
-      val taxonId1 = insertTaxon("Scientific name")
-      insertTaxon("Name scientific")
+      val taxonId1 = insertGbifTaxon("Scientific name")
+      insertGbifTaxon("Name scientific")
 
       val expected = listOf(namesRow(taxonId1, "Scientific name"))
 
@@ -102,10 +95,10 @@ internal class GbifStoreTest : DatabaseTest() {
 
     @Test
     fun `returns results in alphabetical order with first-word matches at the top`() {
-      val taxonId1 = insertTaxon("Species c")
-      val taxonId2 = insertTaxon("Species a")
-      val taxonId3 = insertTaxon("Species b")
-      val taxonId4 = insertTaxon("Another species")
+      val taxonId1 = insertGbifTaxon("Species c")
+      val taxonId2 = insertGbifTaxon("Species a")
+      val taxonId3 = insertGbifTaxon("Species b")
+      val taxonId4 = insertGbifTaxon("Another species")
 
       val expected =
           listOf(
@@ -121,8 +114,8 @@ internal class GbifStoreTest : DatabaseTest() {
 
     @Test
     fun `ignores diacritics`() {
-      val taxonId1 = insertTaxon("Spécies a")
-      val taxonId2 = insertTaxon("Species b")
+      val taxonId1 = insertGbifTaxon("Spécies a")
+      val taxonId2 = insertGbifTaxon("Species b")
 
       val expected = listOf(namesRow(taxonId1, "Spécies a"), namesRow(taxonId2, "Species b"))
 
@@ -132,9 +125,9 @@ internal class GbifStoreTest : DatabaseTest() {
 
     @Test
     fun `returns partial list of results if number of matches exceeds the maximum`() {
-      val taxonId1 = insertTaxon("Species a")
-      val taxonId2 = insertTaxon("Species b")
-      insertTaxon("Species c")
+      val taxonId1 = insertGbifTaxon("Species a")
+      val taxonId2 = insertGbifTaxon("Species b")
+      insertGbifTaxon("Species c")
 
       val expected =
           listOf(
@@ -148,8 +141,8 @@ internal class GbifStoreTest : DatabaseTest() {
 
     @Test
     fun `does not return duplicate scientific names`() {
-      val taxonId1 = insertTaxon("Species a", fullScientificName = "Species a (Someone 1985)")
-      insertTaxon("Species a", fullScientificName = "Species a (Someone else 1986)")
+      val taxonId1 = insertGbifTaxon("Species a", fullScientificName = "Species a (Someone 1985)")
+      insertGbifTaxon("Species a", fullScientificName = "Species a (Someone else 1986)")
 
       val expected = listOf(namesRow(taxonId1, "Species a"))
 
@@ -168,7 +161,7 @@ internal class GbifStoreTest : DatabaseTest() {
     @Test
     fun `returns vernacular names in multiple languages if no language specified`() {
       val taxonId =
-          insertTaxon(
+          insertGbifTaxon(
               "Scientific name",
               listOf("Common en" to "en", "Common xx" to "xx", "Common unknown" to null),
               "Family",
@@ -195,7 +188,7 @@ internal class GbifStoreTest : DatabaseTest() {
     @Test
     fun `excludes vernacular names in languages other than the specified one`() {
       val taxonId =
-          insertTaxon(
+          insertGbifTaxon(
               "Scientific name",
               listOf(
                   "Common es" to "es",
@@ -224,7 +217,7 @@ internal class GbifStoreTest : DatabaseTest() {
     @Test
     fun `falls back to English if no vernacular names exist in requested language`() {
       val taxonId =
-          insertTaxon(
+          insertGbifTaxon(
               "Scientific name",
               listOf(
                   "Common en" to "en",
@@ -252,18 +245,18 @@ internal class GbifStoreTest : DatabaseTest() {
 
     @Test
     fun `returns data for accepted name if multiple taxa have same name`() {
-      insertTaxon(
+      insertGbifTaxon(
           "Scientific name",
           fullScientificName = "Scientific name (1)",
           taxonomicStatus = "doubtful",
       )
       val taxonId2 =
-          insertTaxon(
+          insertGbifTaxon(
               "Scientific name",
               fullScientificName = "Scientific name (2)",
               taxonomicStatus = "accepted",
           )
-      insertTaxon(
+      insertGbifTaxon(
           "Scientific name",
           fullScientificName = "Scientific name (3)",
           taxonomicStatus = "synonym",
@@ -281,7 +274,7 @@ internal class GbifStoreTest : DatabaseTest() {
     @Test
     fun `returns null if name is already correct`() {
       val scientificName = "Scientific name"
-      insertTaxon(scientificName)
+      insertGbifTaxon(scientificName)
 
       val actual = store.checkScientificName(scientificName)
       assertNull(actual)
@@ -289,7 +282,7 @@ internal class GbifStoreTest : DatabaseTest() {
 
     @Test
     fun `returns not-found problem if there are no close matches`() {
-      insertTaxon("Scientific name")
+      insertGbifTaxon("Scientific name")
 
       val expected =
           SpeciesProblemsRow(
@@ -304,7 +297,7 @@ internal class GbifStoreTest : DatabaseTest() {
     @Test
     fun `returns suggested name if it is a close match`() {
       val scientificName = "Scientific name"
-      insertTaxon(scientificName)
+      insertGbifTaxon(scientificName)
 
       val expected =
           SpeciesProblemsRow(
@@ -321,8 +314,8 @@ internal class GbifStoreTest : DatabaseTest() {
     fun `returns accepted name if input is a synonym`() {
       val newName = "New name"
       val oldName = "Older synonym"
-      val newNameTaxonId = insertTaxon(newName)
-      insertTaxon(oldName, taxonomicStatus = "synonym", acceptedNameUsageId = newNameTaxonId)
+      val newNameTaxonId = insertGbifTaxon(newName)
+      insertGbifTaxon(oldName, taxonomicStatus = "synonym", acceptedNameUsageId = newNameTaxonId)
 
       val expected =
           SpeciesProblemsRow(
@@ -338,8 +331,8 @@ internal class GbifStoreTest : DatabaseTest() {
     @Test
     fun `returns accepted name if input is a misspelled synonym`() {
       val newName = "New name"
-      val newNameTaxonId = insertTaxon(newName)
-      insertTaxon(
+      val newNameTaxonId = insertGbifTaxon(newName)
+      insertGbifTaxon(
           "Correct synonym",
           taxonomicStatus = "synonym",
           acceptedNameUsageId = newNameTaxonId,
@@ -358,78 +351,14 @@ internal class GbifStoreTest : DatabaseTest() {
 
     @Test
     fun `returns null if there are multiple taxa whose scientific names we render identically`() {
-      insertTaxon("Scientific name", fullScientificName = "Scientific name (author1)")
-      insertTaxon(
+      insertGbifTaxon("Scientific name", fullScientificName = "Scientific name (author1)")
+      insertGbifTaxon(
           "Scientific name",
           fullScientificName = "Scientific name (author2)",
           taxonomicStatus = "doubtful",
       )
 
       assertNull(store.checkScientificName("Scientific name"))
-    }
-  }
-
-  private fun insertTaxon(
-      scientificName: String,
-      commonNames: Collection<Pair<String, String?>> = emptyList(),
-      familyName: String = scientificName.substringBefore(' '),
-      threatStatus: String? = null,
-      fullScientificName: String = scientificName,
-      acceptedNameUsageId: GbifTaxonId? = null,
-      taxonomicStatus: String = GbifStore.TAXONOMIC_STATUS_ACCEPTED,
-  ): GbifTaxonId {
-    val taxonId = GbifTaxonId(nextTaxonId.getAndIncrement())
-
-    dslContext
-        .insertInto(GBIF_TAXA)
-        .set(GBIF_TAXA.TAXON_ID, taxonId)
-        .set(GBIF_TAXA.SCIENTIFIC_NAME, fullScientificName)
-        .set(GBIF_TAXA.FAMILY, familyName)
-        .set(GBIF_TAXA.TAXON_RANK, "species")
-        .set(GBIF_TAXA.TAXONOMIC_STATUS, taxonomicStatus)
-        .set(GBIF_TAXA.ACCEPTED_NAME_USAGE_ID, acceptedNameUsageId)
-        .execute()
-
-    insertName(taxonId, scientificName, true)
-
-    commonNames.forEach { (name, language) ->
-      dslContext
-          .insertInto(GBIF_VERNACULAR_NAMES)
-          .set(GBIF_VERNACULAR_NAMES.TAXON_ID, taxonId)
-          .set(GBIF_VERNACULAR_NAMES.VERNACULAR_NAME, name)
-          .set(GBIF_VERNACULAR_NAMES.LANGUAGE, language)
-          .execute()
-
-      insertName(taxonId, name, false)
-    }
-
-    if (threatStatus != null) {
-      dslContext
-          .insertInto(GBIF_DISTRIBUTIONS)
-          .set(GBIF_DISTRIBUTIONS.TAXON_ID, taxonId)
-          .set(GBIF_DISTRIBUTIONS.THREAT_STATUS, threatStatus)
-          .execute()
-    }
-
-    return taxonId
-  }
-
-  private fun insertName(taxonId: GbifTaxonId, name: String, isScientific: Boolean) {
-    val nameId =
-        dslContext
-            .insertInto(GBIF_NAMES)
-            .set(GBIF_NAMES.TAXON_ID, taxonId)
-            .set(GBIF_NAMES.NAME, name)
-            .set(GBIF_NAMES.IS_SCIENTIFIC, isScientific)
-            .returning(GBIF_NAMES.ID)
-            .fetchOne(GBIF_NAMES.ID)!!
-
-    name.split(' ').forEach { word ->
-      dslContext
-          .insertInto(GBIF_NAME_WORDS)
-          .set(GBIF_NAME_WORDS.GBIF_NAME_ID, nameId)
-          .set(GBIF_NAME_WORDS.WORD, word.removeDiacritics().lowercase())
-          .execute()
     }
   }
 
@@ -449,17 +378,5 @@ internal class GbifStoreTest : DatabaseTest() {
 
   private fun assertNamesEqual(expected: List<GbifNamesRow>, actual: List<GbifNamesRow>) {
     assertEquals(expected, actual.map { it.copy(id = null) })
-  }
-
-  companion object {
-    /**
-     * Taxon IDs are defined in the GBIF dataset, not allocated locally by the database, but they
-     * are required to be unique in our data model. Use taxon IDs that are unique across threads to
-     * avoid database deadlocks if multiple of these tests are running concurrently and try to
-     * insert the same taxon ID at the same time.
-     *
-     * This starts at a high number to avoid colliding with the taxon IDs in [GbifImporterTest].
-     */
-    val nextTaxonId = AtomicLong(1000000)
   }
 }


### PR DESCRIPTION
To allow tests other than GbifStoreTest to insert GBIF taxa, move the insert
helper function to DatabaseBackedTest.