### PR TITLE
SW-8652 Tell client the source of species names

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/species/api/SpeciesDataSourcePayload.kt
+++ b/src/main/kotlin/com/terraformation/backend/species/api/SpeciesDataSourcePayload.kt
@@ -1,0 +1,9 @@
+package com.terraformation.backend.species.api
+
+import com.terraformation.backend.db.default_schema.ExternalDatasetType
+import java.time.LocalDate
+
+data class SpeciesDataSourcePayload(
+    val datasetDate: LocalDate,
+    val datasetType: ExternalDatasetType,
+)

--- a/src/main/kotlin/com/terraformation/backend/species/api/SpeciesLookupController.kt
+++ b/src/main/kotlin/com/terraformation/backend/species/api/SpeciesLookupController.kt
@@ -5,8 +5,10 @@ import com.terraformation.backend.api.ApiResponse404
 import com.terraformation.backend.api.CustomerEndpoint
 import com.terraformation.backend.api.SuccessResponsePayload
 import com.terraformation.backend.db.default_schema.ConservationCategory
+import com.terraformation.backend.db.default_schema.ExternalDatasetType
 import com.terraformation.backend.db.default_schema.SpeciesProblemType
 import com.terraformation.backend.db.default_schema.tables.pojos.SpeciesProblemsRow
+import com.terraformation.backend.species.db.ExternalDatasetStore
 import com.terraformation.backend.species.db.GbifStore
 import com.terraformation.backend.species.model.GbifTaxonModel
 import com.terraformation.backend.species.model.GbifVernacularNameModel
@@ -18,6 +20,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse
 import jakarta.validation.constraints.Size
 import jakarta.ws.rs.BadRequestException
 import jakarta.ws.rs.NotFoundException
+import java.time.LocalDate
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
@@ -26,7 +29,10 @@ import org.springframework.web.bind.annotation.RestController
 @CustomerEndpoint
 @RestController
 @RequestMapping("/api/v1/species/lookup")
-class SpeciesLookupController(private val gbifStore: GbifStore) {
+class SpeciesLookupController(
+    private val externalDatasetStore: ExternalDatasetStore,
+    private val gbifStore: GbifStore,
+) {
   @GetMapping("/names")
   @Operation(
       description =
@@ -86,7 +92,11 @@ class SpeciesLookupController(private val gbifStore: GbifStore) {
         gbifStore.fetchOneByScientificName(scientificName, language)
             ?: throw NotFoundException("$scientificName not found")
     val problem = gbifStore.checkScientificName(scientificName)
-    return SpeciesLookupDetailsResponsePayload(model, problem)
+    return SpeciesLookupDetailsResponsePayload(
+        model,
+        problem,
+        externalDatasetStore.getDatasetDate(ExternalDatasetType.GBIF),
+    )
   }
 }
 
@@ -125,8 +135,10 @@ data class SpeciesLookupDetailsResponsePayload(
         externalDocs =
             ExternalDocumentation(url = "https://en.wikipedia.org/wiki/IUCN_Red_List#Categories"),
     )
+    val commonNameSource: SpeciesDataSourcePayload,
     val conservationCategory: ConservationCategory?,
     val familyName: String,
+    val familyNameSource: SpeciesDataSourcePayload,
     @Schema(
         description =
             "If this is not the accepted name for the species, the type of problem the name has. " +
@@ -143,12 +155,16 @@ data class SpeciesLookupDetailsResponsePayload(
   constructor(
       model: GbifTaxonModel,
       problem: SpeciesProblemsRow?,
+      datasetDate: LocalDate,
   ) : this(
-      model.scientificName,
-      model.vernacularNames.map { SpeciesLookupCommonNamePayload(it) }.ifEmpty { null },
-      model.conservationCategory,
-      model.familyName,
-      problem?.typeId,
-      problem?.suggestedValue,
+      commonNames =
+          model.vernacularNames.map { SpeciesLookupCommonNamePayload(it) }.ifEmpty { null },
+      commonNameSource = SpeciesDataSourcePayload(datasetDate, ExternalDatasetType.GBIF),
+      conservationCategory = model.conservationCategory,
+      familyName = model.familyName,
+      familyNameSource = SpeciesDataSourcePayload(datasetDate, ExternalDatasetType.GBIF),
+      problemType = problem?.typeId,
+      scientificName = model.scientificName,
+      suggestedScientificName = problem?.suggestedValue,
   )
 }

--- a/src/main/kotlin/com/terraformation/backend/species/db/ExternalDatasetStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/species/db/ExternalDatasetStore.kt
@@ -1,0 +1,27 @@
+package com.terraformation.backend.species.db
+
+import com.terraformation.backend.db.default_schema.ExternalDatasetType
+import com.terraformation.backend.db.default_schema.tables.references.EXTERNAL_DATASET_IMPORTS
+import jakarta.inject.Named
+import java.time.LocalDate
+import java.time.ZoneOffset
+import org.jooq.DSLContext
+
+@Named
+class ExternalDatasetStore(private val dslContext: DSLContext) {
+  /**
+   * Returns the date of the most recent import of the GBIF dataset. Some datasets don't include
+   * publication dates in their metadata, so fall back to the date of the most recent import in the
+   * UTC time zone.
+   */
+  fun getDatasetDate(datasetType: ExternalDatasetType): LocalDate {
+    val importRecord =
+        dslContext.fetchOne(
+            EXTERNAL_DATASET_IMPORTS,
+            EXTERNAL_DATASET_IMPORTS.EXTERNAL_DATASET_TYPE_ID.eq(datasetType),
+        ) ?: throw IllegalStateException("No import record found for $datasetType dataset")
+
+    return importRecord.lastPublicationDate
+        ?: importRecord.importedTime!!.atZone(ZoneOffset.UTC).toLocalDate()
+  }
+}

--- a/src/test/kotlin/com/terraformation/backend/db/DatabaseBackedTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/db/DatabaseBackedTest.kt
@@ -6104,7 +6104,7 @@ abstract class DatabaseBackedTest {
   fun insertExternalDatasetImport(
       type: ExternalDatasetType = ExternalDatasetType.GRIIS,
       importedTime: Instant = Instant.EPOCH,
-      lastPublicationDate: LocalDate = LocalDate.of(2026, 1, 1),
+      lastPublicationDate: LocalDate? = LocalDate.of(2026, 1, 1),
   ) {
     ExternalDatasetImportsRecord(
             externalDatasetTypeId = type,

--- a/src/test/kotlin/com/terraformation/backend/species/db/ExternalDatasetStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/species/db/ExternalDatasetStoreTest.kt
@@ -1,0 +1,45 @@
+package com.terraformation.backend.species.db
+
+import com.terraformation.backend.db.DatabaseTest
+import com.terraformation.backend.db.default_schema.ExternalDatasetType
+import java.time.LocalDate
+import java.time.LocalTime
+import java.time.ZoneOffset
+import java.time.ZonedDateTime
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+class ExternalDatasetStoreTest : DatabaseTest() {
+  private val store: ExternalDatasetStore by lazy { ExternalDatasetStore(dslContext) }
+
+  @Nested
+  inner class GetDatasetDate {
+    @Test
+    fun `returns publication date if present`() {
+      val publicationDate = LocalDate.of(2026, 2, 2)
+      insertExternalDatasetImport(ExternalDatasetType.GRIIS, lastPublicationDate = publicationDate)
+
+      assertEquals(publicationDate, store.getDatasetDate(ExternalDatasetType.GRIIS))
+    }
+
+    @Test
+    fun `returns UTC date of import if publication date not present`() {
+      val importDate = LocalDate.of(2026, 2, 2)
+      insertExternalDatasetImport(
+          ExternalDatasetType.GRIIS,
+          importedTime =
+              ZonedDateTime.of(importDate, LocalTime.of(23, 59, 59), ZoneOffset.UTC).toInstant(),
+          lastPublicationDate = null,
+      )
+
+      assertEquals(importDate, store.getDatasetDate(ExternalDatasetType.GRIIS))
+    }
+
+    @Test
+    fun `throws exception if no import record for dataset`() {
+      assertThrows<IllegalStateException> { store.getDatasetDate(ExternalDatasetType.WCVP) }
+    }
+  }
+}


### PR DESCRIPTION
To allow the client to show attributions for names while the user is editing a
species, update the species details lookup API to include the dataset type and
date that was used for the common names and the family name.