### PR TITLE
Move SpeciesStore.acceptProblemSuggestion to SpeciesService

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/species/SpeciesService.kt
+++ b/src/main/kotlin/com/terraformation/backend/species/SpeciesService.kt
@@ -1,8 +1,14 @@
 package com.terraformation.backend.species
 
 import com.terraformation.backend.customer.model.requirePermissions
+import com.terraformation.backend.db.ScientificNameExistsException
 import com.terraformation.backend.db.SpeciesInUseException
+import com.terraformation.backend.db.SpeciesProblemHasNoSuggestionException
+import com.terraformation.backend.db.SpeciesProblemNotFoundException
 import com.terraformation.backend.db.default_schema.SpeciesId
+import com.terraformation.backend.db.default_schema.SpeciesProblemField
+import com.terraformation.backend.db.default_schema.SpeciesProblemId
+import com.terraformation.backend.db.default_schema.SpeciesProblemType
 import com.terraformation.backend.species.db.SpeciesChecker
 import com.terraformation.backend.species.db.SpeciesStore
 import com.terraformation.backend.species.event.SpeciesEditedEvent
@@ -11,6 +17,7 @@ import com.terraformation.backend.species.model.NewSpeciesModel
 import jakarta.inject.Named
 import org.jooq.DSLContext
 import org.springframework.context.ApplicationEventPublisher
+import org.springframework.dao.DuplicateKeyException
 
 @Named
 class SpeciesService(
@@ -51,5 +58,41 @@ class SpeciesService(
     }
 
     speciesStore.deleteSpecies(speciesId)
+  }
+
+  fun acceptProblemSuggestion(problemId: SpeciesProblemId): ExistingSpeciesModel {
+    val problem = speciesStore.fetchProblemById(problemId)
+    val speciesId = problem.speciesId ?: throw SpeciesProblemNotFoundException(problemId)
+    val existingSpecies = speciesStore.fetchSpeciesById(speciesId)
+
+    val fieldId = problem.fieldId ?: throw IllegalStateException("Species problem had no field")
+    val typeId = problem.typeId ?: throw IllegalStateException("Species problem had no type")
+
+    val correctedSpecies =
+        when (typeId) {
+          SpeciesProblemType.NameNotFound -> throw SpeciesProblemHasNoSuggestionException(problemId)
+          SpeciesProblemType.NameIsSynonym,
+          SpeciesProblemType.NameMisspelled -> {
+            // Only one field defined right now but use a "when" so this will break the build if
+            // we add a second field and forget to handle it here.
+            when (fieldId) {
+              SpeciesProblemField.ScientificName ->
+                  existingSpecies.copy(scientificName = problem.suggestedValue!!)
+            }
+          }
+        }
+
+    return try {
+      dslContext.transactionResult { _ ->
+        speciesStore.deleteProblem(problemId)
+        speciesStore.updateSpecies(correctedSpecies)
+      }
+    } catch (e: DuplicateKeyException) {
+      if (fieldId == SpeciesProblemField.ScientificName) {
+        throw ScientificNameExistsException(problem.suggestedValue)
+      } else {
+        throw e
+      }
+    }
   }
 }

--- a/src/main/kotlin/com/terraformation/backend/species/api/SpeciesController.kt
+++ b/src/main/kotlin/com/terraformation/backend/species/api/SpeciesController.kt
@@ -175,7 +175,7 @@ class SpeciesController(
   fun acceptProblemSuggestion(
       @PathVariable problemId: SpeciesProblemId
   ): GetSpeciesResponsePayload {
-    val updatedRow = speciesStore.acceptProblemSuggestion(problemId)
+    val updatedRow = speciesService.acceptProblemSuggestion(problemId)
     val remainingProblems = speciesStore.fetchProblemsBySpeciesId(updatedRow.id)
     return GetSpeciesResponsePayload(SpeciesResponseElement(updatedRow, remainingProblems))
   }

--- a/src/main/kotlin/com/terraformation/backend/species/db/SpeciesStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/species/db/SpeciesStore.kt
@@ -5,7 +5,6 @@ import com.terraformation.backend.customer.model.requirePermissions
 import com.terraformation.backend.db.EnumFromReferenceTable
 import com.terraformation.backend.db.ScientificNameExistsException
 import com.terraformation.backend.db.SpeciesNotFoundException
-import com.terraformation.backend.db.SpeciesProblemHasNoSuggestionException
 import com.terraformation.backend.db.SpeciesProblemNotFoundException
 import com.terraformation.backend.db.asNonNullable
 import com.terraformation.backend.db.default_schema.EcosystemType
@@ -13,9 +12,7 @@ import com.terraformation.backend.db.default_schema.GrowthForm
 import com.terraformation.backend.db.default_schema.OrganizationId
 import com.terraformation.backend.db.default_schema.PlantMaterialSourcingMethod
 import com.terraformation.backend.db.default_schema.SpeciesId
-import com.terraformation.backend.db.default_schema.SpeciesProblemField
 import com.terraformation.backend.db.default_schema.SpeciesProblemId
-import com.terraformation.backend.db.default_schema.SpeciesProblemType
 import com.terraformation.backend.db.default_schema.SuccessionalGroup
 import com.terraformation.backend.db.default_schema.tables.daos.SpeciesDao
 import com.terraformation.backend.db.default_schema.tables.daos.SpeciesEcosystemTypesDao
@@ -818,42 +815,6 @@ class SpeciesStore(
           .set(SPECIES.CHECKED_TIME, clock.instant())
           .where(SPECIES.ID.eq(speciesId))
           .execute()
-    }
-  }
-
-  fun acceptProblemSuggestion(problemId: SpeciesProblemId): ExistingSpeciesModel {
-    val problem = fetchProblemById(problemId)
-    val speciesId = problem.speciesId ?: throw SpeciesProblemNotFoundException(problemId)
-    val existingSpecies = fetchSpeciesById(speciesId)
-
-    val fieldId = problem.fieldId ?: throw IllegalStateException("Species problem had no field")
-    val typeId = problem.typeId ?: throw IllegalStateException("Species problem had no type")
-
-    val correctedSpecies =
-        when (typeId) {
-          SpeciesProblemType.NameNotFound -> throw SpeciesProblemHasNoSuggestionException(problemId)
-          SpeciesProblemType.NameIsSynonym,
-          SpeciesProblemType.NameMisspelled -> {
-            // Only one field defined right now but use a "when" so this will break the build if
-            // we add a second field and forget to handle it here.
-            when (fieldId) {
-              SpeciesProblemField.ScientificName ->
-                  existingSpecies.copy(scientificName = problem.suggestedValue!!)
-            }
-          }
-        }
-
-    return try {
-      dslContext.transactionResult { _ ->
-        deleteProblem(problemId)
-        updateSpecies(correctedSpecies)
-      }
-    } catch (e: DuplicateKeyException) {
-      if (fieldId == SpeciesProblemField.ScientificName) {
-        throw ScientificNameExistsException(problem.suggestedValue)
-      } else {
-        throw e
-      }
     }
   }
 }

--- a/src/test/kotlin/com/terraformation/backend/species/SpeciesServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/species/SpeciesServiceTest.kt
@@ -5,9 +5,13 @@ import com.terraformation.backend.TestClock
 import com.terraformation.backend.TestEventPublisher
 import com.terraformation.backend.customer.model.TerrawareUser
 import com.terraformation.backend.db.DatabaseTest
+import com.terraformation.backend.db.ScientificNameExistsException
 import com.terraformation.backend.db.SpeciesInUseException
 import com.terraformation.backend.db.SpeciesNotFoundException
 import com.terraformation.backend.db.default_schema.OrganizationId
+import com.terraformation.backend.db.default_schema.SpeciesProblemField
+import com.terraformation.backend.db.default_schema.SpeciesProblemType
+import com.terraformation.backend.db.default_schema.tables.pojos.SpeciesProblemsRow
 import com.terraformation.backend.mockUser
 import com.terraformation.backend.species.db.SpeciesChecker
 import com.terraformation.backend.species.db.SpeciesStore
@@ -19,6 +23,7 @@ import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
 import io.mockk.verify
+import java.time.Instant
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.BeforeEach
@@ -158,6 +163,56 @@ internal class SpeciesServiceTest : DatabaseTest(), RunsAsUser {
 
       service.deleteSpecies(speciesId)
       assertThrows<SpeciesNotFoundException> { speciesStore.fetchSpeciesById(speciesId) }
+    }
+  }
+
+  @Nested
+  inner class AcceptProblemSuggestion {
+    @Test
+    fun `updates species if name is synonym`() {
+      val speciesId =
+          service.createSpecies(
+              NewSpeciesModel(organizationId = organizationId, scientificName = "Incorrect name")
+          )
+
+      val problemsRow =
+          SpeciesProblemsRow(
+              createdTime = Instant.EPOCH,
+              fieldId = SpeciesProblemField.ScientificName,
+              speciesId = speciesId,
+              suggestedValue = "Correct name",
+              typeId = SpeciesProblemType.NameIsSynonym,
+          )
+      speciesProblemsDao.insert(problemsRow)
+
+      val updated = service.acceptProblemSuggestion(problemsRow.id!!)
+
+      assertEquals("Correct name", updated.scientificName, "Scientific name")
+      assertEquals("Incorrect name", updated.initialScientificName, "Initial scientific name")
+    }
+
+    @Test
+    fun `throws exception if suggested scientific name is already in use`() {
+      service.createSpecies(
+          NewSpeciesModel(organizationId = organizationId, scientificName = "Correct name")
+      )
+      val speciesIdWithOutdatedName =
+          service.createSpecies(
+              NewSpeciesModel(organizationId = organizationId, scientificName = "Outdated name")
+          )
+      val problemsRow =
+          SpeciesProblemsRow(
+              createdTime = Instant.EPOCH,
+              fieldId = SpeciesProblemField.ScientificName,
+              speciesId = speciesIdWithOutdatedName,
+              suggestedValue = "Correct name",
+              typeId = SpeciesProblemType.NameIsSynonym,
+          )
+      speciesProblemsDao.insert(problemsRow)
+
+      assertThrows<ScientificNameExistsException> {
+        service.acceptProblemSuggestion(problemsRow.id!!)
+      }
     }
   }
 }

--- a/src/test/kotlin/com/terraformation/backend/species/db/SpeciesStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/species/db/SpeciesStoreTest.kt
@@ -747,33 +747,6 @@ internal class SpeciesStoreTest : DatabaseTest(), RunsAsUser {
   }
 
   @Nested
-  inner class AcceptProblemSuggestion {
-    @Test
-    fun `throws exception if suggested scientific name is already in use`() {
-      store.createSpecies(
-          NewSpeciesModel(organizationId = organizationId, scientificName = "Correct name")
-      )
-      val speciesIdWithOutdatedName =
-          store.createSpecies(
-              NewSpeciesModel(organizationId = organizationId, scientificName = "Outdated name")
-          )
-      val problemsRow =
-          SpeciesProblemsRow(
-              createdTime = Instant.EPOCH,
-              fieldId = SpeciesProblemField.ScientificName,
-              speciesId = speciesIdWithOutdatedName,
-              suggestedValue = "Correct name",
-              typeId = SpeciesProblemType.NameIsSynonym,
-          )
-      speciesProblemsDao.insert(problemsRow)
-
-      assertThrows<ScientificNameExistsException> {
-        store.acceptProblemSuggestion(problemsRow.id!!)
-      }
-    }
-  }
-
-  @Nested
   inner class FindAllSpeciesInUse {
     @Test
     fun `returns no species when none in use`() {


### PR DESCRIPTION
In preparation for adding more logic to species edits, move the code that
accepts suggested edits to SpeciesService so it will be able to access
other store classes. No change in functionality here, though there is a
new test to verify the happy-path behavior.