### PR TITLE
SW-8671 Return project data in species API

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/species/api/SpeciesController.kt
+++ b/src/main/kotlin/com/terraformation/backend/species/api/SpeciesController.kt
@@ -18,6 +18,7 @@ import com.terraformation.backend.db.default_schema.PlantMaterialSourcingMethod
 import com.terraformation.backend.db.default_schema.ProjectId
 import com.terraformation.backend.db.default_schema.SeedStorageBehavior
 import com.terraformation.backend.db.default_schema.SpeciesId
+import com.terraformation.backend.db.default_schema.SpeciesNativity
 import com.terraformation.backend.db.default_schema.SpeciesProblemField
 import com.terraformation.backend.db.default_schema.SpeciesProblemId
 import com.terraformation.backend.db.default_schema.SpeciesProblemType
@@ -28,6 +29,7 @@ import com.terraformation.backend.species.SpeciesService
 import com.terraformation.backend.species.db.ProjectSpeciesStore
 import com.terraformation.backend.species.db.SpeciesStore
 import com.terraformation.backend.species.model.ExistingSpeciesModel
+import com.terraformation.backend.species.model.ExistingSpeciesProjectModel
 import com.terraformation.backend.species.model.NewSpeciesModel
 import io.swagger.v3.oas.annotations.ExternalDocumentation
 import io.swagger.v3.oas.annotations.Operation
@@ -244,6 +246,25 @@ data class SpeciesProblemElement(
 }
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
+data class SpeciesProjectElement(
+    val calculatedNativity: SpeciesNativity?,
+    val calculatedNativitySource: SpeciesDataSourcePayload?,
+    val overriddenJustification: String?,
+    val overriddenNativity: SpeciesNativity?,
+    val projectId: ProjectId?,
+) {
+  constructor(
+      model: ExistingSpeciesProjectModel
+  ) : this(
+      calculatedNativity = model.calculatedNativity,
+      calculatedNativitySource = model.calculatedNativitySource?.toPayload(),
+      overriddenJustification = model.overriddenJustification,
+      overriddenNativity = model.overriddenNativity,
+      projectId = model.projectId,
+  )
+}
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
 data class SpeciesResponseElement(
     val averageWoodDensity: BigDecimal?,
     val commonName: String?,
@@ -270,6 +291,7 @@ data class SpeciesResponseElement(
     val nativeEcosystem: String?,
     val plantMaterialSourcingMethods: Set<PlantMaterialSourcingMethod>?,
     val problems: List<SpeciesProblemElement>?,
+    val projects: List<SpeciesProjectElement>,
     val otherFacts: String?,
     val rare: Boolean?,
     val scientificName: String,
@@ -301,6 +323,7 @@ data class SpeciesResponseElement(
       nativeEcosystem = model.nativeEcosystem,
       plantMaterialSourcingMethods = model.plantMaterialSourcingMethods,
       problems = problems?.map { SpeciesProblemElement(it) }?.ifEmpty { null },
+      projects = model.projects.map { SpeciesProjectElement(it) },
       otherFacts = model.otherFacts,
       rare = model.rare,
       scientificName = model.scientificName,

--- a/src/main/kotlin/com/terraformation/backend/species/db/SpeciesStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/species/db/SpeciesStore.kt
@@ -22,6 +22,7 @@ import com.terraformation.backend.db.default_schema.tables.pojos.SpeciesEcosyste
 import com.terraformation.backend.db.default_schema.tables.pojos.SpeciesGrowthFormsRow
 import com.terraformation.backend.db.default_schema.tables.pojos.SpeciesProblemsRow
 import com.terraformation.backend.db.default_schema.tables.pojos.SpeciesRow
+import com.terraformation.backend.db.default_schema.tables.references.PROJECT_SPECIES
 import com.terraformation.backend.db.default_schema.tables.references.SPECIES
 import com.terraformation.backend.db.default_schema.tables.references.SPECIES_ECOSYSTEM_TYPES
 import com.terraformation.backend.db.default_schema.tables.references.SPECIES_GROWTH_FORMS
@@ -41,6 +42,7 @@ import com.terraformation.backend.db.tracking.tables.references.SUBSTRATA
 import com.terraformation.backend.log.perClassLogger
 import com.terraformation.backend.species.SpeciesService
 import com.terraformation.backend.species.model.ExistingSpeciesModel
+import com.terraformation.backend.species.model.ExistingSpeciesProjectModel
 import com.terraformation.backend.species.model.NewSpeciesModel
 import jakarta.inject.Named
 import java.time.Clock
@@ -63,6 +65,26 @@ class SpeciesStore(
     private val speciesProblemsDao: SpeciesProblemsDao,
 ) {
   private val log = perClassLogger()
+
+  private val projectSpeciesMultiset: Field<List<ExistingSpeciesProjectModel>> =
+      with(PROJECT_SPECIES) {
+        DSL.multiset(
+                DSL.select(
+                        CALCULATED_NATIVITY_DATASET_DATE,
+                        CALCULATED_NATIVITY_DATASET_TYPE_ID,
+                        CALCULATED_NATIVITY_ID,
+                        OVERRIDDEN_JUSTIFICATION,
+                        OVERRIDDEN_NATIVITY_ID,
+                        PROJECT_ID,
+                    )
+                    .from(PROJECT_SPECIES)
+                    .where(SPECIES_ID.eq(SPECIES.ID))
+                    .orderBy(PROJECT_ID)
+            )
+            .convertFrom { result ->
+              result.map { record -> ExistingSpeciesProjectModel.of(record) }
+            }
+      }
 
   private val speciesEcosystemTypesMultiset: Field<Set<EcosystemType>> =
       DSL.multiset(
@@ -146,6 +168,7 @@ class SpeciesStore(
     return dslContext
         .select(
             SPECIES.asterisk(),
+            projectSpeciesMultiset,
             speciesEcosystemTypesMultiset,
             speciesGrowthFormsMultiset,
             speciesPlantMaterialSourcingMethodsMultiset,
@@ -160,6 +183,7 @@ class SpeciesStore(
               speciesEcosystemTypesMultiset,
               speciesGrowthFormsMultiset,
               speciesPlantMaterialSourcingMethodsMultiset,
+              projectSpeciesMultiset,
               speciesSuccessionalGroupsMultiset,
           )
         } ?: throw SpeciesNotFoundException(speciesId)
@@ -171,6 +195,7 @@ class SpeciesStore(
     return dslContext
         .select(
             SPECIES.asterisk(),
+            projectSpeciesMultiset,
             speciesEcosystemTypesMultiset,
             speciesGrowthFormsMultiset,
             speciesPlantMaterialSourcingMethodsMultiset,
@@ -191,6 +216,7 @@ class SpeciesStore(
               speciesEcosystemTypesMultiset,
               speciesGrowthFormsMultiset,
               speciesPlantMaterialSourcingMethodsMultiset,
+              projectSpeciesMultiset,
               speciesSuccessionalGroupsMultiset,
           )
         }
@@ -210,6 +236,7 @@ class SpeciesStore(
     return dslContext
         .select(
             SPECIES.asterisk(),
+            projectSpeciesMultiset,
             speciesEcosystemTypesMultiset,
             speciesGrowthFormsMultiset,
             speciesPlantMaterialSourcingMethodsMultiset,
@@ -245,6 +272,7 @@ class SpeciesStore(
               speciesEcosystemTypesMultiset,
               speciesGrowthFormsMultiset,
               speciesPlantMaterialSourcingMethodsMultiset,
+              projectSpeciesMultiset,
               speciesSuccessionalGroupsMultiset,
           )
         }
@@ -278,6 +306,7 @@ class SpeciesStore(
     return dslContext
         .select(
             SPECIES.asterisk(),
+            projectSpeciesMultiset,
             speciesEcosystemTypesMultiset,
             speciesGrowthFormsMultiset,
             speciesPlantMaterialSourcingMethodsMultiset,
@@ -294,6 +323,7 @@ class SpeciesStore(
               speciesEcosystemTypesMultiset,
               speciesGrowthFormsMultiset,
               speciesPlantMaterialSourcingMethodsMultiset,
+              projectSpeciesMultiset,
               speciesSuccessionalGroupsMultiset,
           )
         }

--- a/src/main/kotlin/com/terraformation/backend/species/model/SpeciesModel.kt
+++ b/src/main/kotlin/com/terraformation/backend/species/model/SpeciesModel.kt
@@ -5,15 +5,43 @@ import com.terraformation.backend.db.default_schema.EcosystemType
 import com.terraformation.backend.db.default_schema.GrowthForm
 import com.terraformation.backend.db.default_schema.OrganizationId
 import com.terraformation.backend.db.default_schema.PlantMaterialSourcingMethod
+import com.terraformation.backend.db.default_schema.ProjectId
 import com.terraformation.backend.db.default_schema.SeedStorageBehavior
 import com.terraformation.backend.db.default_schema.SpeciesId
+import com.terraformation.backend.db.default_schema.SpeciesNativity
 import com.terraformation.backend.db.default_schema.SuccessionalGroup
 import com.terraformation.backend.db.default_schema.WoodDensityLevel
+import com.terraformation.backend.db.default_schema.tables.references.PROJECT_SPECIES
 import com.terraformation.backend.db.default_schema.tables.references.SPECIES
 import java.math.BigDecimal
 import java.time.Instant
 import org.jooq.Field
 import org.jooq.Record
+
+data class ExistingSpeciesProjectModel(
+    val calculatedNativity: SpeciesNativity?,
+    val calculatedNativitySource: SpeciesDataSourceModel?,
+    val overriddenJustification: String?,
+    val overriddenNativity: SpeciesNativity?,
+    val projectId: ProjectId?,
+) {
+  companion object {
+    fun of(record: Record) =
+        with(PROJECT_SPECIES) {
+          ExistingSpeciesProjectModel(
+              calculatedNativity = record[CALCULATED_NATIVITY_ID],
+              calculatedNativitySource =
+                  SpeciesDataSourceModel.of(
+                      record[CALCULATED_NATIVITY_DATASET_DATE],
+                      record[CALCULATED_NATIVITY_DATASET_TYPE_ID],
+                  ),
+              overriddenJustification = record[OVERRIDDEN_JUSTIFICATION],
+              overriddenNativity = record[OVERRIDDEN_NATIVITY_ID],
+              projectId = record[PROJECT_ID],
+          )
+        }
+  }
+}
 
 data class ExistingSpeciesModel(
     val averageWoodDensity: BigDecimal? = null,
@@ -39,6 +67,7 @@ data class ExistingSpeciesModel(
     val organizationId: OrganizationId,
     val otherFacts: String? = null,
     val plantMaterialSourcingMethods: Set<PlantMaterialSourcingMethod> = emptySet(),
+    val projects: List<ExistingSpeciesProjectModel> = emptyList(),
     val rare: Boolean? = null,
     val scientificName: String,
     val seedStorageBehavior: SeedStorageBehavior? = null,
@@ -52,6 +81,7 @@ data class ExistingSpeciesModel(
         ecosystemTypesMultiset: Field<Set<EcosystemType>>? = null,
         growthFormsMultiset: Field<Set<GrowthForm>>? = null,
         plantMaterialSourcingMethodsMultiset: Field<Set<PlantMaterialSourcingMethod>>? = null,
+        projectSpeciesMultiset: Field<List<ExistingSpeciesProjectModel>>? = null,
         successionalGroupsMultiset: Field<Set<SuccessionalGroup>>? = null,
     ): ExistingSpeciesModel =
         ExistingSpeciesModel(
@@ -88,6 +118,7 @@ data class ExistingSpeciesModel(
             otherFacts = record[SPECIES.OTHER_FACTS],
             plantMaterialSourcingMethods =
                 plantMaterialSourcingMethodsMultiset?.let { record[it] } ?: emptySet(),
+            projects = projectSpeciesMultiset?.let { record[it] } ?: emptyList(),
             rare = record[SPECIES.RARE],
             scientificName = record[SPECIES.SCIENTIFIC_NAME]!!,
             seedStorageBehavior = record[SPECIES.SEED_STORAGE_BEHAVIOR_ID],

--- a/src/test/kotlin/com/terraformation/backend/species/db/SpeciesStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/species/db/SpeciesStoreTest.kt
@@ -10,12 +10,14 @@ import com.terraformation.backend.db.SpeciesNotFoundException
 import com.terraformation.backend.db.attach
 import com.terraformation.backend.db.default_schema.ConservationCategory
 import com.terraformation.backend.db.default_schema.EcosystemType
+import com.terraformation.backend.db.default_schema.ExternalDatasetType
 import com.terraformation.backend.db.default_schema.FacilityType
 import com.terraformation.backend.db.default_schema.GrowthForm
 import com.terraformation.backend.db.default_schema.OrganizationId
 import com.terraformation.backend.db.default_schema.PlantMaterialSourcingMethod
 import com.terraformation.backend.db.default_schema.SeedStorageBehavior
 import com.terraformation.backend.db.default_schema.SpeciesId
+import com.terraformation.backend.db.default_schema.SpeciesNativity
 import com.terraformation.backend.db.default_schema.SpeciesProblemField
 import com.terraformation.backend.db.default_schema.SpeciesProblemType
 import com.terraformation.backend.db.default_schema.SuccessionalGroup
@@ -31,11 +33,14 @@ import com.terraformation.backend.db.tracking.RecordedSpeciesCertainty
 import com.terraformation.backend.db.tracking.tables.records.ObservedSiteSpeciesTotalsRecord
 import com.terraformation.backend.mockUser
 import com.terraformation.backend.species.model.ExistingSpeciesModel
+import com.terraformation.backend.species.model.ExistingSpeciesProjectModel
 import com.terraformation.backend.species.model.NewSpeciesModel
+import com.terraformation.backend.species.model.SpeciesDataSourceModel
 import com.terraformation.backend.tracking.db.SubstratumNotFoundException
 import io.mockk.every
 import java.math.BigDecimal
 import java.time.Instant
+import java.time.LocalDate
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.BeforeEach
@@ -502,6 +507,7 @@ internal class SpeciesStoreTest : DatabaseTest(), RunsAsUser {
   inner class FetchSpeciesById {
     @Test
     fun `returns species if it is not deleted`() {
+      val projectId = insertProject()
       val speciesId =
           store.createSpecies(
               NewSpeciesModel(
@@ -510,6 +516,13 @@ internal class SpeciesStoreTest : DatabaseTest(), RunsAsUser {
                   scientificName = "test",
               )
           )
+      insertProjectSpecies(
+          calculatedNativity = SpeciesNativity.Unknown,
+          calculatedNativityDatasetDate = LocalDate.of(2026, 1, 1),
+          calculatedNativityDatasetType = ExternalDatasetType.GBIF,
+          overriddenNativityId = SpeciesNativity.Native,
+          speciesId = speciesId,
+      )
 
       val expected =
           ExistingSpeciesModel(
@@ -519,6 +532,20 @@ internal class SpeciesStoreTest : DatabaseTest(), RunsAsUser {
               initialScientificName = "test",
               modifiedTime = Instant.EPOCH,
               organizationId = organizationId,
+              projects =
+                  listOf(
+                      ExistingSpeciesProjectModel(
+                          calculatedNativity = SpeciesNativity.Unknown,
+                          calculatedNativitySource =
+                              SpeciesDataSourceModel(
+                                  LocalDate.of(2026, 1, 1),
+                                  ExternalDatasetType.GBIF,
+                              ),
+                          overriddenJustification = "Justification",
+                          overriddenNativity = SpeciesNativity.Native,
+                          projectId = projectId,
+                      )
+                  ),
               scientificName = "test",
           )
 


### PR DESCRIPTION
Add a `projects` property to the species details payload. It contains a list of
per-project data for the species. Note that "per-project" has a special case:
for organizations without projects, the project ID will be absent, but there
still might be nativity information.