### PR TITLE
SW-8671 Add endpoint to override species nativity

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/species/api/SpeciesController.kt
+++ b/src/main/kotlin/com/terraformation/backend/species/api/SpeciesController.kt
@@ -31,6 +31,7 @@ import com.terraformation.backend.species.db.SpeciesStore
 import com.terraformation.backend.species.model.ExistingSpeciesModel
 import com.terraformation.backend.species.model.ExistingSpeciesProjectModel
 import com.terraformation.backend.species.model.NewSpeciesModel
+import com.terraformation.backend.species.model.ProjectSpeciesOverride
 import io.swagger.v3.oas.annotations.ExternalDocumentation
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.media.Schema
@@ -207,6 +208,15 @@ class SpeciesController(
       @RequestBody payload: AssignSpeciesToProjectsPayload
   ): SimpleSuccessResponsePayload {
     projectSpeciesStore.assignProjects(payload.toMap())
+    return SimpleSuccessResponsePayload()
+  }
+
+  @PostMapping("/projects/override")
+  @Operation(summary = "Overrides calculated per-project species data.")
+  fun overrideProjectSpeciesData(
+      @RequestBody payload: OverrideSpeciesProjectDataRequestPayload
+  ): SimpleSuccessResponsePayload {
+    projectSpeciesStore.overridePerProjectData(payload.overrides.map { it.toModel() })
     return SimpleSuccessResponsePayload()
   }
 
@@ -422,6 +432,21 @@ data class SpeciesProjectsPayload(
     val projectIds: Set<ProjectId>,
 )
 
+data class OverrideSpeciesProjectDataElement(
+    val overriddenJustification: String,
+    val overriddenNativity: SpeciesNativity,
+    val projectId: ProjectId?,
+    val speciesId: SpeciesId,
+) {
+  fun toModel() =
+      ProjectSpeciesOverride(
+          overriddenJustification = overriddenJustification,
+          overriddenNativity = overriddenNativity,
+          projectId = projectId,
+          speciesId = speciesId,
+      )
+}
+
 data class AssignSpeciesToProjectsPayload(
     @Schema(description = "The species to assign, each with the projects to associate it with.")
     val species: List<SpeciesProjectsPayload>,
@@ -433,6 +458,10 @@ data class AssignSpeciesToProjectsPayload(
             accumulator?.let { it + element.projectIds } ?: element.projectIds
           }
 }
+
+data class OverrideSpeciesProjectDataRequestPayload(
+    val overrides: List<OverrideSpeciesProjectDataElement>,
+)
 
 data class CreateSpeciesResponsePayload(val id: SpeciesId) : SuccessResponsePayload
 

--- a/src/main/kotlin/com/terraformation/backend/species/db/ProjectSpeciesStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/species/db/ProjectSpeciesStore.kt
@@ -1,5 +1,6 @@
 package com.terraformation.backend.species.db
 
+import com.terraformation.backend.auth.currentUser
 import com.terraformation.backend.customer.model.requirePermissions
 import com.terraformation.backend.db.ProjectInDifferentOrganizationException
 import com.terraformation.backend.db.default_schema.OrganizationId
@@ -8,13 +9,16 @@ import com.terraformation.backend.db.default_schema.SpeciesId
 import com.terraformation.backend.db.default_schema.tables.references.PROJECTS
 import com.terraformation.backend.db.default_schema.tables.references.PROJECT_SPECIES
 import com.terraformation.backend.db.default_schema.tables.references.SPECIES
+import com.terraformation.backend.species.model.ProjectSpeciesOverride
 import jakarta.inject.Named
+import java.time.InstantSource
 import org.jooq.DSLContext
 import org.jooq.Row3
 import org.jooq.impl.DSL
 
 @Named
 class ProjectSpeciesStore(
+    private val clock: InstantSource,
     private val dslContext: DSLContext,
 ) {
   fun assignProjects(assignments: Map<SpeciesId, Set<ProjectId>>) {
@@ -32,6 +36,60 @@ class ProjectSpeciesStore(
         .valuesOfRows(rowsFor(organizationId, assignments))
         .onConflictDoNothing()
         .execute()
+  }
+
+  fun overridePerProjectData(overrides: List<ProjectSpeciesOverride>) {
+    require(overrides.isNotEmpty()) { "No overrides specified" }
+
+    require(overrides.distinctBy { it.speciesId to it.projectId }.size == overrides.size) {
+      "Duplicate species/project in overrides list"
+    }
+
+    val organizationId =
+        checkOrganization(
+            overrides
+                .groupingBy { it.speciesId }
+                .aggregate { _, accumulator, element, _ ->
+                  accumulator?.let { it + setOfNotNull(element.projectId) }
+                      ?: setOfNotNull(element.projectId)
+                }
+        )
+    val now = clock.instant()
+    val userId = currentUser().userId
+
+    val rows = overrides.map { override ->
+      DSL.row(
+          organizationId,
+          userId,
+          override.overriddenJustification,
+          override.overriddenNativity,
+          now,
+          override.projectId,
+          override.speciesId,
+      )
+    }
+
+    with(PROJECT_SPECIES) {
+      dslContext
+          .insertInto(
+              PROJECT_SPECIES,
+              ORGANIZATION_ID,
+              OVERRIDDEN_BY,
+              OVERRIDDEN_JUSTIFICATION,
+              OVERRIDDEN_NATIVITY_ID,
+              OVERRIDDEN_TIME,
+              PROJECT_ID,
+              SPECIES_ID,
+          )
+          .valuesOfRows(rows)
+          .onConflict(ORGANIZATION_ID, PROJECT_ID, SPECIES_ID)
+          .doUpdate()
+          .set(OVERRIDDEN_BY, DSL.excluded(OVERRIDDEN_BY))
+          .set(OVERRIDDEN_JUSTIFICATION, DSL.excluded(OVERRIDDEN_JUSTIFICATION))
+          .set(OVERRIDDEN_NATIVITY_ID, DSL.excluded(OVERRIDDEN_NATIVITY_ID))
+          .set(OVERRIDDEN_TIME, DSL.excluded(OVERRIDDEN_TIME))
+          .execute()
+    }
   }
 
   fun removeProjects(assignments: Map<SpeciesId, Set<ProjectId>>) {

--- a/src/main/kotlin/com/terraformation/backend/species/model/ProjectSpeciesOverride.kt
+++ b/src/main/kotlin/com/terraformation/backend/species/model/ProjectSpeciesOverride.kt
@@ -1,0 +1,12 @@
+package com.terraformation.backend.species.model
+
+import com.terraformation.backend.db.default_schema.ProjectId
+import com.terraformation.backend.db.default_schema.SpeciesId
+import com.terraformation.backend.db.default_schema.SpeciesNativity
+
+data class ProjectSpeciesOverride(
+    val overriddenJustification: String,
+    val overriddenNativity: SpeciesNativity,
+    val projectId: ProjectId?,
+    val speciesId: SpeciesId,
+)

--- a/src/test/kotlin/com/terraformation/backend/species/db/ProjectSpeciesStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/species/db/ProjectSpeciesStoreTest.kt
@@ -1,11 +1,13 @@
 package com.terraformation.backend.species.db
 
 import com.terraformation.backend.RunsAsDatabaseUser
+import com.terraformation.backend.TestClock
 import com.terraformation.backend.customer.model.TerrawareUser
 import com.terraformation.backend.db.DatabaseTest
 import com.terraformation.backend.db.ProjectInDifferentOrganizationException
 import com.terraformation.backend.db.ProjectNotFoundException
 import com.terraformation.backend.db.SpeciesNotFoundException
+import com.terraformation.backend.db.default_schema.ExternalDatasetType
 import com.terraformation.backend.db.default_schema.OrganizationId
 import com.terraformation.backend.db.default_schema.ProjectId
 import com.terraformation.backend.db.default_schema.Role
@@ -13,6 +15,9 @@ import com.terraformation.backend.db.default_schema.SpeciesId
 import com.terraformation.backend.db.default_schema.SpeciesNativity
 import com.terraformation.backend.db.default_schema.tables.records.ProjectSpeciesRecord
 import com.terraformation.backend.db.default_schema.tables.references.PROJECT_SPECIES
+import com.terraformation.backend.species.model.ProjectSpeciesOverride
+import java.time.Instant
+import java.time.LocalDate
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
@@ -23,7 +28,8 @@ import org.springframework.security.access.AccessDeniedException
 internal class ProjectSpeciesStoreTest : DatabaseTest(), RunsAsDatabaseUser {
   override lateinit var user: TerrawareUser
 
-  private val store: ProjectSpeciesStore by lazy { ProjectSpeciesStore(dslContext) }
+  private val clock = TestClock()
+  private val store: ProjectSpeciesStore by lazy { ProjectSpeciesStore(clock, dslContext) }
 
   private lateinit var organizationId: OrganizationId
   private lateinit var projectId: ProjectId
@@ -36,6 +42,8 @@ internal class ProjectSpeciesStoreTest : DatabaseTest(), RunsAsDatabaseUser {
     speciesId = insertSpecies()
 
     insertOrganizationUser(role = Role.Manager)
+
+    clock.instant = Instant.ofEpochSecond(1234)
   }
 
   @Nested
@@ -128,6 +136,84 @@ internal class ProjectSpeciesStoreTest : DatabaseTest(), RunsAsDatabaseUser {
     fun `throws exception when a project does not exist`() {
       assertThrows<ProjectNotFoundException> {
         store.assignProjects(mapOf(speciesId to setOf(ProjectId(999999))))
+      }
+    }
+  }
+
+  @Nested
+  inner class OverridePerProjectData {
+    @Test
+    fun `overrides nativity for org-level species`() {
+      store.overridePerProjectData(
+          listOf(
+              ProjectSpeciesOverride(
+                  overriddenJustification = "Justification",
+                  overriddenNativity = SpeciesNativity.Introduced,
+                  projectId = null,
+                  speciesId = speciesId,
+              )
+          )
+      )
+
+      assertTableEquals(
+          ProjectSpeciesRecord(
+              organizationId = organizationId,
+              overriddenBy = user.userId,
+              overriddenJustification = "Justification",
+              overriddenNativityId = SpeciesNativity.Introduced,
+              overriddenTime = clock.instant,
+              speciesId = speciesId,
+          )
+      )
+    }
+
+    @Test
+    fun `overrides nativity for species in project`() {
+      insertProjectSpecies(calculatedNativity = SpeciesNativity.Unknown)
+
+      store.overridePerProjectData(
+          listOf(
+              ProjectSpeciesOverride(
+                  overriddenJustification = "Justification",
+                  overriddenNativity = SpeciesNativity.Introduced,
+                  projectId = projectId,
+                  speciesId = speciesId,
+              )
+          )
+      )
+
+      assertTableEquals(
+          ProjectSpeciesRecord(
+              calculatedNativityDatasetDate = LocalDate.EPOCH,
+              calculatedNativityDatasetTypeId = ExternalDatasetType.GRIIS,
+              calculatedNativityId = SpeciesNativity.Unknown,
+              organizationId = organizationId,
+              overriddenBy = user.userId,
+              overriddenJustification = "Justification",
+              overriddenNativityId = SpeciesNativity.Introduced,
+              overriddenTime = clock.instant,
+              projectId = projectId,
+              speciesId = speciesId,
+          )
+      )
+    }
+
+    @Test
+    fun `throws exception if no permission to update species`() {
+      deleteOrganizationUser()
+      insertOrganizationUser(role = Role.Contributor)
+
+      assertThrows<AccessDeniedException> {
+        store.overridePerProjectData(
+            listOf(
+                ProjectSpeciesOverride(
+                    overriddenJustification = "Justification",
+                    overriddenNativity = SpeciesNativity.Introduced,
+                    projectId = projectId,
+                    speciesId = speciesId,
+                )
+            )
+        )
       }
     }
   }


### PR DESCRIPTION
Allow clients to override the calculated nativities of species on a per-project
basis.