### PR TITLE
SW-8673 Set calculated nativity on project assignment

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/species/db/ProjectSpeciesStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/species/db/ProjectSpeciesStore.kt
@@ -3,39 +3,73 @@ package com.terraformation.backend.species.db
 import com.terraformation.backend.auth.currentUser
 import com.terraformation.backend.customer.model.requirePermissions
 import com.terraformation.backend.db.ProjectInDifferentOrganizationException
+import com.terraformation.backend.db.asNonNullable
 import com.terraformation.backend.db.default_schema.OrganizationId
 import com.terraformation.backend.db.default_schema.ProjectId
 import com.terraformation.backend.db.default_schema.SpeciesId
+import com.terraformation.backend.db.default_schema.tables.references.ORGANIZATIONS
 import com.terraformation.backend.db.default_schema.tables.references.PROJECTS
 import com.terraformation.backend.db.default_schema.tables.references.PROJECT_SPECIES
 import com.terraformation.backend.db.default_schema.tables.references.SPECIES
 import com.terraformation.backend.species.model.ProjectSpeciesOverride
+import com.terraformation.backend.species.model.SourcedSpeciesNativity
 import jakarta.inject.Named
 import java.time.InstantSource
 import org.jooq.DSLContext
-import org.jooq.Row3
 import org.jooq.impl.DSL
 
 @Named
 class ProjectSpeciesStore(
     private val clock: InstantSource,
     private val dslContext: DSLContext,
+    private val speciesNativityCalculator: SpeciesNativityCalculator,
 ) {
   fun assignProjects(assignments: Map<SpeciesId, Set<ProjectId>>) {
     require(assignments.isNotEmpty()) { "No species assignments specified" }
 
     val organizationId = checkOrganization(assignments)
 
-    dslContext
-        .insertInto(
-            PROJECT_SPECIES,
-            PROJECT_SPECIES.ORGANIZATION_ID,
-            PROJECT_SPECIES.PROJECT_ID,
-            PROJECT_SPECIES.SPECIES_ID,
+    val speciesIdsByProject: Map<ProjectId, List<SpeciesId>> =
+        assignments.entries
+            .flatMap { (speciesId, projectIds) ->
+              projectIds.map { it to speciesId }
+            }
+            .groupBy { (projectId, _) -> projectId }
+            .mapValues { (_, projectAndSpecies) -> projectAndSpecies.map { it.second } }
+
+    val calculatedNativities: Map<Pair<SpeciesId, ProjectId>, SourcedSpeciesNativity> =
+        calculateNativities(speciesIdsByProject)
+
+    val rows = assignments.flatMap { (speciesId, projectIds) ->
+      projectIds.map { projectId ->
+        val calculatedNativity = calculatedNativities[speciesId to projectId]
+
+        DSL.row(
+            calculatedNativity?.datasetDate,
+            calculatedNativity?.datasetType,
+            calculatedNativity?.speciesNativity,
+            organizationId,
+            projectId,
+            speciesId,
         )
-        .valuesOfRows(rowsFor(organizationId, assignments))
-        .onConflictDoNothing()
-        .execute()
+      }
+    }
+
+    with(PROJECT_SPECIES) {
+      dslContext
+          .insertInto(
+              PROJECT_SPECIES,
+              CALCULATED_NATIVITY_DATASET_DATE,
+              CALCULATED_NATIVITY_DATASET_TYPE_ID,
+              CALCULATED_NATIVITY_ID,
+              ORGANIZATION_ID,
+              PROJECT_ID,
+              SPECIES_ID,
+          )
+          .valuesOfRows(rows)
+          .onConflictDoNothing()
+          .execute()
+    }
   }
 
   fun overridePerProjectData(overrides: List<ProjectSpeciesOverride>) {
@@ -97,6 +131,10 @@ class ProjectSpeciesStore(
 
     val organizationId = checkOrganization(assignments)
 
+    val rows = assignments.flatMap { (speciesId, projectIds) ->
+      projectIds.map { projectId -> DSL.row(organizationId, projectId, speciesId) }
+    }
+
     dslContext
         .deleteFrom(PROJECT_SPECIES)
         .where(
@@ -105,18 +143,10 @@ class ProjectSpeciesStore(
                     PROJECT_SPECIES.PROJECT_ID,
                     PROJECT_SPECIES.SPECIES_ID,
                 )
-                .`in`(rowsFor(organizationId, assignments))
+                .`in`(rows)
         )
         .execute()
   }
-
-  private fun rowsFor(
-      organizationId: OrganizationId,
-      assignments: Map<SpeciesId, Set<ProjectId>>,
-  ): List<Row3<OrganizationId?, ProjectId?, SpeciesId?>> =
-      assignments.flatMap { (speciesId, projectIds) ->
-        projectIds.map { projectId -> DSL.row(organizationId, projectId, speciesId) }
-      }
 
   /**
    * Verifies the current user may update the species and read the projects, and that every species
@@ -149,4 +179,84 @@ class ProjectSpeciesStore(
 
     return organizationIds.first()
   }
+
+  private fun calculateNativities(
+      speciesIdsByProject: Map<ProjectId, Collection<SpeciesId>>
+  ): Map<Pair<SpeciesId, ProjectId>, SourcedSpeciesNativity> {
+    val locationsByProjectId = getProjectLocations(speciesIdsByProject.keys)
+
+    val speciesIdsForProjectsWithLocations = speciesIdsByProject.filterKeys { projectId ->
+      locationsByProjectId[projectId]?.botanicalCountryCode != null &&
+          locationsByProjectId[projectId]?.countryCode != null
+    }
+    val namesBySpeciesId =
+        getSpeciesScientificNames(speciesIdsForProjectsWithLocations.values.flatten().toSet())
+
+    // Group projects by location so that a given species is only looked up once for a given
+    // location, even if it's assigned to multiple projects that share that location.
+    val projectIdsByLocation =
+        speciesIdsForProjectsWithLocations.keys.groupBy { locationsByProjectId.getValue(it) }
+
+    val nativitiesByLocation: Map<ProjectLocation, Map<String, SourcedSpeciesNativity>> =
+        projectIdsByLocation.mapValues { (location, projectIds) ->
+          val scientificNames =
+              projectIds
+                  .flatMap { speciesIdsForProjectsWithLocations.getValue(it) }
+                  .mapNotNull { namesBySpeciesId[it] }
+                  .toSet()
+          speciesNativityCalculator.calculateNativities(
+              location.botanicalCountryCode!!,
+              location.countryCode!!,
+              scientificNames,
+          )
+        }
+
+    return speciesIdsForProjectsWithLocations
+        .flatMap { (projectId, speciesIds) ->
+          val location = locationsByProjectId.getValue(projectId)
+          val nativitiesByName = nativitiesByLocation.getValue(location)
+          speciesIds.mapNotNull { speciesId ->
+            val scientificName = namesBySpeciesId[speciesId] ?: return@mapNotNull null
+            val sourcedNativity = nativitiesByName[scientificName] ?: return@mapNotNull null
+            (speciesId to projectId) to sourcedNativity
+          }
+        }
+        .toMap()
+  }
+
+  private fun getProjectLocations(projectIds: Set<ProjectId>): Map<ProjectId, ProjectLocation> {
+    return dslContext
+        .select(
+            PROJECTS.ID,
+            DSL.coalesce(PROJECTS.BOTANICAL_COUNTRY_CODE, ORGANIZATIONS.BOTANICAL_COUNTRY_CODE),
+            DSL.coalesce(PROJECTS.COUNTRY_CODE, ORGANIZATIONS.COUNTRY_CODE),
+        )
+        .from(PROJECTS)
+        .leftJoin(ORGANIZATIONS)
+        .on(PROJECTS.ORGANIZATION_ID.eq(ORGANIZATIONS.ID))
+        .and(
+            // Only fall back to org-level location if org has only one project.
+            DSL.field(
+                    DSL.selectCount()
+                        .from(PROJECTS)
+                        .where(PROJECTS.ORGANIZATION_ID.eq(ORGANIZATIONS.ID))
+                )
+                .eq(1)
+        )
+        .where(PROJECTS.ID.`in`(projectIds))
+        .fetchMap(PROJECTS.ID.asNonNullable()) { ProjectLocation(it.value2(), it.value3()) }
+  }
+
+  private fun getSpeciesScientificNames(speciesIds: Collection<SpeciesId>): Map<SpeciesId, String> {
+    return dslContext
+        .select(SPECIES.ID, SPECIES.SCIENTIFIC_NAME)
+        .from(SPECIES)
+        .where(SPECIES.ID.`in`(speciesIds))
+        .fetchMap(SPECIES.ID.asNonNullable(), SPECIES.SCIENTIFIC_NAME.asNonNullable())
+  }
+
+  data class ProjectLocation(
+      val botanicalCountryCode: String?,
+      val countryCode: String?,
+  )
 }

--- a/src/main/kotlin/com/terraformation/backend/species/db/ProjectSpeciesStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/species/db/ProjectSpeciesStore.kt
@@ -228,14 +228,26 @@ class ProjectSpeciesStore(
     return dslContext
         .select(
             PROJECTS.ID,
-            DSL.coalesce(PROJECTS.BOTANICAL_COUNTRY_CODE, ORGANIZATIONS.BOTANICAL_COUNTRY_CODE),
-            DSL.coalesce(PROJECTS.COUNTRY_CODE, ORGANIZATIONS.COUNTRY_CODE),
+            DSL.case_()
+                .`when`(
+                    PROJECTS.BOTANICAL_COUNTRY_CODE.isNotNull.and(PROJECTS.COUNTRY_CODE.isNotNull),
+                    PROJECTS.BOTANICAL_COUNTRY_CODE,
+                )
+                .else_(ORGANIZATIONS.BOTANICAL_COUNTRY_CODE),
+            DSL.case_()
+                .`when`(
+                    PROJECTS.BOTANICAL_COUNTRY_CODE.isNotNull.and(PROJECTS.COUNTRY_CODE.isNotNull),
+                    PROJECTS.COUNTRY_CODE,
+                )
+                .else_(ORGANIZATIONS.COUNTRY_CODE),
         )
         .from(PROJECTS)
+        // Only fall back to org-level location if org has only one project and has both locations.
         .leftJoin(ORGANIZATIONS)
         .on(PROJECTS.ORGANIZATION_ID.eq(ORGANIZATIONS.ID))
+        .and(ORGANIZATIONS.BOTANICAL_COUNTRY_CODE.isNotNull)
+        .and(ORGANIZATIONS.COUNTRY_CODE.isNotNull)
         .and(
-            // Only fall back to org-level location if org has only one project.
             DSL.field(
                     DSL.selectCount()
                         .from(PROJECTS)

--- a/src/test/kotlin/com/terraformation/backend/species/db/ProjectSpeciesStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/species/db/ProjectSpeciesStoreTest.kt
@@ -14,6 +14,7 @@ import com.terraformation.backend.db.default_schema.Role
 import com.terraformation.backend.db.default_schema.SpeciesId
 import com.terraformation.backend.db.default_schema.SpeciesNativity
 import com.terraformation.backend.db.default_schema.tables.records.ProjectSpeciesRecord
+import com.terraformation.backend.db.default_schema.tables.references.ORGANIZATIONS
 import com.terraformation.backend.db.default_schema.tables.references.PROJECT_SPECIES
 import com.terraformation.backend.species.model.ProjectSpeciesOverride
 import java.time.Instant
@@ -29,7 +30,13 @@ internal class ProjectSpeciesStoreTest : DatabaseTest(), RunsAsDatabaseUser {
   override lateinit var user: TerrawareUser
 
   private val clock = TestClock()
-  private val store: ProjectSpeciesStore by lazy { ProjectSpeciesStore(clock, dslContext) }
+  private val store: ProjectSpeciesStore by lazy {
+    ProjectSpeciesStore(
+        clock,
+        dslContext,
+        SpeciesNativityCalculator(dslContext),
+    )
+  }
 
   private lateinit var organizationId: OrganizationId
   private lateinit var projectId: ProjectId
@@ -39,7 +46,7 @@ internal class ProjectSpeciesStoreTest : DatabaseTest(), RunsAsDatabaseUser {
   fun setUp() {
     organizationId = insertOrganization()
     projectId = insertProject()
-    speciesId = insertSpecies()
+    speciesId = insertSpecies(scientificName = "Scientific name")
 
     insertOrganizationUser(role = Role.Manager)
 
@@ -50,6 +57,120 @@ internal class ProjectSpeciesStoreTest : DatabaseTest(), RunsAsDatabaseUser {
   inner class AssignProjects {
     @Test
     fun `creates rows with only the ID columns populated`() {
+      store.assignProjects(mapOf(speciesId to setOf(projectId)))
+
+      assertTableEquals(ProjectSpeciesRecord(organizationId, projectId, speciesId))
+    }
+
+    @Test
+    fun `uses project locations to calculate species nativity`() {
+      val botanicalCountryCode1 = insertBotanicalCountry()
+      val botanicalCountryCode2 = insertBotanicalCountry()
+
+      val griisDate = LocalDate.of(2026, 1, 2)
+      val wcvpDate = LocalDate.of(2026, 2, 3)
+      insertExternalDatasetImport(type = ExternalDatasetType.GRIIS, lastPublicationDate = griisDate)
+      insertExternalDatasetImport(type = ExternalDatasetType.WCVP, lastPublicationDate = wcvpDate)
+      insertGriisResource(countryCode = "KE")
+      insertGriisTaxon(scientificName = "Scientific name", isInvasive = true)
+      insertWcvpTaxon(scientificName = "Scientific name")
+      insertWcvpDistribution(
+          botanicalCountryCode = botanicalCountryCode2,
+          speciesNativity = SpeciesNativity.Introduced,
+      )
+
+      val projectId1 =
+          insertProject(botanicalCountryCode = botanicalCountryCode1, countryCode = "KE")
+      val projectId2 =
+          insertProject(botanicalCountryCode = botanicalCountryCode2, countryCode = "GH")
+      // Project in a location where there are no listings for the species.
+      val projectId3 =
+          insertProject(botanicalCountryCode = botanicalCountryCode1, countryCode = "TZ")
+
+      store.assignProjects(mapOf(speciesId to setOf(projectId1, projectId2, projectId3)))
+
+      assertTableEquals(
+          listOf(
+              ProjectSpeciesRecord(
+                  organizationId = organizationId,
+                  projectId = projectId1,
+                  speciesId = speciesId,
+                  calculatedNativityId = SpeciesNativity.Invasive,
+                  calculatedNativityDatasetTypeId = ExternalDatasetType.GRIIS,
+                  calculatedNativityDatasetDate = griisDate,
+              ),
+              ProjectSpeciesRecord(
+                  organizationId = organizationId,
+                  projectId = projectId2,
+                  speciesId = speciesId,
+                  calculatedNativityId = SpeciesNativity.Introduced,
+                  calculatedNativityDatasetTypeId = ExternalDatasetType.WCVP,
+                  calculatedNativityDatasetDate = wcvpDate,
+              ),
+              ProjectSpeciesRecord(
+                  organizationId = organizationId,
+                  projectId = projectId3,
+                  speciesId = speciesId,
+                  calculatedNativityId = SpeciesNativity.Unknown,
+              ),
+          )
+      )
+    }
+
+    @Test
+    fun `uses organization location to calculate species nativity if only one project`() {
+      insertBotanicalCountry()
+
+      dslContext
+          .fetchSingle(ORGANIZATIONS, ORGANIZATIONS.ID.eq(organizationId))
+          .apply {
+            botanicalCountryCode = inserted.botanicalCountryCode
+            countryCode = "KE"
+          }
+          .update()
+
+      insertExternalDatasetImport(
+          type = ExternalDatasetType.GRIIS,
+          lastPublicationDate = LocalDate.of(2026, 1, 2),
+      )
+      insertGriisResource(countryCode = "KE")
+      insertGriisTaxon(scientificName = "Scientific name", isInvasive = true)
+
+      store.assignProjects(mapOf(speciesId to setOf(projectId)))
+
+      assertTableEquals(
+          ProjectSpeciesRecord(
+              organizationId = organizationId,
+              projectId = projectId,
+              speciesId = speciesId,
+              calculatedNativityId = SpeciesNativity.Invasive,
+              calculatedNativityDatasetTypeId = ExternalDatasetType.GRIIS,
+              calculatedNativityDatasetDate = LocalDate.of(2026, 1, 2),
+          )
+      )
+    }
+
+    @Test
+    fun `does not use organization location to calculate species nativity if multiple projects`() {
+      insertBotanicalCountry()
+
+      dslContext
+          .fetchSingle(ORGANIZATIONS, ORGANIZATIONS.ID.eq(organizationId))
+          .apply {
+            botanicalCountryCode = inserted.botanicalCountryCode
+            countryCode = "KE"
+          }
+          .update()
+
+      insertExternalDatasetImport(
+          type = ExternalDatasetType.GRIIS,
+          lastPublicationDate = LocalDate.of(2026, 1, 2),
+      )
+      insertGriisResource(countryCode = "KE")
+      insertGriisTaxon(scientificName = "Scientific name", isInvasive = true)
+
+      insertProject()
+
       store.assignProjects(mapOf(speciesId to setOf(projectId)))
 
       assertTableEquals(ProjectSpeciesRecord(organizationId, projectId, speciesId))


### PR DESCRIPTION
When a species is assigned to a project, and the project (or its organization
if it is the only project in the organization) has both a botanical country
code and a country code, store the calculated nativity for the species.

Later changes will handle updating the calculated nativities on existing
species/project associations when the project location changes, as well as
calculating nativities for organizations with no projects.