### PR TITLE
SW-8673 Publish event on organization location change

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/customer/db/OrganizationStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/db/OrganizationStore.kt
@@ -5,6 +5,7 @@ import com.terraformation.backend.customer.event.OrganizationAbandonedEvent
 import com.terraformation.backend.customer.event.OrganizationCreatedEvent
 import com.terraformation.backend.customer.event.OrganizationDeletedEvent
 import com.terraformation.backend.customer.event.OrganizationDeletionStartedEvent
+import com.terraformation.backend.customer.event.OrganizationLocationUpdatedEvent
 import com.terraformation.backend.customer.event.OrganizationRenamedEvent
 import com.terraformation.backend.customer.event.OrganizationRenamedEventValues
 import com.terraformation.backend.customer.event.OrganizationTimeZoneChangedEvent
@@ -265,6 +266,19 @@ class OrganizationStore(
           OrganizationRenamedEvent(
               changedFrom = OrganizationRenamedEventValues(name = existingRow.name),
               changedTo = OrganizationRenamedEventValues(name = row.name),
+              organizationId = organizationId,
+          )
+      )
+    }
+
+    if (
+        existingRow.botanicalCountryCode != row.botanicalCountryCode ||
+            existingRow.countryCode != row.countryCode
+    ) {
+      publisher.publishEvent(
+          OrganizationLocationUpdatedEvent(
+              botanicalCountryCode = row.botanicalCountryCode,
+              countryCode = row.countryCode,
               organizationId = organizationId,
           )
       )

--- a/src/main/kotlin/com/terraformation/backend/customer/event/OrganizationLocationUpdatedEvent.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/event/OrganizationLocationUpdatedEvent.kt
@@ -1,0 +1,10 @@
+package com.terraformation.backend.customer.event
+
+import com.terraformation.backend.db.default_schema.OrganizationId
+
+/** Published when an organization's location information has changed. */
+data class OrganizationLocationUpdatedEvent(
+    val botanicalCountryCode: String?,
+    val countryCode: String?,
+    val organizationId: OrganizationId,
+)

--- a/src/main/kotlin/com/terraformation/backend/customer/event/OrganizationLocationUpdatedEvent.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/event/OrganizationLocationUpdatedEvent.kt
@@ -2,7 +2,6 @@ package com.terraformation.backend.customer.event
 
 import com.terraformation.backend.db.default_schema.OrganizationId
 
-/** Published when an organization's location information has changed. */
 data class OrganizationLocationUpdatedEvent(
     val botanicalCountryCode: String?,
     val countryCode: String?,

--- a/src/test/kotlin/com/terraformation/backend/customer/db/OrganizationStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/db/OrganizationStoreTest.kt
@@ -5,6 +5,7 @@ import com.terraformation.backend.TestClock
 import com.terraformation.backend.TestEventPublisher
 import com.terraformation.backend.auth.currentUser
 import com.terraformation.backend.customer.event.OrganizationAbandonedEvent
+import com.terraformation.backend.customer.event.OrganizationLocationUpdatedEvent
 import com.terraformation.backend.customer.event.OrganizationRenamedEvent
 import com.terraformation.backend.customer.event.OrganizationRenamedEventValues
 import com.terraformation.backend.customer.event.OrganizationTimeZoneChangedEvent
@@ -422,11 +423,18 @@ internal class OrganizationStoreTest : DatabaseTest(), RunsAsUser {
 
     assertEquals(expected, actual)
 
-    publisher.assertEventPublished(
-        OrganizationRenamedEvent(
-            changedFrom = OrganizationRenamedEventValues(name = "Organization 1"),
-            changedTo = OrganizationRenamedEventValues(name = "New Name"),
-            organizationId = organizationId,
+    publisher.assertEventsPublished(
+        setOf(
+            OrganizationLocationUpdatedEvent(
+                botanicalCountryCode = botanicalCountryCode,
+                countryCode = "ZA",
+                organizationId = organizationId,
+            ),
+            OrganizationRenamedEvent(
+                changedFrom = OrganizationRenamedEventValues(name = "Organization 1"),
+                changedTo = OrganizationRenamedEventValues(name = "New Name"),
+                organizationId = organizationId,
+            ),
         )
     )
   }


### PR DESCRIPTION
To support triggering recalculation of species nativity data when the nativities
are based on the org-level location, publish an event when an organization's
country or botanical country are updated.