### PR TITLE
SW-8673 Recalculate nativities on org location change

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/species/SpeciesService.kt
+++ b/src/main/kotlin/com/terraformation/backend/species/SpeciesService.kt
@@ -1,5 +1,6 @@
 package com.terraformation.backend.species
 
+import com.terraformation.backend.customer.event.OrganizationLocationUpdatedEvent
 import com.terraformation.backend.customer.event.ProjectUpdatedEvent
 import com.terraformation.backend.customer.model.requirePermissions
 import com.terraformation.backend.db.ScientificNameExistsException
@@ -11,6 +12,7 @@ import com.terraformation.backend.db.default_schema.SpeciesId
 import com.terraformation.backend.db.default_schema.SpeciesProblemField
 import com.terraformation.backend.db.default_schema.SpeciesProblemId
 import com.terraformation.backend.db.default_schema.SpeciesProblemType
+import com.terraformation.backend.db.default_schema.tables.references.PROJECTS
 import com.terraformation.backend.species.db.ExternalDatasetStore
 import com.terraformation.backend.species.db.GbifStore
 import com.terraformation.backend.species.db.ProjectSpeciesStore
@@ -134,6 +136,24 @@ class SpeciesService(
       } else {
         throw e
       }
+    }
+  }
+
+  @EventListener
+  fun on(event: OrganizationLocationUpdatedEvent) {
+    // Organization location change should only trigger a project-level species nativity
+    // recaulcation if the organization has exactly one project and the project lacks a location.
+    val projects =
+        dslContext
+            .selectFrom(PROJECTS)
+            .where(PROJECTS.ORGANIZATION_ID.eq(event.organizationId))
+            .limit(2)
+            .fetch()
+    if (
+        projects.size == 1 &&
+            (projects[0].botanicalCountryCode == null || projects[0].countryCode == null)
+    ) {
+      projectSpeciesStore.recalculateNativities(projects[0].id!!)
     }
   }
 

--- a/src/main/kotlin/com/terraformation/backend/species/SpeciesService.kt
+++ b/src/main/kotlin/com/terraformation/backend/species/SpeciesService.kt
@@ -145,15 +145,17 @@ class SpeciesService(
     // recaulcation if the organization has exactly one project and the project lacks a location.
     val projects =
         dslContext
-            .selectFrom(PROJECTS)
+            .select(PROJECTS.BOTANICAL_COUNTRY_CODE, PROJECTS.COUNTRY_CODE, PROJECTS.ID)
+            .from(PROJECTS)
             .where(PROJECTS.ORGANIZATION_ID.eq(event.organizationId))
             .limit(2)
             .fetch()
     if (
         projects.size == 1 &&
-            (projects[0].botanicalCountryCode == null || projects[0].countryCode == null)
+            (projects[0][PROJECTS.BOTANICAL_COUNTRY_CODE] == null ||
+                projects[0][PROJECTS.COUNTRY_CODE] == null)
     ) {
-      projectSpeciesStore.recalculateNativities(projects[0].id!!)
+      projectSpeciesStore.recalculateNativities(projects[0][PROJECTS.ID]!!)
     }
   }
 

--- a/src/test/kotlin/com/terraformation/backend/species/SpeciesServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/species/SpeciesServiceTest.kt
@@ -4,6 +4,7 @@ import com.terraformation.backend.RunsAsUser
 import com.terraformation.backend.TestClock
 import com.terraformation.backend.TestEventPublisher
 import com.terraformation.backend.assertIsEventListener
+import com.terraformation.backend.customer.event.OrganizationLocationUpdatedEvent
 import com.terraformation.backend.customer.event.ProjectUpdatedEvent
 import com.terraformation.backend.customer.event.ProjectUpdatedEventValues
 import com.terraformation.backend.customer.model.TerrawareUser
@@ -453,6 +454,54 @@ internal class SpeciesServiceTest : DatabaseTest(), RunsAsUser {
               projectId = inserted.projectId,
           )
       )
+
+      assertTableEquals(before)
+    }
+  }
+
+  @Nested
+  inner class OnOrganizationLocationUpdatedEvent {
+    @Test
+    fun `recalculates species nativity on location change for single-project org`() {
+      // The recalculation logic is tested in ProjectSpeciesStoreTest; this is just to make sure the
+      // event triggers a recalculation at all.
+      insertProject()
+      insertSpecies()
+      insertProjectSpecies(calculatedNativity = SpeciesNativity.Invasive)
+
+      service.on(OrganizationLocationUpdatedEvent(null, null, organizationId))
+
+      assertTableEquals(
+          ProjectSpeciesRecord(organizationId, inserted.projectId, inserted.speciesId)
+      )
+
+      assertIsEventListener<OrganizationLocationUpdatedEvent>(service)
+    }
+
+    @Test
+    fun `does not update project species if project has a location`() {
+      insertProject(botanicalCountryCode = insertBotanicalCountry(), countryCode = "US")
+      insertSpecies()
+      insertProjectSpecies(calculatedNativity = SpeciesNativity.Invasive)
+
+      val before = dslContext.fetch(PROJECT_SPECIES)
+
+      service.on(OrganizationLocationUpdatedEvent(null, null, organizationId))
+
+      assertTableEquals(before)
+    }
+
+    @Test
+    fun `does not update project species in multi-project org`() {
+      insertProject()
+      insertSpecies()
+      insertProjectSpecies(calculatedNativity = SpeciesNativity.Invasive)
+      insertProject()
+      insertProjectSpecies(calculatedNativity = SpeciesNativity.Introduced)
+
+      val before = dslContext.fetch(PROJECT_SPECIES)
+
+      service.on(OrganizationLocationUpdatedEvent(null, null, organizationId))
 
       assertTableEquals(before)
     }


### PR DESCRIPTION
When an organization's location is changed and the org has a single project that
doesn't have a location of its own, it counts as a project location change;
trigger a recalculation of the project's species nativities.