### PR TITLE
Fix flaky ParticipantProjectSpeciesStore test

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/accelerator/db/ParticipantProjectSpeciesStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/db/ParticipantProjectSpeciesStore.kt
@@ -184,6 +184,7 @@ class ParticipantProjectSpeciesStore(
         .join(PROJECTS)
         .on(PARTICIPANT_PROJECT_SPECIES.PROJECT_ID.eq(PROJECTS.ID))
         .where(PROJECTS.ID.eq(projectId))
+        .orderBy(PROJECTS.ID, SPECIES.ID)
         .fetch { SpeciesForParticipantProject.of(it) }
         .filter { user.canReadProject(it.project.id) }
   }


### PR DESCRIPTION
`fetchSpeciesForParticipantProject` wasn't ordering its query results, but its
test assumed the results would be in a particular order, and would fail when
the database chose a different order.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>