### PR TITLE
SW-8671 Allow setting projects at species creation

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/species/SpeciesService.kt
+++ b/src/main/kotlin/com/terraformation/backend/species/SpeciesService.kt
@@ -73,6 +73,11 @@ class SpeciesService(
 
       val speciesId = speciesStore.createSpecies(populatedModel)
       speciesChecker.checkSpecies(speciesId)
+
+      if (model.projectIds.isNotEmpty()) {
+        projectSpeciesStore.assignProjects(mapOf(speciesId to model.projectIds))
+      }
+
       speciesId
     }
   }

--- a/src/main/kotlin/com/terraformation/backend/species/api/SpeciesController.kt
+++ b/src/main/kotlin/com/terraformation/backend/species/api/SpeciesController.kt
@@ -89,7 +89,9 @@ class SpeciesController(
   )
   @Operation(summary = "Creates a new species.")
   @PostMapping
-  fun createSpecies(@RequestBody payload: SpeciesRequestPayload): CreateSpeciesResponsePayload {
+  fun createSpecies(
+      @RequestBody payload: CreateSpeciesRequestPayload
+  ): CreateSpeciesResponsePayload {
     try {
       val speciesId = speciesService.createSpecies(payload.toNew())
       return CreateSpeciesResponsePayload(speciesId)
@@ -125,7 +127,7 @@ class SpeciesController(
   @PutMapping("/{speciesId}")
   fun updateSpecies(
       @PathVariable speciesId: SpeciesId,
-      @RequestBody payload: SpeciesRequestPayload,
+      @RequestBody payload: UpdateSpeciesRequestPayload,
   ): SimpleSuccessResponsePayload {
     try {
       speciesService.updateSpecies(payload.toExisting(speciesId))
@@ -343,7 +345,64 @@ data class SpeciesResponseElement(
   )
 }
 
-data class SpeciesRequestPayload(
+data class CreateSpeciesRequestPayload(
+    val averageWoodDensity: BigDecimal?,
+    val commonName: String?,
+    @Schema(
+        description = "IUCN Red List conservation category code.",
+        externalDocs =
+            ExternalDocumentation(url = "https://en.wikipedia.org/wiki/IUCN_Red_List#Categories"),
+    )
+    val conservationCategory: ConservationCategory?,
+    val dbhSource: String?,
+    val dbhValue: BigDecimal?,
+    val ecologicalRoleKnown: String?,
+    val ecosystemTypes: Set<EcosystemType>?,
+    val familyName: String?,
+    val growthForms: Set<GrowthForm>?,
+    val heightAtMaturitySource: String?,
+    val heightAtMaturityValue: BigDecimal?,
+    val localUsesKnown: String?,
+    val nativeEcosystem: String?,
+    @Schema(description = "Which organization's species list to update.")
+    val organizationId: OrganizationId,
+    val otherFacts: String?,
+    val plantMaterialSourcingMethods: Set<PlantMaterialSourcingMethod>?,
+    val projectIds: Set<ProjectId>?,
+    val rare: Boolean?,
+    val scientificName: String,
+    val seedStorageBehavior: SeedStorageBehavior?,
+    val successionalGroups: Set<SuccessionalGroup>?,
+    val woodDensityLevel: WoodDensityLevel?,
+) {
+  fun toNew() =
+      NewSpeciesModel(
+          averageWoodDensity = averageWoodDensity,
+          commonName = commonName,
+          conservationCategory = conservationCategory,
+          dbhSource = dbhSource,
+          dbhValue = dbhValue,
+          ecologicalRoleKnown = ecologicalRoleKnown,
+          ecosystemTypes = ecosystemTypes ?: emptySet(),
+          familyName = familyName,
+          growthForms = growthForms ?: emptySet(),
+          heightAtMaturitySource = heightAtMaturitySource,
+          heightAtMaturityValue = heightAtMaturityValue,
+          localUsesKnown = localUsesKnown,
+          nativeEcosystem = nativeEcosystem,
+          rare = rare,
+          organizationId = organizationId,
+          otherFacts = otherFacts,
+          plantMaterialSourcingMethods = plantMaterialSourcingMethods ?: emptySet(),
+          projectIds = projectIds ?: emptySet(),
+          scientificName = scientificName,
+          seedStorageBehavior = seedStorageBehavior,
+          successionalGroups = successionalGroups ?: emptySet(),
+          woodDensityLevel = woodDensityLevel,
+      )
+}
+
+data class UpdateSpeciesRequestPayload(
     val averageWoodDensity: BigDecimal?,
     val commonName: String?,
     @Schema(
@@ -390,31 +449,6 @@ data class SpeciesRequestPayload(
           initialScientificName = scientificName,
           localUsesKnown = localUsesKnown,
           modifiedTime = Instant.EPOCH, // Dummy value; ignored on update
-          nativeEcosystem = nativeEcosystem,
-          rare = rare,
-          organizationId = organizationId,
-          otherFacts = otherFacts,
-          plantMaterialSourcingMethods = plantMaterialSourcingMethods ?: emptySet(),
-          scientificName = scientificName,
-          seedStorageBehavior = seedStorageBehavior,
-          successionalGroups = successionalGroups ?: emptySet(),
-          woodDensityLevel = woodDensityLevel,
-      )
-
-  fun toNew() =
-      NewSpeciesModel(
-          averageWoodDensity = averageWoodDensity,
-          commonName = commonName,
-          conservationCategory = conservationCategory,
-          dbhSource = dbhSource,
-          dbhValue = dbhValue,
-          ecologicalRoleKnown = ecologicalRoleKnown,
-          ecosystemTypes = ecosystemTypes ?: emptySet(),
-          familyName = familyName,
-          growthForms = growthForms ?: emptySet(),
-          heightAtMaturitySource = heightAtMaturitySource,
-          heightAtMaturityValue = heightAtMaturityValue,
-          localUsesKnown = localUsesKnown,
           nativeEcosystem = nativeEcosystem,
           rare = rare,
           organizationId = organizationId,

--- a/src/main/kotlin/com/terraformation/backend/species/model/SpeciesModel.kt
+++ b/src/main/kotlin/com/terraformation/backend/species/model/SpeciesModel.kt
@@ -19,10 +19,10 @@ import org.jooq.Field
 import org.jooq.Record
 
 data class ExistingSpeciesProjectModel(
-    val calculatedNativity: SpeciesNativity?,
-    val calculatedNativitySource: SpeciesDataSourceModel?,
-    val overriddenJustification: String?,
-    val overriddenNativity: SpeciesNativity?,
+    val calculatedNativity: SpeciesNativity? = null,
+    val calculatedNativitySource: SpeciesDataSourceModel? = null,
+    val overriddenJustification: String? = null,
+    val overriddenNativity: SpeciesNativity? = null,
     val projectId: ProjectId?,
 ) {
   companion object {
@@ -149,6 +149,7 @@ data class NewSpeciesModel(
     val organizationId: OrganizationId,
     val otherFacts: String? = null,
     val plantMaterialSourcingMethods: Set<PlantMaterialSourcingMethod> = emptySet(),
+    val projectIds: Set<ProjectId> = emptySet(),
     val rare: Boolean? = null,
     val scientificName: String,
     val seedStorageBehavior: SeedStorageBehavior? = null,

--- a/src/test/kotlin/com/terraformation/backend/species/SpeciesServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/species/SpeciesServiceTest.kt
@@ -29,6 +29,7 @@ import com.terraformation.backend.species.db.SpeciesNativityCalculator
 import com.terraformation.backend.species.db.SpeciesStore
 import com.terraformation.backend.species.event.SpeciesEditedEvent
 import com.terraformation.backend.species.model.ExistingSpeciesModel
+import com.terraformation.backend.species.model.ExistingSpeciesProjectModel
 import com.terraformation.backend.species.model.NewSpeciesModel
 import com.terraformation.backend.species.model.SpeciesDataSourceModel
 import io.mockk.Runs
@@ -153,6 +154,66 @@ internal class SpeciesServiceTest : DatabaseTest(), RunsAsUser {
           SpeciesDataSourceModel(gbifImportedDate, ExternalDatasetType.GBIF),
           speciesModel.familyNameSource,
           "Family name source",
+      )
+    }
+
+    @Test
+    fun `sets nativity based on project location`() {
+      every { user.canReadProject(any()) } returns true
+
+      val botanicalCountryCode = insertBotanicalCountry()
+      val griisDate = LocalDate.of(2026, 1, 2)
+      val projectId = insertProject(botanicalCountryCode = botanicalCountryCode, countryCode = "AR")
+      insertExternalDatasetImport(type = ExternalDatasetType.GRIIS, lastPublicationDate = griisDate)
+      insertGriisResource(countryCode = "AR")
+      insertGriisTaxon(scientificName = "Scientific name", isInvasive = true)
+
+      val speciesId =
+          service.createSpecies(
+              NewSpeciesModel(
+                  organizationId = organizationId,
+                  projectIds = setOf(projectId),
+                  scientificName = "Scientific name",
+              )
+          )
+
+      val speciesModel = speciesStore.fetchSpeciesById(speciesId)
+
+      assertEquals(
+          listOf(
+              ExistingSpeciesProjectModel(
+                  calculatedNativity = SpeciesNativity.Invasive,
+                  calculatedNativitySource =
+                      SpeciesDataSourceModel(griisDate, ExternalDatasetType.GRIIS),
+                  projectId = projectId,
+              )
+          ),
+          speciesModel.projects,
+          "Species project details",
+      )
+    }
+
+    @Test
+    fun `assigns without nativity if project has no location`() {
+      every { user.canReadProject(any()) } returns true
+
+      val projectId = insertProject()
+
+      val speciesId =
+          service.createSpecies(
+              NewSpeciesModel(
+                  organizationId = organizationId,
+                  projectIds = setOf(projectId),
+                  scientificName = "Scientific name",
+              )
+          )
+
+      val speciesModel = speciesStore.fetchSpeciesById(speciesId)
+
+      assertEquals(
+          listOf(ExistingSpeciesProjectModel(projectId = projectId)),
+          speciesModel.projects,
+          "Species project details",
       )
     }
   }


### PR DESCRIPTION
Add a `projectIds` property to the species creation API payload.

Since we have separate, explicit API endpoints for modifying the project
assignemnts of existing species, we don't want this property on the update
endpoint; the create and update payloads thus have to be split into distinct
classes.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>