### PR TITLE
SW-8673 Recalculate org-level species nativities

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/species/SpeciesService.kt
+++ b/src/main/kotlin/com/terraformation/backend/species/SpeciesService.kt
@@ -12,7 +12,6 @@ import com.terraformation.backend.db.default_schema.SpeciesId
 import com.terraformation.backend.db.default_schema.SpeciesProblemField
 import com.terraformation.backend.db.default_schema.SpeciesProblemId
 import com.terraformation.backend.db.default_schema.SpeciesProblemType
-import com.terraformation.backend.db.default_schema.tables.references.PROJECTS
 import com.terraformation.backend.species.db.ExternalDatasetStore
 import com.terraformation.backend.species.db.GbifStore
 import com.terraformation.backend.species.db.ProjectSpeciesStore
@@ -146,22 +145,7 @@ class SpeciesService(
 
   @EventListener
   fun on(event: OrganizationLocationUpdatedEvent) {
-    // Organization location change should only trigger a project-level species nativity
-    // recaulcation if the organization has exactly one project and the project lacks a location.
-    val projects =
-        dslContext
-            .select(PROJECTS.BOTANICAL_COUNTRY_CODE, PROJECTS.COUNTRY_CODE, PROJECTS.ID)
-            .from(PROJECTS)
-            .where(PROJECTS.ORGANIZATION_ID.eq(event.organizationId))
-            .limit(2)
-            .fetch()
-    if (
-        projects.size == 1 &&
-            (projects[0][PROJECTS.BOTANICAL_COUNTRY_CODE] == null ||
-                projects[0][PROJECTS.COUNTRY_CODE] == null)
-    ) {
-      projectSpeciesStore.recalculateNativities(projects[0][PROJECTS.ID]!!)
-    }
+    projectSpeciesStore.recalculateNativities(event.organizationId)
   }
 
   @EventListener

--- a/src/main/kotlin/com/terraformation/backend/species/db/ProjectSpeciesStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/species/db/ProjectSpeciesStore.kt
@@ -13,6 +13,7 @@ import com.terraformation.backend.db.default_schema.tables.references.ORGANIZATI
 import com.terraformation.backend.db.default_schema.tables.references.PROJECTS
 import com.terraformation.backend.db.default_schema.tables.references.PROJECT_SPECIES
 import com.terraformation.backend.db.default_schema.tables.references.SPECIES
+import com.terraformation.backend.log.perClassLogger
 import com.terraformation.backend.species.model.ProjectSpeciesOverride
 import com.terraformation.backend.species.model.SourcedSpeciesNativity
 import jakarta.inject.Named
@@ -29,6 +30,8 @@ class ProjectSpeciesStore(
     private val dslContext: DSLContext,
     private val speciesNativityCalculator: SpeciesNativityCalculator,
 ) {
+  private val log = perClassLogger()
+
   fun assignProjects(assignments: Map<SpeciesId, Set<ProjectId>>) {
     require(assignments.isNotEmpty()) { "No species assignments specified" }
 
@@ -74,6 +77,59 @@ class ProjectSpeciesStore(
           .valuesOfRows(rows)
           .onConflictDoNothing()
           .execute()
+    }
+  }
+
+  /**
+   * Recalculates nativities for all the species in an organization if the organization has fewer
+   * than two projects.
+   */
+  fun recalculateNativities(organizationId: OrganizationId) {
+    val numProjects = dslContext.fetchCount(PROJECTS, PROJECTS.ORGANIZATION_ID.eq(organizationId))
+    if (numProjects > 1) {
+      log.info(
+          "Organization $organizationId has $numProjects projects; not recalculating nativities"
+      )
+      return
+    }
+
+    val speciesIds =
+        with(SPECIES) {
+          dslContext
+              .select(ID)
+              .from(SPECIES)
+              .where(ORGANIZATION_ID.eq(organizationId))
+              .fetch(ID.asNonNullable())
+        }
+    if (speciesIds.isEmpty()) {
+      return
+    }
+
+    val nativities = calculateOrganizationNativities(organizationId, speciesIds)
+
+    val existingSpeciesIds =
+        dslContext
+            .select(PROJECT_SPECIES.SPECIES_ID)
+            .from(PROJECT_SPECIES)
+            .where(PROJECT_SPECIES.ORGANIZATION_ID.eq(organizationId))
+            .and(PROJECT_SPECIES.SPECIES_ID.`in`(speciesIds))
+            .fetchSet(PROJECT_SPECIES.SPECIES_ID.asNonNullable())
+
+    // Species that already have a project_species row (whether or not it's associated with a
+    // project) get their existing row's calculated nativity updated in place. This avoids inserting
+    // a redundant row with a null project ID for a species that's already tied to the org's single
+    // project.
+    val existingRows = existingSpeciesIds.map { speciesId ->
+      rowForUpdate(speciesId, nativities[speciesId])
+    }
+    if (existingRows.isNotEmpty()) {
+      updateCalculatedNativities(existingRows, PROJECT_SPECIES.ORGANIZATION_ID.eq(organizationId))
+    }
+
+    // Species that don't have a project_species row yet get a new row with no project ID.
+    val missingSpeciesIds = speciesIds.filterNot { it in existingSpeciesIds }
+    if (missingSpeciesIds.isNotEmpty()) {
+      insertCalculatedNativities(organizationId, missingSpeciesIds, nativities)
     }
   }
 
@@ -205,6 +261,29 @@ class ProjectSpeciesStore(
     return organizationIds.first()
   }
 
+  private fun calculateOrganizationNativities(
+      organizationId: OrganizationId,
+      speciesIds: Collection<SpeciesId>,
+  ): Map<SpeciesId, SourcedSpeciesNativity> {
+    val location = getOrganizationLocation(organizationId)
+    if (location.botanicalCountryCode == null || location.countryCode == null) {
+      return emptyMap()
+    }
+
+    val namesBySpeciesId = getSpeciesScientificNames(speciesIds)
+
+    val nativities =
+        speciesNativityCalculator.calculateNativities(
+            location.botanicalCountryCode,
+            location.countryCode,
+            namesBySpeciesId.values,
+        )
+
+    return speciesIds.associateWith { speciesId ->
+      nativities.getValue(namesBySpeciesId.getValue(speciesId))
+    }
+  }
+
   private fun calculateNativities(
       speciesIdsByProject: Map<ProjectId, Collection<SpeciesId>>
   ): Map<Pair<SpeciesId, ProjectId>, SourcedSpeciesNativity> {
@@ -288,6 +367,49 @@ class ProjectSpeciesStore(
           .where(scopeCondition)
           .and(SPECIES_ID.eq(speciesIdField))
           .execute()
+    }
+  }
+
+  private fun insertCalculatedNativities(
+      organizationId: OrganizationId,
+      speciesIds: Collection<SpeciesId>,
+      nativities: Map<SpeciesId, SourcedSpeciesNativity>,
+  ) {
+    val rows = speciesIds.map { speciesId ->
+      val sourcedNativity = nativities[speciesId]
+
+      DSL.row(
+          sourcedNativity?.datasetDate,
+          sourcedNativity?.datasetType,
+          sourcedNativity?.speciesNativity,
+          organizationId,
+          speciesId,
+      )
+    }
+
+    with(PROJECT_SPECIES) {
+      dslContext
+          .insertInto(
+              PROJECT_SPECIES,
+              CALCULATED_NATIVITY_DATASET_DATE,
+              CALCULATED_NATIVITY_DATASET_TYPE_ID,
+              CALCULATED_NATIVITY_ID,
+              ORGANIZATION_ID,
+              SPECIES_ID,
+          )
+          .valuesOfRows(rows)
+          .onConflictDoNothing()
+          .execute()
+    }
+  }
+
+  private fun getOrganizationLocation(organizationId: OrganizationId): ProjectLocation {
+    return with(ORGANIZATIONS) {
+      dslContext
+          .select(BOTANICAL_COUNTRY_CODE, COUNTRY_CODE)
+          .from(ORGANIZATIONS)
+          .where(ID.eq(organizationId))
+          .fetchSingle { ProjectLocation(it.value1(), it.value2()) }
     }
   }
 

--- a/src/test/kotlin/com/terraformation/backend/species/SpeciesServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/species/SpeciesServiceTest.kt
@@ -540,19 +540,6 @@ internal class SpeciesServiceTest : DatabaseTest(), RunsAsUser {
     }
 
     @Test
-    fun `does not update project species if project has a location`() {
-      insertProject(botanicalCountryCode = insertBotanicalCountry(), countryCode = "US")
-      insertSpecies()
-      insertProjectSpecies(calculatedNativity = SpeciesNativity.Invasive)
-
-      val before = dslContext.fetch(PROJECT_SPECIES)
-
-      service.on(OrganizationLocationUpdatedEvent(null, null, organizationId))
-
-      assertTableEquals(before)
-    }
-
-    @Test
     fun `does not update project species in multi-project org`() {
       insertProject()
       insertSpecies()

--- a/src/test/kotlin/com/terraformation/backend/species/db/ProjectSpeciesStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/species/db/ProjectSpeciesStoreTest.kt
@@ -471,6 +471,178 @@ internal class ProjectSpeciesStoreTest : DatabaseTest(), RunsAsDatabaseUser {
   }
 
   @Nested
+  inner class RecalculateNativitiesForOrganization {
+    @Test
+    fun `recalculates nativities if organization has no projects`() {
+      val botanicalCountryCode = insertBotanicalCountry()
+      val griisDate = LocalDate.of(2026, 1, 2)
+      insertExternalDatasetImport(type = ExternalDatasetType.GRIIS, lastPublicationDate = griisDate)
+      insertGriisResource(countryCode = "KE")
+      insertGriisTaxon(scientificName = "Scientific name", isInvasive = true)
+
+      val locatedOrganizationId =
+          insertOrganization(botanicalCountryCode = botanicalCountryCode, countryCode = "KE")
+      // Species without a project is still tracked in project_species with a null project ID.
+      val orgSpeciesId = insertSpecies(scientificName = "Scientific name")
+      insertProjectSpecies(
+          projectId = null,
+          calculatedNativity = SpeciesNativity.Native,
+          overriddenNativityId = SpeciesNativity.Introduced,
+      )
+
+      store.recalculateNativities(locatedOrganizationId)
+
+      assertTableEquals(
+          ProjectSpeciesRecord(
+              organizationId = locatedOrganizationId,
+              projectId = null,
+              speciesId = orgSpeciesId,
+              calculatedNativityDatasetDate = griisDate,
+              calculatedNativityDatasetTypeId = ExternalDatasetType.GRIIS,
+              calculatedNativityId = SpeciesNativity.Invasive,
+          )
+      )
+    }
+
+    @Test
+    fun `recalculates nativities based on organization location for organization with one project`() {
+      insertBotanicalCountry()
+
+      dslContext
+          .fetchSingle(ORGANIZATIONS, ORGANIZATIONS.ID.eq(organizationId))
+          .apply {
+            botanicalCountryCode = inserted.botanicalCountryCode
+            countryCode = "KE"
+          }
+          .update()
+
+      val griisDate = LocalDate.of(2026, 1, 2)
+      insertExternalDatasetImport(type = ExternalDatasetType.GRIIS, lastPublicationDate = griisDate)
+      insertGriisResource(countryCode = "KE")
+      insertGriisTaxon(scientificName = "Scientific name", isInvasive = true)
+
+      insertProjectSpecies(
+          projectId = projectId,
+          speciesId = speciesId,
+          calculatedNativity = SpeciesNativity.Native,
+          overriddenNativityId = SpeciesNativity.Introduced,
+      )
+
+      val nonProjectSpeciesId = insertSpecies(scientificName = "Scientific 2")
+      insertProjectSpecies(projectId = null)
+
+      store.recalculateNativities(organizationId)
+
+      assertTableEquals(
+          listOf(
+              ProjectSpeciesRecord(
+                  organizationId = organizationId,
+                  projectId = projectId,
+                  speciesId = speciesId,
+                  calculatedNativityDatasetDate = griisDate,
+                  calculatedNativityDatasetTypeId = ExternalDatasetType.GRIIS,
+                  calculatedNativityId = SpeciesNativity.Invasive,
+              ),
+              ProjectSpeciesRecord(
+                  organizationId = organizationId,
+                  projectId = null,
+                  speciesId = nonProjectSpeciesId,
+                  calculatedNativityId = SpeciesNativity.Unknown,
+              ),
+          )
+      )
+    }
+
+    @Test
+    fun `inserts rows for unlisted species without duplicating project-associated species`() {
+      insertBotanicalCountry()
+
+      dslContext
+          .fetchSingle(ORGANIZATIONS, ORGANIZATIONS.ID.eq(organizationId))
+          .apply {
+            botanicalCountryCode = inserted.botanicalCountryCode
+            countryCode = "KE"
+          }
+          .update()
+
+      val griisDate = LocalDate.of(2026, 1, 2)
+      insertExternalDatasetImport(type = ExternalDatasetType.GRIIS, lastPublicationDate = griisDate)
+      insertGriisResource(countryCode = "KE")
+      insertGriisTaxon(scientificName = "Scientific name", isInvasive = true)
+
+      // This species is already tied to the org's single project; it should be updated in place
+      // rather than getting an additional row with a null project ID.
+      insertProjectSpecies(
+          projectId = projectId,
+          speciesId = speciesId,
+          calculatedNativity = SpeciesNativity.Native,
+      )
+
+      // This species isn't listed in project_species yet; it should get a new null-project row.
+      val unlistedSpeciesId = insertSpecies(scientificName = "Scientific 2")
+
+      store.recalculateNativities(organizationId)
+
+      assertTableEquals(
+          listOf(
+              ProjectSpeciesRecord(
+                  organizationId = organizationId,
+                  projectId = projectId,
+                  speciesId = speciesId,
+                  calculatedNativityDatasetDate = griisDate,
+                  calculatedNativityDatasetTypeId = ExternalDatasetType.GRIIS,
+                  calculatedNativityId = SpeciesNativity.Invasive,
+              ),
+              ProjectSpeciesRecord(
+                  organizationId = organizationId,
+                  projectId = null,
+                  speciesId = unlistedSpeciesId,
+                  calculatedNativityId = SpeciesNativity.Unknown,
+              ),
+          )
+      )
+    }
+
+    @Test
+    fun `clears nativities when organization has no location`() {
+      insertProjectSpecies(
+          projectId = projectId,
+          speciesId = speciesId,
+          calculatedNativity = SpeciesNativity.Invasive,
+          overriddenNativityId = SpeciesNativity.Introduced,
+      )
+
+      store.recalculateNativities(organizationId)
+
+      assertTableEquals(
+          ProjectSpeciesRecord(
+              organizationId = organizationId,
+              projectId = projectId,
+              speciesId = speciesId,
+          )
+      )
+    }
+
+    @Test
+    fun `is a no-op if organization has more than one project`() {
+      insertProject()
+
+      insertProjectSpecies(
+          projectId = projectId,
+          speciesId = speciesId,
+          calculatedNativity = SpeciesNativity.Native,
+          overriddenNativityId = SpeciesNativity.Introduced,
+      )
+
+      val before = dslContext.fetch(PROJECT_SPECIES)
+
+      store.recalculateNativities(organizationId)
+
+      assertTableEquals(before)
+    }
+  }
+
+  @Nested
   inner class RemoveProjects {
     @Test
     fun `deletes requested associations`() {


### PR DESCRIPTION
When an organization's location changes, and the organization has fewer than two
projects, recalculate the nativities of all its species.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>