### PR TITLE
SW-8673 Set org-level nativity at species creation

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/species/SpeciesService.kt
+++ b/src/main/kotlin/com/terraformation/backend/species/SpeciesService.kt
@@ -75,6 +75,8 @@ class SpeciesService(
 
       if (model.projectIds.isNotEmpty()) {
         projectSpeciesStore.assignProjects(mapOf(speciesId to model.projectIds))
+      } else {
+        projectSpeciesStore.recalculateNativity(model.organizationId, speciesId)
       }
 
       speciesId

--- a/src/main/kotlin/com/terraformation/backend/species/db/ProjectSpeciesStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/species/db/ProjectSpeciesStore.kt
@@ -81,6 +81,50 @@ class ProjectSpeciesStore(
   }
 
   /**
+   * Recalculates the organization-level nativity for a species if the organization has fewer than
+   * two projects and the species is not assigned to a project.
+   */
+  fun recalculateNativity(organizationId: OrganizationId, speciesId: SpeciesId) {
+    requirePermissions { updateSpecies(speciesId) }
+
+    val numProjects = dslContext.fetchCount(PROJECTS, PROJECTS.ORGANIZATION_ID.eq(organizationId))
+    if (numProjects > 1) {
+      return
+    }
+
+    val numProjectAssignments =
+        dslContext.fetchCount(
+            PROJECT_SPECIES,
+            PROJECT_SPECIES.SPECIES_ID.eq(speciesId),
+            PROJECT_SPECIES.PROJECT_ID.isNotNull,
+        )
+    if (numProjectAssignments > 0) {
+      return
+    }
+
+    val sourcedNativity =
+        calculateOrganizationNativities(organizationId, setOf(speciesId))[speciesId]
+
+    if (sourcedNativity != null) {
+      with(PROJECT_SPECIES) {
+        dslContext
+            .insertInto(PROJECT_SPECIES)
+            .set(CALCULATED_NATIVITY_DATASET_DATE, sourcedNativity.datasetDate)
+            .set(CALCULATED_NATIVITY_DATASET_TYPE_ID, sourcedNativity.datasetType)
+            .set(CALCULATED_NATIVITY_ID, sourcedNativity.speciesNativity)
+            .set(ORGANIZATION_ID, organizationId)
+            .set(SPECIES_ID, speciesId)
+            .onConflict(ORGANIZATION_ID, PROJECT_ID, SPECIES_ID)
+            .doUpdate()
+            .set(CALCULATED_NATIVITY_DATASET_DATE, sourcedNativity.datasetDate)
+            .set(CALCULATED_NATIVITY_DATASET_TYPE_ID, sourcedNativity.datasetType)
+            .set(CALCULATED_NATIVITY_ID, sourcedNativity.speciesNativity)
+            .execute()
+      }
+    }
+  }
+
+  /**
    * Recalculates nativities for all the species in an organization if the organization has fewer
    * than two projects.
    */

--- a/src/main/kotlin/com/terraformation/backend/species/model/SpeciesModel.kt
+++ b/src/main/kotlin/com/terraformation/backend/species/model/SpeciesModel.kt
@@ -23,7 +23,7 @@ data class ExistingSpeciesProjectModel(
     val calculatedNativitySource: SpeciesDataSourceModel? = null,
     val overriddenJustification: String? = null,
     val overriddenNativity: SpeciesNativity? = null,
-    val projectId: ProjectId?,
+    val projectId: ProjectId? = null,
 ) {
   companion object {
     fun of(record: Record) =

--- a/src/test/kotlin/com/terraformation/backend/species/SpeciesServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/species/SpeciesServiceTest.kt
@@ -98,8 +98,8 @@ internal class SpeciesServiceTest : DatabaseTest(), RunsAsUser {
 
     every { speciesChecker.checkSpecies(any()) } just Runs
     every { speciesChecker.recheckSpecies(any(), any()) } just Runs
-    every { user.canCreateSpecies(organizationId) } returns true
-    every { user.canReadOrganization(organizationId) } returns true
+    every { user.canCreateSpecies(any()) } returns true
+    every { user.canReadOrganization(any()) } returns true
     every { user.canReadSpecies(any()) } returns true
     every { user.canUpdateSpecies(any()) } returns true
     every { user.canDeleteSpecies(any()) } returns true
@@ -194,16 +194,21 @@ internal class SpeciesServiceTest : DatabaseTest(), RunsAsUser {
     }
 
     @Test
-    fun `assigns without nativity if project has no location`() {
-      every { user.canReadProject(any()) } returns true
+    fun `sets org-level nativity if org has location and fewer than two projects`() {
+      val botanicalCountryCode = insertBotanicalCountry()
+      val locatedOrganizationId =
+          insertOrganization(botanicalCountryCode = botanicalCountryCode, countryCode = "AR")
+      insertProject()
 
-      val projectId = insertProject()
+      val griisDate = LocalDate.of(2026, 1, 2)
+      insertExternalDatasetImport(type = ExternalDatasetType.GRIIS, lastPublicationDate = griisDate)
+      insertGriisResource(countryCode = "AR")
+      insertGriisTaxon(scientificName = "Scientific name", isInvasive = true)
 
       val speciesId =
           service.createSpecies(
               NewSpeciesModel(
-                  organizationId = organizationId,
-                  projectIds = setOf(projectId),
+                  organizationId = locatedOrganizationId,
                   scientificName = "Scientific name",
               )
           )
@@ -211,7 +216,13 @@ internal class SpeciesServiceTest : DatabaseTest(), RunsAsUser {
       val speciesModel = speciesStore.fetchSpeciesById(speciesId)
 
       assertEquals(
-          listOf(ExistingSpeciesProjectModel(projectId = projectId)),
+          listOf(
+              ExistingSpeciesProjectModel(
+                  calculatedNativity = SpeciesNativity.Invasive,
+                  calculatedNativitySource =
+                      SpeciesDataSourceModel(griisDate, ExternalDatasetType.GRIIS),
+              )
+          ),
           speciesModel.projects,
           "Species project details",
       )

--- a/src/test/kotlin/com/terraformation/backend/species/db/ProjectSpeciesStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/species/db/ProjectSpeciesStoreTest.kt
@@ -643,6 +643,141 @@ internal class ProjectSpeciesStoreTest : DatabaseTest(), RunsAsDatabaseUser {
   }
 
   @Nested
+  inner class RecalculateNativity {
+    @Test
+    fun `sets organization-level nativity for a species not assigned to a project`() {
+      setOrganizationLocation()
+
+      val griisDate = LocalDate.of(2026, 1, 2)
+      insertExternalDatasetImport(type = ExternalDatasetType.GRIIS, lastPublicationDate = griisDate)
+      insertGriisResource(countryCode = "KE")
+      insertGriisTaxon(scientificName = "Scientific name", isInvasive = true)
+
+      store.recalculateNativity(organizationId, speciesId)
+
+      assertTableEquals(
+          ProjectSpeciesRecord(
+              calculatedNativityDatasetDate = griisDate,
+              calculatedNativityDatasetTypeId = ExternalDatasetType.GRIIS,
+              calculatedNativityId = SpeciesNativity.Invasive,
+              organizationId = organizationId,
+              speciesId = speciesId,
+          )
+      )
+    }
+
+    @Test
+    fun `updates existing organization-level row`() {
+      setOrganizationLocation()
+
+      val griisDate = LocalDate.of(2026, 1, 2)
+      insertExternalDatasetImport(type = ExternalDatasetType.GRIIS, lastPublicationDate = griisDate)
+      insertGriisResource(countryCode = "KE")
+      insertGriisTaxon(scientificName = "Scientific name", isInvasive = true)
+
+      insertProjectSpecies(projectId = null, calculatedNativity = SpeciesNativity.Native)
+
+      store.recalculateNativity(organizationId, speciesId)
+
+      assertTableEquals(
+          ProjectSpeciesRecord(
+              calculatedNativityDatasetDate = griisDate,
+              calculatedNativityDatasetTypeId = ExternalDatasetType.GRIIS,
+              calculatedNativityId = SpeciesNativity.Invasive,
+              organizationId = organizationId,
+              speciesId = speciesId,
+          )
+      )
+    }
+
+    @Test
+    fun `sets nativity to unknown when species is not listed in the current location`() {
+      setOrganizationLocation()
+
+      store.recalculateNativity(organizationId, speciesId)
+
+      assertTableEquals(
+          ProjectSpeciesRecord(
+              calculatedNativityId = SpeciesNativity.Unknown,
+              organizationId = organizationId,
+              speciesId = speciesId,
+          )
+      )
+    }
+
+    @Test
+    fun `does not insert a row when organization has no location`() {
+      store.recalculateNativity(organizationId, speciesId)
+
+      assertTableEmpty(PROJECT_SPECIES)
+    }
+
+    @Test
+    fun `is a no-op when the species is assigned to a project`() {
+      setOrganizationLocation()
+
+      insertExternalDatasetImport(
+          type = ExternalDatasetType.GRIIS,
+          lastPublicationDate = LocalDate.of(2026, 1, 2),
+      )
+      insertGriisResource(countryCode = "KE")
+      insertGriisTaxon(scientificName = "Scientific name", isInvasive = true)
+
+      insertProjectSpecies(
+          projectId = projectId,
+          speciesId = speciesId,
+          calculatedNativity = SpeciesNativity.Native,
+      )
+
+      val before = dslContext.fetch(PROJECT_SPECIES)
+
+      store.recalculateNativity(organizationId, speciesId)
+
+      assertTableEquals(before)
+    }
+
+    @Test
+    fun `is a no-op when organization has more than one project`() {
+      setOrganizationLocation()
+
+      insertExternalDatasetImport(
+          type = ExternalDatasetType.GRIIS,
+          lastPublicationDate = LocalDate.of(2026, 1, 2),
+      )
+      insertGriisResource(countryCode = "KE")
+      insertGriisTaxon(scientificName = "Scientific name", isInvasive = true)
+
+      insertProject()
+
+      store.recalculateNativity(organizationId, speciesId)
+
+      assertTableEmpty(PROJECT_SPECIES)
+    }
+
+    @Test
+    fun `throws exception when user cannot update species`() {
+      deleteOrganizationUser()
+      insertOrganizationUser(role = Role.Contributor)
+
+      assertThrows<AccessDeniedException> {
+        store.recalculateNativity(organizationId, speciesId)
+      }
+    }
+
+    private fun setOrganizationLocation() {
+      insertBotanicalCountry()
+
+      dslContext
+          .fetchSingle(ORGANIZATIONS, ORGANIZATIONS.ID.eq(organizationId))
+          .apply {
+            botanicalCountryCode = inserted.botanicalCountryCode
+            countryCode = "KE"
+          }
+          .update()
+    }
+  }
+
+  @Nested
   inner class RemoveProjects {
     @Test
     fun `deletes requested associations`() {


### PR DESCRIPTION
If a new species is created without a project assignment in an organization that
has fewer than two projects and has organization-level location details,
calculate the nativity of the species and store it.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>