### PR TITLE
SW-8673 Replace org-level nativity with project-level

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/species/db/ProjectSpeciesStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/species/db/ProjectSpeciesStore.kt
@@ -63,20 +63,29 @@ class ProjectSpeciesStore(
       }
     }
 
-    with(PROJECT_SPECIES) {
-      dslContext
-          .insertInto(
-              PROJECT_SPECIES,
-              CALCULATED_NATIVITY_DATASET_DATE,
-              CALCULATED_NATIVITY_DATASET_TYPE_ID,
-              CALCULATED_NATIVITY_ID,
-              ORGANIZATION_ID,
-              PROJECT_ID,
-              SPECIES_ID,
-          )
-          .valuesOfRows(rows)
-          .onConflictDoNothing()
-          .execute()
+    dslContext.transaction { _ ->
+      with(PROJECT_SPECIES) {
+        dslContext
+            .insertInto(
+                PROJECT_SPECIES,
+                CALCULATED_NATIVITY_DATASET_DATE,
+                CALCULATED_NATIVITY_DATASET_TYPE_ID,
+                CALCULATED_NATIVITY_ID,
+                ORGANIZATION_ID,
+                PROJECT_ID,
+                SPECIES_ID,
+            )
+            .valuesOfRows(rows)
+            .onConflictDoNothing()
+            .execute()
+
+        dslContext
+            .deleteFrom(PROJECT_SPECIES)
+            .where(ORGANIZATION_ID.eq(organizationId))
+            .and(PROJECT_ID.isNull)
+            .and(SPECIES_ID.`in`(assignments.keys))
+            .execute()
+      }
     }
   }
 

--- a/src/main/kotlin/com/terraformation/backend/species/db/ProjectSpeciesStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/species/db/ProjectSpeciesStore.kt
@@ -79,11 +79,13 @@ class ProjectSpeciesStore(
             .onConflictDoNothing()
             .execute()
 
+        val speciesIdsWithAssignments = assignments.filterValues { it.isNotEmpty() }.keys
+
         dslContext
             .deleteFrom(PROJECT_SPECIES)
             .where(ORGANIZATION_ID.eq(organizationId))
             .and(PROJECT_ID.isNull)
-            .and(SPECIES_ID.`in`(assignments.keys))
+            .and(SPECIES_ID.`in`(speciesIdsWithAssignments))
             .execute()
       }
     }

--- a/src/test/kotlin/com/terraformation/backend/species/db/ProjectSpeciesStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/species/db/ProjectSpeciesStoreTest.kt
@@ -209,6 +209,15 @@ internal class ProjectSpeciesStoreTest : DatabaseTest(), RunsAsDatabaseUser {
     }
 
     @Test
+    fun `removes organization-level nativity on project assignment`() {
+      insertProjectSpecies(calculatedNativity = SpeciesNativity.Invasive, projectId = null)
+
+      store.assignProjects(mapOf(speciesId to setOf(projectId)))
+
+      assertTableEquals(ProjectSpeciesRecord(organizationId, projectId, speciesId))
+    }
+
+    @Test
     fun `throws exception when species and project are in different organizations`() {
       insertOrganization()
       insertOrganizationUser()


### PR DESCRIPTION
When a species has an org-level nativity and it is assigned to a project, remove
the org-level value since we'll now have a project-level one and we don't want
two potentially conflicting values.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>