### PR TITLE
SW-8673 Delete per-project data when species deleted

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/species/SpeciesService.kt
+++ b/src/main/kotlin/com/terraformation/backend/species/SpeciesService.kt
@@ -106,7 +106,10 @@ class SpeciesService(
       throw SpeciesInUseException(speciesId)
     }
 
-    speciesStore.deleteSpecies(speciesId)
+    dslContext.transaction { _ ->
+      projectSpeciesStore.deleteForSpecies(speciesId)
+      speciesStore.deleteSpecies(speciesId)
+    }
   }
 
   fun acceptProblemSuggestion(problemId: SpeciesProblemId): ExistingSpeciesModel {

--- a/src/main/kotlin/com/terraformation/backend/species/db/ProjectSpeciesStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/species/db/ProjectSpeciesStore.kt
@@ -154,6 +154,7 @@ class ProjectSpeciesStore(
               .select(ID)
               .from(SPECIES)
               .where(ORGANIZATION_ID.eq(organizationId))
+              .and(DELETED_TIME.isNull)
               .fetch(ID.asNonNullable())
         }
     if (speciesIds.isEmpty()) {
@@ -282,6 +283,17 @@ class ProjectSpeciesStore(
                 .`in`(rows)
         )
         .execute()
+  }
+
+  /**
+   * Deletes the project associations and project- and org-level nativities for a species. This is
+   * called when a species is soft-deleted; we don't want it to continue to be associated with
+   * projects.
+   */
+  fun deleteForSpecies(speciesId: SpeciesId) {
+    requirePermissions { updateSpecies(speciesId) }
+
+    dslContext.deleteFrom(PROJECT_SPECIES).where(PROJECT_SPECIES.SPECIES_ID.eq(speciesId)).execute()
   }
 
   /**

--- a/src/test/kotlin/com/terraformation/backend/species/SpeciesServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/species/SpeciesServiceTest.kt
@@ -415,10 +415,15 @@ internal class SpeciesServiceTest : DatabaseTest(), RunsAsUser {
     @Test
     fun `deletes species when not in use`() {
       val speciesId = insertSpecies("species name")
+      insertProject()
+      insertProjectSpecies()
       assertNotNull(speciesStore.fetchSpeciesById(speciesId))
 
       service.deleteSpecies(speciesId)
+
       assertThrows<SpeciesNotFoundException> { speciesStore.fetchSpeciesById(speciesId) }
+
+      assertTableEmpty(PROJECT_SPECIES)
     }
   }
 


### PR DESCRIPTION
When a species is deleted, we don't want to keep it associated with any projects
or keep its org-level nativity.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>