### PR TITLE
SW-8693 Copy location from org on 2nd project creation

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/customer/db/ProjectStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/db/ProjectStore.kt
@@ -26,6 +26,7 @@ import com.terraformation.backend.db.default_schema.tables.daos.ProjectsDao
 import com.terraformation.backend.db.default_schema.tables.pojos.ProjectInternalUsersRow
 import com.terraformation.backend.db.default_schema.tables.pojos.ProjectsRow
 import com.terraformation.backend.db.default_schema.tables.references.BOTANICAL_COUNTRIES
+import com.terraformation.backend.db.default_schema.tables.references.ORGANIZATIONS
 import com.terraformation.backend.db.default_schema.tables.references.PROJECTS
 import com.terraformation.backend.db.default_schema.tables.references.PROJECT_INTERNAL_USERS
 import com.terraformation.backend.util.nullIfEquals
@@ -89,25 +90,58 @@ class ProjectStore(
             organizationId = model.organizationId,
         )
 
-    try {
-      projectsDao.insert(row)
-    } catch (e: DuplicateKeyException) {
-      throw ProjectNameInUseException(model.name)
+    return dslContext.transactionResult { _ ->
+      val existingProjects = projectsDao.fetchByOrganizationId(model.organizationId)
+
+      try {
+        projectsDao.insert(row)
+      } catch (e: DuplicateKeyException) {
+        throw ProjectNameInUseException(model.name)
+      }
+
+      val projectId = row.id!!
+
+      eventPublisher.publishEvent(
+          ProjectCreatedEvent(
+              botanicalCountryCode = model.botanicalCountryCode,
+              countryCode = model.countryCode,
+              name = model.name,
+              organizationId = model.organizationId,
+              projectId = projectId,
+          )
+      )
+
+      // If we are transitioning from 1 project to 2 projects, the existing project should inherit
+      // the organization's location unless it already has its own.
+      if (existingProjects.size == 1) {
+        val existingProject = existingProjects.first()
+
+        val orgLocation =
+            with(ORGANIZATIONS) {
+              dslContext
+                  .select(BOTANICAL_COUNTRY_CODE, COUNTRY_CODE)
+                  .from(ORGANIZATIONS)
+                  .where(ID.eq(model.organizationId))
+                  .fetchSingleInto(ORGANIZATIONS)
+            }
+
+        if (
+            existingProject.botanicalCountryCode == null &&
+                existingProject.countryCode == null &&
+                orgLocation.botanicalCountryCode != null &&
+                orgLocation.countryCode != null
+        ) {
+          update(existingProject.id!!) {
+            it.copy(
+                botanicalCountryCode = orgLocation.botanicalCountryCode,
+                countryCode = orgLocation.countryCode,
+            )
+          }
+        }
+      }
+
+      projectId
     }
-
-    val projectId = row.id!!
-
-    eventPublisher.publishEvent(
-        ProjectCreatedEvent(
-            botanicalCountryCode = model.botanicalCountryCode,
-            countryCode = model.countryCode,
-            name = model.name,
-            organizationId = model.organizationId,
-            projectId = projectId,
-        )
-    )
-
-    return projectId
   }
 
   fun delete(projectId: ProjectId) {

--- a/src/test/kotlin/com/terraformation/backend/customer/db/ProjectStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/db/ProjectStoreTest.kt
@@ -30,6 +30,8 @@ import com.terraformation.backend.db.default_schema.tables.pojos.ProjectInternal
 import com.terraformation.backend.db.default_schema.tables.pojos.ProjectsRow
 import com.terraformation.backend.db.default_schema.tables.records.OrganizationUsersRecord
 import com.terraformation.backend.db.default_schema.tables.records.ProjectInternalUsersRecord
+import com.terraformation.backend.db.default_schema.tables.records.ProjectsRecord
+import com.terraformation.backend.db.default_schema.tables.references.ORGANIZATIONS
 import com.terraformation.backend.db.default_schema.tables.references.PROJECT_INTERNAL_USERS
 import java.time.Instant
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -110,6 +112,55 @@ class ProjectStoreTest : DatabaseTest(), RunsAsDatabaseUser {
               name = "Project name",
               organizationId = organizationId,
               projectId = newProjectId,
+          )
+      )
+    }
+
+    @Test
+    fun `first project inherits org location when second project created`() {
+      val newBotanicalCountryCode = insertBotanicalCountry()
+
+      dslContext
+          .fetchSingle(ORGANIZATIONS)
+          .apply {
+            botanicalCountryCode = newBotanicalCountryCode
+            countryCode = "US"
+          }
+          .update()
+
+      val projectId1 = insertProject()
+
+      val projectId2 =
+          store.create(
+              NewProjectModel(
+                  id = null,
+                  name = "Second project",
+                  organizationId = organizationId,
+              )
+          )
+
+      assertTableEquals(
+          listOf(
+              ProjectsRecord(
+                  botanicalCountryCode = newBotanicalCountryCode,
+                  countryCode = "US",
+                  createdBy = user.userId,
+                  createdTime = Instant.EPOCH,
+                  id = projectId1,
+                  modifiedBy = user.userId,
+                  modifiedTime = Instant.EPOCH,
+                  name = "Project 1",
+                  organizationId = organizationId,
+              ),
+              ProjectsRecord(
+                  createdBy = user.userId,
+                  createdTime = Instant.EPOCH,
+                  id = projectId2,
+                  modifiedBy = user.userId,
+                  modifiedTime = Instant.EPOCH,
+                  name = "Second project",
+                  organizationId = organizationId,
+              ),
           )
       )
     }


### PR DESCRIPTION
When an additional project is created in an organization that has one existing
project without project-level location data, copy the location from the
organization if it's set there.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>