### PR TITLE
Move to timestamp-based Flyway migrations

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -62,6 +62,7 @@ spring:
       exception-override-class-name: "software.amazon.jdbc.util.HikariCPSQLException"
 
   flyway:
+    outOfOrder: true
     placeholders:
       jsonColumnType: "JSONB"
       uuidColumnType: "UUID"

--- a/src/main/resources/db/migration/README.md
+++ b/src/main/resources/db/migration/README.md
@@ -6,9 +6,17 @@ The server uses [Flyway](https://flywaydb.org) to create and modify the database
 * Numbered migrations, whose filenames are prefixed with `V`, are run in numeric order. Once run, a numbered migration is never run again.
 * Replayable migrations, whose filenames are prefixed with `R`, are run whenever they are modified or created. They should be idempotent. They are run after numbered migrations.
 
-## Migration subdirectories
+## Migration subdirectories and naming
 
-The migrations for production systems all live under this directory. Numbered migrations should be organized in groups of 50 in subdirectories; when you add a new migration, put it in the correct subdirectory (creating the subdirectory if necessary).
+The migrations for production systems all live under this directory. They are numbered based on the dates and times they were added. There are two subdirectory levels for year and month, and then under that, the migrations should be named like `V<year><month><day>.<hour><minute>__<title>.sql`. For example, `2026/07/V20260711.1156__AddSomething.sql`.  The timestamp can be in your local time zone.
+
+The timestamps are intended to be granular enough to make it unlikely that two people working in parallel would add migrations with exactly the same version number.
+
+### Migration order
+
+In the case where multiple people are adding migrations, it's possible for the migrations to be applied out of order. For example, if pull request #1 adds a `V20260711.1037` migration, pull request #2 adds `V20260712.1152`, and #2 is merged first, the later-numbered migration will have already been applied when pull request #1 is merged and deployed.
+
+We configure Flyway to allow out-of-order migrations, and in the typical case where the two migrations make unrelated changes, there's no issue. But you should keep an eye out for situations where two migrations make changes that either conflict or produce functionally different results depending on what order they're applied. In that case, you may need to renumber one of the migrations to ensure they're applied in a consistent order.
 
 ## Database features
 
@@ -25,3 +33,7 @@ There is a `dev` subdirectory that has migrations that should only be applied in
 Currently, the build process creates a temporary database and runs all the migrations from the beginning before examining the database schema to do code generation. That helps protect against people making manual schema changes and then unwittingly writing migrations that depend on those manual steps.
 
 If the build system detects that the migration scripts haven't changed, it skips running migrations and doing code generation.
+
+## Older migrations
+
+We moved to timestamp-based migration numbering after there were already several hundred migrations in place. The older migrations used a sequential numbering scheme. They are applied in order before the timestamp-based migrations.


### PR DESCRIPTION
To avoid the recurring problem where we have multiple parallel changes that add
migrations with conflicting numbers, move to a timestamp-based numbering scheme.
This requires configuring Flyway to accept out-of-order migration numbers since
it'll be possible for a higher-numbered migration to be merged before a
lower-numbered one.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>