### PR TITLE
Update timezone test to a zone with multiple cities

### DIFF
--- a/src/test/kotlin/com/terraformation/backend/i18n/TimeZonesTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/i18n/TimeZonesTest.kt
@@ -89,8 +89,8 @@ internal class TimeZonesTest {
   fun `includes city name if there are multiple cities in the same zone`() {
     val names = timeZones.getTimeZoneNames(Locale.ENGLISH)
 
-    assertEquals("Pacific Time - Los Angeles", names[ZoneId.of("America/Los_Angeles")])
-    assertEquals("Pacific Time - Vancouver", names[ZoneId.of("America/Vancouver")])
+    assertEquals("Central European Time - Paris", names[ZoneId.of("Europe/Paris")])
+    assertEquals("Central European Time - Berlin", names[ZoneId.of("Europe/Berlin")])
   }
 
   @Test


### PR DESCRIPTION
British Columbia no longer observes DST as of March of this year, and the latest version of corretto 26 includes this change which caused a test to start failing. Update the test to use a different timezone that does have multiple cities.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>