### PR TITLE
Restore Spotless SQL format check

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -355,7 +355,6 @@ spotless {
     target("*.md", "buildSrc/*.md", "docs/*.md", "src/**/*.md")
     flexmark()
   }
-  /* Temporarily disable SQL migration formatting so it doesn't fire on the bulk rename.
   format("sql") {
     // Only apply to newly-added SQL files since editing existing ones will cause the checksums
     // to change which Flyway will detect as invalid edits of already-applied migrations.
@@ -365,7 +364,6 @@ spotless {
     endWithNewline()
     trimTrailingWhitespace()
   }
-  */
 }
 
 openApi {


### PR DESCRIPTION
Now that the bulk rename of old migrations is merged to main, it's safe
to reenable the Spotless check that monitors the formats of SQL files
that differ from what's in main.
