### PR TITLE
SW-8694 Add pending nativity to project species

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/species/SpeciesService.kt
+++ b/src/main/kotlin/com/terraformation/backend/species/SpeciesService.kt
@@ -76,7 +76,7 @@ class SpeciesService(
       if (model.projectIds.isNotEmpty()) {
         projectSpeciesStore.assignProjects(mapOf(speciesId to model.projectIds))
       } else {
-        projectSpeciesStore.recalculateNativity(model.organizationId, speciesId)
+        projectSpeciesStore.resetNativities(speciesId)
       }
 
       speciesId
@@ -150,7 +150,7 @@ class SpeciesService(
 
   @EventListener
   fun on(event: OrganizationLocationUpdatedEvent) {
-    projectSpeciesStore.recalculateNativities(event.organizationId)
+    projectSpeciesStore.recalculateNativities(event.organizationId, autoAccept = true)
   }
 
   @EventListener
@@ -159,7 +159,7 @@ class SpeciesService(
         event.changedFrom.botanicalCountryCode != event.changedTo.botanicalCountryCode ||
             event.changedFrom.countryCode != event.changedTo.countryCode
     ) {
-      projectSpeciesStore.recalculateNativities(event.projectId)
+      projectSpeciesStore.recalculateNativities(event.projectId, autoAccept = true)
     }
   }
 

--- a/src/main/kotlin/com/terraformation/backend/species/db/ProjectSpeciesStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/species/db/ProjectSpeciesStore.kt
@@ -45,18 +45,18 @@ class ProjectSpeciesStore(
             .groupBy { (projectId, _) -> projectId }
             .mapValues { (_, projectAndSpecies) -> projectAndSpecies.map { it.second } }
 
-    val calculatedNativities: Map<Pair<SpeciesId, ProjectId>, SourcedSpeciesNativity> =
+    val pendingNativities: Map<Pair<SpeciesId, ProjectId>, SourcedSpeciesNativity> =
         calculateNativities(speciesIdsByProject)
 
     val rows = assignments.flatMap { (speciesId, projectIds) ->
       projectIds.map { projectId ->
-        val calculatedNativity = calculatedNativities[speciesId to projectId]
+        val pendingNativity = pendingNativities[speciesId to projectId]
 
         DSL.row(
-            calculatedNativity?.datasetDate,
-            calculatedNativity?.datasetType,
-            calculatedNativity?.speciesNativity,
             organizationId,
+            pendingNativity?.datasetDate,
+            pendingNativity?.datasetType,
+            pendingNativity?.speciesNativity,
             projectId,
             speciesId,
         )
@@ -68,10 +68,10 @@ class ProjectSpeciesStore(
         dslContext
             .insertInto(
                 PROJECT_SPECIES,
-                CALCULATED_NATIVITY_DATASET_DATE,
-                CALCULATED_NATIVITY_DATASET_TYPE_ID,
-                CALCULATED_NATIVITY_ID,
                 ORGANIZATION_ID,
+                PENDING_NATIVITY_DATASET_DATE,
+                PENDING_NATIVITY_DATASET_TYPE_ID,
+                PENDING_NATIVITY_ID,
                 PROJECT_ID,
                 SPECIES_ID,
             )
@@ -92,54 +92,76 @@ class ProjectSpeciesStore(
   }
 
   /**
-   * Recalculates the organization-level nativity for a species if the organization has fewer than
-   * two projects and the species is not assigned to a project.
+   * Recalculates the pending nativities of a single species everywhere it appears, using the
+   * location of each project it's assigned to, or the organization's location if it isn't assigned
+   * to any projects. The user will have to review the new values and approve or override them.
    */
-  fun recalculateNativity(organizationId: OrganizationId, speciesId: SpeciesId) {
+  fun resetNativities(speciesId: SpeciesId) {
     requirePermissions { updateSpecies(speciesId) }
 
-    val numProjects = dslContext.fetchCount(PROJECTS, PROJECTS.ORGANIZATION_ID.eq(organizationId))
-    if (numProjects > 1) {
-      return
-    }
+    val projectIds =
+        dslContext
+            .select(PROJECT_SPECIES.PROJECT_ID)
+            .from(PROJECT_SPECIES)
+            .where(PROJECT_SPECIES.SPECIES_ID.eq(speciesId))
+            .and(PROJECT_SPECIES.PROJECT_ID.isNotNull)
+            .fetchSet(PROJECT_SPECIES.PROJECT_ID.asNonNullable())
 
-    val numProjectAssignments =
-        dslContext.fetchCount(
-            PROJECT_SPECIES,
-            PROJECT_SPECIES.SPECIES_ID.eq(speciesId),
-            PROJECT_SPECIES.PROJECT_ID.isNotNull,
-        )
-    if (numProjectAssignments > 0) {
-      return
-    }
-
-    val sourcedNativity =
-        calculateOrganizationNativities(organizationId, setOf(speciesId))[speciesId]
-
-    if (sourcedNativity != null) {
+    dslContext.transaction { _ ->
       with(PROJECT_SPECIES) {
         dslContext
-            .insertInto(PROJECT_SPECIES)
-            .set(CALCULATED_NATIVITY_DATASET_DATE, sourcedNativity.datasetDate)
-            .set(CALCULATED_NATIVITY_DATASET_TYPE_ID, sourcedNativity.datasetType)
-            .set(CALCULATED_NATIVITY_ID, sourcedNativity.speciesNativity)
-            .set(ORGANIZATION_ID, organizationId)
-            .set(SPECIES_ID, speciesId)
-            .onConflict(ORGANIZATION_ID, PROJECT_ID, SPECIES_ID)
-            .doUpdate()
-            .set(CALCULATED_NATIVITY_DATASET_DATE, sourcedNativity.datasetDate)
-            .set(CALCULATED_NATIVITY_DATASET_TYPE_ID, sourcedNativity.datasetType)
-            .set(CALCULATED_NATIVITY_ID, sourcedNativity.speciesNativity)
+            .update(PROJECT_SPECIES)
+            .setNull(CALCULATED_NATIVITY_DATASET_DATE)
+            .setNull(CALCULATED_NATIVITY_DATASET_TYPE_ID)
+            .setNull(CALCULATED_NATIVITY_ID)
+            .setNull(OVERRIDDEN_BY)
+            .setNull(OVERRIDDEN_JUSTIFICATION)
+            .setNull(OVERRIDDEN_NATIVITY_ID)
+            .setNull(OVERRIDDEN_TIME)
+            .setNull(PENDING_NATIVITY_DATASET_DATE)
+            .setNull(PENDING_NATIVITY_DATASET_TYPE_ID)
+            .setNull(PENDING_NATIVITY_ID)
+            .where(SPECIES_ID.eq(speciesId))
             .execute()
+      }
+
+      if (projectIds.isEmpty()) {
+        val organizationId =
+            dslContext
+                .select(SPECIES.ORGANIZATION_ID)
+                .from(SPECIES)
+                .where(SPECIES.ID.eq(speciesId))
+                .fetchSingle { it.value1()!! }
+
+        val orgProjectCount =
+            dslContext.fetchCount(PROJECTS, PROJECTS.ORGANIZATION_ID.eq(organizationId))
+
+        if (orgProjectCount < 2) {
+          updateOrganizationNativity(organizationId, speciesId)
+        }
+      } else {
+        val nativities = calculateNativities(projectIds.associateWith { listOf(speciesId) })
+
+        projectIds.forEach { projectId ->
+          applyNativities(
+              listOf(rowForUpdate(speciesId, nativities[speciesId to projectId])),
+              PROJECT_SPECIES.PROJECT_ID.eq(projectId),
+              autoAccept = false,
+          )
+        }
       }
     }
   }
 
   /**
-   * Recalculates nativities for all the species in an organization if the organization has fewer
-   * than two projects.
+   * Recalculates the nativities for all the species in an organization if the organization has
+   * fewer than two projects.
+   *
+   * @param autoAccept If false, the recalculated nativities become pending ones for the user to
+   *   promote, and the rows' existing nativities and overrides are left alone. If true, the
+   *   recalculated nativities are accepted right away and any overrides are discarded.
    */
-  fun recalculateNativities(organizationId: OrganizationId) {
+  fun recalculateNativities(organizationId: OrganizationId, autoAccept: Boolean = false) {
     val numProjects = dslContext.fetchCount(PROJECTS, PROJECTS.ORGANIZATION_ID.eq(organizationId))
     if (numProjects > 1) {
       log.info(
@@ -172,24 +194,34 @@ class ProjectSpeciesStore(
             .fetchSet(PROJECT_SPECIES.SPECIES_ID.asNonNullable())
 
     // Species that already have a project_species row (whether or not it's associated with a
-    // project) get their existing row's calculated nativity updated in place. This avoids inserting
-    // a redundant row with a null project ID for a species that's already tied to the org's single
-    // project.
+    // project) get their existing row updated in place. This avoids inserting a redundant row with
+    // a null project ID for a species that's already tied to the org's single project.
     val existingRows = existingSpeciesIds.map { speciesId ->
       rowForUpdate(speciesId, nativities[speciesId])
     }
     if (existingRows.isNotEmpty()) {
-      updateCalculatedNativities(existingRows, PROJECT_SPECIES.ORGANIZATION_ID.eq(organizationId))
+      applyNativities(
+          existingRows,
+          PROJECT_SPECIES.ORGANIZATION_ID.eq(organizationId),
+          autoAccept,
+      )
     }
 
     // Species that don't have a project_species row yet get a new row with no project ID.
     val missingSpeciesIds = speciesIds.filterNot { it in existingSpeciesIds }
     if (missingSpeciesIds.isNotEmpty()) {
-      insertCalculatedNativities(organizationId, missingSpeciesIds, nativities)
+      insertNativities(organizationId, missingSpeciesIds, nativities, autoAccept)
     }
   }
 
-  fun recalculateNativities(projectId: ProjectId) {
+  /**
+   * Recalculates the nativities of all the species assigned to a project.
+   *
+   * @param autoAccept If false, the recalculated nativities become pending ones for the user to
+   *   promote, and the rows' existing nativities and overrides are left alone. If true, the
+   *   recalculated nativities are accepted right away and any overrides are discarded.
+   */
+  fun recalculateNativities(projectId: ProjectId, autoAccept: Boolean = false) {
     val speciesIds =
         dslContext
             .select(PROJECT_SPECIES.SPECIES_ID)
@@ -206,7 +238,7 @@ class ProjectSpeciesStore(
       rowForUpdate(speciesId, nativities[speciesId to projectId])
     }
 
-    updateCalculatedNativities(rows, PROJECT_SPECIES.PROJECT_ID.eq(projectId))
+    applyNativities(rows, PROJECT_SPECIES.PROJECT_ID.eq(projectId), autoAccept)
   }
 
   fun overridePerProjectData(overrides: List<ProjectSpeciesOverride>) {
@@ -328,6 +360,33 @@ class ProjectSpeciesStore(
     return organizationIds.first()
   }
 
+  private fun updateOrganizationNativity(
+      organizationId: OrganizationId,
+      speciesId: SpeciesId,
+  ) {
+    val sourcedNativity =
+        calculateOrganizationNativities(organizationId, setOf(speciesId))[speciesId]
+
+    if (sourcedNativity != null) {
+      dslContext.transaction { _ ->
+        with(PROJECT_SPECIES) {
+          dslContext
+              .insertInto(PROJECT_SPECIES, ORGANIZATION_ID, SPECIES_ID)
+              .values(organizationId, speciesId)
+              .onConflictDoNothing()
+              .execute()
+        }
+
+        applyNativities(
+            listOf(rowForUpdate(speciesId, sourcedNativity)),
+            PROJECT_SPECIES.ORGANIZATION_ID.eq(organizationId)
+                .and(PROJECT_SPECIES.PROJECT_ID.isNull),
+            autoAccept = false,
+        )
+      }
+    }
+  }
+
   private fun calculateOrganizationNativities(
       organizationId: OrganizationId,
       speciesIds: Collection<SpeciesId>,
@@ -402,66 +461,95 @@ class ProjectSpeciesStore(
     return with(PROJECT_SPECIES) {
       DSL.row(
           DSL.value(speciesId, SPECIES_ID.dataType),
-          DSL.value(sourcedNativity?.datasetDate, CALCULATED_NATIVITY_DATASET_DATE.dataType),
-          DSL.value(sourcedNativity?.datasetType, CALCULATED_NATIVITY_DATASET_TYPE_ID.dataType),
-          DSL.value(sourcedNativity?.speciesNativity, CALCULATED_NATIVITY_ID.dataType),
+          DSL.value(sourcedNativity?.datasetDate, PENDING_NATIVITY_DATASET_DATE.dataType),
+          DSL.value(sourcedNativity?.datasetType, PENDING_NATIVITY_DATASET_TYPE_ID.dataType),
+          DSL.value(sourcedNativity?.speciesNativity, PENDING_NATIVITY_ID.dataType),
       )
     }
   }
 
-  private fun updateCalculatedNativities(
+  /**
+   * Applies recalculated nativities to the existing rows matching [scopeCondition].
+   *
+   * @param autoAccept If false, the recalculated nativities become pending ones for the user to
+   *   promote, and the rows' existing nativities and overrides are left alone. If true, the
+   *   recalculated nativities are accepted right away and any overrides are discarded.
+   */
+  private fun applyNativities(
       rows: List<Row4<SpeciesId?, LocalDate?, ExternalDatasetType?, SpeciesNativity?>>,
       scopeCondition: Condition,
-  ): Int {
+      autoAccept: Boolean,
+  ) {
     with(PROJECT_SPECIES) {
       val updateValues = DSL.values(*(rows.toTypedArray()))
 
       val speciesIdField = updateValues.field(0, SPECIES_ID.dataType)!!
-      val datasetDateField = updateValues.field(1, CALCULATED_NATIVITY_DATASET_DATE.dataType)!!
-      val datasetTypeField = updateValues.field(2, CALCULATED_NATIVITY_DATASET_TYPE_ID.dataType)!!
-      val nativityField = updateValues.field(3, CALCULATED_NATIVITY_ID.dataType)!!
+      val datasetDateField = updateValues.field(1, PENDING_NATIVITY_DATASET_DATE.dataType)!!
+      val datasetTypeField = updateValues.field(2, PENDING_NATIVITY_DATASET_TYPE_ID.dataType)!!
+      val nativityField = updateValues.field(3, PENDING_NATIVITY_ID.dataType)!!
 
-      return dslContext
-          .update(PROJECT_SPECIES)
-          .set(CALCULATED_NATIVITY_DATASET_DATE, datasetDateField)
-          .set(CALCULATED_NATIVITY_DATASET_TYPE_ID, datasetTypeField)
-          .set(CALCULATED_NATIVITY_ID, nativityField)
-          .setNull(OVERRIDDEN_BY)
-          .setNull(OVERRIDDEN_NATIVITY_ID)
-          .setNull(OVERRIDDEN_JUSTIFICATION)
-          .setNull(OVERRIDDEN_TIME)
-          .from(updateValues)
-          .where(scopeCondition)
-          .and(SPECIES_ID.eq(speciesIdField))
-          .execute()
+      val update =
+          if (autoAccept) {
+            dslContext
+                .update(PROJECT_SPECIES)
+                .set(CALCULATED_NATIVITY_DATASET_DATE, datasetDateField)
+                .set(CALCULATED_NATIVITY_DATASET_TYPE_ID, datasetTypeField)
+                .set(CALCULATED_NATIVITY_ID, nativityField)
+                .setNull(OVERRIDDEN_BY)
+                .setNull(OVERRIDDEN_JUSTIFICATION)
+                .setNull(OVERRIDDEN_NATIVITY_ID)
+                .setNull(OVERRIDDEN_TIME)
+                .setNull(PENDING_NATIVITY_DATASET_DATE)
+                .setNull(PENDING_NATIVITY_DATASET_TYPE_ID)
+                .setNull(PENDING_NATIVITY_ID)
+          } else {
+            dslContext
+                .update(PROJECT_SPECIES)
+                .set(PENDING_NATIVITY_DATASET_DATE, datasetDateField)
+                .set(PENDING_NATIVITY_DATASET_TYPE_ID, datasetTypeField)
+                .set(PENDING_NATIVITY_ID, nativityField)
+          }
+
+      update.from(updateValues).where(scopeCondition).and(SPECIES_ID.eq(speciesIdField)).execute()
     }
   }
 
-  private fun insertCalculatedNativities(
+  /**
+   * Inserts organization-level rows for species that don't have any [PROJECT_SPECIES] rows yet.
+   * [autoAccept] chooses whether the nativities are accepted or pending, as in [applyNativities].
+   */
+  private fun insertNativities(
       organizationId: OrganizationId,
       speciesIds: Collection<SpeciesId>,
       nativities: Map<SpeciesId, SourcedSpeciesNativity>,
+      autoAccept: Boolean,
   ) {
     val rows = speciesIds.map { speciesId ->
       val sourcedNativity = nativities[speciesId]
 
       DSL.row(
+          organizationId,
           sourcedNativity?.datasetDate,
           sourcedNativity?.datasetType,
           sourcedNativity?.speciesNativity,
-          organizationId,
           speciesId,
       )
     }
 
     with(PROJECT_SPECIES) {
+      val datasetDateField =
+          if (autoAccept) CALCULATED_NATIVITY_DATASET_DATE else PENDING_NATIVITY_DATASET_DATE
+      val datasetTypeField =
+          if (autoAccept) CALCULATED_NATIVITY_DATASET_TYPE_ID else PENDING_NATIVITY_DATASET_TYPE_ID
+      val nativityField = if (autoAccept) CALCULATED_NATIVITY_ID else PENDING_NATIVITY_ID
+
       dslContext
           .insertInto(
               PROJECT_SPECIES,
-              CALCULATED_NATIVITY_DATASET_DATE,
-              CALCULATED_NATIVITY_DATASET_TYPE_ID,
-              CALCULATED_NATIVITY_ID,
               ORGANIZATION_ID,
+              datasetDateField,
+              datasetTypeField,
+              nativityField,
               SPECIES_ID,
           )
           .valuesOfRows(rows)

--- a/src/main/resources/db/migration/2026/07/V20260727.1554__PendingNativity.sql
+++ b/src/main/resources/db/migration/2026/07/V20260727.1554__PendingNativity.sql
@@ -1,0 +1,18 @@
+ALTER TABLE project_species
+    ADD COLUMN pending_nativity_id INTEGER REFERENCES species_nativities,
+    ADD COLUMN pending_nativity_dataset_date DATE,
+    ADD COLUMN pending_nativity_dataset_type_id INTEGER REFERENCES external_dataset_types,
+
+    ADD CONSTRAINT pending_nativity_dataset_has_both_values
+        CHECK (
+            (pending_nativity_dataset_date IS NULL) =
+            (pending_nativity_dataset_type_id IS NULL)
+        ),
+
+    -- Nativity 4 = Unknown
+    ADD CONSTRAINT known_pending_nativity_has_dataset
+        CHECK (
+            ((pending_nativity_id = 4 OR pending_nativity_id IS NULL)
+            AND pending_nativity_dataset_date IS NULL)
+            OR pending_nativity_dataset_date IS NOT NULL
+        );

--- a/src/test/kotlin/com/terraformation/backend/db/DatabaseBackedTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/db/DatabaseBackedTest.kt
@@ -1662,6 +1662,11 @@ abstract class DatabaseBackedTest {
       overriddenBy: UserId? = overriddenNativityId?.let { inserted.userId },
       overriddenJustification: String? = overriddenNativityId?.let { "Justification" },
       overriddenTime: Instant? = overriddenNativityId?.let { Instant.EPOCH },
+      pendingNativity: SpeciesNativity? = null,
+      pendingNativityDatasetDate: LocalDate? = pendingNativity?.let { LocalDate.EPOCH },
+      pendingNativityDatasetType: ExternalDatasetType? = pendingNativity?.let {
+        ExternalDatasetType.GRIIS
+      },
       speciesId: SpeciesId = inserted.speciesId,
   ) {
     ProjectSpeciesRecord(
@@ -1673,6 +1678,9 @@ abstract class DatabaseBackedTest {
             overriddenJustification = overriddenJustification,
             overriddenNativityId = overriddenNativityId,
             overriddenTime = overriddenTime,
+            pendingNativityDatasetDate = pendingNativityDatasetDate,
+            pendingNativityDatasetTypeId = pendingNativityDatasetType,
+            pendingNativityId = pendingNativity,
             projectId = projectId,
             speciesId = speciesId,
         )

--- a/src/test/kotlin/com/terraformation/backend/species/SpeciesServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/species/SpeciesServiceTest.kt
@@ -29,7 +29,6 @@ import com.terraformation.backend.species.db.SpeciesNativityCalculator
 import com.terraformation.backend.species.db.SpeciesStore
 import com.terraformation.backend.species.event.SpeciesEditedEvent
 import com.terraformation.backend.species.model.ExistingSpeciesModel
-import com.terraformation.backend.species.model.ExistingSpeciesProjectModel
 import com.terraformation.backend.species.model.NewSpeciesModel
 import com.terraformation.backend.species.model.SpeciesDataSourceModel
 import io.mockk.Runs
@@ -158,7 +157,7 @@ internal class SpeciesServiceTest : DatabaseTest(), RunsAsUser {
     }
 
     @Test
-    fun `sets nativity based on project location`() {
+    fun `sets pending nativity based on project location`() {
       every { user.canReadProject(any()) } returns true
 
       val botanicalCountryCode = insertBotanicalCountry()
@@ -177,24 +176,20 @@ internal class SpeciesServiceTest : DatabaseTest(), RunsAsUser {
               )
           )
 
-      val speciesModel = speciesStore.fetchSpeciesById(speciesId)
-
-      assertEquals(
-          listOf(
-              ExistingSpeciesProjectModel(
-                  calculatedNativity = SpeciesNativity.Invasive,
-                  calculatedNativitySource =
-                      SpeciesDataSourceModel(griisDate, ExternalDatasetType.GRIIS),
-                  projectId = projectId,
-              )
-          ),
-          speciesModel.projects,
-          "Species project details",
+      assertTableEquals(
+          ProjectSpeciesRecord(
+              organizationId = organizationId,
+              pendingNativityDatasetDate = griisDate,
+              pendingNativityDatasetTypeId = ExternalDatasetType.GRIIS,
+              pendingNativityId = SpeciesNativity.Invasive,
+              projectId = projectId,
+              speciesId = speciesId,
+          )
       )
     }
 
     @Test
-    fun `sets org-level nativity if org has location and fewer than two projects`() {
+    fun `sets pending org-level nativity if org has location and fewer than two projects`() {
       val botanicalCountryCode = insertBotanicalCountry()
       val locatedOrganizationId =
           insertOrganization(botanicalCountryCode = botanicalCountryCode, countryCode = "AR")
@@ -213,18 +208,14 @@ internal class SpeciesServiceTest : DatabaseTest(), RunsAsUser {
               )
           )
 
-      val speciesModel = speciesStore.fetchSpeciesById(speciesId)
-
-      assertEquals(
-          listOf(
-              ExistingSpeciesProjectModel(
-                  calculatedNativity = SpeciesNativity.Invasive,
-                  calculatedNativitySource =
-                      SpeciesDataSourceModel(griisDate, ExternalDatasetType.GRIIS),
-              )
-          ),
-          speciesModel.projects,
-          "Species project details",
+      assertTableEquals(
+          ProjectSpeciesRecord(
+              organizationId = locatedOrganizationId,
+              pendingNativityDatasetDate = griisDate,
+              pendingNativityDatasetTypeId = ExternalDatasetType.GRIIS,
+              pendingNativityId = SpeciesNativity.Invasive,
+              speciesId = speciesId,
+          )
       )
     }
   }

--- a/src/test/kotlin/com/terraformation/backend/species/db/ProjectSpeciesStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/species/db/ProjectSpeciesStoreTest.kt
@@ -42,6 +42,9 @@ internal class ProjectSpeciesStoreTest : DatabaseTest(), RunsAsDatabaseUser {
   private lateinit var projectId: ProjectId
   private lateinit var speciesId: SpeciesId
 
+  private val griisDate = LocalDate.of(2026, 1, 2)
+  private val wcvpDate = LocalDate.of(2026, 2, 3)
+
   @BeforeEach
   fun setUp() {
     organizationId = insertOrganization()
@@ -63,16 +66,12 @@ internal class ProjectSpeciesStoreTest : DatabaseTest(), RunsAsDatabaseUser {
     }
 
     @Test
-    fun `uses project locations to calculate species nativity`() {
+    fun `uses project locations to calculate pending species nativity`() {
       val botanicalCountryCode1 = insertBotanicalCountry()
       val botanicalCountryCode2 = insertBotanicalCountry()
 
-      val griisDate = LocalDate.of(2026, 1, 2)
-      val wcvpDate = LocalDate.of(2026, 2, 3)
-      insertExternalDatasetImport(type = ExternalDatasetType.GRIIS, lastPublicationDate = griisDate)
+      insertGriisInvasiveListing()
       insertExternalDatasetImport(type = ExternalDatasetType.WCVP, lastPublicationDate = wcvpDate)
-      insertGriisResource(countryCode = "KE")
-      insertGriisTaxon(scientificName = "Scientific name", isInvasive = true)
       insertWcvpTaxon(scientificName = "Scientific name")
       insertWcvpDistribution(
           botanicalCountryCode = botanicalCountryCode2,
@@ -95,46 +94,32 @@ internal class ProjectSpeciesStoreTest : DatabaseTest(), RunsAsDatabaseUser {
                   organizationId = organizationId,
                   projectId = projectId1,
                   speciesId = speciesId,
-                  calculatedNativityId = SpeciesNativity.Invasive,
-                  calculatedNativityDatasetTypeId = ExternalDatasetType.GRIIS,
-                  calculatedNativityDatasetDate = griisDate,
+                  pendingNativityId = SpeciesNativity.Invasive,
+                  pendingNativityDatasetTypeId = ExternalDatasetType.GRIIS,
+                  pendingNativityDatasetDate = griisDate,
               ),
               ProjectSpeciesRecord(
                   organizationId = organizationId,
                   projectId = projectId2,
                   speciesId = speciesId,
-                  calculatedNativityId = SpeciesNativity.Introduced,
-                  calculatedNativityDatasetTypeId = ExternalDatasetType.WCVP,
-                  calculatedNativityDatasetDate = wcvpDate,
+                  pendingNativityId = SpeciesNativity.Introduced,
+                  pendingNativityDatasetTypeId = ExternalDatasetType.WCVP,
+                  pendingNativityDatasetDate = wcvpDate,
               ),
               ProjectSpeciesRecord(
                   organizationId = organizationId,
                   projectId = projectId3,
                   speciesId = speciesId,
-                  calculatedNativityId = SpeciesNativity.Unknown,
+                  pendingNativityId = SpeciesNativity.Unknown,
               ),
           )
       )
     }
 
     @Test
-    fun `uses organization location to calculate species nativity if only one project`() {
-      insertBotanicalCountry()
-
-      dslContext
-          .fetchSingle(ORGANIZATIONS, ORGANIZATIONS.ID.eq(organizationId))
-          .apply {
-            botanicalCountryCode = inserted.botanicalCountryCode
-            countryCode = "KE"
-          }
-          .update()
-
-      insertExternalDatasetImport(
-          type = ExternalDatasetType.GRIIS,
-          lastPublicationDate = LocalDate.of(2026, 1, 2),
-      )
-      insertGriisResource(countryCode = "KE")
-      insertGriisTaxon(scientificName = "Scientific name", isInvasive = true)
+    fun `uses organization location to calculate pending species nativity if only one project`() {
+      setOrganizationLocation()
+      insertGriisInvasiveListing()
 
       store.assignProjects(mapOf(speciesId to setOf(projectId)))
 
@@ -143,31 +128,17 @@ internal class ProjectSpeciesStoreTest : DatabaseTest(), RunsAsDatabaseUser {
               organizationId = organizationId,
               projectId = projectId,
               speciesId = speciesId,
-              calculatedNativityId = SpeciesNativity.Invasive,
-              calculatedNativityDatasetTypeId = ExternalDatasetType.GRIIS,
-              calculatedNativityDatasetDate = LocalDate.of(2026, 1, 2),
+              pendingNativityId = SpeciesNativity.Invasive,
+              pendingNativityDatasetTypeId = ExternalDatasetType.GRIIS,
+              pendingNativityDatasetDate = griisDate,
           )
       )
     }
 
     @Test
-    fun `does not use organization location to calculate species nativity if multiple projects`() {
-      insertBotanicalCountry()
-
-      dslContext
-          .fetchSingle(ORGANIZATIONS, ORGANIZATIONS.ID.eq(organizationId))
-          .apply {
-            botanicalCountryCode = inserted.botanicalCountryCode
-            countryCode = "KE"
-          }
-          .update()
-
-      insertExternalDatasetImport(
-          type = ExternalDatasetType.GRIIS,
-          lastPublicationDate = LocalDate.of(2026, 1, 2),
-      )
-      insertGriisResource(countryCode = "KE")
-      insertGriisTaxon(scientificName = "Scientific name", isInvasive = true)
+    fun `does not use organization location to calculate pending nativity if multiple projects`() {
+      setOrganizationLocation()
+      insertGriisInvasiveListing()
 
       insertProject()
 
@@ -349,22 +320,12 @@ internal class ProjectSpeciesStoreTest : DatabaseTest(), RunsAsDatabaseUser {
   }
 
   @Nested
-  inner class RecalculateNativities {
+  inner class RecalculateNativitiesForProject {
     @Test
-    fun `recalculates nativities for project species`() {
+    fun `accepts recalculated nativities when autoAccept is set`() {
       val botanicalCountryCode = insertBotanicalCountry()
-      val griisDate = LocalDate.of(2026, 1, 2)
-      val wcvpDate = LocalDate.of(2026, 2, 3)
-      insertExternalDatasetImport(
-          type = ExternalDatasetType.GRIIS,
-          lastPublicationDate = griisDate,
-      )
-      insertExternalDatasetImport(
-          type = ExternalDatasetType.WCVP,
-          lastPublicationDate = wcvpDate,
-      )
-      insertGriisResource(countryCode = "KE")
-      insertGriisTaxon(scientificName = "Scientific name", isInvasive = true)
+      insertGriisInvasiveListing()
+      insertExternalDatasetImport(type = ExternalDatasetType.WCVP, lastPublicationDate = wcvpDate)
 
       val wcvpSpeciesId = insertSpecies(scientificName = "Other name")
       insertWcvpTaxon(scientificName = "Other name")
@@ -387,12 +348,13 @@ internal class ProjectSpeciesStoreTest : DatabaseTest(), RunsAsDatabaseUser {
           calculatedNativity = SpeciesNativity.Native,
           overriddenNativityId = SpeciesNativity.Introduced,
       )
+      // A species whose only existing nativity is a pending one should get an accepted nativity.
       insertProjectSpecies(
           speciesId = wcvpSpeciesId,
-          calculatedNativity = SpeciesNativity.Native,
+          pendingNativity = SpeciesNativity.Native,
       )
 
-      store.recalculateNativities(locatedProjectId)
+      store.recalculateNativities(locatedProjectId, autoAccept = true)
 
       assertTableEquals(
           listOf(
@@ -430,6 +392,53 @@ internal class ProjectSpeciesStoreTest : DatabaseTest(), RunsAsDatabaseUser {
     }
 
     @Test
+    fun `leaves recalculated nativities pending by default`() {
+      val botanicalCountryCode = insertBotanicalCountry()
+      insertGriisInvasiveListing()
+
+      val locatedProjectId =
+          insertProject(botanicalCountryCode = botanicalCountryCode, countryCode = "KE")
+      insertProjectSpecies(projectId = locatedProjectId, speciesId = speciesId)
+
+      val otherSpeciesId = insertSpecies(scientificName = "Scientific name 2")
+      insertProjectSpecies(
+          projectId = locatedProjectId,
+          speciesId = otherSpeciesId,
+          calculatedNativity = SpeciesNativity.Native,
+          overriddenNativityId = SpeciesNativity.Introduced,
+      )
+
+      store.recalculateNativities(locatedProjectId)
+
+      assertTableEquals(
+          listOf(
+              ProjectSpeciesRecord(
+                  organizationId = organizationId,
+                  pendingNativityDatasetDate = griisDate,
+                  pendingNativityDatasetTypeId = ExternalDatasetType.GRIIS,
+                  pendingNativityId = SpeciesNativity.Invasive,
+                  projectId = locatedProjectId,
+                  speciesId = speciesId,
+              ),
+              // An existing nativity and override are left alone when autoAccept isn't set.
+              ProjectSpeciesRecord(
+                  calculatedNativityDatasetDate = LocalDate.EPOCH,
+                  calculatedNativityDatasetTypeId = ExternalDatasetType.GRIIS,
+                  calculatedNativityId = SpeciesNativity.Native,
+                  organizationId = organizationId,
+                  overriddenBy = inserted.userId,
+                  overriddenJustification = "Justification",
+                  overriddenNativityId = SpeciesNativity.Introduced,
+                  overriddenTime = Instant.EPOCH,
+                  pendingNativityId = SpeciesNativity.Unknown,
+                  projectId = locatedProjectId,
+                  speciesId = otherSpeciesId,
+              ),
+          )
+      )
+    }
+
+    @Test
     fun `sets nativity to unknown when species is not listed in the current location`() {
       val botanicalCountryCode = insertBotanicalCountry()
       val locatedProjectId =
@@ -440,32 +449,49 @@ internal class ProjectSpeciesStoreTest : DatabaseTest(), RunsAsDatabaseUser {
           calculatedNativity = SpeciesNativity.Invasive,
       )
 
-      store.recalculateNativities(locatedProjectId)
+      store.recalculateNativities(locatedProjectId, autoAccept = true)
 
       assertTableEquals(
           ProjectSpeciesRecord(
+              calculatedNativityId = SpeciesNativity.Unknown,
               organizationId = organizationId,
               projectId = locatedProjectId,
               speciesId = speciesId,
-              calculatedNativityId = SpeciesNativity.Unknown,
           )
       )
     }
 
     @Test
-    fun `clears nativities when the project has no location`() {
-      insertProjectSpecies(
-          projectId = projectId,
-          speciesId = speciesId,
-          calculatedNativity = SpeciesNativity.Invasive,
-          overriddenNativityId = SpeciesNativity.Introduced,
+    fun `clears nativities and overrides when the project has no location`() {
+      insertProjectSpeciesWithAllNativities()
+
+      store.recalculateNativities(projectId, autoAccept = true)
+
+      assertTableEquals(
+          ProjectSpeciesRecord(
+              organizationId = organizationId,
+              projectId = projectId,
+              speciesId = speciesId,
+          )
       )
+    }
+
+    @Test
+    fun `clears pending nativity but retains existing values when the project has no location`() {
+      insertProjectSpeciesWithAllNativities()
 
       store.recalculateNativities(projectId)
 
       assertTableEquals(
           ProjectSpeciesRecord(
+              calculatedNativityDatasetDate = LocalDate.EPOCH,
+              calculatedNativityDatasetTypeId = ExternalDatasetType.GRIIS,
+              calculatedNativityId = SpeciesNativity.Invasive,
               organizationId = organizationId,
+              overriddenBy = inserted.userId,
+              overriddenJustification = "Justification",
+              overriddenNativityId = SpeciesNativity.Introduced,
+              overriddenTime = Instant.EPOCH,
               projectId = projectId,
               speciesId = speciesId,
           )
@@ -482,12 +508,9 @@ internal class ProjectSpeciesStoreTest : DatabaseTest(), RunsAsDatabaseUser {
   @Nested
   inner class RecalculateNativitiesForOrganization {
     @Test
-    fun `recalculates nativities if organization has no projects`() {
+    fun `accepts recalculated nativity if organization has no projects`() {
       val botanicalCountryCode = insertBotanicalCountry()
-      val griisDate = LocalDate.of(2026, 1, 2)
-      insertExternalDatasetImport(type = ExternalDatasetType.GRIIS, lastPublicationDate = griisDate)
-      insertGriisResource(countryCode = "KE")
-      insertGriisTaxon(scientificName = "Scientific name", isInvasive = true)
+      insertGriisInvasiveListing()
 
       val locatedOrganizationId =
           insertOrganization(botanicalCountryCode = botanicalCountryCode, countryCode = "KE")
@@ -499,7 +522,7 @@ internal class ProjectSpeciesStoreTest : DatabaseTest(), RunsAsDatabaseUser {
           overriddenNativityId = SpeciesNativity.Introduced,
       )
 
-      store.recalculateNativities(locatedOrganizationId)
+      store.recalculateNativities(locatedOrganizationId, autoAccept = true)
 
       assertTableEquals(
           ProjectSpeciesRecord(
@@ -514,22 +537,12 @@ internal class ProjectSpeciesStoreTest : DatabaseTest(), RunsAsDatabaseUser {
     }
 
     @Test
-    fun `recalculates nativities based on organization location for organization with one project`() {
-      insertBotanicalCountry()
+    fun `recalculates nativities based on org location for organization with one project`() {
+      setOrganizationLocation()
+      insertGriisInvasiveListing()
 
-      dslContext
-          .fetchSingle(ORGANIZATIONS, ORGANIZATIONS.ID.eq(organizationId))
-          .apply {
-            botanicalCountryCode = inserted.botanicalCountryCode
-            countryCode = "KE"
-          }
-          .update()
-
-      val griisDate = LocalDate.of(2026, 1, 2)
-      insertExternalDatasetImport(type = ExternalDatasetType.GRIIS, lastPublicationDate = griisDate)
-      insertGriisResource(countryCode = "KE")
-      insertGriisTaxon(scientificName = "Scientific name", isInvasive = true)
-
+      // This species is already tied to the org's single project; it should be updated in place
+      // rather than getting an additional row with a null project ID.
       insertProjectSpecies(
           projectId = projectId,
           speciesId = speciesId,
@@ -537,10 +550,14 @@ internal class ProjectSpeciesStoreTest : DatabaseTest(), RunsAsDatabaseUser {
           overriddenNativityId = SpeciesNativity.Introduced,
       )
 
+      // This species already has an org-level row, which should be updated in place.
       val nonProjectSpeciesId = insertSpecies(scientificName = "Scientific 2")
       insertProjectSpecies(projectId = null)
 
-      store.recalculateNativities(organizationId)
+      // This species isn't listed in project_species yet; it should get a new null-project row.
+      val unlistedSpeciesId = insertSpecies(scientificName = "Scientific 3")
+
+      store.recalculateNativities(organizationId, autoAccept = true)
 
       assertTableEquals(
           listOf(
@@ -558,50 +575,6 @@ internal class ProjectSpeciesStoreTest : DatabaseTest(), RunsAsDatabaseUser {
                   speciesId = nonProjectSpeciesId,
                   calculatedNativityId = SpeciesNativity.Unknown,
               ),
-          )
-      )
-    }
-
-    @Test
-    fun `inserts rows for unlisted species without duplicating project-associated species`() {
-      insertBotanicalCountry()
-
-      dslContext
-          .fetchSingle(ORGANIZATIONS, ORGANIZATIONS.ID.eq(organizationId))
-          .apply {
-            botanicalCountryCode = inserted.botanicalCountryCode
-            countryCode = "KE"
-          }
-          .update()
-
-      val griisDate = LocalDate.of(2026, 1, 2)
-      insertExternalDatasetImport(type = ExternalDatasetType.GRIIS, lastPublicationDate = griisDate)
-      insertGriisResource(countryCode = "KE")
-      insertGriisTaxon(scientificName = "Scientific name", isInvasive = true)
-
-      // This species is already tied to the org's single project; it should be updated in place
-      // rather than getting an additional row with a null project ID.
-      insertProjectSpecies(
-          projectId = projectId,
-          speciesId = speciesId,
-          calculatedNativity = SpeciesNativity.Native,
-      )
-
-      // This species isn't listed in project_species yet; it should get a new null-project row.
-      val unlistedSpeciesId = insertSpecies(scientificName = "Scientific 2")
-
-      store.recalculateNativities(organizationId)
-
-      assertTableEquals(
-          listOf(
-              ProjectSpeciesRecord(
-                  organizationId = organizationId,
-                  projectId = projectId,
-                  speciesId = speciesId,
-                  calculatedNativityDatasetDate = griisDate,
-                  calculatedNativityDatasetTypeId = ExternalDatasetType.GRIIS,
-                  calculatedNativityId = SpeciesNativity.Invasive,
-              ),
               ProjectSpeciesRecord(
                   organizationId = organizationId,
                   projectId = null,
@@ -613,15 +586,53 @@ internal class ProjectSpeciesStoreTest : DatabaseTest(), RunsAsDatabaseUser {
     }
 
     @Test
-    fun `clears nativities when organization has no location`() {
+    fun `leaves recalculated nativities pending by default`() {
+      setOrganizationLocation()
+      insertGriisInvasiveListing()
+
       insertProjectSpecies(
           projectId = projectId,
           speciesId = speciesId,
-          calculatedNativity = SpeciesNativity.Invasive,
+          calculatedNativity = SpeciesNativity.Native,
           overriddenNativityId = SpeciesNativity.Introduced,
       )
 
+      val unlistedSpeciesId = insertSpecies(scientificName = "Scientific 2")
+
       store.recalculateNativities(organizationId)
+
+      assertTableEquals(
+          listOf(
+              ProjectSpeciesRecord(
+                  calculatedNativityDatasetDate = LocalDate.EPOCH,
+                  calculatedNativityDatasetTypeId = ExternalDatasetType.GRIIS,
+                  calculatedNativityId = SpeciesNativity.Native,
+                  organizationId = organizationId,
+                  overriddenBy = inserted.userId,
+                  overriddenJustification = "Justification",
+                  overriddenNativityId = SpeciesNativity.Introduced,
+                  overriddenTime = Instant.EPOCH,
+                  pendingNativityDatasetDate = griisDate,
+                  pendingNativityDatasetTypeId = ExternalDatasetType.GRIIS,
+                  pendingNativityId = SpeciesNativity.Invasive,
+                  projectId = projectId,
+                  speciesId = speciesId,
+              ),
+              ProjectSpeciesRecord(
+                  organizationId = organizationId,
+                  pendingNativityId = SpeciesNativity.Unknown,
+                  projectId = null,
+                  speciesId = unlistedSpeciesId,
+              ),
+          )
+      )
+    }
+
+    @Test
+    fun `clears nativities and overrides when organization has no location`() {
+      insertProjectSpeciesWithAllNativities()
+
+      store.recalculateNativities(organizationId, autoAccept = true)
 
       assertTableEquals(
           ProjectSpeciesRecord(
@@ -652,115 +663,115 @@ internal class ProjectSpeciesStoreTest : DatabaseTest(), RunsAsDatabaseUser {
   }
 
   @Nested
-  inner class RecalculateNativity {
+  inner class ResetNativities {
     @Test
-    fun `sets organization-level nativity for a species not assigned to a project`() {
-      setOrganizationLocation()
+    fun `leaves recalculated nativities pending for every project the species is assigned to`() {
+      val botanicalCountryCode = insertBotanicalCountry()
+      insertGriisInvasiveListing()
+      insertExternalDatasetImport(type = ExternalDatasetType.WCVP, lastPublicationDate = wcvpDate)
+      insertWcvpTaxon(scientificName = "Scientific name")
+      insertWcvpDistribution(
+          botanicalCountryCode = botanicalCountryCode,
+          speciesNativity = SpeciesNativity.Native,
+      )
 
-      val griisDate = LocalDate.of(2026, 1, 2)
-      insertExternalDatasetImport(type = ExternalDatasetType.GRIIS, lastPublicationDate = griisDate)
-      insertGriisResource(countryCode = "KE")
-      insertGriisTaxon(scientificName = "Scientific name", isInvasive = true)
+      val griisProjectId =
+          insertProject(botanicalCountryCode = botanicalCountryCode, countryCode = "KE")
+      insertProjectSpecies(
+          projectId = griisProjectId,
+          speciesId = speciesId,
+          calculatedNativity = SpeciesNativity.Unknown,
+          overriddenNativityId = SpeciesNativity.Introduced,
+      )
 
-      store.recalculateNativity(organizationId, speciesId)
+      // Other species in the same project should be left alone.
+      val otherSpeciesId = insertSpecies(scientificName = "Other name")
+      insertProjectSpecies(
+          projectId = griisProjectId,
+          speciesId = otherSpeciesId,
+          calculatedNativity = SpeciesNativity.Native,
+          overriddenNativityId = SpeciesNativity.Introduced,
+      )
+
+      // The species doesn't have a nativity in this project yet.
+      val wcvpProjectId =
+          insertProject(botanicalCountryCode = botanicalCountryCode, countryCode = "GH")
+      insertProjectSpecies(projectId = wcvpProjectId, speciesId = speciesId)
+
+      store.resetNativities(speciesId)
 
       assertTableEquals(
-          ProjectSpeciesRecord(
-              calculatedNativityDatasetDate = griisDate,
-              calculatedNativityDatasetTypeId = ExternalDatasetType.GRIIS,
-              calculatedNativityId = SpeciesNativity.Invasive,
-              organizationId = organizationId,
-              speciesId = speciesId,
+          listOf(
+              ProjectSpeciesRecord(
+                  organizationId = organizationId,
+                  pendingNativityDatasetDate = griisDate,
+                  pendingNativityDatasetTypeId = ExternalDatasetType.GRIIS,
+                  pendingNativityId = SpeciesNativity.Invasive,
+                  projectId = griisProjectId,
+                  speciesId = speciesId,
+              ),
+              ProjectSpeciesRecord(
+                  calculatedNativityDatasetDate = LocalDate.EPOCH,
+                  calculatedNativityDatasetTypeId = ExternalDatasetType.GRIIS,
+                  calculatedNativityId = SpeciesNativity.Native,
+                  organizationId = organizationId,
+                  overriddenBy = inserted.userId,
+                  overriddenJustification = "Justification",
+                  overriddenNativityId = SpeciesNativity.Introduced,
+                  overriddenTime = Instant.EPOCH,
+                  projectId = griisProjectId,
+                  speciesId = otherSpeciesId,
+              ),
+              ProjectSpeciesRecord(
+                  organizationId = organizationId,
+                  pendingNativityDatasetDate = wcvpDate,
+                  pendingNativityDatasetTypeId = ExternalDatasetType.WCVP,
+                  pendingNativityId = SpeciesNativity.Native,
+                  projectId = wcvpProjectId,
+                  speciesId = speciesId,
+              ),
           )
       )
     }
 
     @Test
-    fun `updates existing organization-level row`() {
+    fun `recalculates organization-level nativity when species has no project`() {
       setOrganizationLocation()
-
-      val griisDate = LocalDate.of(2026, 1, 2)
-      insertExternalDatasetImport(type = ExternalDatasetType.GRIIS, lastPublicationDate = griisDate)
-      insertGriisResource(countryCode = "KE")
-      insertGriisTaxon(scientificName = "Scientific name", isInvasive = true)
-
-      insertProjectSpecies(projectId = null, calculatedNativity = SpeciesNativity.Native)
-
-      store.recalculateNativity(organizationId, speciesId)
-
-      assertTableEquals(
-          ProjectSpeciesRecord(
-              calculatedNativityDatasetDate = griisDate,
-              calculatedNativityDatasetTypeId = ExternalDatasetType.GRIIS,
-              calculatedNativityId = SpeciesNativity.Invasive,
-              organizationId = organizationId,
-              speciesId = speciesId,
-          )
-      )
-    }
-
-    @Test
-    fun `sets nativity to unknown when species is not listed in the current location`() {
-      setOrganizationLocation()
-
-      store.recalculateNativity(organizationId, speciesId)
-
-      assertTableEquals(
-          ProjectSpeciesRecord(
-              calculatedNativityId = SpeciesNativity.Unknown,
-              organizationId = organizationId,
-              speciesId = speciesId,
-          )
-      )
-    }
-
-    @Test
-    fun `does not insert a row when organization has no location`() {
-      store.recalculateNativity(organizationId, speciesId)
-
-      assertTableEmpty(PROJECT_SPECIES)
-    }
-
-    @Test
-    fun `is a no-op when the species is assigned to a project`() {
-      setOrganizationLocation()
-
-      insertExternalDatasetImport(
-          type = ExternalDatasetType.GRIIS,
-          lastPublicationDate = LocalDate.of(2026, 1, 2),
-      )
-      insertGriisResource(countryCode = "KE")
-      insertGriisTaxon(scientificName = "Scientific name", isInvasive = true)
+      insertGriisInvasiveListing()
 
       insertProjectSpecies(
-          projectId = projectId,
+          projectId = null,
           speciesId = speciesId,
-          calculatedNativity = SpeciesNativity.Native,
+          calculatedNativity = SpeciesNativity.Unknown,
+          overriddenNativityId = SpeciesNativity.Introduced,
       )
 
-      val before = dslContext.fetch(PROJECT_SPECIES)
+      store.resetNativities(speciesId)
 
-      store.recalculateNativity(organizationId, speciesId)
-
-      assertTableEquals(before)
+      assertTableEquals(
+          ProjectSpeciesRecord(
+              organizationId = organizationId,
+              pendingNativityDatasetDate = griisDate,
+              pendingNativityDatasetTypeId = ExternalDatasetType.GRIIS,
+              pendingNativityId = SpeciesNativity.Invasive,
+              speciesId = speciesId,
+          )
+      )
     }
 
     @Test
-    fun `is a no-op when organization has more than one project`() {
-      setOrganizationLocation()
+    fun `clears nativities when the project has no location`() {
+      insertProjectSpeciesWithAllNativities()
 
-      insertExternalDatasetImport(
-          type = ExternalDatasetType.GRIIS,
-          lastPublicationDate = LocalDate.of(2026, 1, 2),
+      store.resetNativities(speciesId)
+
+      assertTableEquals(
+          ProjectSpeciesRecord(
+              organizationId = organizationId,
+              projectId = projectId,
+              speciesId = speciesId,
+          )
       )
-      insertGriisResource(countryCode = "KE")
-      insertGriisTaxon(scientificName = "Scientific name", isInvasive = true)
-
-      insertProject()
-
-      store.recalculateNativity(organizationId, speciesId)
-
-      assertTableEmpty(PROJECT_SPECIES)
     }
 
     @Test
@@ -768,21 +779,7 @@ internal class ProjectSpeciesStoreTest : DatabaseTest(), RunsAsDatabaseUser {
       deleteOrganizationUser()
       insertOrganizationUser(role = Role.Contributor)
 
-      assertThrows<AccessDeniedException> {
-        store.recalculateNativity(organizationId, speciesId)
-      }
-    }
-
-    private fun setOrganizationLocation() {
-      insertBotanicalCountry()
-
-      dslContext
-          .fetchSingle(ORGANIZATIONS, ORGANIZATIONS.ID.eq(organizationId))
-          .apply {
-            botanicalCountryCode = inserted.botanicalCountryCode
-            countryCode = "KE"
-          }
-          .update()
+      assertThrows<AccessDeniedException> { store.resetNativities(speciesId) }
     }
   }
 
@@ -815,5 +812,36 @@ internal class ProjectSpeciesStoreTest : DatabaseTest(), RunsAsDatabaseUser {
         store.removeProjects(mapOf(speciesId to setOf(projectId)))
       }
     }
+  }
+
+  /** Inserts a project species row that has accepted, overridden, and pending nativities. */
+  private fun insertProjectSpeciesWithAllNativities() {
+    insertProjectSpecies(
+        calculatedNativity = SpeciesNativity.Invasive,
+        overriddenNativityId = SpeciesNativity.Introduced,
+        pendingNativity = SpeciesNativity.Native,
+        projectId = projectId,
+        speciesId = speciesId,
+    )
+  }
+
+  /** Publishes a GRIIS listing of a species as invasive in Kenya. */
+  private fun insertGriisInvasiveListing(scientificName: String = "Scientific name") {
+    insertExternalDatasetImport(type = ExternalDatasetType.GRIIS, lastPublicationDate = griisDate)
+    insertGriisResource(countryCode = "KE")
+    insertGriisTaxon(scientificName = scientificName, isInvasive = true)
+  }
+
+  /** Gives the organization a location so its species' nativities can be calculated. */
+  private fun setOrganizationLocation() {
+    insertBotanicalCountry()
+
+    dslContext
+        .fetchSingle(ORGANIZATIONS, ORGANIZATIONS.ID.eq(organizationId))
+        .apply {
+          botanicalCountryCode = inserted.botanicalCountryCode
+          countryCode = "KE"
+        }
+        .update()
   }
 }


### PR DESCRIPTION
We need users to be able to cancel a species check without updating any
nativity values. Add the concept of a "pending" nativity which is the
latest calculated value. Pending nativities will be copied to calculated
nativities by an API request, and will be exposed via an API request,
both to be added in a later change.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>