### PR TITLE
SW-8694 Include pending nativities in species API

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/species/api/SpeciesController.kt
+++ b/src/main/kotlin/com/terraformation/backend/species/api/SpeciesController.kt
@@ -263,6 +263,14 @@ data class SpeciesProjectElement(
     val calculatedNativitySource: SpeciesDataSourcePayload?,
     val overriddenJustification: String?,
     val overriddenNativity: SpeciesNativity?,
+    @Schema(
+        description =
+            "Latest calculated nativity value for the species, if different from " +
+                "calculatedNativity. This nativity is considered 'pending' until it is accepted " +
+                "by the user."
+    )
+    val pendingNativity: SpeciesNativity?,
+    val pendingNativitySource: SpeciesDataSourcePayload?,
     val projectId: ProjectId?,
 ) {
   constructor(
@@ -272,6 +280,18 @@ data class SpeciesProjectElement(
       calculatedNativitySource = model.calculatedNativitySource?.toPayload(),
       overriddenJustification = model.overriddenJustification,
       overriddenNativity = model.overriddenNativity,
+      pendingNativity =
+          if (model.calculatedNativity != model.pendingNativity) {
+            model.pendingNativity
+          } else {
+            null
+          },
+      pendingNativitySource =
+          if (model.calculatedNativity != model.pendingNativity) {
+            model.pendingNativitySource?.toPayload()
+          } else {
+            null
+          },
       projectId = model.projectId,
   )
 }

--- a/src/main/kotlin/com/terraformation/backend/species/db/SpeciesStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/species/db/SpeciesStore.kt
@@ -75,6 +75,9 @@ class SpeciesStore(
                         CALCULATED_NATIVITY_ID,
                         OVERRIDDEN_JUSTIFICATION,
                         OVERRIDDEN_NATIVITY_ID,
+                        PENDING_NATIVITY_DATASET_DATE,
+                        PENDING_NATIVITY_DATASET_TYPE_ID,
+                        PENDING_NATIVITY_ID,
                         PROJECT_ID,
                     )
                     .from(PROJECT_SPECIES)

--- a/src/main/kotlin/com/terraformation/backend/species/model/SpeciesModel.kt
+++ b/src/main/kotlin/com/terraformation/backend/species/model/SpeciesModel.kt
@@ -23,6 +23,8 @@ data class ExistingSpeciesProjectModel(
     val calculatedNativitySource: SpeciesDataSourceModel? = null,
     val overriddenJustification: String? = null,
     val overriddenNativity: SpeciesNativity? = null,
+    val pendingNativity: SpeciesNativity? = null,
+    val pendingNativitySource: SpeciesDataSourceModel? = null,
     val projectId: ProjectId? = null,
 ) {
   companion object {
@@ -37,6 +39,12 @@ data class ExistingSpeciesProjectModel(
                   ),
               overriddenJustification = record[OVERRIDDEN_JUSTIFICATION],
               overriddenNativity = record[OVERRIDDEN_NATIVITY_ID],
+              pendingNativity = record[PENDING_NATIVITY_ID],
+              pendingNativitySource =
+                  SpeciesDataSourceModel.of(
+                      record[PENDING_NATIVITY_DATASET_DATE],
+                      record[PENDING_NATIVITY_DATASET_TYPE_ID],
+                  ),
               projectId = record[PROJECT_ID],
           )
         }

--- a/src/test/kotlin/com/terraformation/backend/species/db/SpeciesStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/species/db/SpeciesStoreTest.kt
@@ -521,6 +521,9 @@ internal class SpeciesStoreTest : DatabaseTest(), RunsAsUser {
           calculatedNativityDatasetDate = LocalDate.of(2026, 1, 1),
           calculatedNativityDatasetType = ExternalDatasetType.GBIF,
           overriddenNativityId = SpeciesNativity.Native,
+          pendingNativity = SpeciesNativity.Invasive,
+          pendingNativityDatasetDate = LocalDate.of(2026, 5, 5),
+          pendingNativityDatasetType = ExternalDatasetType.GRIIS,
           speciesId = speciesId,
       )
 
@@ -543,6 +546,12 @@ internal class SpeciesStoreTest : DatabaseTest(), RunsAsUser {
                               ),
                           overriddenJustification = "Justification",
                           overriddenNativity = SpeciesNativity.Native,
+                          pendingNativity = SpeciesNativity.Invasive,
+                          pendingNativitySource =
+                              SpeciesDataSourceModel(
+                                  LocalDate.of(2026, 5, 5),
+                                  ExternalDatasetType.GRIIS,
+                              ),
                           projectId = projectId,
                       )
                   ),


### PR DESCRIPTION
To allow the web app to show nativity changes in the species check UI,
add the pending nativity to the per-project species information API
payload.