### PR TITLE
Fix PlantingSeasonStoreTest failures

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/plantingmanagement/db/PlantingSeasonStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/plantingmanagement/db/PlantingSeasonStore.kt
@@ -322,6 +322,7 @@ class PlantingSeasonStore(
           .select(PLANTING_SEASONS.asterisk(), targetsMultiset)
           .from(PLANTING_SEASONS)
           .where(condition)
+          .orderBy(START_DATE, ID)
           .fetch { record ->
             ExistingPlantingSeasonModel(
                 endDate = record[END_DATE]!!,


### PR DESCRIPTION
The test was relying on planting seasons being returned in a particular
order, but the underlying database query didn't specify an order.
