### PR TITLE
SW-8718 Use cheaper completion subquery for subareas

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/db/JooqHelpers.kt
+++ b/src/main/kotlin/com/terraformation/backend/db/JooqHelpers.kt
@@ -24,3 +24,18 @@ fun Field<Geometry?>.asGeoJson(): Field<String?> =
  */
 fun Field<Geometry?>.forMultiset(): Field<Geometry?> =
     DSL.field("substring(ST_AsEWKB(?)::text, 3)", GeometryBinding.dataType, this)
+
+/**
+ * Returns a dummy multiset that evaluates to an empty list but doesn't actually query anything.
+ * This can be used when you want to conditionally include a multiset in a query, like:
+ *
+ *     val multisetField = if (shouldIncludeRealSubquery) {
+ *       DSL.multiset([real subquery goes here])
+ *     } else {
+ *       emptyMultiset()
+ *     }
+ *
+ * Then you can include `multisetField` in your select list and the resulting jOOQ query will have
+ * the same type signature whether the query has the real multiset or not.
+ */
+fun <T> emptyMultiset(): Field<List<T>> = DSL.multiset(DSL.selectOne()).convertFrom { emptyList() }

--- a/src/main/kotlin/com/terraformation/backend/tracking/db/ObservationResultsStoreV2.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/db/ObservationResultsStoreV2.kt
@@ -5,6 +5,7 @@ import com.terraformation.backend.customer.model.requirePermissions
 import com.terraformation.backend.db.asNonNullable
 import com.terraformation.backend.db.default_schema.OrganizationId
 import com.terraformation.backend.db.default_schema.tables.references.USERS
+import com.terraformation.backend.db.emptyMultiset
 import com.terraformation.backend.db.tracking.ObservationId
 import com.terraformation.backend.db.tracking.ObservationState
 import com.terraformation.backend.db.tracking.PlantingSiteId
@@ -33,6 +34,7 @@ import org.jooq.Condition
 import org.jooq.DSLContext
 import org.jooq.Field
 import org.jooq.Record
+import org.jooq.Record3
 import org.jooq.impl.DSL
 import org.locationtech.jts.geom.Polygon
 
@@ -223,6 +225,42 @@ class ObservationResultsStoreV2(private val dslContext: DSLContext) {
           depth,
       )
 
+  private data class AreaCompletionResults(
+      val anyPlotsCompleted: Boolean,
+      val areaCompletedTime: Instant?,
+  ) {
+    companion object {
+      fun of(record: Record3<Boolean?, Boolean?, Instant?>): AreaCompletionResults {
+        val (anyCompleted, allCompleted, maxCompletedTime) = record
+        return AreaCompletionResults(
+            anyCompleted == true,
+            if (allCompleted == true) maxCompletedTime else null,
+        )
+      }
+    }
+  }
+
+  /**
+   * Queries the completion status of a substratum in an observation. This is used when we aren't
+   * fetching plot-level results.
+   */
+  private val substratumCompletionMultiset: Field<List<AreaCompletionResults>> =
+      DSL.multiset(
+              DSL.select(
+                      DSL.boolOr(OBSERVATION_PLOTS.COMPLETED_TIME.isNotNull),
+                      DSL.boolAnd(OBSERVATION_PLOTS.COMPLETED_TIME.isNotNull),
+                      DSL.max(OBSERVATION_PLOTS.COMPLETED_TIME),
+                  )
+                  .from(OBSERVATION_PLOTS)
+                  .join(MONITORING_PLOT_HISTORIES)
+                  .on(OBSERVATION_PLOTS.MONITORING_PLOT_HISTORY_ID.eq(MONITORING_PLOT_HISTORIES.ID))
+                  .where(
+                      MONITORING_PLOT_HISTORIES.SUBSTRATUM_HISTORY_ID.eq(SUBSTRATUM_HISTORIES.ID)
+                  )
+                  .and(OBSERVATION_PLOTS.OBSERVATION_ID.eq(OBSERVATIONS.ID))
+          )
+          .convertFrom { result -> result.map { AreaCompletionResults.of(it) } }
+
   /**
    * Substratum results. Plant density, plant density std dev, survival rate, and survival rate std
    * dev are read from [OBSERVATION_SUBSTRATUM_RESULTS].
@@ -230,8 +268,19 @@ class ObservationResultsStoreV2(private val dslContext: DSLContext) {
   private fun substrataMultiset(
       depth: ObservationResultsDepth
   ): Field<List<ObservationSubstratumResultsModel>> {
-    val plotsField = substratumMonitoringPlotsMultiset(depth)
+    val plotsField =
+        when (depth) {
+          ObservationResultsDepth.Plot,
+          ObservationResultsDepth.Plant -> substratumMonitoringPlotsMultiset(depth)
+          else -> emptyMultiset()
+        }
     val substratumSpeciesMultisetField = substratumSpeciesMultiset()
+    val substratumCompletionMultisetField =
+        when (depth) {
+          ObservationResultsDepth.Plot,
+          ObservationResultsDepth.Plant -> emptyMultiset()
+          else -> substratumCompletionMultiset
+        }
     return DSL.multiset(
             DSL.select(
                     SUBSTRATUM_HISTORIES.AREA_HA,
@@ -239,6 +288,7 @@ class ObservationResultsStoreV2(private val dslContext: DSLContext) {
                     SUBSTRATUM_HISTORIES.NAME,
                     SUBSTRATA.PLANTING_COMPLETED_TIME,
                     plotsField,
+                    substratumCompletionMultisetField,
                     substratumSpeciesMultisetField,
                     SUBSTRATUM_HISTORIES.stratumHistories.plantingSiteHistories.plantingSites
                         .SURVIVAL_RATE_INCLUDES_TEMP_PLOTS,
@@ -278,6 +328,7 @@ class ObservationResultsStoreV2(private val dslContext: DSLContext) {
         .convertFrom { results ->
           results.map { record: Record ->
             val monitoringPlots = record[plotsField]
+            val completionResults = record[substratumCompletionMultisetField]?.firstOrNull()
 
             val areaHa = record[SUBSTRATUM_HISTORIES.AREA_HA]!!
             val survivalRateIncludesTempPlots =
@@ -286,7 +337,9 @@ class ObservationResultsStoreV2(private val dslContext: DSLContext) {
                         .SURVIVAL_RATE_INCLUDES_TEMP_PLOTS
                         .asNonNullable()]
 
-            val anyCompleted = monitoringPlots.any { it.completedTime != null }
+            val anyCompleted =
+                completionResults?.let { it.anyPlotsCompleted }
+                    ?: monitoringPlots.any { it.completedTime != null }
             val species =
                 if (anyCompleted) {
                   record[substratumSpeciesMultisetField]
@@ -302,14 +355,13 @@ class ObservationResultsStoreV2(private val dslContext: DSLContext) {
                           (it.totalLive + it.totalExisting) > 0
                     }
 
-            val isCompleted =
-                monitoringPlots.isNotEmpty() && monitoringPlots.all { it.completedTime != null }
             val completedTime =
-                if (isCompleted) {
-                  monitoringPlots.maxOf { it.completedTime!! }
-                } else {
-                  null
-                }
+                completionResults?.areaCompletedTime
+                    ?: if (monitoringPlots.all { it.completedTime != null }) {
+                      monitoringPlots.maxOfOrNull { it.completedTime!! }
+                    } else {
+                      null
+                    }
 
             val survivalRate = record[OBSERVATION_SUBSTRATUM_RESULTS.SURVIVAL_RATE]
             val survivalRateStdDev = record[OBSERVATION_SUBSTRATUM_RESULTS.SURVIVAL_RATE_STD_DEV]
@@ -325,6 +377,7 @@ class ObservationResultsStoreV2(private val dslContext: DSLContext) {
                 }
 
             ObservationSubstratumResultsModel(
+                anyPlotsCompleted = anyCompleted,
                 areaHa = areaHa,
                 completedTime = completedTime,
                 estimatedPlants = estimatedPlants,
@@ -346,14 +399,49 @@ class ObservationResultsStoreV2(private val dslContext: DSLContext) {
   }
 
   /**
+   * Queries the completion status of a stratum in an observation. This is used when we aren't
+   * fetching plot-level results.
+   */
+  private val stratumCompletionMultiset: Field<List<AreaCompletionResults>> =
+      DSL.multiset(
+              DSL.select(
+                      DSL.boolOr(OBSERVATION_PLOTS.COMPLETED_TIME.isNotNull),
+                      DSL.boolAnd(OBSERVATION_PLOTS.COMPLETED_TIME.isNotNull),
+                      DSL.max(OBSERVATION_PLOTS.COMPLETED_TIME),
+                  )
+                  .from(OBSERVATION_PLOTS)
+                  .join(MONITORING_PLOT_HISTORIES)
+                  .on(OBSERVATION_PLOTS.MONITORING_PLOT_HISTORY_ID.eq(MONITORING_PLOT_HISTORIES.ID))
+                  .join(SUBSTRATUM_HISTORIES)
+                  .on(MONITORING_PLOT_HISTORIES.SUBSTRATUM_HISTORY_ID.eq(SUBSTRATUM_HISTORIES.ID))
+                  .where(SUBSTRATUM_HISTORIES.STRATUM_HISTORY_ID.eq(STRATUM_HISTORIES.ID))
+                  .and(OBSERVATION_PLOTS.OBSERVATION_ID.eq(OBSERVATIONS.ID))
+          )
+          .convertFrom { result -> result.map { AreaCompletionResults.of(it) } }
+
+  /**
    * Stratum results. Plant density, plant density std dev, survival rate, and survival rate std dev
    * are read from [OBSERVATION_STRATUM_RESULTS].
    */
   private fun stratumMultiset(
       depth: ObservationResultsDepth
   ): Field<List<ObservationStratumResultsModel>> {
-    val substrataField = substrataMultiset(depth)
+    val substrataField =
+        when (depth) {
+          ObservationResultsDepth.Plot,
+          ObservationResultsDepth.Plant,
+          ObservationResultsDepth.Substratum -> substrataMultiset(depth)
+          else -> emptyMultiset()
+        }
+
     val stratumSpeciesMultisetField = stratumSpeciesMultiset()
+    val stratumCompletionMultisetField =
+        when (depth) {
+          ObservationResultsDepth.Plot,
+          ObservationResultsDepth.Plant,
+          ObservationResultsDepth.Substratum -> emptyMultiset()
+          else -> stratumCompletionMultiset
+        }
 
     return DSL.multiset(
             DSL.select(
@@ -361,6 +449,7 @@ class ObservationResultsStoreV2(private val dslContext: DSLContext) {
                     STRATUM_HISTORIES.STRATUM_ID,
                     STRATUM_HISTORIES.NAME,
                     substrataField,
+                    stratumCompletionMultisetField,
                     stratumSpeciesMultisetField,
                     stratumPlantingCompletedField,
                     STRATUM_HISTORIES.plantingSiteHistories.plantingSites
@@ -411,9 +500,9 @@ class ObservationResultsStoreV2(private val dslContext: DSLContext) {
           results.map { record: Record ->
             val areaHa = record[STRATUM_HISTORIES.AREA_HA]!!
             val substrata = record[substrataField]
-            val anyCompleted = substrata.any { substratum ->
-              substratum.monitoringPlots.any { it.completedTime != null }
-            }
+            val completionResults = record[stratumCompletionMultisetField]?.firstOrNull()
+            val anyCompleted =
+                completionResults?.anyPlotsCompleted ?: substrata.any { it.anyPlotsCompleted }
             val species =
                 if (anyCompleted) {
                   record[stratumSpeciesMultisetField]
@@ -432,19 +521,13 @@ class ObservationResultsStoreV2(private val dslContext: DSLContext) {
                   null
                 }
 
-            val isCompleted =
-                substrata.isNotEmpty() &&
-                    substrata.all { substratum ->
-                      substratum.monitoringPlots.all { it.completedTime != null }
-                    }
             val completedTime =
-                if (isCompleted) {
-                  substrata.maxOf { substratum ->
-                    substratum.monitoringPlots.maxOf { it.completedTime!! }
-                  }
-                } else {
-                  null
-                }
+                completionResults?.areaCompletedTime
+                    ?: if (substrata.all { it.completedTime != null }) {
+                      substrata.maxOfOrNull { it.completedTime!! }
+                    } else {
+                      null
+                    }
 
             val survivalRate = record[OBSERVATION_STRATUM_RESULTS.SURVIVAL_RATE]
             val survivalRateStdDev = record[OBSERVATION_STRATUM_RESULTS.SURVIVAL_RATE_STD_DEV]
@@ -461,6 +544,7 @@ class ObservationResultsStoreV2(private val dslContext: DSLContext) {
                 }
 
             ObservationStratumResultsModel(
+                anyPlotsCompleted = anyCompleted,
                 areaHa = areaHa,
                 completedTime = completedTime,
                 estimatedPlants = estimatedPlants,
@@ -491,7 +575,7 @@ class ObservationResultsStoreV2(private val dslContext: DSLContext) {
       limit: Int?,
       includeAdHoc: Boolean,
   ): List<ObservationResultsModel> {
-    val queryDepth =
+    val adHocDepth =
         if (depth == ObservationResultsDepth.Plant) {
           ObservationResultsDepth.Plant
         } else {
@@ -500,11 +584,11 @@ class ObservationResultsStoreV2(private val dslContext: DSLContext) {
 
     val adHocPlotsField: Field<List<ObservationMonitoringPlotResultsModel>> =
         if (includeAdHoc) {
-          adHocMonitoringPlotsMultiset(queryDepth)
+          adHocMonitoringPlotsMultiset(adHocDepth)
         } else {
-          DSL.multiset(DSL.selectOne()).convertFrom { emptyList() }
+          emptyMultiset()
         }
-    val strataField = stratumMultiset(queryDepth)
+    val strataField = stratumMultiset(depth)
     val plantingSiteSpeciesMultisetField = plantingSiteSpeciesMultiset()
 
     val results =
@@ -542,11 +626,7 @@ class ObservationResultsStoreV2(private val dslContext: DSLContext) {
               val areaHa = record[PLANTING_SITE_HISTORIES.AREA_HA]
 
               val strata = record[strataField]
-              val anyCompleted = strata.any { stratum ->
-                stratum.substrata.any { substratum ->
-                  substratum.monitoringPlots.any { it.completedTime != null }
-                }
-              }
+              val anyCompleted = strata.any { stratum -> stratum.anyPlotsCompleted }
               val species =
                   if (anyCompleted) {
                     record[plantingSiteSpeciesMultisetField]
@@ -580,6 +660,7 @@ class ObservationResultsStoreV2(private val dslContext: DSLContext) {
 
               ObservationResultsModel(
                   adHocPlot = record[adHocPlotsField].firstOrNull(),
+                  anyPlotsCompleted = anyCompleted,
                   areaHa = areaHa,
                   biomassDetails = record[biomassDetailsMultiset].firstOrNull(),
                   completedTime = record[OBSERVATIONS.COMPLETED_TIME],

--- a/src/main/kotlin/com/terraformation/backend/tracking/model/ObservationResultsModel.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/model/ObservationResultsModel.kt
@@ -169,6 +169,9 @@ data class ObservationMonitoringPlotResultsModel(
  * strata, planting sites).
  */
 interface BaseAggregatedMonitoringResult : BaseMonitoringResult {
+  /** True if at least one monitoring plot in the aggregated area has completed its observation. */
+  val anyPlotsCompleted: Boolean
+
   /**
    * Estimated number of plants in the region based on estimated planting density and area. Only
    * present if all observed substrata in the region have completed planting.
@@ -189,6 +192,7 @@ interface BaseAggregatedMonitoringResult : BaseMonitoringResult {
 }
 
 data class ObservationSubstratumResultsModel(
+    override val anyPlotsCompleted: Boolean,
     val areaHa: BigDecimal,
     val completedTime: Instant?,
     override val estimatedPlants: Int?,
@@ -207,6 +211,7 @@ data class ObservationSubstratumResultsModel(
 ) : BaseAggregatedMonitoringResult
 
 data class ObservationStratumResultsModel(
+    override val anyPlotsCompleted: Boolean,
     val areaHa: BigDecimal,
     val completedTime: Instant?,
     override val estimatedPlants: Int?,
@@ -231,6 +236,7 @@ data class ObservationStratumResultsModel(
 
 data class ObservationResultsModel(
     val adHocPlot: ObservationMonitoringPlotResultsModel?,
+    override val anyPlotsCompleted: Boolean,
     val areaHa: BigDecimal?,
     val biomassDetails: ExistingBiomassDetailsModel?,
     val completedTime: Instant?,

--- a/src/test/kotlin/com/terraformation/backend/db/DatabaseBackedTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/db/DatabaseBackedTest.kt
@@ -4291,7 +4291,7 @@ abstract class DatabaseBackedTest {
 
     recordedPlantsDao.insert(rowWithDefaults)
 
-    return rowWithDefaults.id!!
+    return rowWithDefaults.id!!.also { inserted.recordedPlantIds.add(it) }
   }
 
   protected fun insertReport(

--- a/src/test/kotlin/com/terraformation/backend/db/InsertedDatabaseIds.kt
+++ b/src/test/kotlin/com/terraformation/backend/db/InsertedDatabaseIds.kt
@@ -57,6 +57,7 @@ import com.terraformation.backend.db.tracking.PlantingSeasonId
 import com.terraformation.backend.db.tracking.PlantingSiteHistoryId
 import com.terraformation.backend.db.tracking.PlantingSiteId
 import com.terraformation.backend.db.tracking.PlantingSiteNotificationId
+import com.terraformation.backend.db.tracking.RecordedPlantId
 import com.terraformation.backend.db.tracking.RecordedTreeId
 import com.terraformation.backend.db.tracking.ScheduledPlantingDateId
 import com.terraformation.backend.db.tracking.StratumHistoryId
@@ -109,6 +110,7 @@ class InsertedDatabaseIds {
   val projectIds = mutableListOf<ProjectId>()
   val projectIndicatorIds = mutableListOf<ProjectIndicatorId>()
   val projectReportConfigIds = mutableListOf<ProjectReportConfigId>()
+  val recordedPlantIds = mutableListOf<RecordedPlantId>()
   val recordedTreeIds = mutableListOf<RecordedTreeId>()
   val reportIds = mutableListOf<ReportId>()
   val scheduledPlantingDateIds = mutableListOf<ScheduledPlantingDateId>()
@@ -255,6 +257,9 @@ class InsertedDatabaseIds {
 
   val projectReportConfigId
     get() = projectReportConfigIds.last()
+
+  val recordedPlantId
+    get() = recordedPlantIds.last()
 
   val recordedTreeId
     get() = recordedTreeIds.last()

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/ObservationScenarioV2Test.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/ObservationScenarioV2Test.kt
@@ -11,12 +11,10 @@ import com.terraformation.backend.db.tracking.RecordedSpeciesCertainty
 import com.terraformation.backend.db.tracking.tables.pojos.RecordedPlantsRow
 import com.terraformation.backend.mockUser
 import com.terraformation.backend.point
-import com.terraformation.backend.tracking.model.ObservationMonitoringPlotResultsModel
 import com.terraformation.backend.tracking.model.ObservationResultsDepth
 import com.terraformation.backend.tracking.model.ObservationResultsModel
-import com.terraformation.backend.tracking.model.ObservationStratumResultsModel
-import com.terraformation.backend.tracking.model.ObservationSubstratumResultsModel
 import com.terraformation.backend.tracking.model.ObservedPlotCoordinatesModel
+import com.terraformation.backend.tracking.model.RecordedPlantModel
 import com.terraformation.backend.util.toPlantsPerHectare
 import io.mockk.every
 import java.math.BigDecimal
@@ -108,6 +106,18 @@ class ObservationScenarioV2Test : ObservationScenarioTest() {
       insertObservation(completedTime = Instant.ofEpochSecond(1))
       insertObservationPlot(claimedBy = user.userId, completedBy = user.userId)
 
+      // Partially completed observation
+      insertObservation()
+      insertObservationPlot()
+      insertMonitoringPlot()
+      insertObservationPlot(claimedBy = user.userId, completedBy = user.userId)
+      insertSpecies()
+      insertObservedPlotSpeciesTotals(totalLive = 1)
+      insertObservedSubstratumSpeciesTotals(totalLive = 1)
+      insertObservedStratumSpeciesTotals(totalLive = 1)
+      insertObservedSiteSpeciesTotals(totalLive = 1)
+      insertRecordedPlant(speciesId = inserted.speciesId)
+
       val plantResults =
           resultsStoreV2.fetchByOrganizationId(
               organizationId,
@@ -129,32 +139,94 @@ class ObservationScenarioV2Test : ObservationScenarioTest() {
           resultsStoreV2.fetchByOrganizationId(organizationId, depth = ObservationResultsDepth.Site)
 
       assertEquals(
-          emptyList<com.terraformation.backend.tracking.model.RecordedPlantModel>(),
-          plantResults[0].strata[0].substrata[0].monitoringPlots[0].plants,
+          listOf(
+              RecordedPlantModel(
+                  certainty = RecordedSpeciesCertainty.Known,
+                  gpsCoordinates = point(1),
+                  id = inserted.recordedPlantId,
+                  speciesId = inserted.speciesId,
+                  speciesName = null,
+                  status = RecordedPlantStatus.Live,
+              )
+          ),
+          plantResults
+              .single { it.observationId == inserted.observationId }
+              .strata[0]
+              .substrata[0]
+              .monitoringPlots
+              .single { it.monitoringPlotId == inserted.monitoringPlotId }
+              .plants,
           "Plant depth contains plants",
       )
 
-      assertNull(
-          plotResults[0].strata[0].substrata[0].monitoringPlots[0].plants,
-          "Plot depth has plants = null",
-      )
+      val expectedPlotResults = plantResults.map { result ->
+        result.copy(
+            strata =
+                result.strata.map { stratum ->
+                  stratum.copy(
+                      substrata =
+                          stratum.substrata.map { substratum ->
+                            substratum.copy(
+                                monitoringPlots =
+                                    substratum.monitoringPlots.map { plot ->
+                                      plot.copy(plants = null)
+                                    }
+                            )
+                          }
+                  )
+                }
+        )
+      }
 
       assertEquals(
-          emptyList<ObservationMonitoringPlotResultsModel>(),
-          substratumResults[0].strata[0].substrata[0].monitoringPlots,
-          "Substratum depth contains empty list of monitoring plots",
+          expectedPlotResults,
+          plotResults,
+          "Plot-level results should have nulled-out plot-level plants list",
       )
 
-      assertEquals(
-          emptyList<ObservationSubstratumResultsModel>(),
-          stratumResults[0].strata[0].substrata,
-          "Stratum depth contains empty list of substrata",
-      )
+      val expectedSubstratumResults = expectedPlotResults.map { result ->
+        result.copy(
+            strata =
+                result.strata.map { stratum ->
+                  stratum.copy(
+                      substrata =
+                          stratum.substrata.map { substratum ->
+                            substratum.copy(monitoringPlots = emptyList())
+                          }
+                  )
+                }
+        )
+      }
 
       assertEquals(
-          emptyList<ObservationStratumResultsModel>(),
-          siteResults[0].strata,
-          "Site depth contains empty list of strata",
+          expectedSubstratumResults,
+          substratumResults,
+          "Substratum-level results should have empty plot lists",
+      )
+
+      val expectedStratumResults = expectedSubstratumResults.map { result ->
+        result.copy(
+            strata =
+                result.strata.map { stratum ->
+                  stratum.copy(substrata = emptyList())
+                }
+        )
+      }
+
+      assertEquals(
+          expectedStratumResults,
+          stratumResults,
+          "Stratum-level results should have empty substratum lists",
+      )
+
+      val expectedSiteResults = expectedStratumResults.map { result ->
+        result.copy(strata = emptyList())
+      }
+
+      assertEquals(
+          expectedSiteResults,
+          siteResults,
+          "Site-level results should have empty stratum lists",
       )
     }
 


### PR DESCRIPTION
If the user requests site-, stratum-, or substratum-level results,
we previously still pulled the plot-level data from the database
because it was needed in order to tell whether or not the plots
in the larger area had completed their observations.

Replace the plot-level query with a much more streamlined check
for plot completion in cases where the client doesn't request
plot-level results.
