### PR TITLE
Don't rely on smart cast of Google email

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/file/RemoteGoogleDriveWriter.kt
+++ b/src/main/kotlin/com/terraformation/backend/file/RemoteGoogleDriveWriter.kt
@@ -60,11 +60,8 @@ class RemoteGoogleDriveWriter(
     // access. Documentation:
     // https://developers.google.com/identity/protocols/oauth2/service-account#delegatingauthority
     val credentials =
-        if (config.report.googleEmail != null) {
-          serviceAccountCredentials.createDelegated(config.report.googleEmail)
-        } else {
-          serviceAccountCredentials
-        }
+        config.report.googleEmail?.let { serviceAccountCredentials.createDelegated(it) }
+            ?: serviceAccountCredentials
 
     Drive.Builder(
             NetHttpTransport(),


### PR DESCRIPTION
The latest version of the Google OAuth library adds a non-nullable
constraint to the parameter of `GoogleCredentials.createDelegated`
which breaks our code because it's passing a value from an open
getter function which the compiler can't guarantee is non-null.
Use `?.let` instead.
