### PR TITLE
Remove unnecessary Python types dependency

### DIFF
--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -1,6 +1,5 @@
 pyjwt==2.13.0
 requests==2.34.2
-types-requests==2.33.0.20260518
 
 # Not needed at runtime, but needed for dev/CI
 black==26.5.1


### PR DESCRIPTION
The requests package started including type annotations in version
2.34.0, so the old types-requests package is no longer necessary.
