### PR TITLE
SW-5189 Update DB schema to allow cross-site reassignments

### DIFF
--- a/jooq/src/main/kotlin/com/terraformation/backend/jooq/Config.kt
+++ b/jooq/src/main/kotlin/com/terraformation/backend/jooq/Config.kt
@@ -564,7 +564,14 @@ val ID_WRAPPERS =
                     "BiomassSpeciesId",
                     listOf("observation_biomass_species\\.id", ".*\\.biomass_species_id"),
                 ),
-                IdWrapper("DeliveryId", listOf("deliveries\\.id", ".*\\.delivery_id")),
+                IdWrapper(
+                    "DeliveryId",
+                    listOf(
+                        "deliveries\\.id",
+                        ".*\\.delivery_id",
+                        ".*\\.reassigned_from_delivery_id",
+                    ),
+                ),
                 IdWrapper("DraftPlantingSiteId", listOf("draft_planting_sites\\.id")),
                 IdWrapper(
                     "MonitoringPlotHistoryId",

--- a/src/main/kotlin/com/terraformation/backend/search/table/NurseryWithdrawalsTable.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/table/NurseryWithdrawalsTable.kt
@@ -32,7 +32,7 @@ class NurseryWithdrawalsTable(private val tables: SearchTables) : SearchTable() 
           ),
           deliveries.asSingleValueSublist(
               "delivery",
-              WITHDRAWAL_SUMMARIES.ID.eq(DELIVERIES.WITHDRAWAL_ID),
+              WITHDRAWAL_SUMMARIES.DELIVERY_ID.eq(DELIVERIES.ID),
               isRequired = false,
           ),
           facilities.asSingleValueSublist(

--- a/src/main/resources/db/migration/2026/07/V20260730.1013__CrossSiteReassignments.sql
+++ b/src/main/resources/db/migration/2026/07/V20260730.1013__CrossSiteReassignments.sql
@@ -1,0 +1,109 @@
+-- Allow a withdrawal to have deliveries at more than one planting site so that plants can be
+-- reassigned to other planting sites.
+
+ALTER TABLE tracking.deliveries
+    DROP CONSTRAINT deliveries_withdrawal_id_key;
+
+ALTER TABLE tracking.deliveries
+    ADD COLUMN reassigned_from_delivery_id BIGINT
+        REFERENCES tracking.deliveries ON DELETE SET NULL DEFERRABLE,
+    ADD CONSTRAINT deliveries_withdrawal_id_planting_site_id_key
+        UNIQUE (withdrawal_id, planting_site_id);
+
+CREATE INDEX ON tracking.deliveries (reassigned_from_delivery_id);
+
+-- Previous version was in V497. A withdrawal can now have more than one delivery, so the view
+-- selects the lowest-numbered one. Reassignment substratum names and destination site names
+-- are gathered across all of the withdrawal's deliveries.
+CREATE OR REPLACE VIEW nursery.withdrawal_summaries AS
+SELECT withdrawals.id,
+       withdrawals.facility_id,
+       withdrawals.purpose_id,
+       withdrawals.withdrawn_date,
+       withdrawals.created_by,
+       withdrawals.created_time,
+       withdrawals.modified_by,
+       withdrawals.modified_time,
+       withdrawals.destination_facility_id,
+       withdrawals.notes,
+       withdrawals.undoes_withdrawal_id,
+       undoes_withdrawals.withdrawn_date AS undoes_withdrawal_date,
+       undone_by_withdrawals.id AS undone_by_withdrawal_id,
+       undone_by_withdrawals.withdrawn_date AS undone_by_withdrawal_date,
+       facilities.organization_id,
+       deliveries.id AS delivery_id,
+       totals.total_withdrawn,
+       COALESCE(dest_nurseries.name, dest_sites.name) AS destination_name,
+       COALESCE(reassignment_substrata.stratum_names,
+                delivery_substrata.stratum_names) AS stratum_names,
+       COALESCE(reassignment_substrata.substratum_names,
+                delivery_substrata.substratum_names) AS substratum_names,
+       COALESCE(reassignment_substrata.substratum_full_names,
+                delivery_substrata.substratum_full_names) AS substratum_full_names,
+       (EXISTS (SELECT 1
+                FROM tracking.plantings p
+                WHERE p.delivery_id = deliveries.id
+                  AND p.planting_type_id = 2)) AS has_reassignments,
+       withdrawals.planting_season_id,
+       withdrawals.scheduled_planting_date_request_id
+FROM nursery.withdrawals withdrawals
+         JOIN facilities ON withdrawals.facility_id = facilities.id
+         LEFT JOIN LATERAL ( SELECT d.id
+                             FROM tracking.deliveries d
+                             WHERE d.withdrawal_id = withdrawals.id
+                               AND withdrawals.purpose_id = 3
+                             ORDER BY d.id
+                             LIMIT 1) deliveries ON true
+         LEFT JOIN nursery.withdrawals AS undone_by_withdrawals
+                   ON withdrawals.id = undone_by_withdrawals.undoes_withdrawal_id
+         LEFT JOIN nursery.withdrawals AS undoes_withdrawals
+                   ON withdrawals.undoes_withdrawal_id = undoes_withdrawals.id
+         LEFT JOIN LATERAL ( SELECT COALESCE(sum(bw.germinating_quantity_withdrawn +
+                                                 bw.hardening_off_quantity_withdrawn +
+                                                 bw.active_growth_quantity_withdrawn +
+                                                 bw.ready_quantity_withdrawn),
+                                             0::bigint) AS total_withdrawn
+                             FROM nursery.batch_withdrawals bw
+                             WHERE withdrawals.id = bw.withdrawal_id) totals ON true
+         LEFT JOIN LATERAL ( SELECT string_agg(DISTINCT ss.full_name, ', '::text
+                                               ORDER BY ss.full_name) AS substratum_full_names,
+                                    string_agg(DISTINCT ss.name, ', '::text
+                                               ORDER BY ss.name) AS substratum_names,
+                                    string_agg(DISTINCT s.name, ', '::text
+                                               ORDER BY s.name) AS stratum_names
+                             FROM tracking.substrata ss
+                                      JOIN tracking.plantings pl ON ss.id = pl.substratum_id
+                                      JOIN tracking.strata s ON s.id = ss.stratum_id
+                             WHERE pl.planting_type_id = 1
+                               AND pl.delivery_id = deliveries.id) delivery_substrata ON true
+         LEFT JOIN LATERAL ( SELECT ((delivery_substrata.substratum_full_names || ' ('::text) ||
+                                     string_agg(ss.full_name, ', '::text ORDER BY ss.full_name)) ||
+                                    ')'::text AS substratum_full_names,
+                                    ((delivery_substrata.substratum_names || ' ('::text) ||
+                                     string_agg(ss.name, ', '::text ORDER BY ss.name)) ||
+                                    ')'::text AS substratum_names,
+                                    CASE
+                                        WHEN string_agg(DISTINCT s.name, ', '::text ORDER BY s.name) IS NOT DISTINCT FROM
+                                            delivery_substrata.stratum_names
+                                            THEN delivery_substrata.stratum_names
+                                        ELSE ((delivery_substrata.stratum_names || ' ('::text) ||
+                                              string_agg(DISTINCT s.name, ', '::text ORDER BY s.name)) ||
+                                             ')'::text
+                                        END   AS stratum_names
+                             FROM tracking.substrata ss
+                                      JOIN tracking.plantings pl ON ss.id = pl.substratum_id
+                                      JOIN tracking.strata s ON s.id = ss.stratum_id
+                                      JOIN tracking.deliveries d ON d.id = pl.delivery_id
+                             WHERE pl.planting_type_id = 3
+                               AND d.withdrawal_id = withdrawals.id
+                               AND withdrawals.purpose_id = 3) reassignment_substrata ON true
+         LEFT JOIN LATERAL ( SELECT f.name
+                             FROM facilities f
+                             WHERE f.id = withdrawals.destination_facility_id
+                               AND withdrawals.purpose_id = 1) dest_nurseries ON true
+         LEFT JOIN LATERAL ( SELECT string_agg(DISTINCT ps.name, ', '::text
+                                               ORDER BY ps.name) AS name
+                             FROM tracking.planting_sites ps
+                                      JOIN tracking.deliveries d ON ps.id = d.planting_site_id
+                             WHERE d.withdrawal_id = withdrawals.id
+                               AND withdrawals.purpose_id = 3) dest_sites ON true;

--- a/src/main/resources/db/migration/R__Comments.sql
+++ b/src/main/resources/db/migration/R__Comments.sql
@@ -446,6 +446,7 @@ COMMENT ON COLUMN tracking.deliveries.modified_by IS 'Which user most recently m
 COMMENT ON COLUMN tracking.deliveries.modified_time IS 'When the delivery was most recently modified.';
 COMMENT ON COLUMN tracking.deliveries.planting_site_id IS 'Which planting site received the delivery.';
 COMMENT ON COLUMN tracking.deliveries.reassigned_by IS 'Which user recorded the reassignment of plants in this delivery. Null if this delivery has no reassignment.';
+COMMENT ON COLUMN tracking.deliveries.reassigned_from_delivery_id IS 'If this delivery was created by reassigning plants from a delivery at another planting site, the ID of that delivery.';
 COMMENT ON COLUMN tracking.deliveries.reassigned_time IS 'When the reassignment was recorded. Null if this delivery has no reassignment.';
 COMMENT ON COLUMN tracking.deliveries.withdrawal_id IS 'Which nursery withdrawal the plants came from.';
 

--- a/src/test/kotlin/com/terraformation/backend/db/DatabaseBackedTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/db/DatabaseBackedTest.kt
@@ -3199,6 +3199,7 @@ abstract class DatabaseBackedTest {
       modifiedBy: UserId = row.modifiedBy ?: createdBy,
       modifiedTime: Instant = row.modifiedTime ?: createdTime,
       plantingSiteId: PlantingSiteId = row.plantingSiteId ?: inserted.plantingSiteId,
+      reassignedFromDeliveryId: DeliveryId? = row.reassignedFromDeliveryId,
       withdrawalId: WithdrawalId = row.withdrawalId ?: inserted.withdrawalId,
   ): DeliveryId {
     val rowWithDetails =
@@ -3208,6 +3209,7 @@ abstract class DatabaseBackedTest {
             modifiedBy = modifiedBy,
             modifiedTime = modifiedTime,
             plantingSiteId = plantingSiteId,
+            reassignedFromDeliveryId = reassignedFromDeliveryId,
             withdrawalId = withdrawalId,
         )
 

--- a/src/test/kotlin/com/terraformation/backend/nursery/NurserySearchTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/nursery/NurserySearchTest.kt
@@ -15,6 +15,7 @@ import com.terraformation.backend.db.nursery.WithdrawalId
 import com.terraformation.backend.db.nursery.WithdrawalPurpose
 import com.terraformation.backend.db.nursery.tables.pojos.BatchesRow
 import com.terraformation.backend.db.tracking.PlantingType
+import com.terraformation.backend.db.tracking.tables.pojos.DeliveriesRow
 import com.terraformation.backend.mockUser
 import com.terraformation.backend.point
 import com.terraformation.backend.search.AndNode
@@ -972,6 +973,39 @@ internal class NurserySearchTest : DatabaseTest(), RunsAsUser {
                   ),
               )
           )
+
+      val actual = searchService.search(prefix, fields, mapOf(prefix to NoConditionNode()), orderBy)
+
+      assertJsonEquals(expected, actual)
+    }
+
+    @Test
+    fun `withdrawal delivery resolves the original delivery when a withdrawal spans two sites`() {
+      insertBatch()
+      val withdrawalId =
+          insertNurseryWithdrawal(
+              facilityId = facilityId,
+              purpose = WithdrawalPurpose.OutPlant,
+              withdrawnDate = LocalDate.of(2024, 1, 15),
+          )
+      insertBatchWithdrawal(readyQuantityWithdrawn = 1)
+
+      val originPlantingSiteId = insertPlantingSite()
+      val deliveryId =
+          insertDelivery(plantingSiteId = originPlantingSiteId, withdrawalId = withdrawalId)
+      val otherPlantingSiteId = insertPlantingSite()
+      insertDelivery(
+          row = DeliveriesRow(reassignedFromDeliveryId = deliveryId),
+          plantingSiteId = otherPlantingSiteId,
+          withdrawalId = withdrawalId,
+      )
+
+      val prefix = SearchFieldPrefix(searchTables.nurseryWithdrawals)
+      val fields = listOf("id", "delivery_id").map { prefix.resolve(it) }
+      val orderBy = listOf(SearchSortField(prefix.resolve("id")))
+
+      val expected =
+          SearchResults(listOf(mapOf("id" to "$withdrawalId", "delivery_id" to "$deliveryId")))
 
       val actual = searchService.search(prefix, fields, mapOf(prefix to NoConditionNode()), orderBy)
 


### PR DESCRIPTION
We're going to allow reassigning delivered plants across planting sites,
rather than just across substrata at a single planting site. Since
reassignments are children of deliveries, and each delivery is
associated with a single planting site, we'll need to allow for multiple
deliveries on a single withdrawal.

Change the database constraints to remove the "one delivery per
withdrawal" rule, and update the withdrawal summaries view to account
for the fact that a withdrawal can have more than one delivery.

Add a "reassigned from delivery ID" column to the deliveries table to
represent the link between additional reassignment deliveries and the
original deliveries they come from.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
