### PR TITLE
SW-5189 Return original delivery IDs for reassignments

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/search/table/DeliveriesTable.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/table/DeliveriesTable.kt
@@ -36,6 +36,9 @@ class DeliveriesTable(private val tables: SearchTables) : SearchTable() {
     listOf(
         timestampField("createdTime", DELIVERIES.CREATED_TIME),
         idWrapperField("id", DELIVERIES.ID) { DeliveryId(it) },
+        idWrapperField("reassignedFromDeliveryId", DELIVERIES.REASSIGNED_FROM_DELIVERY_ID) {
+          DeliveryId(it)
+        },
         timestampField("reassignedTime", DELIVERIES.REASSIGNED_TIME),
     )
   }

--- a/src/main/kotlin/com/terraformation/backend/tracking/api/DeliveriesController.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/api/DeliveriesController.kt
@@ -87,6 +87,12 @@ data class DeliveryPayload(
     val id: DeliveryId,
     val plantings: List<PlantingPayload>,
     val plantingSiteId: PlantingSiteId,
+    @Schema(
+        description =
+            "IDs of deliveries created by reassigning plants from this delivery to substrata at " +
+                "other planting sites. Empty if this delivery has no cross-site reassignments."
+    )
+    val reassignmentDeliveryIds: List<DeliveryId>,
     val withdrawalId: WithdrawalId,
 ) {
   constructor(
@@ -95,6 +101,7 @@ data class DeliveryPayload(
       id = model.id,
       plantings = model.plantings.map { PlantingPayload(it) },
       plantingSiteId = model.plantingSiteId,
+      reassignmentDeliveryIds = model.reassignmentDeliveryIds,
       withdrawalId = model.withdrawalId,
   )
 }

--- a/src/main/kotlin/com/terraformation/backend/tracking/db/DeliveryStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/db/DeliveryStore.kt
@@ -54,24 +54,37 @@ class DeliveryStore(
           )
           .convertFrom { result -> result.map { PlantingModel(it) } }
 
+  private val reassignmentDeliveries = DELIVERIES.`as`("reassignment_deliveries")
+
+  private val reassignmentDeliveryIdsMultiset =
+      DSL.multiset(
+              DSL.select(reassignmentDeliveries.ID)
+                  .from(reassignmentDeliveries)
+                  .where(reassignmentDeliveries.REASSIGNED_FROM_DELIVERY_ID.eq(DELIVERIES.ID))
+                  .orderBy(reassignmentDeliveries.ID)
+          )
+          .convertFrom { result -> result.map { it[reassignmentDeliveries.ID]!! } }
+
   fun fetchOneById(deliveryId: DeliveryId): DeliveryModel {
     requirePermissions { readDelivery(deliveryId) }
 
     return dslContext
-        .select(DELIVERIES.asterisk(), plantingsMultiset)
+        .select(DELIVERIES.asterisk(), plantingsMultiset, reassignmentDeliveryIdsMultiset)
         .from(DELIVERIES)
         .where(DELIVERIES.ID.eq(deliveryId))
-        .fetchOne { DeliveryModel(it, plantingsMultiset) }
+        .fetchOne { DeliveryModel(it, plantingsMultiset, reassignmentDeliveryIdsMultiset) }
         ?: throw DeliveryNotFoundException(deliveryId)
   }
 
   fun fetchOneByWithdrawalId(withdrawalId: WithdrawalId): DeliveryModel? {
     val model =
         dslContext
-            .select(DELIVERIES.asterisk(), plantingsMultiset)
+            .select(DELIVERIES.asterisk(), plantingsMultiset, reassignmentDeliveryIdsMultiset)
             .from(DELIVERIES)
             .where(DELIVERIES.WITHDRAWAL_ID.eq(withdrawalId))
-            .fetchOne { DeliveryModel(it, plantingsMultiset) }
+            .orderBy(DELIVERIES.ID)
+            .limit(1)
+            .fetchOne { DeliveryModel(it, plantingsMultiset, reassignmentDeliveryIdsMultiset) }
 
     return if (model?.id != null && currentUser().canReadDelivery(model.id)) model else null
   }

--- a/src/main/kotlin/com/terraformation/backend/tracking/model/DeliveryModel.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/model/DeliveryModel.kt
@@ -13,16 +13,19 @@ data class DeliveryModel(
     val id: DeliveryId,
     val plantings: List<PlantingModel>,
     val plantingSiteId: PlantingSiteId,
+    val reassignmentDeliveryIds: List<DeliveryId> = emptyList(),
     val withdrawalId: WithdrawalId,
 ) {
   constructor(
       record: Record,
       plantingsMultisetField: Field<List<PlantingModel>>,
+      reassignmentDeliveryIdsMultisetField: Field<List<DeliveryId>>,
   ) : this(
       record[DELIVERIES.CREATED_TIME]!!,
       record[DELIVERIES.ID]!!,
       record[plantingsMultisetField],
       record[DELIVERIES.PLANTING_SITE_ID]!!,
+      record[reassignmentDeliveryIdsMultisetField],
       record[DELIVERIES.WITHDRAWAL_ID]!!,
   )
 }

--- a/src/main/resources/i18n/Messages_en.properties
+++ b/src/main/resources/i18n/Messages_en.properties
@@ -797,6 +797,7 @@ search.deliverables.sensitive=Deliverable is sensitive
 search.deliverables.type=Deliverable type
 search.deliveries.createdTime=Created time (delivery)
 search.deliveries.id=Delivery ID
+search.deliveries.reassignedFromDeliveryId=Reassigned from delivery ID
 search.deliveries.reassignedTime=Reassigned time
 search.documentTemplates.id=Document template name
 search.documentTemplates.name=Document template ID

--- a/src/main/resources/i18n/Messages_es.properties
+++ b/src/main/resources/i18n/Messages_es.properties
@@ -1399,6 +1399,8 @@ search.deliverables.type=Tipo de producto entregable
 search.deliveries.createdTime=Tiempo de creación (entrega)
 # aa95ac0f
 search.deliveries.id=ID de entrega
+# b04bf1c3
+search.deliveries.reassignedFromDeliveryId=Reasignado desde el ID de entrega
 # ce0e570e
 search.deliveries.reassignedTime=Tiempo reasignado
 # 537dbe44

--- a/src/main/resources/i18n/Messages_fr.properties
+++ b/src/main/resources/i18n/Messages_fr.properties
@@ -1399,6 +1399,8 @@ search.deliverables.type=Type de produit
 search.deliveries.createdTime=Heure de création (livraison)
 # aa95ac0f
 search.deliveries.id=Identifiant de livraison
+# b04bf1c3
+search.deliveries.reassignedFromDeliveryId=Réaffecté à partir de l’ID de livraison
 # ce0e570e
 search.deliveries.reassignedTime=Heure réassignée
 # 537dbe44

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/DeliveryStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/DeliveryStoreTest.kt
@@ -519,6 +519,45 @@ internal class DeliveryStoreTest : DatabaseTest(), RunsAsUser {
 
       assertNull(store.fetchOneByWithdrawalId(withdrawalId))
     }
+
+    @Test
+    fun `returns IDs of deliveries reassigned out of this one`() {
+      val otherPlantingSiteId = insertPlantingSite()
+      val originalDeliveryId =
+          insertDelivery(plantingSiteId = plantingSiteId, withdrawalId = withdrawalId)
+      insertPlanting(substratumId = substratumId, speciesId = speciesId1)
+      val reassignmentDeliveryId =
+          insertDelivery(
+              row = DeliveriesRow(reassignedFromDeliveryId = originalDeliveryId),
+              plantingSiteId = otherPlantingSiteId,
+              withdrawalId = withdrawalId,
+          )
+
+      assertEquals(
+          listOf(reassignmentDeliveryId),
+          store.fetchOneById(originalDeliveryId).reassignmentDeliveryIds,
+          "Reassignment delivery IDs on original delivery",
+      )
+      assertEquals(
+          emptyList<DeliveryId>(),
+          store.fetchOneById(reassignmentDeliveryId).reassignmentDeliveryIds,
+          "Reassignment delivery IDs on reassignment delivery",
+      )
+    }
+
+    @Test
+    fun `fetchOneByWithdrawalId returns the original delivery when a withdrawal spans two sites`() {
+      val otherPlantingSiteId = insertPlantingSite()
+      val originalDeliveryId =
+          insertDelivery(plantingSiteId = plantingSiteId, withdrawalId = withdrawalId)
+      insertDelivery(
+          row = DeliveriesRow(reassignedFromDeliveryId = originalDeliveryId),
+          plantingSiteId = otherPlantingSiteId,
+          withdrawalId = withdrawalId,
+      )
+
+      assertEquals(originalDeliveryId, store.fetchOneByWithdrawalId(withdrawalId)?.id)
+    }
   }
 
   @Nested


### PR DESCRIPTION
Cross-site reassignments cause additional deliveries to be created for
the original withdrawal. Expose those delivery IDs in the API so clients
can use them to navigate to the originals.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
