### PR TITLE
SW-5189 Undo all deliveries when withdrawal is undone

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/tracking/db/DeliveryStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/db/DeliveryStore.kt
@@ -376,54 +376,78 @@ class DeliveryStore(
       throw WithdrawalNotUndoException(undoWithdrawalId)
     }
 
+    val reassignmentDeliveries = originalDelivery.reassignmentDeliveryIds.map { fetchOneById(it) }
+
     return dslContext.transactionResult { _ ->
-      val deliveriesRow =
-          DeliveriesRow(
-              createdBy = userId,
-              createdTime = now,
-              modifiedBy = userId,
-              modifiedTime = now,
-              plantingSiteId = originalDelivery.plantingSiteId,
-              withdrawalId = undoWithdrawalId,
-          )
+      val undoDeliveryId = undoOneDelivery(originalDelivery, undoWithdrawalId, null, userId, now)
 
-      deliveriesDao.insert(deliveriesRow)
-      val undoDeliveryId = deliveriesRow.id!!
-
-      originalDelivery.plantings.forEach { originalPlanting ->
-        val plantingType =
-            when (originalPlanting.type) {
-              PlantingType.Delivery -> PlantingType.Undo
-              PlantingType.ReassignmentFrom -> PlantingType.ReassignmentTo
-              PlantingType.ReassignmentTo -> PlantingType.ReassignmentFrom
-              PlantingType.Undo ->
-                  throw UndoOfUndoNotAllowedException(originalDelivery.withdrawalId)
-            }
-
-        val newPlantingsRow =
-            PlantingsRow(
-                createdBy = userId,
-                createdTime = now,
-                deliveryId = undoDeliveryId,
-                numPlants = -originalPlanting.numPlants,
-                plantingSiteId = originalDelivery.plantingSiteId,
-                substratumId = originalPlanting.substratumId,
-                plantingTypeId = plantingType,
-                speciesId = originalPlanting.speciesId,
-            )
-
-        plantingsDao.insert(newPlantingsRow)
-
-        addToPopulations(
-            originalDelivery.plantingSiteId,
-            originalPlanting.substratumId,
-            originalPlanting.speciesId,
-            -originalPlanting.numPlants,
-        )
+      reassignmentDeliveries.forEach { reassignmentDelivery ->
+        undoOneDelivery(reassignmentDelivery, undoWithdrawalId, undoDeliveryId, userId, now)
       }
 
       undoDeliveryId
     }
+  }
+
+  private fun undoOneDelivery(
+      delivery: DeliveryModel,
+      undoWithdrawalId: WithdrawalId,
+      reassignedFromDeliveryId: DeliveryId?,
+      userId: UserId,
+      now: Instant,
+  ): DeliveryId {
+    val deliveriesRow =
+        DeliveriesRow(
+            createdBy = userId,
+            createdTime = now,
+            modifiedBy = userId,
+            modifiedTime = now,
+            plantingSiteId = delivery.plantingSiteId,
+            reassignedFromDeliveryId = reassignedFromDeliveryId,
+            withdrawalId = undoWithdrawalId,
+        )
+
+    deliveriesDao.insert(deliveriesRow)
+    val undoDeliveryId = deliveriesRow.id!!
+
+    delivery.plantings.forEach { originalPlanting ->
+      val plantingType =
+          when (originalPlanting.type) {
+            PlantingType.Delivery -> PlantingType.Undo
+            PlantingType.ReassignmentFrom -> PlantingType.ReassignmentTo
+            PlantingType.ReassignmentTo -> PlantingType.ReassignmentFrom
+            PlantingType.Undo -> throw UndoOfUndoNotAllowedException(delivery.withdrawalId)
+          }
+
+      plantingsDao.insert(
+          PlantingsRow(
+              createdBy = userId,
+              createdTime = now,
+              deliveryId = undoDeliveryId,
+              numPlants = -originalPlanting.numPlants,
+              plantingSiteId = delivery.plantingSiteId,
+              substratumId = originalPlanting.substratumId,
+              plantingTypeId = plantingType,
+              speciesId = originalPlanting.speciesId,
+          )
+      )
+
+      addToPopulations(
+          delivery.plantingSiteId,
+          originalPlanting.substratumId,
+          originalPlanting.speciesId,
+          -originalPlanting.numPlants,
+          deleteZeroedRows = false,
+      )
+    }
+
+    val speciesIds = delivery.plantings.map { it.speciesId }.toSet()
+    val substratumIds = delivery.plantings.mapNotNull { it.substratumId }.toSet()
+
+    deleteEmptySitePopulations(delivery.plantingSiteId, speciesIds)
+    deleteEmptySubstratumPopulations(substratumIds, speciesIds)
+
+    return undoDeliveryId
   }
 
   /**

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/DeliveryStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/DeliveryStoreTest.kt
@@ -25,6 +25,9 @@ import com.terraformation.backend.db.tracking.tables.records.StratumPopulationsR
 import com.terraformation.backend.db.tracking.tables.records.SubstratumPopulationsRecord
 import com.terraformation.backend.db.tracking.tables.references.DELIVERIES
 import com.terraformation.backend.db.tracking.tables.references.PLANTINGS
+import com.terraformation.backend.db.tracking.tables.references.PLANTING_SITE_POPULATIONS
+import com.terraformation.backend.db.tracking.tables.references.STRATUM_POPULATIONS
+import com.terraformation.backend.db.tracking.tables.references.SUBSTRATUM_POPULATIONS
 import com.terraformation.backend.mockUser
 import com.terraformation.backend.nursery.db.UndoOfUndoNotAllowedException
 import com.terraformation.backend.tracking.model.DeliveryModel
@@ -947,6 +950,65 @@ internal class DeliveryStoreTest : DatabaseTest(), RunsAsUser {
       assertThrows<AccessDeniedException> {
         store.undoDelivery(inserted.deliveryId, inserted.withdrawalId)
       }
+    }
+
+    @Test
+    fun `undoes deliveries at both sites of a cross-site reassignment`() {
+      val otherPlantingSiteId = insertPlantingSite()
+      val otherSiteStratumId = insertStratum(plantingSiteId = otherPlantingSiteId)
+      val otherSiteSubstratumId = insertSubstratum(stratumId = otherSiteStratumId)
+
+      val deliveryId =
+          store.createDelivery(withdrawalId, plantingSiteId, substratumId, mapOf(speciesId1 to 100))
+      val plantingId = plantingsDao.findAll().single().id!!
+
+      store.reassignDelivery(
+          deliveryId,
+          listOf(
+              DeliveryStore.Reassignment(
+                  fromPlantingId = plantingId,
+                  numPlants = 30,
+                  toSubstratumId = otherSiteSubstratumId,
+              )
+          ),
+      )
+
+      val deliveriesBeforeUndo = dslContext.fetch(DELIVERIES).onEach { it.id = null }
+
+      val undoWithdrawalId =
+          insertNurseryWithdrawal(
+              purpose = WithdrawalPurpose.Undo,
+              undoesWithdrawalId = withdrawalId,
+          )
+
+      val undoDeliveryId = store.undoDelivery(deliveryId, undoWithdrawalId)
+
+      assertTableEquals(
+          deliveriesBeforeUndo +
+              listOf(
+                  DeliveriesRecord(
+                      createdBy = user.userId,
+                      createdTime = clock.instant,
+                      modifiedBy = user.userId,
+                      modifiedTime = clock.instant,
+                      plantingSiteId = plantingSiteId,
+                      withdrawalId = undoWithdrawalId,
+                  ),
+                  DeliveriesRecord(
+                      createdBy = user.userId,
+                      createdTime = clock.instant,
+                      modifiedBy = user.userId,
+                      modifiedTime = clock.instant,
+                      plantingSiteId = otherPlantingSiteId,
+                      reassignedFromDeliveryId = undoDeliveryId,
+                      withdrawalId = undoWithdrawalId,
+                  ),
+              ),
+      )
+
+      assertTableEmpty(PLANTING_SITE_POPULATIONS)
+      assertTableEmpty(STRATUM_POPULATIONS)
+      assertTableEmpty(SUBSTRATUM_POPULATIONS)
     }
   }
 }


### PR DESCRIPTION
When a withdrawal is undone, we need to undo all the effects it had on
planting site populations. Since cross-site reassignments can now create
multiple deliveries associated with the same withdrawal, we need to undo
all of them.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
