### PR TITLE
Reversed report sort orders

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/accelerator/db/ReportStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/db/ReportStore.kt
@@ -1157,7 +1157,7 @@ class ReportStore(
             .leftJoin(PROJECT_ACCELERATOR_DETAILS)
             .on(REPORTS.PROJECT_ID.eq(PROJECT_ACCELERATOR_DETAILS.PROJECT_ID))
             .where(condition)
-            .orderBy(REPORTS.START_DATE)
+            .orderBy(REPORTS.START_DATE.desc())
             .fetch {
               ReportModel.of(
                   record = it,

--- a/src/main/kotlin/com/terraformation/backend/search/table/AcceleratorReportsTable.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/table/AcceleratorReportsTable.kt
@@ -67,7 +67,7 @@ class AcceleratorReportsTable(tables: SearchTables) : SearchTable() {
       )
 
   override val defaultOrderFields: List<OrderField<*>>
-    get() = listOf(REPORTS.START_DATE, REPORTS.ID)
+    get() = listOf(REPORTS.START_DATE.desc(), REPORTS.ID)
 
   override fun conditionForVisibility(): Condition {
     return if (currentUser().canReadAllAcceleratorDetails()) {

--- a/src/test/kotlin/com/terraformation/backend/accelerator/AcceleratorReportSearchTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/AcceleratorReportSearchTest.kt
@@ -223,7 +223,7 @@ class AcceleratorReportSearchTest : DatabaseTest(), RunsAsUser {
                 mapOf(
                     "id" to "$projectId",
                     "acceleratorReports" to
-                        listOf(mapOf("id" to "$reportId"), mapOf("id" to "$laterReportId")),
+                        listOf(mapOf("id" to "$laterReportId"), mapOf("id" to "$reportId")),
                 )
             )
         )
@@ -235,7 +235,7 @@ class AcceleratorReportSearchTest : DatabaseTest(), RunsAsUser {
   }
 
   @Test
-  fun `returns reports ordered by start date by default`() {
+  fun `returns reports ordered by descending start date by default`() {
     val secondQuarterReportId =
         insertReport(
             startDate = LocalDate.of(2026, 4, 1),
@@ -254,8 +254,8 @@ class AcceleratorReportSearchTest : DatabaseTest(), RunsAsUser {
     val expected =
         SearchResults(
             listOf(
-                mapOf("id" to "$firstQuarterReportId"),
                 mapOf("id" to "$secondQuarterReportId"),
+                mapOf("id" to "$firstQuarterReportId"),
             )
         )
 

--- a/src/test/kotlin/com/terraformation/backend/accelerator/db/ReportStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/db/ReportStoreTest.kt
@@ -933,6 +933,34 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
     }
 
     @Test
+    fun `returns reports in descending start date order`() {
+      insertProjectReportConfig()
+
+      val q1ReportId =
+          insertReport(
+              quarter = ReportQuarter.Q1,
+              startDate = LocalDate.of(2030, Month.JANUARY, 1),
+              endDate = LocalDate.of(2030, Month.MARCH, 31),
+          )
+      val q3ReportId =
+          insertReport(
+              quarter = ReportQuarter.Q3,
+              startDate = LocalDate.of(2030, Month.JULY, 1),
+              endDate = LocalDate.of(2030, Month.SEPTEMBER, 30),
+          )
+      val q2ReportId =
+          insertReport(
+              quarter = ReportQuarter.Q2,
+              startDate = LocalDate.of(2030, Month.APRIL, 1),
+              endDate = LocalDate.of(2030, Month.JUNE, 30),
+          )
+
+      clock.instant = LocalDate.of(2031, Month.JANUARY, 1).atStartOfDay().toInstant(ZoneOffset.UTC)
+
+      assertEquals(listOf(q3ReportId, q2ReportId, q1ReportId), store.fetch().map { it.id })
+    }
+
+    @Test
     fun `returns only visible reports`() {
       deleteOrganizationUser(organizationId = organizationId)
       deleteUserGlobalRole(role = GlobalRole.AcceleratorAdmin)


### PR DESCRIPTION
Reports should be shown by recency. Reverse the fetch order.