### PR TITLE
SW-8742 Add target plant density

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/admin/AdminPlantingSitesController.kt
+++ b/src/main/kotlin/com/terraformation/backend/admin/AdminPlantingSitesController.kt
@@ -514,6 +514,7 @@ class AdminPlantingSitesController(
       @RequestParam numPermanent: Int,
       @RequestParam numTemporary: Int,
       @RequestParam initialPlantingDensity: BigDecimal,
+      @RequestParam targetPlantDensity: BigDecimal?,
       redirectAttributes: RedirectAttributes,
   ): String {
     try {
@@ -525,6 +526,7 @@ class AdminPlantingSitesController(
             numPermanentPlots = numPermanent,
             numTemporaryPlots = numTemporary,
             studentsT = studentsT,
+            targetPlantDensity = targetPlantDensity,
             variance = variance,
         )
       }

--- a/src/main/kotlin/com/terraformation/backend/tracking/api/PlantingSitesController.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/api/PlantingSitesController.kt
@@ -399,6 +399,11 @@ data class StratumResponsePayload(
     val numPermanentPlots: Int,
     val numTemporaryPlots: Int,
     val substrata: List<SubstratumResponsePayload>,
+    @Schema(
+        description =
+            "Number of plants per hectare that the stratum should have after planting is completed."
+    )
+    val targetPlantDensity: BigDecimal?,
     @Schema(deprecated = true, description = "Use initialPlantingDensity instead.")
     val targetPlantingDensity: BigDecimal?,
 ) {
@@ -416,6 +421,7 @@ data class StratumResponsePayload(
       numPermanentPlots = model.numPermanentPlots,
       numTemporaryPlots = model.numTemporaryPlots,
       substrata = model.substrata.map { SubstratumResponsePayload(it) },
+      targetPlantDensity = model.targetPlantDensity,
       targetPlantingDensity = model.initialPlantingDensity,
   )
 }
@@ -635,6 +641,11 @@ data class NewStratumPayload(
     )
     val name: String,
     val substrata: List<NewSubstratumPayload>?,
+    @Schema(
+        description =
+            "Number of plants per hectare that the stratum should have after planting is completed."
+    )
+    val targetPlantDensity: BigDecimal?,
     @Schema(deprecated = true, description = "Use initialPlantingDensity instead.")
     val targetPlantingDensity: BigDecimal?,
 ) {
@@ -656,6 +667,7 @@ data class NewStratumPayload(
                 ?: targetPlantingDensity
                 ?: StratumModel.DEFAULT_INITIAL_PLANTING_DENSITY,
         substrata = substrata?.map { it.toModel(name, exclusion) } ?: emptyList(),
+        targetPlantDensity = targetPlantDensity,
     )
   }
 }

--- a/src/main/kotlin/com/terraformation/backend/tracking/db/PlantingSiteStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/db/PlantingSiteStore.kt
@@ -1114,6 +1114,7 @@ class PlantingSiteStore(
             .set(NUM_PERMANENT_PLOTS, edited.numPermanentPlots)
             .set(NUM_TEMPORARY_PLOTS, edited.numTemporaryPlots)
             .set(STUDENTS_T, edited.studentsT)
+            .set(TARGET_PLANT_DENSITY, edited.targetPlantDensity)
             .set(VARIANCE, edited.variance)
             .where(ID.eq(stratumId))
             .execute()
@@ -1215,6 +1216,7 @@ class PlantingSiteStore(
             plantingSiteId = plantingSiteId,
             stableId = stratum.stableId,
             studentsT = stratum.studentsT,
+            targetPlantDensity = stratum.targetPlantDensity,
             variance = stratum.variance,
         )
 
@@ -2378,6 +2380,7 @@ class PlantingSiteStore(
                     STRATA.STABLE_ID,
                     substrataField,
                     STRATA.STUDENTS_T,
+                    STRATA.TARGET_PLANT_DENSITY,
                     STRATA.VARIANCE,
                 )
                 .from(STRATA)
@@ -2406,6 +2409,7 @@ class PlantingSiteStore(
                 stableId = record[STRATA.STABLE_ID]!!,
                 studentsT = record[STRATA.STUDENTS_T]!!,
                 substrata = substrataField?.let { record[it] } ?: emptyList(),
+                targetPlantDensity = record[STRATA.TARGET_PLANT_DENSITY],
                 variance = record[STRATA.VARIANCE]!!,
             )
           }

--- a/src/main/kotlin/com/terraformation/backend/tracking/model/StratumModel.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/model/StratumModel.kt
@@ -43,6 +43,7 @@ data class StratumModel<
     val substrata: List<SubstratumModel<SSID>>,
     val stableId: StableId,
     val studentsT: BigDecimal = DEFAULT_STUDENTS_T,
+    val targetPlantDensity: BigDecimal? = null,
     val variance: BigDecimal = DEFAULT_VARIANCE,
 ) {
   /**
@@ -391,6 +392,7 @@ data class StratumModel<
         studentsT.equalsIgnoreScale(other.studentsT) &&
         variance.equalsIgnoreScale(other.variance) &&
         initialPlantingDensity.equalsIgnoreScale(other.initialPlantingDensity) &&
+        targetPlantDensity.equalsIgnoreScale(other.targetPlantDensity) &&
         substrata.zip(other.substrata).all { (a, b) -> a.equals(b, tolerance) } &&
         boundary.equalsExact(other.boundary, tolerance)
   }
@@ -409,6 +411,7 @@ data class StratumModel<
           substrata = substrata.map { it.toNew() },
           stableId = stableId,
           studentsT = studentsT,
+          targetPlantDensity = targetPlantDensity,
           variance = variance,
       )
 
@@ -438,6 +441,7 @@ data class StratumModel<
         numTemporaryPlots: Int? = null,
         stableId: StableId = StableId(name),
         studentsT: BigDecimal = DEFAULT_STUDENTS_T,
+        targetPlantDensity: BigDecimal? = null,
         variance: BigDecimal = DEFAULT_VARIANCE,
     ): NewStratumModel {
       val areaHa: BigDecimal = boundary.differenceNullable(exclusion).calculateAreaHectares()
@@ -461,6 +465,7 @@ data class StratumModel<
           substrata = substrata,
           stableId = stableId,
           studentsT = studentsT,
+          targetPlantDensity = targetPlantDensity,
           variance = variance,
       )
     }

--- a/src/main/resources/db/migration/2026/08/V20260805.1646__TargetPlantDensity.sql
+++ b/src/main/resources/db/migration/2026/08/V20260805.1646__TargetPlantDensity.sql
@@ -1,0 +1,3 @@
+ALTER TABLE tracking.strata ADD COLUMN target_plant_density NUMERIC;
+ALTER TABLE tracking.strata ADD CONSTRAINT target_plant_density_positive
+    CHECK (target_plant_density > 0);

--- a/src/main/resources/db/migration/R__Comments.sql
+++ b/src/main/resources/db/migration/R__Comments.sql
@@ -648,12 +648,14 @@ COMMENT ON COLUMN tracking.strata.boundary_modified_by IS 'Which user most recen
 COMMENT ON COLUMN tracking.strata.boundary_modified_time IS 'When the stratum''s boundary was most recently modified.';
 COMMENT ON COLUMN tracking.strata.created_by IS 'Which user created the stratum.';
 COMMENT ON COLUMN tracking.strata.created_time IS 'When the stratum was originally created.';
+COMMENT ON COLUMN tracking.strata.initial_planting_density IS 'Number of plants per hectare that should be planted in the stratum initially.';
 COMMENT ON COLUMN tracking.strata.modified_by IS 'Which user most recently modified the stratum.';
 COMMENT ON COLUMN tracking.strata.modified_time IS 'When the stratum was most recently modified.';
 COMMENT ON COLUMN tracking.strata.name IS 'Short name of this stratum. This is often just a single letter. Must be unique within a planting site.';
 COMMENT ON COLUMN tracking.strata.num_permanent_plots IS 'Number of permanent plots to assign to the next observation. This is typically derived from a statistical formula.';
 COMMENT ON COLUMN tracking.strata.planting_site_id IS 'Which planting site this stratum is part of.';
 COMMENT ON COLUMN tracking.strata.stable_id IS 'Stratum identifier that doesn''t change even if the stratum is renamed or edited. Defaults to the stratum name.';
+COMMENT ON COLUMN tracking.strata.target_plant_density IS 'Number of plants per hectare that the stratum should have after planting is fully completed. This may be less than the initial planting density to account for seedlings not surviving.';
 
 COMMENT ON TABLE tracking.plantings IS 'Details about plants that were planted or reassigned as part of a delivery. There is one plantings row per species in a delivery.';
 COMMENT ON COLUMN tracking.plantings.created_by IS 'Which user created the planting.';

--- a/src/main/resources/templates/admin/plantingSite.html
+++ b/src/main/resources/templates/admin/plantingSite.html
@@ -199,6 +199,7 @@
                 <th>Stratum ID</th>
                 <th>Name</th>
                 <th>Initial<br/>Density</th>
+                <th>Target<br/>Density</th>
                 <th>Variance</th>
                 <th>Error</th>
                 <th>Student's t</th>
@@ -218,6 +219,11 @@
                 <td>
                     <input type="number" required min="1" name="initialPlantingDensity" size="8"
                            th:value="${stratum.initialPlantingDensity}"
+                           th:form="|stratum-${stratum.id}|"/>
+                </td>
+                <td>
+                    <input type="number" min="1" name="targetPlantDensity" size="8"
+                           th:value="${stratum.targetPlantDensity}"
                            th:form="|stratum-${stratum.id}|"/>
                 </td>
                 <td>

--- a/src/test/kotlin/com/terraformation/backend/db/DatabaseBackedTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/db/DatabaseBackedTest.kt
@@ -2838,6 +2838,7 @@ abstract class DatabaseBackedTest {
       numTemporaryPlots: Int = row.numTemporaryPlots ?: StratumModel.DEFAULT_NUM_TEMPORARY_PLOTS,
       stableId: Any = row.name ?: name,
       studentsT: BigDecimal = row.studentsT ?: StratumModel.DEFAULT_STUDENTS_T,
+      targetPlantDensity: BigDecimal? = row.targetPlantDensity,
       variance: BigDecimal = row.variance ?: StratumModel.DEFAULT_VARIANCE,
       insertHistory: Boolean = true,
       boundaryModifiedBy: UserId = row.boundaryModifiedBy ?: modifiedBy,
@@ -2861,6 +2862,7 @@ abstract class DatabaseBackedTest {
             plantingSiteId = plantingSiteId,
             stableId = StableId("$stableId"),
             studentsT = studentsT,
+            targetPlantDensity = targetPlantDensity,
             variance = variance,
         )
 

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/plantingSiteStore/PlantingSiteStoreCreateSiteTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/plantingSiteStore/PlantingSiteStoreCreateSiteTest.kt
@@ -163,6 +163,7 @@ internal class PlantingSiteStoreCreateSiteTest : BasePlantingSiteStoreTest() {
                                   ),
                               ),
                           studentsT = BigDecimal(5),
+                          targetPlantDensity = BigDecimal(8),
                           variance = BigDecimal(7),
                       ),
                       StratumModel.create(
@@ -243,6 +244,7 @@ internal class PlantingSiteStoreCreateSiteTest : BasePlantingSiteStoreTest() {
                   numTemporaryPlots = 4,
                   stableId = StableId("Stratum 1"),
                   studentsT = BigDecimal(5),
+                  targetPlantDensity = BigDecimal(8),
                   variance = BigDecimal(7),
               ),
               commonStrataRow.copy(

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/plantingSiteStore/PlantingSiteStoreFetchSiteTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/plantingSiteStore/PlantingSiteStoreFetchSiteTest.kt
@@ -247,7 +247,8 @@ internal class PlantingSiteStoreFetchSiteTest : BasePlantingSiteStoreTest() {
           insertStratum(
               boundary = multiPolygon(2.0),
               boundaryModifiedTime = boundaryModifiedTime,
-              initialPlantingDensity = BigDecimal.ONE,
+              initialPlantingDensity = BigDecimal.TWO,
+              targetPlantDensity = BigDecimal.ONE,
           )
       val substratumId11 = insertSubstratum(boundary = multiPolygon(1.0))
       val monitoringPlotId111 = insertMonitoringPlot(boundary = polygon(0.1))
@@ -367,7 +368,7 @@ internal class PlantingSiteStoreFetchSiteTest : BasePlantingSiteStoreTest() {
                           boundary = multiPolygon(2.0),
                           boundaryModifiedTime = boundaryModifiedTime,
                           id = stratumId1,
-                          initialPlantingDensity = BigDecimal.ONE,
+                          initialPlantingDensity = BigDecimal.TWO,
                           latestObservationCompletedTime = Instant.ofEpochSecond(2000),
                           latestObservationId = observationId2,
                           name = "S1",
@@ -441,6 +442,7 @@ internal class PlantingSiteStoreFetchSiteTest : BasePlantingSiteStoreTest() {
                                   ),
                               ),
                           stableId = StableId("S1"),
+                          targetPlantDensity = BigDecimal.ONE,
                       ),
                       ExistingStratumModel(
                           areaHa = BigDecimal.TEN,

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/plantingSiteStore/PlantingSiteStoreUpdateStratumTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/plantingSiteStore/PlantingSiteStoreUpdateStratumTest.kt
@@ -54,6 +54,7 @@ internal class PlantingSiteStoreUpdateStratumTest : BasePlantingSiteStoreTest() 
       val newPermanent = 13
       val newTemporary = 14
       val newInitialPlantingDensity = BigDecimal(13)
+      val newTargetPlantDensity = BigDecimal(15)
 
       val expected =
           initialRow.copy(
@@ -66,6 +67,7 @@ internal class PlantingSiteStoreUpdateStratumTest : BasePlantingSiteStoreTest() 
               numPermanentPlots = newPermanent,
               numTemporaryPlots = newTemporary,
               studentsT = newStudentsT,
+              targetPlantDensity = newTargetPlantDensity,
               variance = newVariance,
           )
 
@@ -78,6 +80,7 @@ internal class PlantingSiteStoreUpdateStratumTest : BasePlantingSiteStoreTest() 
             numPermanentPlots = newPermanent,
             numTemporaryPlots = newTemporary,
             studentsT = newStudentsT,
+            targetPlantDensity = newTargetPlantDensity,
             variance = newVariance,
             // Not editable
             boundaryModifiedBy = user.userId,


### PR DESCRIPTION
Add a new stratum property to track the number of plants that should
exist in the stratum after planting is completed. This is distinct from
the old "target planting density" which is now renamed to "initial
planting density."