### PR TITLE
Support building outside of git repos

### DIFF
--- a/buildSrc/src/main/kotlin/com/terraformation/gradle/GitVersion.kt
+++ b/buildSrc/src/main/kotlin/com/terraformation/gradle/GitVersion.kt
@@ -5,21 +5,28 @@ import org.eclipse.jgit.storage.file.FileRepositoryBuilder
 import org.gradle.api.Project
 
 /**
- * Returns a version number based on the current git revision. The version number is of the form
- * `[baseVersion-]gitRev[-SNAPSHOT]`. The `-SNAPSHOT` suffix is appended if the repo is dirty, that
- * is, if `git status` would show edits or untracked files.
+ * Returns a version number based on the current git revision, if available. The version number is
+ * of the form `[baseVersion-]gitRev[-SNAPSHOT]`. The `-SNAPSHOT` suffix is appended if the repo is
+ * dirty, that is, if `git status` would show edits or untracked files.
+ *
+ * If the project isn't in a git repo, returns a version number of the form `baseVersion-SNAPSHOT`.
  */
 fun Project.computeGitVersion(baseVersion: String?): String {
-  val repo = FileRepositoryBuilder().findGitDir(projectDir).build()
-  val head = repo.findRef("HEAD")
-  val clean = Git(repo).status().call().isClean
-
+  val repoBuilder = FileRepositoryBuilder().findGitDir(projectDir)
   val versionParts =
-      listOfNotNull(
-          baseVersion,
-          repo.newObjectReader().abbreviate(head.objectId).name(),
-          if (clean) null else "SNAPSHOT",
-      )
+      if (repoBuilder.gitDir != null) {
+        val repo = repoBuilder.build()
+        val head = repo.findRef("HEAD")
+        val clean = Git(repo).status().call().isClean
+
+        listOfNotNull(
+            baseVersion,
+            repo.newObjectReader().abbreviate(head.objectId).name(),
+            if (clean) null else "SNAPSHOT",
+        )
+      } else {
+        listOf(baseVersion ?: "0.0.1", "SNAPSHOT")
+      }
 
   return versionParts.joinToString("-")
 }


### PR DESCRIPTION
Stop requiring a git revision in the software version number that gets
generated at build time.

This enables the server to be built in jj workspaces.