### PR TITLE
Move planting site locking function to separate class

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/tracking/db/PlantingSiteLocker.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/db/PlantingSiteLocker.kt
@@ -1,0 +1,36 @@
+package com.terraformation.backend.tracking.db
+
+import com.terraformation.backend.customer.model.requirePermissions
+import com.terraformation.backend.db.tracking.PlantingSiteId
+import com.terraformation.backend.db.tracking.tables.references.PLANTING_SITES
+import jakarta.inject.Named
+import org.jooq.DSLContext
+
+@Named
+class PlantingSiteLocker(
+    private val dslContext: DSLContext,
+) {
+  /**
+   * Acquires a row lock on a planting site and executes a function in a transaction with the lock
+   * held.
+   */
+  fun <T> withLockedPlantingSite(plantingSiteId: PlantingSiteId, func: () -> T): T {
+    requirePermissions { updatePlantingSite(plantingSiteId) }
+
+    return dslContext.transactionResult { _ ->
+      val rowsLocked =
+          dslContext
+              .selectOne()
+              .from(PLANTING_SITES)
+              .where(PLANTING_SITES.ID.eq(plantingSiteId))
+              .forUpdate()
+              .execute()
+
+      if (rowsLocked != 1) {
+        throw PlantingSiteNotFoundException(plantingSiteId)
+      }
+
+      func()
+    }
+  }
+}

--- a/src/main/kotlin/com/terraformation/backend/tracking/db/PlantingSiteStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/db/PlantingSiteStore.kt
@@ -126,6 +126,7 @@ class PlantingSiteStore(
     private val identifierGenerator: IdentifierGenerator,
     private val monitoringPlotsDao: MonitoringPlotsDao,
     private val parentStore: ParentStore,
+    private val plantingSiteLocker: PlantingSiteLocker,
     private val plantingSitesDao: PlantingSitesDao,
     private val rateLimitedEventPublisher: RateLimitedEventPublisher,
     private val strataDao: StrataDao,
@@ -579,7 +580,7 @@ class PlantingSiteStore(
           countryDetector.getCountries(it).singleOrNull()
         }
 
-    return withLockedPlantingSite(plantingSiteId) {
+    return plantingSiteLocker.withLockedPlantingSite(plantingSiteId) {
       val existing = fetchSiteById(plantingSiteId, PlantingSiteDepth.Plot)
       val now = clock.instant()
       val userId = currentUser().userId
@@ -1102,7 +1103,7 @@ class PlantingSiteStore(
     val initial = strataDao.fetchOneById(stratumId) ?: throw StratumNotFoundException(stratumId)
     val edited = editFunc(initial)
 
-    withLockedPlantingSite(initial.plantingSiteId!!) {
+    plantingSiteLocker.withLockedPlantingSite(initial.plantingSiteId!!) {
       with(STRATA) {
         dslContext
             .update(STRATA)
@@ -1473,7 +1474,7 @@ class PlantingSiteStore(
       updatePlantingSite(plantingSiteId)
     }
 
-    return withLockedPlantingSite(plantingSiteId) {
+    return plantingSiteLocker.withLockedPlantingSite(plantingSiteId) {
       val plantingSite = fetchSiteById(plantingSiteId, PlantingSiteDepth.Plot)
       val stratum =
           plantingSite.findStratumWithMonitoringPlot(monitoringPlotId)
@@ -1536,7 +1537,7 @@ class PlantingSiteStore(
   fun ensurePermanentPlotsExist(plantingSiteId: PlantingSiteId): List<MonitoringPlotId> {
     requirePermissions { updatePlantingSite(plantingSiteId) }
 
-    return withLockedPlantingSite(plantingSiteId) {
+    return plantingSiteLocker.withLockedPlantingSite(plantingSiteId) {
       val plantingSite = fetchSiteById(plantingSiteId, PlantingSiteDepth.Plot)
 
       plantingSite.strata.flatMap { stratum ->
@@ -1743,7 +1744,7 @@ class PlantingSiteStore(
     val userId = currentUser().userId
     val now = clock.instant()
 
-    return withLockedPlantingSite(plantingSiteId) {
+    return plantingSiteLocker.withLockedPlantingSite(plantingSiteId) {
       val plantingSite = fetchSiteById(plantingSiteId, PlantingSiteDepth.Plot)
       val stratum =
           plantingSite.strata.singleOrNull { it.id == stratumId }
@@ -2630,30 +2631,6 @@ class PlantingSiteStore(
               totalSpecies = species.size,
           )
         }
-  }
-
-  /**
-   * Acquires a row lock on a planting site and executes a function in a transaction with the lock
-   * held.
-   */
-  private fun <T> withLockedPlantingSite(plantingSiteId: PlantingSiteId, func: () -> T): T {
-    requirePermissions { updatePlantingSite(plantingSiteId) }
-
-    return dslContext.transactionResult { _ ->
-      val rowsLocked =
-          dslContext
-              .selectOne()
-              .from(PLANTING_SITES)
-              .where(PLANTING_SITES.ID.eq(plantingSiteId))
-              .forUpdate()
-              .execute()
-
-      if (rowsLocked != 1) {
-        throw PlantingSiteNotFoundException(plantingSiteId)
-      }
-
-      func()
-    }
   }
 
   private fun insertPlantingSiteHistory(

--- a/src/test/kotlin/com/terraformation/backend/accelerator/ObservationActivityServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/ObservationActivityServiceTest.kt
@@ -37,6 +37,7 @@ import com.terraformation.backend.tracking.db.BiomassStore
 import com.terraformation.backend.tracking.db.ObservationLocker
 import com.terraformation.backend.tracking.db.ObservationResultsStoreV2
 import com.terraformation.backend.tracking.db.ObservationStore
+import com.terraformation.backend.tracking.db.PlantingSiteLocker
 import com.terraformation.backend.tracking.db.PlantingSiteNotificationStore
 import com.terraformation.backend.tracking.db.PlantingSiteStore
 import com.terraformation.backend.tracking.event.ObservationCompletedEvent
@@ -90,6 +91,7 @@ class ObservationActivityServiceTest : DatabaseTest(), RunsAsDatabaseUser {
         mockk(),
         monitoringPlotsDao,
         parentStore,
+        PlantingSiteLocker(dslContext),
         plantingSitesDao,
         eventPublisher,
         strataDao,

--- a/src/test/kotlin/com/terraformation/backend/customer/ProjectServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/ProjectServiceTest.kt
@@ -32,6 +32,7 @@ import com.terraformation.backend.seedbank.db.BagStore
 import com.terraformation.backend.seedbank.db.GeolocationStore
 import com.terraformation.backend.seedbank.db.ViabilityTestStore
 import com.terraformation.backend.seedbank.db.WithdrawalStore
+import com.terraformation.backend.tracking.db.PlantingSiteLocker
 import com.terraformation.backend.tracking.db.PlantingSiteStore
 import com.terraformation.backend.util.GeometrySimplifier
 import io.mockk.every
@@ -100,6 +101,7 @@ class ProjectServiceTest : DatabaseTest(), RunsAsUser {
             IdentifierGenerator(clock, dslContext),
             monitoringPlotsDao,
             parentStore,
+            PlantingSiteLocker(dslContext),
             plantingSitesDao,
             publisher,
             strataDao,

--- a/src/test/kotlin/com/terraformation/backend/notification/NotificationServiceAppTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/notification/NotificationServiceAppTest.kt
@@ -103,6 +103,7 @@ import com.terraformation.backend.splat.event.SplatGenerationCompletedEvent
 import com.terraformation.backend.splat.event.SplatGenerationFailedEvent
 import com.terraformation.backend.splat.event.SplatMarkedNeedsAttentionEvent
 import com.terraformation.backend.tracking.db.ObservationStore
+import com.terraformation.backend.tracking.db.PlantingSiteLocker
 import com.terraformation.backend.tracking.db.PlantingSiteStore
 import com.terraformation.backend.tracking.event.ObservationStartedEvent
 import com.terraformation.backend.tracking.event.ObservationUpcomingNotificationDueEvent
@@ -233,6 +234,7 @@ internal class NotificationServiceAppTest : DatabaseTest(), RunsAsUser {
             IdentifierGenerator(clock, dslContext),
             monitoringPlotsDao,
             parentStore,
+            PlantingSiteLocker(dslContext),
             plantingSitesDao,
             publisher,
             strataDao,

--- a/src/test/kotlin/com/terraformation/backend/report/SeedFundReportServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/report/SeedFundReportServiceTest.kt
@@ -50,6 +50,7 @@ import com.terraformation.backend.report.model.SeedFundReportModel
 import com.terraformation.backend.report.render.SeedFundReportRenderer
 import com.terraformation.backend.seedbank.db.AccessionStore
 import com.terraformation.backend.species.db.SpeciesStore
+import com.terraformation.backend.tracking.db.PlantingSiteLocker
 import com.terraformation.backend.tracking.db.PlantingSiteStore
 import com.terraformation.backend.util.GeometrySimplifier
 import io.mockk.every
@@ -150,6 +151,7 @@ class SeedFundReportServiceTest : DatabaseTest(), RunsAsUser {
             IdentifierGenerator(clock, dslContext),
             monitoringPlotsDao,
             parentStore,
+            PlantingSiteLocker(dslContext),
             plantingSitesDao,
             publisher,
             strataDao,

--- a/src/test/kotlin/com/terraformation/backend/tracking/ObservationServiceMergeObservationsTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/ObservationServiceMergeObservationsTest.kt
@@ -32,6 +32,7 @@ import com.terraformation.backend.tracking.db.ObservationLocker
 import com.terraformation.backend.tracking.db.ObservationMergeNotAllowedException
 import com.terraformation.backend.tracking.db.ObservationStore
 import com.terraformation.backend.tracking.db.ObservationTestHelper
+import com.terraformation.backend.tracking.db.PlantingSiteLocker
 import com.terraformation.backend.tracking.db.PlantingSiteNotificationStore
 import com.terraformation.backend.tracking.db.PlantingSiteStore
 import com.terraformation.backend.tracking.event.ObservationMediaFileDeletedEvent
@@ -85,6 +86,7 @@ class ObservationServiceMergeObservationsTest : DatabaseTest(), RunsAsDatabaseUs
         IdentifierGenerator(clock, dslContext),
         monitoringPlotsDao,
         parentStore,
+        PlantingSiteLocker(dslContext),
         plantingSitesDao,
         eventPublisher,
         strataDao,

--- a/src/test/kotlin/com/terraformation/backend/tracking/ObservationServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/ObservationServiceTest.kt
@@ -75,6 +75,7 @@ import com.terraformation.backend.tracking.db.ObservationPlotNotFoundException
 import com.terraformation.backend.tracking.db.ObservationRescheduleStateException
 import com.terraformation.backend.tracking.db.ObservationStore
 import com.terraformation.backend.tracking.db.ObservationTestHelper
+import com.terraformation.backend.tracking.db.PlantingSiteLocker
 import com.terraformation.backend.tracking.db.PlantingSiteNotDetailedException
 import com.terraformation.backend.tracking.db.PlantingSiteNotFoundException
 import com.terraformation.backend.tracking.db.PlantingSiteNotificationStore
@@ -188,6 +189,7 @@ class ObservationServiceTest : DatabaseTest(), RunsAsDatabaseUser {
         IdentifierGenerator(clock, dslContext),
         monitoringPlotsDao,
         parentStore,
+        PlantingSiteLocker(dslContext),
         plantingSitesDao,
         eventPublisher,
         strataDao,

--- a/src/test/kotlin/com/terraformation/backend/tracking/PlantingSiteServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/PlantingSiteServiceTest.kt
@@ -18,6 +18,7 @@ import com.terraformation.backend.db.tracking.tables.records.StratumPopulationsR
 import com.terraformation.backend.db.tracking.tables.references.SUBSTRATUM_POPULATIONS
 import com.terraformation.backend.mockUser
 import com.terraformation.backend.tracking.db.DeliveryStore
+import com.terraformation.backend.tracking.db.PlantingSiteLocker
 import com.terraformation.backend.tracking.db.PlantingSiteNotFoundException
 import com.terraformation.backend.tracking.db.PlantingSiteStore
 import com.terraformation.backend.tracking.edit.PlantingSiteEdit
@@ -57,6 +58,7 @@ class PlantingSiteServiceTest : DatabaseTest(), RunsAsUser {
         IdentifierGenerator(clock, dslContext),
         monitoringPlotsDao,
         parentStore,
+        PlantingSiteLocker(dslContext),
         plantingSitesDao,
         eventPublisher,
         strataDao,

--- a/src/test/kotlin/com/terraformation/backend/tracking/PlotAssignmentTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/PlotAssignmentTest.kt
@@ -14,6 +14,7 @@ import com.terraformation.backend.mockUser
 import com.terraformation.backend.tracking.db.ObservationLocker
 import com.terraformation.backend.tracking.db.ObservationStore
 import com.terraformation.backend.tracking.db.PlantingSiteImporter
+import com.terraformation.backend.tracking.db.PlantingSiteLocker
 import com.terraformation.backend.tracking.db.PlantingSiteNotificationStore
 import com.terraformation.backend.tracking.db.PlantingSiteStore
 import com.terraformation.backend.tracking.model.ExistingPlantingSiteModel
@@ -65,6 +66,7 @@ class PlotAssignmentTest : DatabaseTest(), RunsAsUser {
         IdentifierGenerator(clock, dslContext),
         monitoringPlotsDao,
         parentStore,
+        PlantingSiteLocker(dslContext),
         plantingSitesDao,
         eventPublisher,
         strataDao,

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/PlantingSiteImporterTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/PlantingSiteImporterTest.kt
@@ -46,6 +46,7 @@ internal class PlantingSiteImporterTest : DatabaseTest(), RunsAsUser {
             IdentifierGenerator(clock, dslContext),
             monitoringPlotsDao,
             ParentStore(dslContext),
+            PlantingSiteLocker(dslContext),
             plantingSitesDao,
             eventPublisher,
             strataDao,

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/plantingSiteStore/BasePlantingSiteStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/plantingSiteStore/BasePlantingSiteStoreTest.kt
@@ -9,6 +9,7 @@ import com.terraformation.backend.db.DatabaseTest
 import com.terraformation.backend.db.IdentifierGenerator
 import com.terraformation.backend.db.default_schema.OrganizationId
 import com.terraformation.backend.mockUser
+import com.terraformation.backend.tracking.db.PlantingSiteLocker
 import com.terraformation.backend.tracking.db.PlantingSiteStore
 import com.terraformation.backend.util.GeometrySimplifier
 import io.mockk.every
@@ -37,6 +38,7 @@ internal abstract class BasePlantingSiteStoreTest : DatabaseTest(), RunsAsUser {
         identifierGenerator,
         monitoringPlotsDao,
         ParentStore(dslContext),
+        PlantingSiteLocker(dslContext),
         plantingSitesDao,
         rateLimitedEventPublisher,
         strataDao,

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/plantingSiteStore/PlantingSiteStoreCreateAdHocMonitoringPlotsTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/plantingSiteStore/PlantingSiteStoreCreateAdHocMonitoringPlotsTest.kt
@@ -13,6 +13,7 @@ import com.terraformation.backend.db.default_schema.Role
 import com.terraformation.backend.db.tracking.tables.pojos.MonitoringPlotsRow
 import com.terraformation.backend.multiPolygon
 import com.terraformation.backend.point
+import com.terraformation.backend.tracking.db.PlantingSiteLocker
 import com.terraformation.backend.tracking.db.PlantingSiteNotFoundException
 import com.terraformation.backend.tracking.db.PlantingSiteStore
 import com.terraformation.backend.tracking.model.MONITORING_PLOT_SIZE_INT
@@ -42,6 +43,7 @@ class PlantingSiteStoreCreateAdHocMonitoringPlotsTest : DatabaseTest(), RunsAsDa
         IdentifierGenerator(clock, dslContext),
         monitoringPlotsDao,
         ParentStore(dslContext),
+        PlantingSiteLocker(dslContext),
         plantingSitesDao,
         eventPublisher,
         strataDao,

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/plantingSiteStore/PlantingSiteStoreFetchSiteHistoryByIdTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/plantingSiteStore/PlantingSiteStoreFetchSiteHistoryByIdTest.kt
@@ -16,6 +16,7 @@ import com.terraformation.backend.multiPolygon
 import com.terraformation.backend.point
 import com.terraformation.backend.polygon
 import com.terraformation.backend.tracking.db.PlantingSiteHistoryNotFoundException
+import com.terraformation.backend.tracking.db.PlantingSiteLocker
 import com.terraformation.backend.tracking.db.PlantingSiteNotFoundException
 import com.terraformation.backend.tracking.db.PlantingSiteStore
 import com.terraformation.backend.tracking.model.MONITORING_PLOT_SIZE_INT
@@ -50,6 +51,7 @@ internal class PlantingSiteStoreFetchSiteHistoryByIdTest : DatabaseTest(), RunsA
         IdentifierGenerator(clock, dslContext),
         monitoringPlotsDao,
         ParentStore(dslContext),
+        PlantingSiteLocker(dslContext),
         plantingSitesDao,
         eventPublisher,
         strataDao,

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/plantingSiteStore/PlantingSiteStoreMonitoringPlotElevationTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/plantingSiteStore/PlantingSiteStoreMonitoringPlotElevationTest.kt
@@ -14,6 +14,7 @@ import com.terraformation.backend.db.default_schema.Role
 import com.terraformation.backend.db.tracking.tables.records.MonitoringPlotsRecord
 import com.terraformation.backend.multiPolygon
 import com.terraformation.backend.polygon
+import com.terraformation.backend.tracking.db.PlantingSiteLocker
 import com.terraformation.backend.tracking.db.PlantingSiteStore
 import com.terraformation.backend.tracking.model.MonitoringPlotModel
 import com.terraformation.backend.util.GeometrySimplifier
@@ -41,6 +42,7 @@ class PlantingSiteStoreMonitoringPlotElevationTest : DatabaseTest(), RunsAsDatab
         IdentifierGenerator(clock, dslContext),
         monitoringPlotsDao,
         ParentStore(dslContext),
+        PlantingSiteLocker(dslContext),
         plantingSitesDao,
         eventPublisher,
         strataDao,

--- a/src/test/kotlin/com/terraformation/backend/tracking/scenario/ObservationScenario.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/scenario/ObservationScenario.kt
@@ -25,6 +25,7 @@ import com.terraformation.backend.gis.CountryDetector
 import com.terraformation.backend.tracking.db.ObservationLocker
 import com.terraformation.backend.tracking.db.ObservationResultsStoreV2
 import com.terraformation.backend.tracking.db.ObservationStore
+import com.terraformation.backend.tracking.db.PlantingSiteLocker
 import com.terraformation.backend.tracking.db.PlantingSiteStore
 import com.terraformation.backend.tracking.db.T0Store
 import com.terraformation.backend.tracking.event.MonitoringSpeciesTotalsEditedEvent
@@ -110,6 +111,7 @@ class ObservationScenario(
                 identifierGenerator,
                 MonitoringPlotsDao(configuration),
                 parentStore,
+                PlantingSiteLocker(test.dslContext),
                 PlantingSitesDao(configuration),
                 eventPublisher,
                 StrataDao(configuration),


### PR DESCRIPTION
To allow multiple store classes to lock a planting site while they work,
move the lock function to its own service.