### PR TITLE
Fix incorrect sublist in InternalTagsTable

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/search/table/InternalTagsTable.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/table/InternalTagsTable.kt
@@ -19,7 +19,7 @@ class InternalTagsTable(tables: SearchTables) : SearchTable() {
   override val sublists: List<SublistField> by lazy {
     with(tables) {
       listOf(
-          organizations.asMultiValueSublist(
+          organizationInternalTags.asMultiValueSublist(
               "organizationInternalTags",
               INTERNAL_TAGS.ID.eq(ORGANIZATION_INTERNAL_TAGS.INTERNAL_TAG_ID),
           ),


### PR DESCRIPTION
The sublist's join condition was correct, but it was using the wrong
SearchTable.