### PR TITLE
TWS-1214 Allow local accession collected times

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/api/UtcDefaultInstantDeserializer.kt
+++ b/src/main/kotlin/com/terraformation/backend/api/UtcDefaultInstantDeserializer.kt
@@ -1,0 +1,33 @@
+package com.terraformation.backend.api
+
+import com.fasterxml.jackson.core.JsonParser
+import com.fasterxml.jackson.databind.DeserializationContext
+import com.fasterxml.jackson.databind.JsonDeserializer
+import java.time.Instant
+import java.time.LocalDateTime
+import java.time.ZoneOffset
+import java.time.format.DateTimeParseException
+
+/**
+ * Custom deserializer for `Instant` fields that accepts either a full timestamp with time zone or a
+ * local date-time string. In the latter case, the local time is interpreted as being in the UTC
+ * time zone.
+ *
+ * This is a workaround for an issue where some mobile clients are not including time zones in some
+ * of their timestamps.
+ */
+class UtcDefaultInstantDeserializer : JsonDeserializer<Instant?>() {
+  override fun deserialize(p: JsonParser, ctxt: DeserializationContext): Instant? {
+    val value = p.getText()
+    if (value.isNullOrBlank()) {
+      return null
+    }
+
+    return try {
+      Instant.parse(value)
+    } catch (e: DateTimeParseException) {
+      // No zone/offset present, e.g. 2024-01-15T10:30:00 -> assume UTC
+      LocalDateTime.parse(value).toInstant(ZoneOffset.UTC)
+    }
+  }
+}

--- a/src/main/kotlin/com/terraformation/backend/seedbank/api/AccessionsV2Controller.kt
+++ b/src/main/kotlin/com/terraformation/backend/seedbank/api/AccessionsV2Controller.kt
@@ -4,10 +4,12 @@ import com.fasterxml.jackson.annotation.JsonAutoDetect
 import com.fasterxml.jackson.annotation.JsonCreator
 import com.fasterxml.jackson.annotation.JsonInclude
 import com.fasterxml.jackson.annotation.JsonValue
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize
 import com.terraformation.backend.api.ApiResponse404
 import com.terraformation.backend.api.ApiResponse409
 import com.terraformation.backend.api.SeedBankAppEndpoint
 import com.terraformation.backend.api.SuccessResponsePayload
+import com.terraformation.backend.api.UtcDefaultInstantDeserializer
 import com.terraformation.backend.customer.db.FacilityStore
 import com.terraformation.backend.db.default_schema.FacilityId
 import com.terraformation.backend.db.default_schema.ProjectId
@@ -328,6 +330,7 @@ data class CreateAccessionRequestPayloadV2(
     val bagNumbers: Set<String>? = null,
     @Schema(description = "Will be derived from collectedTime if present.", deprecated = true)
     val collectedDate: LocalDate? = null,
+    @JsonDeserialize(using = UtcDefaultInstantDeserializer::class)
     @Schema(description = "Date and time the seeds were collected.")
     val collectedTime: Instant? = null,
     val collectionSiteCity: String? = null,

--- a/src/test/kotlin/com/terraformation/backend/seedbank/api/CreateAccessionRequestPayloadV2Test.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/api/CreateAccessionRequestPayloadV2Test.kt
@@ -1,0 +1,38 @@
+package com.terraformation.backend.seedbank.api
+
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.fasterxml.jackson.module.kotlin.readValue
+import java.time.ZoneOffset
+import java.time.ZonedDateTime
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class CreateAccessionRequestPayloadV2Test {
+  private val objectMapper = jacksonObjectMapper()
+
+  @Test
+  fun `accepts collected time with time zone`() {
+    val payload =
+        objectMapper.readValue<CreateAccessionRequestPayloadV2>(
+            """{ "collectedTime": "2026-08-13T11:08:00-08:00", "facilityId": 1 }"""
+        )
+
+    assertEquals(
+        ZonedDateTime.of(2026, 8, 13, 11, 8, 0, 0, ZoneOffset.ofHours(-8)).toInstant(),
+        payload.collectedTime,
+    )
+  }
+
+  @Test
+  fun `treats collected time without time zone as UTC`() {
+    val payload =
+        objectMapper.readValue<CreateAccessionRequestPayloadV2>(
+            """{ "collectedTime": "2026-08-13T11:08:00", "facilityId": 1 }"""
+        )
+
+    assertEquals(
+        ZonedDateTime.of(2026, 8, 13, 11, 8, 0, 0, ZoneOffset.UTC).toInstant(),
+        payload.collectedTime,
+    )
+  }
+}


### PR DESCRIPTION
The `collectedTime` field of the create-accession payload is an `Instant` which
requires that the client include a time zone in the value, but there's an issue
with some mobile app versions that is causing them to omit the time zone. Add a
custom deserializer that defaults the time zone to UTC if not supplied.