### PR TITLE
SW-7604 Surface quantity edit notes in the event log

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/eventlog/EventLogPayloadTransformer.kt
+++ b/src/main/kotlin/com/terraformation/backend/eventlog/EventLogPayloadTransformer.kt
@@ -177,7 +177,7 @@ class EventLogPayloadTransformer(
       // Events that can self-describe which fields were updated can be transformed generically.
       is FieldsUpdatedPersistentEvent ->
           event.listUpdatedFields(messages).map {
-            FieldUpdatedActionPayload(it.fieldName, it.changedFrom, it.changedTo)
+            FieldUpdatedActionPayload(it.fieldName, it.changedFrom, it.changedTo, it.notes)
           }
 
       // Create and delete actions don't need any event-type-specific arguments because the details

--- a/src/main/kotlin/com/terraformation/backend/eventlog/FieldsUpdatedPersistentEvent.kt
+++ b/src/main/kotlin/com/terraformation/backend/eventlog/FieldsUpdatedPersistentEvent.kt
@@ -72,6 +72,13 @@ interface FieldsUpdatedPersistentEvent : EntityUpdatedPersistentEvent {
        * field is, e.g., a set of enum values. This value should be localized if applicable.
        */
       val changedTo: List<String>?,
+      /**
+       * User-entered notes about why the field changed, if the operation that changed it accepts
+       * notes. These describe the change rather than being a value of the field, so they travel
+       * alongside the values instead of being a field of their own; that keeps them attached to the
+       * change they explain, since each [UpdatedField] becomes a separate event log entry.
+       */
+      val notes: String? = null,
   )
 
   /**
@@ -83,9 +90,10 @@ interface FieldsUpdatedPersistentEvent : EntityUpdatedPersistentEvent {
       fieldName: String,
       changedFrom: List<String>?,
       changedTo: List<String>?,
+      notes: String? = null,
   ): UpdatedField? {
     return if (changedFrom != null || changedTo != null) {
-      UpdatedField(fieldName, changedFrom, changedTo)
+      UpdatedField(fieldName, changedFrom, changedTo, notes)
     } else {
       null
     }
@@ -100,11 +108,13 @@ interface FieldsUpdatedPersistentEvent : EntityUpdatedPersistentEvent {
       fieldName: String,
       changedFrom: String?,
       changedTo: String?,
+      notes: String? = null,
   ): UpdatedField? {
     return createUpdatedField(
         fieldName,
         changedFrom?.let { listOf(it) },
         changedTo?.let { listOf(it) },
+        notes,
     )
   }
 }

--- a/src/main/kotlin/com/terraformation/backend/eventlog/api/EventActionPayload.kt
+++ b/src/main/kotlin/com/terraformation/backend/eventlog/api/EventActionPayload.kt
@@ -29,4 +29,5 @@ data class FieldUpdatedActionPayload(
     val fieldName: String,
     val changedFrom: List<String>?,
     val changedTo: List<String>?,
+    val notes: String? = null,
 ) : EventActionPayload

--- a/src/main/kotlin/com/terraformation/backend/seedbank/event/AccessionPersistentEvent.kt
+++ b/src/main/kotlin/com/terraformation/backend/seedbank/event/AccessionPersistentEvent.kt
@@ -228,6 +228,7 @@ data class AccessionQuantityUpdatedEventV1(
               "quantity",
               changedFrom.quantity?.toString(),
               changedTo.quantity?.toString(),
+              notes,
           )
       )
 }

--- a/src/test/kotlin/com/terraformation/backend/eventlog/EventLogPayloadTransformerTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/eventlog/EventLogPayloadTransformerTest.kt
@@ -44,6 +44,8 @@ import com.terraformation.backend.seedbank.event.AccessionDeletedEvent
 import com.terraformation.backend.seedbank.event.AccessionPhotoAddedEvent
 import com.terraformation.backend.seedbank.event.AccessionPhotoDeletedEvent
 import com.terraformation.backend.seedbank.event.AccessionPhotoReplacedEvent
+import com.terraformation.backend.seedbank.event.AccessionQuantityUpdatedEvent
+import com.terraformation.backend.seedbank.event.AccessionQuantityUpdatedEventValues
 import com.terraformation.backend.seedbank.event.AccessionUpdatedEvent
 import com.terraformation.backend.seedbank.event.AccessionUpdatedEventValues
 import com.terraformation.backend.seedbank.event.AccessionUploadedEvent
@@ -307,6 +309,24 @@ class EventLogPayloadTransformerTest : DatabaseTest(), RunsAsDatabaseUser {
                 organizationId = organizationId,
             ),
         )
+    val quantityEntry =
+        eventLogEntry(
+            knownUserId,
+            AccessionQuantityUpdatedEvent(
+                changedFrom =
+                    AccessionQuantityUpdatedEventValues(
+                        quantity = SeedQuantityModel(BigDecimal(500), SeedQuantityUnits.Seeds)
+                    ),
+                changedTo =
+                    AccessionQuantityUpdatedEventValues(
+                        quantity = SeedQuantityModel(BigDecimal(300), SeedQuantityUnits.Seeds)
+                    ),
+                notes = "Recounted after drying",
+                accessionId = accessionId,
+                facilityId = facilityId,
+                organizationId = organizationId,
+            ),
+        )
 
     val subject =
         AccessionSubjectPayload(
@@ -338,9 +358,25 @@ class EventLogPayloadTransformerTest : DatabaseTest(), RunsAsDatabaseUser {
                 userId = knownUserId,
                 userName = "Known User",
             ),
+            EventLogEntryPayload(
+                action =
+                    FieldUpdatedActionPayload(
+                        fieldName = "quantity",
+                        changedFrom = listOf("SeedQuantityModel(quantity=500, units=Seeds)"),
+                        changedTo = listOf("SeedQuantityModel(quantity=300, units=Seeds)"),
+                        notes = "Recounted after drying",
+                    ),
+                subject = subject,
+                timestamp = quantityEntry.createdTime,
+                userId = knownUserId,
+                userName = "Known User",
+            ),
         )
 
-    assertEquals(expected, transformer.eventsToPayloads(listOf(createEntry, updateEntry)))
+    assertEquals(
+        expected,
+        transformer.eventsToPayloads(listOf(createEntry, updateEntry, quantityEntry)),
+    )
   }
 
   @Test


### PR DESCRIPTION
AccessionQuantityUpdatedEventV1 persists the notes the user entered with a
manual quantity edit, but they were never projected into the API payload, so
clients couldn't show them.

Co-Authored-By: Claude Opus 5 (1M context) [noreply@anthropic.com](mailto:noreply@anthropic.com)