### PR TITLE
SW-7604 Add ViabilityTestCreatedEventV2 with creation-time field values

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/eventlog/db/EventUpgradeUtils.kt
+++ b/src/main/kotlin/com/terraformation/backend/eventlog/db/EventUpgradeUtils.kt
@@ -9,8 +9,13 @@ import com.terraformation.backend.db.ProjectNotFoundException
 import com.terraformation.backend.db.default_schema.EventLogId
 import com.terraformation.backend.db.default_schema.OrganizationId
 import com.terraformation.backend.db.default_schema.ProjectId
+import com.terraformation.backend.db.seedbank.ViabilityTestId
+import com.terraformation.backend.db.seedbank.tables.references.VIABILITY_TESTS
 import com.terraformation.backend.db.seedbank.tables.references.WITHDRAWALS
 import com.terraformation.backend.eventlog.UpgradableEvent
+import com.terraformation.backend.seedbank.event.ViabilityTestCreatedEventV1
+import com.terraformation.backend.seedbank.event.ViabilityTestCreatedEventV2
+import com.terraformation.backend.seedbank.event.ViabilityTestUpdatedEvent
 import com.terraformation.backend.seedbank.event.WithdrawalCreatedEventV1
 import com.terraformation.backend.seedbank.event.WithdrawalCreatedEventV2
 import com.terraformation.backend.seedbank.event.WithdrawalUpdatedEvent
@@ -100,6 +105,48 @@ class EventUpgradeUtils(
         withdrawnQuantity = original.withdrawnQuantity,
     )
   }
+
+  fun getViabilityTestValuesMissingFromV1(
+      viabilityTestId: ViabilityTestId,
+      createdEventLogId: EventLogId,
+  ): ViabilityTestValuesMissingFromV1 {
+    val currentRow =
+        dslContext
+            .select(VIABILITY_TESTS.NOTES, VIABILITY_TESTS.STAFF_RESPONSIBLE)
+            .from(VIABILITY_TESTS)
+            .where(VIABILITY_TESTS.ID.eq(viabilityTestId))
+            .fetchOne()
+
+    val laterEdits =
+        eventLogStore
+            .fetchByIdsSince(
+                mapOf(viabilityTestId to createdEventLogId),
+                listOf(ViabilityTestUpdatedEvent::class),
+            )
+            .map { it.event }
+
+    return ViabilityTestValuesMissingFromV1(
+        notes =
+            valueAtCreation(
+                laterEdits,
+                currentRow?.get(VIABILITY_TESTS.NOTES),
+                { it.changedFrom.notes },
+                { it.changedTo.notes },
+            ),
+        staffResponsible =
+            valueAtCreation(
+                laterEdits,
+                currentRow?.get(VIABILITY_TESTS.STAFF_RESPONSIBLE),
+                { it.changedFrom.staffResponsible },
+                { it.changedTo.staffResponsible },
+            ),
+    )
+  }
+
+  data class ViabilityTestValuesMissingFromV1(
+      val notes: String?,
+      val staffResponsible: String?,
+  )
 
   private fun <T, V> valueAtCreation(
       laterEdits: List<T>,

--- a/src/main/kotlin/com/terraformation/backend/eventlog/db/EventUpgradeUtils.kt
+++ b/src/main/kotlin/com/terraformation/backend/eventlog/db/EventUpgradeUtils.kt
@@ -13,8 +13,6 @@ import com.terraformation.backend.db.seedbank.ViabilityTestId
 import com.terraformation.backend.db.seedbank.tables.references.VIABILITY_TESTS
 import com.terraformation.backend.db.seedbank.tables.references.WITHDRAWALS
 import com.terraformation.backend.eventlog.UpgradableEvent
-import com.terraformation.backend.seedbank.event.ViabilityTestCreatedEventV1
-import com.terraformation.backend.seedbank.event.ViabilityTestCreatedEventV2
 import com.terraformation.backend.seedbank.event.ViabilityTestUpdatedEvent
 import com.terraformation.backend.seedbank.event.WithdrawalCreatedEventV1
 import com.terraformation.backend.seedbank.event.WithdrawalCreatedEventV2

--- a/src/main/kotlin/com/terraformation/backend/eventlog/db/EventUpgradeUtils.kt
+++ b/src/main/kotlin/com/terraformation/backend/eventlog/db/EventUpgradeUtils.kt
@@ -9,8 +9,13 @@ import com.terraformation.backend.db.ProjectNotFoundException
 import com.terraformation.backend.db.default_schema.EventLogId
 import com.terraformation.backend.db.default_schema.OrganizationId
 import com.terraformation.backend.db.default_schema.ProjectId
+import com.terraformation.backend.db.seedbank.ViabilityTestId
+import com.terraformation.backend.db.seedbank.tables.references.VIABILITY_TESTS
 import com.terraformation.backend.db.seedbank.tables.references.WITHDRAWALS
 import com.terraformation.backend.eventlog.UpgradableEvent
+import com.terraformation.backend.seedbank.event.ViabilityTestCreatedEventV1
+import com.terraformation.backend.seedbank.event.ViabilityTestCreatedEventV2
+import com.terraformation.backend.seedbank.event.ViabilityTestUpdatedEvent
 import com.terraformation.backend.seedbank.event.WithdrawalCreatedEventV1
 import com.terraformation.backend.seedbank.event.WithdrawalCreatedEventV2
 import com.terraformation.backend.seedbank.event.WithdrawalUpdatedEvent
@@ -108,6 +113,48 @@ class EventUpgradeUtils(
       )
     }
   }
+
+  fun getViabilityTestValuesMissingFromV1(
+      viabilityTestId: ViabilityTestId,
+      createdEventLogId: EventLogId,
+  ): ViabilityTestValuesMissingFromV1 {
+    val currentRow =
+        dslContext
+            .select(VIABILITY_TESTS.NOTES, VIABILITY_TESTS.STAFF_RESPONSIBLE)
+            .from(VIABILITY_TESTS)
+            .where(VIABILITY_TESTS.ID.eq(viabilityTestId))
+            .fetchOne()
+
+    val laterEdits =
+        eventLogStore
+            .fetchByIdsSince(
+                mapOf(viabilityTestId to createdEventLogId),
+                listOf(ViabilityTestUpdatedEvent::class),
+            )
+            .map { it.event }
+
+    return ViabilityTestValuesMissingFromV1(
+        notes =
+            valueAtCreation(
+                laterEdits,
+                currentRow?.get(VIABILITY_TESTS.NOTES),
+                { it.changedFrom.notes },
+                { it.changedTo.notes },
+            ),
+        staffResponsible =
+            valueAtCreation(
+                laterEdits,
+                currentRow?.get(VIABILITY_TESTS.STAFF_RESPONSIBLE),
+                { it.changedFrom.staffResponsible },
+                { it.changedTo.staffResponsible },
+            ),
+    )
+  }
+
+  data class ViabilityTestValuesMissingFromV1(
+      val notes: String?,
+      val staffResponsible: String?,
+  )
 
   private fun <T, V> valueAtCreation(
       laterEdits: List<T>,

--- a/src/main/kotlin/com/terraformation/backend/seedbank/db/ViabilityTestStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/seedbank/db/ViabilityTestStore.kt
@@ -208,6 +208,8 @@ class ViabilityTestStore(
             startDate = calculatedTest.startDate,
             endDate = calculatedTest.endDate,
             seedType = calculatedTest.seedType,
+            notes = calculatedTest.notes,
+            staffResponsible = calculatedTest.staffResponsible,
             viabilityTestId = testId,
             accessionId = accessionId,
             facilityId = facilityId,
@@ -305,6 +307,8 @@ class ViabilityTestStore(
                       seedsFilled = existingTest.seedsFilled.nullIfEquals(desiredTest.seedsFilled),
                       seedsTested = existingTest.seedsTested.nullIfEquals(desiredTest.seedsTested),
                       seedType = existingTest.seedType.nullIfEquals(desiredTest.seedType),
+                      staffResponsible =
+                          existingTest.staffResponsible.nullIfEquals(desiredTest.staffResponsible),
                       startDate = existingTest.startDate.nullIfEquals(desiredTest.startDate),
                       substrate = existingTest.substrate.nullIfEquals(desiredTest.substrate),
                       totalSeedsGerminated =
@@ -325,6 +329,8 @@ class ViabilityTestStore(
                       seedsFilled = desiredTest.seedsFilled.nullIfEquals(existingTest.seedsFilled),
                       seedsTested = desiredTest.seedsTested.nullIfEquals(existingTest.seedsTested),
                       seedType = desiredTest.seedType.nullIfEquals(existingTest.seedType),
+                      staffResponsible =
+                          desiredTest.staffResponsible.nullIfEquals(existingTest.staffResponsible),
                       startDate = desiredTest.startDate.nullIfEquals(existingTest.startDate),
                       substrate = desiredTest.substrate.nullIfEquals(existingTest.substrate),
                       totalSeedsGerminated =

--- a/src/main/kotlin/com/terraformation/backend/seedbank/event/ViabilityTestPersistentEvent.kt
+++ b/src/main/kotlin/com/terraformation/backend/seedbank/event/ViabilityTestPersistentEvent.kt
@@ -20,24 +20,24 @@ import com.terraformation.backend.i18n.currentLocale
 import java.time.LocalDate
 
 sealed interface ViabilityTestPersistentEvent : PersistentEvent {
-  val viabilityTestId: ViabilityTestId
   val accessionId: AccessionId
   val facilityId: FacilityId
   val organizationId: OrganizationId
+  val viabilityTestId: ViabilityTestId
 }
 
 data class ViabilityTestCreatedEventV1(
-    val testType: ViabilityTestType,
-    val seedsTested: Int? = null,
-    val substrate: ViabilityTestSubstrate? = null,
-    val treatment: SeedTreatment? = null,
-    val startDate: LocalDate? = null,
-    val endDate: LocalDate? = null,
-    val seedType: ViabilityTestSeedType? = null,
-    override val viabilityTestId: ViabilityTestId,
     override val accessionId: AccessionId,
+    val endDate: LocalDate? = null,
     override val facilityId: FacilityId,
     override val organizationId: OrganizationId,
+    val seedsTested: Int? = null,
+    val seedType: ViabilityTestSeedType? = null,
+    val startDate: LocalDate? = null,
+    val substrate: ViabilityTestSubstrate? = null,
+    val testType: ViabilityTestType,
+    val treatment: SeedTreatment? = null,
+    override val viabilityTestId: ViabilityTestId,
 ) : UpgradableEvent, ViabilityTestPersistentEvent {
   override fun toNextVersion(
       eventLogId: EventLogId,
@@ -47,50 +47,50 @@ data class ViabilityTestCreatedEventV1(
         eventUpgradeUtils.getViabilityTestValuesMissingFromV1(viabilityTestId, eventLogId)
 
     return ViabilityTestCreatedEventV2(
-        testType = testType,
-        seedsTested = seedsTested,
-        substrate = substrate,
-        treatment = treatment,
-        startDate = startDate,
-        endDate = endDate,
-        seedType = seedType,
-        notes = missingValues.notes,
-        staffResponsible = missingValues.staffResponsible,
-        viabilityTestId = viabilityTestId,
         accessionId = accessionId,
+        endDate = endDate,
         facilityId = facilityId,
+        notes = missingValues.notes,
         organizationId = organizationId,
+        seedsTested = seedsTested,
+        seedType = seedType,
+        staffResponsible = missingValues.staffResponsible,
+        startDate = startDate,
+        substrate = substrate,
+        testType = testType,
+        treatment = treatment,
+        viabilityTestId = viabilityTestId,
     )
   }
 }
 
 /** Published when a viability test is added to an accession. */
 data class ViabilityTestCreatedEventV2(
-    val testType: ViabilityTestType,
-    val seedsTested: Int? = null,
-    val substrate: ViabilityTestSubstrate? = null,
-    val treatment: SeedTreatment? = null,
-    val startDate: LocalDate? = null,
-    val endDate: LocalDate? = null,
-    val seedType: ViabilityTestSeedType? = null,
-    val notes: String? = null,
-    val staffResponsible: String? = null,
-    override val viabilityTestId: ViabilityTestId,
     override val accessionId: AccessionId,
+    val endDate: LocalDate? = null,
     override val facilityId: FacilityId,
+    val notes: String? = null,
     override val organizationId: OrganizationId,
+    val seedsTested: Int? = null,
+    val seedType: ViabilityTestSeedType? = null,
+    val staffResponsible: String? = null,
+    val startDate: LocalDate? = null,
+    val substrate: ViabilityTestSubstrate? = null,
+    val testType: ViabilityTestType,
+    val treatment: SeedTreatment? = null,
+    override val viabilityTestId: ViabilityTestId,
 ) : FieldsCreatedPersistentEvent, ViabilityTestPersistentEvent {
   override fun listInitialFields(messages: Messages) =
       listOfNotNull(
-          createInitialField("testType", testType.jsonValue),
-          createInitialField("seedsTested", seedsTested?.toString()),
-          createInitialField("substrate", substrate?.jsonValue),
-          createInitialField("treatment", treatment?.jsonValue),
-          createInitialField("startDate", startDate?.toString()),
           createInitialField("endDate", endDate?.toString()),
-          createInitialField("seedType", seedType?.jsonValue),
           createInitialField("notes", notes),
+          createInitialField("seedsTested", seedsTested?.toString()),
+          createInitialField("seedType", seedType?.getDisplayName(currentLocale())),
           createInitialField("staffResponsible", staffResponsible),
+          createInitialField("startDate", startDate?.toString()),
+          createInitialField("substrate", substrate?.getDisplayName(currentLocale())),
+          createInitialField("testType", testType.getDisplayName(currentLocale())),
+          createInitialField("treatment", treatment?.getDisplayName(currentLocale())),
       )
 }
 
@@ -100,12 +100,12 @@ typealias ViabilityTestCreatedEvent = ViabilityTestCreatedEventV2
  * Published when the user edits an existing viability test, including its germination recordings.
  */
 data class ViabilityTestUpdatedEventV1(
+    override val accessionId: AccessionId,
     val changedFrom: Values,
     val changedTo: Values,
-    override val viabilityTestId: ViabilityTestId,
-    override val accessionId: AccessionId,
     override val facilityId: FacilityId,
     override val organizationId: OrganizationId,
+    override val viabilityTestId: ViabilityTestId,
 ) : FieldsUpdatedPersistentEvent, ViabilityTestPersistentEvent {
   data class Values(
       val endDate: LocalDate? = null,
@@ -195,10 +195,10 @@ typealias ViabilityTestUpdatedEventValues = ViabilityTestUpdatedEventV1.Values
 
 /** Published when a viability test is deleted from an accession. */
 data class ViabilityTestDeletedEventV1(
-    override val viabilityTestId: ViabilityTestId,
     override val accessionId: AccessionId,
     override val facilityId: FacilityId,
     override val organizationId: OrganizationId,
+    override val viabilityTestId: ViabilityTestId,
 ) : EntityDeletedPersistentEvent, ViabilityTestPersistentEvent
 
 typealias ViabilityTestDeletedEvent = ViabilityTestDeletedEventV1

--- a/src/main/kotlin/com/terraformation/backend/seedbank/event/ViabilityTestPersistentEvent.kt
+++ b/src/main/kotlin/com/terraformation/backend/seedbank/event/ViabilityTestPersistentEvent.kt
@@ -1,5 +1,6 @@
 package com.terraformation.backend.seedbank.event
 
+import com.terraformation.backend.db.default_schema.EventLogId
 import com.terraformation.backend.db.default_schema.FacilityId
 import com.terraformation.backend.db.default_schema.OrganizationId
 import com.terraformation.backend.db.default_schema.SeedTreatment
@@ -8,10 +9,12 @@ import com.terraformation.backend.db.seedbank.ViabilityTestId
 import com.terraformation.backend.db.seedbank.ViabilityTestSeedType
 import com.terraformation.backend.db.seedbank.ViabilityTestSubstrate
 import com.terraformation.backend.db.seedbank.ViabilityTestType
-import com.terraformation.backend.eventlog.EntityCreatedPersistentEvent
 import com.terraformation.backend.eventlog.EntityDeletedPersistentEvent
+import com.terraformation.backend.eventlog.FieldsCreatedPersistentEvent
 import com.terraformation.backend.eventlog.FieldsUpdatedPersistentEvent
 import com.terraformation.backend.eventlog.PersistentEvent
+import com.terraformation.backend.eventlog.UpgradableEvent
+import com.terraformation.backend.eventlog.db.EventUpgradeUtils
 import com.terraformation.backend.i18n.Messages
 import com.terraformation.backend.i18n.currentLocale
 import java.time.LocalDate
@@ -23,7 +26,6 @@ sealed interface ViabilityTestPersistentEvent : PersistentEvent {
   val organizationId: OrganizationId
 }
 
-/** Published when a viability test is added to an accession. */
 data class ViabilityTestCreatedEventV1(
     val testType: ViabilityTestType,
     val seedsTested: Int? = null,
@@ -32,13 +34,67 @@ data class ViabilityTestCreatedEventV1(
     val startDate: LocalDate? = null,
     val endDate: LocalDate? = null,
     val seedType: ViabilityTestSeedType? = null,
+    val viabilityTestId: ViabilityTestId,
+    val accessionId: AccessionId,
+    val facilityId: FacilityId,
+    val organizationId: OrganizationId,
+) : UpgradableEvent {
+  override fun toNextVersion(
+      eventLogId: EventLogId,
+      eventUpgradeUtils: EventUpgradeUtils,
+  ): ViabilityTestCreatedEventV2 {
+    val missingValues =
+        eventUpgradeUtils.getViabilityTestValuesMissingFromV1(viabilityTestId, eventLogId)
+
+    return ViabilityTestCreatedEventV2(
+        testType = testType,
+        seedsTested = seedsTested,
+        substrate = substrate,
+        treatment = treatment,
+        startDate = startDate,
+        endDate = endDate,
+        seedType = seedType,
+        notes = missingValues.notes,
+        staffResponsible = missingValues.staffResponsible,
+        viabilityTestId = viabilityTestId,
+        accessionId = accessionId,
+        facilityId = facilityId,
+        organizationId = organizationId,
+    )
+  }
+}
+
+/** Published when a viability test is added to an accession. */
+data class ViabilityTestCreatedEventV2(
+    val testType: ViabilityTestType,
+    val seedsTested: Int? = null,
+    val substrate: ViabilityTestSubstrate? = null,
+    val treatment: SeedTreatment? = null,
+    val startDate: LocalDate? = null,
+    val endDate: LocalDate? = null,
+    val seedType: ViabilityTestSeedType? = null,
+    val notes: String? = null,
+    val staffResponsible: String? = null,
     override val viabilityTestId: ViabilityTestId,
     override val accessionId: AccessionId,
     override val facilityId: FacilityId,
     override val organizationId: OrganizationId,
-) : EntityCreatedPersistentEvent, ViabilityTestPersistentEvent
+) : FieldsCreatedPersistentEvent, ViabilityTestPersistentEvent {
+  override fun listInitialFields(messages: Messages) =
+      listOfNotNull(
+          createInitialField("testType", testType.jsonValue),
+          createInitialField("seedsTested", seedsTested?.toString()),
+          createInitialField("substrate", substrate?.jsonValue),
+          createInitialField("treatment", treatment?.jsonValue),
+          createInitialField("startDate", startDate?.toString()),
+          createInitialField("endDate", endDate?.toString()),
+          createInitialField("seedType", seedType?.jsonValue),
+          createInitialField("notes", notes),
+          createInitialField("staffResponsible", staffResponsible),
+      )
+}
 
-typealias ViabilityTestCreatedEvent = ViabilityTestCreatedEventV1
+typealias ViabilityTestCreatedEvent = ViabilityTestCreatedEventV2
 
 /**
  * Published when the user edits an existing viability test, including its germination recordings.
@@ -59,6 +115,7 @@ data class ViabilityTestUpdatedEventV1(
       val seedsFilled: Int? = null,
       val seedsTested: Int? = null,
       val seedType: ViabilityTestSeedType? = null,
+      val staffResponsible: String? = null,
       val startDate: LocalDate? = null,
       val substrate: ViabilityTestSubstrate? = null,
       val totalSeedsGerminated: Int? = null,
@@ -98,6 +155,11 @@ data class ViabilityTestUpdatedEventV1(
               "seedType",
               changedFrom.seedType?.getDisplayName(currentLocale()),
               changedTo.seedType?.getDisplayName(currentLocale()),
+          ),
+          createUpdatedField(
+              "staffResponsible",
+              changedFrom.staffResponsible,
+              changedTo.staffResponsible,
           ),
           createUpdatedField(
               "startDate",

--- a/src/main/kotlin/com/terraformation/backend/seedbank/event/ViabilityTestPersistentEvent.kt
+++ b/src/main/kotlin/com/terraformation/backend/seedbank/event/ViabilityTestPersistentEvent.kt
@@ -34,11 +34,11 @@ data class ViabilityTestCreatedEventV1(
     val startDate: LocalDate? = null,
     val endDate: LocalDate? = null,
     val seedType: ViabilityTestSeedType? = null,
-    val viabilityTestId: ViabilityTestId,
-    val accessionId: AccessionId,
-    val facilityId: FacilityId,
-    val organizationId: OrganizationId,
-) : UpgradableEvent {
+    override val viabilityTestId: ViabilityTestId,
+    override val accessionId: AccessionId,
+    override val facilityId: FacilityId,
+    override val organizationId: OrganizationId,
+) : UpgradableEvent, ViabilityTestPersistentEvent {
   override fun toNextVersion(
       eventLogId: EventLogId,
       eventUpgradeUtils: EventUpgradeUtils,

--- a/src/main/resources/i18n/Messages_en.properties
+++ b/src/main/resources/i18n/Messages_en.properties
@@ -212,6 +212,7 @@ eventSubject.ViabilityTest.field.seedsEmpty=empty seeds
 eventSubject.ViabilityTest.field.seedsFilled=filled seeds
 eventSubject.ViabilityTest.field.seedsTested=seeds tested
 eventSubject.ViabilityTest.field.seedType=seed type
+eventSubject.ViabilityTest.field.staffResponsible=staff responsible
 eventSubject.ViabilityTest.field.startDate=start date
 eventSubject.ViabilityTest.field.substrate=substrate
 eventSubject.ViabilityTest.field.totalSeedsGerminated=total seeds germinated

--- a/src/main/resources/i18n/Messages_es.properties
+++ b/src/main/resources/i18n/Messages_es.properties
@@ -381,6 +381,8 @@ eventSubject.ViabilityTest.field.seedsFilled=semillas llenas
 eventSubject.ViabilityTest.field.seedsTested=semillas analizadas
 # ac314f76
 eventSubject.ViabilityTest.field.seedType=tipo de semilla
+# 2afc7d73
+eventSubject.ViabilityTest.field.staffResponsible=personal responsable
 # cafdab1e
 eventSubject.ViabilityTest.field.startDate=fecha de inicio
 # 93eb06e2

--- a/src/main/resources/i18n/Messages_fr.properties
+++ b/src/main/resources/i18n/Messages_fr.properties
@@ -381,6 +381,8 @@ eventSubject.ViabilityTest.field.seedsFilled=semences pleines
 eventSubject.ViabilityTest.field.seedsTested=semences testées
 # ac314f76
 eventSubject.ViabilityTest.field.seedType=type de semence
+# 2afc7d73
+eventSubject.ViabilityTest.field.staffResponsible=personnel responsable
 # cafdab1e
 eventSubject.ViabilityTest.field.startDate=date de début
 # 93eb06e2

--- a/src/test/kotlin/com/terraformation/backend/eventlog/EventLogPayloadTransformerTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/eventlog/EventLogPayloadTransformerTest.kt
@@ -8,11 +8,13 @@ import com.terraformation.backend.db.default_schema.EventLogId
 import com.terraformation.backend.db.default_schema.FacilityId
 import com.terraformation.backend.db.default_schema.FileId
 import com.terraformation.backend.db.default_schema.OrganizationId
+import com.terraformation.backend.db.default_schema.SeedTreatment
 import com.terraformation.backend.db.default_schema.UserId
 import com.terraformation.backend.db.seedbank.AccessionId
 import com.terraformation.backend.db.seedbank.DataSource
 import com.terraformation.backend.db.seedbank.SeedQuantityUnits
 import com.terraformation.backend.db.seedbank.ViabilityTestId
+import com.terraformation.backend.db.seedbank.ViabilityTestSubstrate
 import com.terraformation.backend.db.seedbank.ViabilityTestType
 import com.terraformation.backend.db.seedbank.WithdrawalId
 import com.terraformation.backend.db.seedbank.WithdrawalPurpose
@@ -517,6 +519,12 @@ class EventLogPayloadTransformerTest : DatabaseTest(), RunsAsDatabaseUser {
             knownUserId,
             ViabilityTestCreatedEvent(
                 testType = ViabilityTestType.Lab,
+                seedsTested = 1,
+                substrate = ViabilityTestSubstrate.Agar,
+                treatment = SeedTreatment.Soak,
+                startDate = LocalDate.of(2021, 1, 1),
+                notes = "initial notes",
+                staffResponsible = "Some Person",
                 viabilityTestId = viabilityTestId,
                 accessionId = accessionId,
                 facilityId = facilityId,
@@ -559,7 +567,18 @@ class EventLogPayloadTransformerTest : DatabaseTest(), RunsAsDatabaseUser {
     val expected =
         listOf(
             EventLogEntryPayload(
-                action = CreatedActionPayload(),
+                action =
+                    CreatedActionPayload(
+                        listOf(
+                            CreatedFieldPayload("testType", listOf("Lab")),
+                            CreatedFieldPayload("seedsTested", listOf("1")),
+                            CreatedFieldPayload("substrate", listOf("Agar")),
+                            CreatedFieldPayload("treatment", listOf("Soak")),
+                            CreatedFieldPayload("startDate", listOf("2021-01-01")),
+                            CreatedFieldPayload("notes", listOf("initial notes")),
+                            CreatedFieldPayload("staffResponsible", listOf("Some Person")),
+                        )
+                    ),
                 subject = subject,
                 timestamp = createEntry.createdTime,
                 userId = knownUserId,

--- a/src/test/kotlin/com/terraformation/backend/eventlog/EventLogPayloadTransformerTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/eventlog/EventLogPayloadTransformerTest.kt
@@ -570,13 +570,13 @@ class EventLogPayloadTransformerTest : DatabaseTest(), RunsAsDatabaseUser {
                 action =
                     CreatedActionPayload(
                         listOf(
-                            CreatedFieldPayload("testType", listOf("Lab")),
-                            CreatedFieldPayload("seedsTested", listOf("1")),
-                            CreatedFieldPayload("substrate", listOf("Agar")),
-                            CreatedFieldPayload("treatment", listOf("Soak")),
-                            CreatedFieldPayload("startDate", listOf("2021-01-01")),
                             CreatedFieldPayload("notes", listOf("initial notes")),
+                            CreatedFieldPayload("seedsTested", listOf("1")),
                             CreatedFieldPayload("staffResponsible", listOf("Some Person")),
+                            CreatedFieldPayload("startDate", listOf("2021-01-01")),
+                            CreatedFieldPayload("substrate", listOf("Agar")),
+                            CreatedFieldPayload("testType", listOf("Lab")),
+                            CreatedFieldPayload("treatment", listOf("Soak")),
                         )
                     ),
                 subject = subject,

--- a/src/test/kotlin/com/terraformation/backend/eventlog/EventLogPayloadTransformerTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/eventlog/EventLogPayloadTransformerTest.kt
@@ -570,13 +570,13 @@ class EventLogPayloadTransformerTest : DatabaseTest(), RunsAsDatabaseUser {
                 action =
                     CreatedActionPayload(
                         listOf(
-                            CreatedFieldPayload("testType", listOf("Lab")),
-                            CreatedFieldPayload("seedsTested", listOf("1")),
-                            CreatedFieldPayload("substrate", listOf("Agar")),
-                            CreatedFieldPayload("treatment", listOf("Soak")),
-                            CreatedFieldPayload("startDate", listOf("2021-01-01")),
                             CreatedFieldPayload("notes", listOf("initial notes")),
+                            CreatedFieldPayload("seedsTested", listOf("1")),
                             CreatedFieldPayload("staffResponsible", listOf("Some Person")),
+                            CreatedFieldPayload("startDate", listOf("2021-01-01")),
+                            CreatedFieldPayload("substrate", listOf("Agar")),
+                            CreatedFieldPayload("testType", listOf("Lab")),
+                            CreatedFieldPayload("treatment", listOf("Soak")),
                         )
                     ),
                 subject = subject,
@@ -631,16 +631,38 @@ class EventLogPayloadTransformerTest : DatabaseTest(), RunsAsDatabaseUser {
             ),
         )
 
-    val payloads = Locales.SPANISH.use { transformer.eventsToPayloads(listOf(createEntry)) }
+    val testEntry =
+        eventLogEntry(
+            knownUserId,
+            ViabilityTestCreatedEvent(
+                testType = ViabilityTestType.Lab,
+                treatment = SeedTreatment.Soak,
+                viabilityTestId = ViabilityTestId(30),
+                accessionId = accessionId,
+                facilityId = facilityId,
+                organizationId = organizationId,
+            ),
+        )
+
+    val payloads =
+        Locales.SPANISH.use { transformer.eventsToPayloads(listOf(createEntry, testEntry)) }
 
     assertEquals(
-        CreatedActionPayload(
-            listOf(
-                CreatedFieldPayload("date", listOf("2021-01-01")),
-                CreatedFieldPayload("purpose", listOf("Pruebas de viabilidad")),
-            )
+        listOf(
+            CreatedActionPayload(
+                listOf(
+                    CreatedFieldPayload("date", listOf("2021-01-01")),
+                    CreatedFieldPayload("purpose", listOf("Pruebas de viabilidad")),
+                )
+            ),
+            CreatedActionPayload(
+                listOf(
+                    CreatedFieldPayload("testType", listOf("Laboratorio")),
+                    CreatedFieldPayload("treatment", listOf("Remojar")),
+                )
+            ),
         ),
-        payloads.single().action,
+        payloads.map { it.action },
     )
   }
 

--- a/src/test/kotlin/com/terraformation/backend/eventlog/db/EventUpgradeUtilsTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/eventlog/db/EventUpgradeUtilsTest.kt
@@ -19,10 +19,15 @@ import com.terraformation.backend.db.default_schema.ProjectId
 import com.terraformation.backend.db.default_schema.UserId
 import com.terraformation.backend.db.seedbank.AccessionId
 import com.terraformation.backend.db.seedbank.ViabilityTestId
+import com.terraformation.backend.db.seedbank.ViabilityTestType
 import com.terraformation.backend.db.seedbank.WithdrawalId
 import com.terraformation.backend.db.seedbank.WithdrawalPurpose
 import com.terraformation.backend.eventlog.PersistentEvent
 import com.terraformation.backend.eventlog.UpgradableEvent
+import com.terraformation.backend.seedbank.event.ViabilityTestCreatedEventV1
+import com.terraformation.backend.seedbank.event.ViabilityTestCreatedEventV2
+import com.terraformation.backend.seedbank.event.ViabilityTestUpdatedEventV1
+import com.terraformation.backend.seedbank.event.ViabilityTestUpdatedEventValues
 import com.terraformation.backend.seedbank.event.WithdrawalCreatedEventV1
 import com.terraformation.backend.seedbank.event.WithdrawalCreatedEventV2
 import com.terraformation.backend.seedbank.event.WithdrawalUpdatedEventV1
@@ -357,6 +362,113 @@ class EventUpgradeUtilsTest : DatabaseTest(), RunsAsDatabaseUser {
             changedFrom = changedFrom,
             changedTo = changedTo,
             withdrawalId = withdrawalId,
+            accessionId = accessionId,
+            facilityId = facilityId,
+            organizationId = inserted.organizationId,
+        )
+  }
+
+  @Nested
+  inner class GetViabilityTestValuesMissingFromV1 {
+    private lateinit var accessionId: AccessionId
+    private lateinit var facilityId: FacilityId
+
+    @BeforeEach
+    fun setUpAccession() {
+      insertOrganization()
+      facilityId = insertFacility()
+      accessionId = insertAccession()
+    }
+
+    @Test
+    fun `uses the current viability test row when no later edit touched the fields`() {
+      val viabilityTestId =
+          insertViabilityTest(notes = "initial notes", staffResponsible = "Some Person")
+
+      testUpgrade(
+          createdEventV1(viabilityTestId),
+          createdEventV2(
+              viabilityTestId,
+              notes = "initial notes",
+              staffResponsible = "Some Person",
+          ),
+      )
+    }
+
+    @Test
+    fun `uses the value from before the earliest edit that changed the field`() {
+      val viabilityTestId = insertViabilityTest(notes = "current notes")
+      val createdEventLogId = insertEvent(createdEventV1(viabilityTestId))
+
+      insertEvent(
+          updatedEvent(
+              viabilityTestId,
+              changedFrom = ViabilityTestUpdatedEventValues(notes = "initial notes"),
+              changedTo = ViabilityTestUpdatedEventValues(notes = "middle notes"),
+          )
+      )
+      insertEvent(
+          updatedEvent(
+              viabilityTestId,
+              changedFrom = ViabilityTestUpdatedEventValues(notes = "middle notes"),
+              changedTo = ViabilityTestUpdatedEventValues(notes = "current notes"),
+          )
+      )
+
+      assertEquals(
+          "initial notes",
+          eventUpgradeUtils
+              .getViabilityTestValuesMissingFromV1(viabilityTestId, createdEventLogId)
+              .notes,
+      )
+    }
+
+    @Test
+    fun `returns nulls if the viability test has been deleted`() {
+      val viabilityTestId = insertViabilityTest(notes = "notes")
+      val createdEventLogId = insertEvent(createdEventV1(viabilityTestId))
+
+      viabilityTestsDao.deleteById(viabilityTestId)
+
+      assertEquals(
+          EventUpgradeUtils.ViabilityTestValuesMissingFromV1(null, null),
+          eventUpgradeUtils.getViabilityTestValuesMissingFromV1(viabilityTestId, createdEventLogId),
+      )
+    }
+
+    private fun createdEventV1(viabilityTestId: ViabilityTestId) =
+        ViabilityTestCreatedEventV1(
+            testType = ViabilityTestType.Lab,
+            viabilityTestId = viabilityTestId,
+            accessionId = accessionId,
+            facilityId = facilityId,
+            organizationId = inserted.organizationId,
+        )
+
+    private fun createdEventV2(
+        viabilityTestId: ViabilityTestId,
+        notes: String? = null,
+        staffResponsible: String? = null,
+    ) =
+        ViabilityTestCreatedEventV2(
+            testType = ViabilityTestType.Lab,
+            notes = notes,
+            staffResponsible = staffResponsible,
+            viabilityTestId = viabilityTestId,
+            accessionId = accessionId,
+            facilityId = facilityId,
+            organizationId = inserted.organizationId,
+        )
+
+    private fun updatedEvent(
+        viabilityTestId: ViabilityTestId,
+        changedFrom: ViabilityTestUpdatedEventValues,
+        changedTo: ViabilityTestUpdatedEventValues,
+    ) =
+        ViabilityTestUpdatedEventV1(
+            changedFrom = changedFrom,
+            changedTo = changedTo,
+            viabilityTestId = viabilityTestId,
             accessionId = accessionId,
             facilityId = facilityId,
             organizationId = inserted.organizationId,

--- a/src/test/kotlin/com/terraformation/backend/eventlog/db/EventUpgradeUtilsTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/eventlog/db/EventUpgradeUtilsTest.kt
@@ -19,10 +19,15 @@ import com.terraformation.backend.db.default_schema.ProjectId
 import com.terraformation.backend.db.default_schema.UserId
 import com.terraformation.backend.db.seedbank.AccessionId
 import com.terraformation.backend.db.seedbank.ViabilityTestId
+import com.terraformation.backend.db.seedbank.ViabilityTestType
 import com.terraformation.backend.db.seedbank.WithdrawalId
 import com.terraformation.backend.db.seedbank.WithdrawalPurpose
 import com.terraformation.backend.eventlog.PersistentEvent
 import com.terraformation.backend.eventlog.UpgradableEvent
+import com.terraformation.backend.seedbank.event.ViabilityTestCreatedEventV1
+import com.terraformation.backend.seedbank.event.ViabilityTestCreatedEventV2
+import com.terraformation.backend.seedbank.event.ViabilityTestUpdatedEventV1
+import com.terraformation.backend.seedbank.event.ViabilityTestUpdatedEventValues
 import com.terraformation.backend.seedbank.event.WithdrawalCreatedEventV1
 import com.terraformation.backend.seedbank.event.WithdrawalCreatedEventV2
 import com.terraformation.backend.seedbank.event.WithdrawalUpdatedEventV1
@@ -360,6 +365,113 @@ class EventUpgradeUtilsTest : DatabaseTest(), RunsAsDatabaseUser {
             changedFrom = changedFrom,
             changedTo = changedTo,
             withdrawalId = withdrawalId,
+            accessionId = accessionId,
+            facilityId = facilityId,
+            organizationId = inserted.organizationId,
+        )
+  }
+
+  @Nested
+  inner class GetViabilityTestValuesMissingFromV1 {
+    private lateinit var accessionId: AccessionId
+    private lateinit var facilityId: FacilityId
+
+    @BeforeEach
+    fun setUpAccession() {
+      insertOrganization()
+      facilityId = insertFacility()
+      accessionId = insertAccession()
+    }
+
+    @Test
+    fun `uses the current viability test row when no later edit touched the fields`() {
+      val viabilityTestId =
+          insertViabilityTest(notes = "initial notes", staffResponsible = "Some Person")
+
+      testUpgrade(
+          createdEventV1(viabilityTestId),
+          createdEventV2(
+              viabilityTestId,
+              notes = "initial notes",
+              staffResponsible = "Some Person",
+          ),
+      )
+    }
+
+    @Test
+    fun `uses the value from before the earliest edit that changed the field`() {
+      val viabilityTestId = insertViabilityTest(notes = "current notes")
+      val createdEventLogId = insertEvent(createdEventV1(viabilityTestId))
+
+      insertEvent(
+          updatedEvent(
+              viabilityTestId,
+              changedFrom = ViabilityTestUpdatedEventValues(notes = "initial notes"),
+              changedTo = ViabilityTestUpdatedEventValues(notes = "middle notes"),
+          )
+      )
+      insertEvent(
+          updatedEvent(
+              viabilityTestId,
+              changedFrom = ViabilityTestUpdatedEventValues(notes = "middle notes"),
+              changedTo = ViabilityTestUpdatedEventValues(notes = "current notes"),
+          )
+      )
+
+      assertEquals(
+          "initial notes",
+          eventUpgradeUtils
+              .getViabilityTestValuesMissingFromV1(viabilityTestId, createdEventLogId)
+              .notes,
+      )
+    }
+
+    @Test
+    fun `returns nulls if the viability test has been deleted`() {
+      val viabilityTestId = insertViabilityTest(notes = "notes")
+      val createdEventLogId = insertEvent(createdEventV1(viabilityTestId))
+
+      viabilityTestsDao.deleteById(viabilityTestId)
+
+      assertEquals(
+          EventUpgradeUtils.ViabilityTestValuesMissingFromV1(null, null),
+          eventUpgradeUtils.getViabilityTestValuesMissingFromV1(viabilityTestId, createdEventLogId),
+      )
+    }
+
+    private fun createdEventV1(viabilityTestId: ViabilityTestId) =
+        ViabilityTestCreatedEventV1(
+            testType = ViabilityTestType.Lab,
+            viabilityTestId = viabilityTestId,
+            accessionId = accessionId,
+            facilityId = facilityId,
+            organizationId = inserted.organizationId,
+        )
+
+    private fun createdEventV2(
+        viabilityTestId: ViabilityTestId,
+        notes: String? = null,
+        staffResponsible: String? = null,
+    ) =
+        ViabilityTestCreatedEventV2(
+            testType = ViabilityTestType.Lab,
+            notes = notes,
+            staffResponsible = staffResponsible,
+            viabilityTestId = viabilityTestId,
+            accessionId = accessionId,
+            facilityId = facilityId,
+            organizationId = inserted.organizationId,
+        )
+
+    private fun updatedEvent(
+        viabilityTestId: ViabilityTestId,
+        changedFrom: ViabilityTestUpdatedEventValues,
+        changedTo: ViabilityTestUpdatedEventValues,
+    ) =
+        ViabilityTestUpdatedEventV1(
+            changedFrom = changedFrom,
+            changedTo = changedTo,
+            viabilityTestId = viabilityTestId,
             accessionId = accessionId,
             facilityId = facilityId,
             organizationId = inserted.organizationId,

--- a/src/test/resources/eventlog/eventProperties.txt
+++ b/src/test/resources/eventlog/eventProperties.txt
@@ -219,6 +219,11 @@ com.terraformation.backend.seedbank.event.ViabilityTestCreatedEventV1/facilityId
 com.terraformation.backend.seedbank.event.ViabilityTestCreatedEventV1/organizationId: OrganizationId
 com.terraformation.backend.seedbank.event.ViabilityTestCreatedEventV1/testType: ViabilityTestType
 com.terraformation.backend.seedbank.event.ViabilityTestCreatedEventV1/viabilityTestId: ViabilityTestId
+com.terraformation.backend.seedbank.event.ViabilityTestCreatedEventV2/accessionId: AccessionId
+com.terraformation.backend.seedbank.event.ViabilityTestCreatedEventV2/facilityId: FacilityId
+com.terraformation.backend.seedbank.event.ViabilityTestCreatedEventV2/organizationId: OrganizationId
+com.terraformation.backend.seedbank.event.ViabilityTestCreatedEventV2/testType: ViabilityTestType
+com.terraformation.backend.seedbank.event.ViabilityTestCreatedEventV2/viabilityTestId: ViabilityTestId
 com.terraformation.backend.seedbank.event.ViabilityTestDeletedEventV1/accessionId: AccessionId
 com.terraformation.backend.seedbank.event.ViabilityTestDeletedEventV1/facilityId: FacilityId
 com.terraformation.backend.seedbank.event.ViabilityTestDeletedEventV1/organizationId: OrganizationId


### PR DESCRIPTION
V2 implements FieldsCreatedPersistentEvent and adds two fields. V1
becomes an UpgradableEvent that fills them in from the earliest later edit
that touched them, falling back to the current row.

Co-Authored-By: Claude Opus 5 (1M context) [noreply@anthropic.com](mailto:noreply@anthropic.com)