### PR TITLE
SW-8773 Support adding seeds to existing batches

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/nursery/db/BatchStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/nursery/db/BatchStore.kt
@@ -257,6 +257,7 @@ class BatchStore(
       batchesDao.insert(rowWithDefaults)
 
       insertQuantityHistoryRow(
+          accessionId = newModel.accessionId,
           activeGrowthQuantity = rowWithDefaults.activeGrowthQuantity!!,
           batchId = rowWithDefaults.id!!,
           germinatingQuantity = rowWithDefaults.germinatingQuantity!!,
@@ -302,7 +303,12 @@ class BatchStore(
       batchDetailsHistorySubLocationsDao.insert(detailsHistorySubLocationsRows)
     }
 
-    return ExistingBatchModel(rowWithDefaults, newModel.subLocationIds, 0)
+    return ExistingBatchModel(
+        row = rowWithDefaults,
+        subLocationIds = newModel.subLocationIds,
+        totalWithdrawn = 0,
+        accessionNumber = rowWithDefaults.accessionId?.let { fetchAccessionNumber(it) },
+    )
   }
 
   fun getSpeciesSummary(speciesId: SpeciesId): SpeciesSummary {
@@ -470,6 +476,7 @@ class BatchStore(
       historyType: BatchQuantityHistoryType,
       withdrawalId: WithdrawalId? = null,
       notes: String? = null,
+      accessionId: AccessionId? = null,
   ) {
     if (germinating < 0 || activeGrowth < 0 || hardeningOff < 0 || ready < 0) {
       throw IllegalArgumentException("Quantities may not be negative")
@@ -499,6 +506,7 @@ class BatchStore(
             newVersion,
             withdrawalId,
             notes,
+            accessionId,
         )
         updateRates(batchId)
       }
@@ -521,6 +529,35 @@ class BatchStore(
               }
             }
       }
+    }
+  }
+
+  fun addToExistingBatch(
+      accessionId: AccessionId,
+      batchId: BatchId,
+      germinatingQuantity: Int,
+  ): ExistingBatchModel {
+    requirePermissions { updateBatch(batchId) }
+
+    if (germinatingQuantity < 0) {
+      throw IllegalArgumentException("Quantities may not be negative")
+    }
+
+    return dslContext.transactionResult { _ ->
+      retryVersionedBatchUpdate(batchId) { batch ->
+        updateQuantities(
+            accessionId = accessionId,
+            activeGrowth = batch.activeGrowthQuantity,
+            batchId = batchId,
+            germinating = batch.germinatingQuantity + germinatingQuantity,
+            hardeningOff = batch.hardeningOffQuantity,
+            historyType = BatchQuantityHistoryType.Computed,
+            ready = batch.readyQuantity,
+            version = batch.version,
+        )
+      }
+
+      fetchOneById(batchId)
     }
   }
 
@@ -1098,9 +1135,11 @@ class BatchStore(
       version: Int,
       withdrawalId: WithdrawalId? = null,
       notes: String? = null,
+      accessionId: AccessionId? = null,
   ) {
     batchQuantityHistoryDao.insert(
         BatchQuantityHistoryRow(
+            accessionId = accessionId,
             activeGrowthQuantity = activeGrowthQuantity,
             batchId = batchId,
             createdBy = currentUser().userId,
@@ -1337,6 +1376,7 @@ class BatchStore(
     val quantityHistory =
         dslContext
             .select(
+                BATCH_QUANTITY_HISTORY.ACCESSION_ID,
                 BATCH_QUANTITY_HISTORY.HISTORY_TYPE_ID,
                 BATCH_QUANTITY_HISTORY.GERMINATING_QUANTITY,
                 BATCH_QUANTITY_HISTORY.ACTIVE_GROWTH_QUANTITY,
@@ -1419,6 +1459,10 @@ class BatchStore(
           purpose == WithdrawalPurpose.NurseryTransfer &&
               current[BATCH_WITHDRAWALS.BATCH_ID] != batchId
       ) {
+        hasAdditionalIncomingTransfers = true
+      }
+
+      if (current[BATCH_QUANTITY_HISTORY.ACCESSION_ID] != null) {
         hasAdditionalIncomingTransfers = true
       }
 

--- a/src/main/kotlin/com/terraformation/backend/nursery/db/Exceptions.kt
+++ b/src/main/kotlin/com/terraformation/backend/nursery/db/Exceptions.kt
@@ -4,8 +4,12 @@ import com.terraformation.backend.db.EntityNotFoundException
 import com.terraformation.backend.db.EntityStaleException
 import com.terraformation.backend.db.MismatchedStateException
 import com.terraformation.backend.db.default_schema.FacilityId
+import com.terraformation.backend.db.default_schema.SpeciesId
 import com.terraformation.backend.db.nursery.BatchId
 import com.terraformation.backend.db.nursery.WithdrawalId
+
+class BatchAtWrongFacilityException(val batchId: BatchId, val facilityId: FacilityId) :
+    MismatchedStateException("Seedling batch $batchId is not at facility $facilityId")
 
 class BatchInventoryInsufficientException(val batchId: BatchId) :
     IllegalArgumentException("Withdrawal quantity can't be more than remaining quantity")
@@ -15,6 +19,9 @@ class BatchNotFoundException(val batchId: BatchId) :
 
 class BatchPhaseReversalNotAllowedException(val batchId: BatchId) :
     IllegalArgumentException("Cannot move quantity from further phase for batch $batchId")
+
+class BatchSpeciesMismatchException(val batchId: BatchId, val speciesId: SpeciesId) :
+    MismatchedStateException("Seedling batch $batchId is not of species $speciesId")
 
 class BatchStaleException(val batchId: BatchId, val requestedVersion: Int) :
     EntityStaleException("Seedling batch $batchId version $requestedVersion out of date")

--- a/src/main/kotlin/com/terraformation/backend/seedbank/AccessionService.kt
+++ b/src/main/kotlin/com/terraformation/backend/seedbank/AccessionService.kt
@@ -3,12 +3,15 @@ package com.terraformation.backend.seedbank
 import com.terraformation.backend.customer.db.ParentStore
 import com.terraformation.backend.customer.model.requirePermissions
 import com.terraformation.backend.db.default_schema.UserId
+import com.terraformation.backend.db.nursery.BatchId
 import com.terraformation.backend.db.seedbank.AccessionId
 import com.terraformation.backend.db.seedbank.SeedQuantityUnits
 import com.terraformation.backend.db.seedbank.ViabilityTestId
 import com.terraformation.backend.db.seedbank.WithdrawalId
 import com.terraformation.backend.db.seedbank.WithdrawalPurpose
 import com.terraformation.backend.db.seedbank.tables.references.ACCESSIONS
+import com.terraformation.backend.nursery.db.BatchAtWrongFacilityException
+import com.terraformation.backend.nursery.db.BatchSpeciesMismatchException
 import com.terraformation.backend.nursery.db.BatchStore
 import com.terraformation.backend.nursery.db.CrossOrganizationNurseryTransferNotAllowedException
 import com.terraformation.backend.nursery.model.ExistingBatchModel
@@ -75,20 +78,28 @@ class AccessionService(
   }
 
   /**
-   * Withdraws seeds from a seed bank and creates a new seedling batch at a nursery.
+   * Withdraws seeds from a seed bank and adds them to a seedling batch at a nursery.
    *
    * Withdrawal details are pulled from [batch], with the withdrawal quantity set to the sum of the
    * batch's germinating, active-growth, hardening-off and ready quantities.
    *
-   * @return The updated accession model and the newly-created batch with its ID populated.
+   * @param batchId If non-null, the seeds are added to the quantities of this existing batch, which
+   *   must be at the facility in [batch] and be of the same species as the accession. If null, a
+   *   new batch is created.
+   * @return The updated accession model and the batch the seeds were added to.
    */
   fun createNurseryTransfer(
       accessionId: AccessionId,
       batch: NewBatchModel,
       withdrawnByUserId: UserId? = null,
+      batchId: BatchId? = null,
   ): Pair<AccessionModel, ExistingBatchModel> {
     requirePermissions {
-      createBatch(batch.facilityId)
+      if (batchId != null) {
+        updateBatch(batchId)
+      } else {
+        createBatch(batch.facilityId)
+      }
       updateAccession(accessionId)
     }
 
@@ -109,24 +120,47 @@ class AccessionService(
     }
 
     val totalSeeds =
-        batch.germinatingQuantity +
-            batch.activeGrowthQuantity +
-            batch.hardeningOffQuantity +
-            batch.readyQuantity
+        if (batchId != null) {
+          batch.germinatingQuantity
+        } else {
+          batch.germinatingQuantity +
+              batch.activeGrowthQuantity +
+              batch.hardeningOffQuantity +
+              batch.readyQuantity
+        }
 
     if (totalSeeds <= 0) {
       throw IllegalArgumentException("Transfers must include at least 1 seed")
     }
 
-    val batchWithAccessionData =
-        batch.copy(
-            accessionId = accessionId,
-            projectId = accession.projectId,
-            speciesId = accession.speciesId,
-        )
+    val existingBatch = batchId?.let { batchStore.fetchOneById(it) }
+    if (existingBatch != null) {
+      if (existingBatch.facilityId != batch.facilityId) {
+        throw BatchAtWrongFacilityException(existingBatch.id, batch.facilityId)
+      }
+
+      if (existingBatch.speciesId != accession.speciesId) {
+        throw BatchSpeciesMismatchException(existingBatch.id, accession.speciesId)
+      }
+    }
 
     return dslContext.transactionResult { _ ->
-      val updatedBatch = batchStore.create(batchWithAccessionData)
+      val updatedBatch =
+          if (existingBatch != null) {
+            batchStore.addToExistingBatch(
+                accessionId = accessionId,
+                batchId = existingBatch.id,
+                germinatingQuantity = batch.germinatingQuantity,
+            )
+          } else {
+            batchStore.create(
+                batch.copy(
+                    accessionId = accessionId,
+                    projectId = accession.projectId,
+                    speciesId = accession.speciesId,
+                )
+            )
+          }
 
       val withdrawal =
           WithdrawalModel(

--- a/src/main/kotlin/com/terraformation/backend/seedbank/api/TransfersController.kt
+++ b/src/main/kotlin/com/terraformation/backend/seedbank/api/TransfersController.kt
@@ -7,6 +7,7 @@ import com.terraformation.backend.api.SeedBankAppEndpoint
 import com.terraformation.backend.api.SuccessResponsePayload
 import com.terraformation.backend.db.default_schema.FacilityId
 import com.terraformation.backend.db.default_schema.UserId
+import com.terraformation.backend.db.nursery.BatchId
 import com.terraformation.backend.db.seedbank.AccessionId
 import com.terraformation.backend.nursery.api.BatchPayload
 import com.terraformation.backend.nursery.model.NewBatchModel
@@ -35,9 +36,10 @@ class TransfersController(
   ): CreateNurseryTransferResponsePayload {
     val (accession, batch) =
         accessionService.createNurseryTransfer(
-            accessionId,
-            payload.toNewBatchModel(),
-            payload.withdrawnByUserId,
+            accessionId = accessionId,
+            batch = payload.toNewBatchModel(),
+            batchId = payload.batchId,
+            withdrawnByUserId = payload.withdrawnByUserId,
         )
     return CreateNurseryTransferResponsePayload(AccessionPayloadV2(accession), BatchPayload(batch))
   }
@@ -45,20 +47,30 @@ class TransfersController(
 
 data class CreateNurseryTransferRequestPayload(
     @JsonSetter(nulls = Nulls.FAIL)
-    @Min(0) //
     @JsonAlias("notReadyQuantity")
+    @Min(0)
+    @Schema(description = "Ignored if batchId is specified.")
     val activeGrowthQuantity: Int,
+    @Schema(
+        description =
+            "If this transfer should add to an existing batch, the batch's ID. Default is to " +
+                "create a new batch. The batch must be at the facility specified by " +
+                "destinationFacilityId, and it must be of the same species as the accession."
+    )
+    val batchId: BatchId?,
     val date: LocalDate,
     val destinationFacilityId: FacilityId,
     @JsonSetter(nulls = Nulls.FAIL)
     @Min(0) //
     val germinatingQuantity: Int,
     @Min(0) //
+    @Schema(description = "Ignored if batchId is specified.")
     val hardeningOffQuantity: Int? = 0,
     val notes: String? = null,
     val readyByDate: LocalDate? = null,
     @JsonSetter(nulls = Nulls.FAIL)
     @Min(0) //
+    @Schema(description = "Ignored if batchId is specified.")
     val readyQuantity: Int,
     @Schema(
         description =
@@ -85,6 +97,6 @@ data class CreateNurseryTransferRequestPayload(
 data class CreateNurseryTransferResponsePayload(
     @Schema(description = "Updated accession that includes a withdrawal for the nursery transfer.")
     val accession: AccessionPayloadV2,
-    @Schema(description = "Details of newly-created seedling batch.") //
+    @Schema(description = "Details of the seedling batch the seeds were added to.")
     val batch: BatchPayload,
 ) : SuccessResponsePayload

--- a/src/main/resources/db/migration/2026/08/V20260818.0723__BatchQuantityAccession.sql
+++ b/src/main/resources/db/migration/2026/08/V20260818.0723__BatchQuantityAccession.sql
@@ -1,0 +1,13 @@
+ALTER TABLE nursery.batch_quantity_history
+    ADD COLUMN accession_id BIGINT
+        REFERENCES seedbank.accessions (id)
+            ON DELETE SET NULL;
+
+UPDATE nursery.batch_quantity_history bqh
+    SET accession_id = b.accession_id
+    FROM nursery.batches b
+    WHERE b.id = bqh.batch_id
+    AND b.accession_id IS NOT NULL
+    AND bqh.version = 1;
+
+CREATE INDEX ON nursery.batch_quantity_history (accession_id);

--- a/src/main/resources/db/migration/R__Comments.sql
+++ b/src/main/resources/db/migration/R__Comments.sql
@@ -360,6 +360,7 @@ COMMENT ON TABLE nursery.batch_photos IS 'Information about photos of batches.';
 COMMENT ON COLUMN nursery.batch_photos.file_id IS 'File ID if the photo exists. Null if the photo has been deleted.';
 
 COMMENT ON TABLE nursery.batch_quantity_history IS 'Record of changes of seedling quantities in each nursery batch.';
+COMMENT ON COLUMN nursery.batch_quantity_history.accession_id IS 'If this change in quantity was due to a transfer of seeds from an accession, the accession''s ID. This may differ from the accession ID of the batch itself if seeds from more than one accession were added to the batch.';
 COMMENT ON COLUMN nursery.batch_quantity_history.batch_id IS 'Which batch''s quantities were changed.';
 COMMENT ON COLUMN nursery.batch_quantity_history.created_by IS 'Which user triggered the change in quantities. "Created" here refers to the history row, not the batch.';
 COMMENT ON COLUMN nursery.batch_quantity_history.created_time IS 'When the change in quantities happened. "Created" here refers to the history row, not the batch.';

--- a/src/test/kotlin/com/terraformation/backend/nursery/db/batchStore/BatchStoreAddToExistingBatchTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/nursery/db/batchStore/BatchStoreAddToExistingBatchTest.kt
@@ -1,0 +1,142 @@
+package com.terraformation.backend.nursery.db.batchStore
+
+import com.terraformation.backend.db.default_schema.FacilityType
+import com.terraformation.backend.db.nursery.BatchId
+import com.terraformation.backend.db.nursery.BatchQuantityHistoryType
+import com.terraformation.backend.db.nursery.tables.records.BatchQuantityHistoryRecord
+import com.terraformation.backend.db.seedbank.AccessionId
+import com.terraformation.backend.nursery.model.ExistingBatchModel
+import java.time.Instant
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+internal class BatchStoreAddToExistingBatchTest : BatchStoreTest() {
+  private val transferTime = Instant.ofEpochSecond(1000)
+
+  private lateinit var batch: ExistingBatchModel
+  private lateinit var batchId: BatchId
+  private lateinit var originalAccessionId: AccessionId
+  private lateinit var secondAccessionId: AccessionId
+
+  @BeforeEach
+  fun setUpTestBatch() {
+    insertFacility(type = FacilityType.SeedBank)
+    originalAccessionId = insertAccession()
+    secondAccessionId = insertAccession()
+
+    batch =
+        store.create(
+            makeNewBatchModel().copy(accessionId = originalAccessionId, germinatingQuantity = 10)
+        )
+
+    batchId = batch.id
+
+    clock.instant = transferTime
+  }
+
+  @Test
+  fun `adds quantities to existing batch`() {
+    val updatedBatch =
+        store.addToExistingBatch(
+            accessionId = secondAccessionId,
+            batchId = batchId,
+            germinatingQuantity = 100,
+        )
+
+    assertEquals(
+        batch.copy(
+            germinatingQuantity = 110,
+            lossRate = null,
+            version = 2,
+        ),
+        updatedBatch,
+        "Batch after adding seeds",
+    )
+  }
+
+  @Test
+  fun `records accession the seeds came from in quantity history`() {
+    store.addToExistingBatch(
+        accessionId = secondAccessionId,
+        batchId = batchId,
+        germinatingQuantity = 100,
+    )
+
+    assertTableEquals(
+        listOf(
+            BatchQuantityHistoryRecord(
+                accessionId = originalAccessionId,
+                activeGrowthQuantity = 1,
+                batchId = batchId,
+                createdBy = user.userId,
+                createdTime = Instant.EPOCH,
+                germinatingQuantity = 10,
+                hardeningOffQuantity = 3,
+                historyTypeId = BatchQuantityHistoryType.Observed,
+                readyQuantity = 2,
+                version = 1,
+            ),
+            BatchQuantityHistoryRecord(
+                accessionId = secondAccessionId,
+                activeGrowthQuantity = 1,
+                batchId = batchId,
+                createdBy = user.userId,
+                createdTime = transferTime,
+                germinatingQuantity = 110,
+                hardeningOffQuantity = 3,
+                historyTypeId = BatchQuantityHistoryType.Computed,
+                readyQuantity = 2,
+                version = 2,
+            ),
+        )
+    )
+  }
+
+  @Test
+  fun `does not modify accession ID of batch`() {
+    store.addToExistingBatch(
+        accessionId = secondAccessionId,
+        batchId = batchId,
+        germinatingQuantity = 1,
+    )
+
+    assertEquals(originalAccessionId, batchesDao.fetchOneById(batchId)?.accessionId)
+  }
+
+  @Test
+  fun `does not calculate rates for batches with seeds from other accessions`() {
+    store.addToExistingBatch(
+        accessionId = secondAccessionId,
+        batchId = batchId,
+        germinatingQuantity = 1,
+    )
+
+    store.updateQuantities(
+        batchId = batchId,
+        version = 2,
+        germinating = 0,
+        activeGrowth = 12,
+        hardeningOff = 3,
+        ready = 2,
+        historyType = BatchQuantityHistoryType.Computed,
+    )
+
+    val batch = batchesDao.fetchOneById(batchId)!!
+
+    assertEquals(null, batch.germinationRate, "Germination rate")
+    assertEquals(null, batch.lossRate, "Loss rate")
+  }
+
+  @Test
+  fun `throws exception if quantities are negative`() {
+    assertThrows<IllegalArgumentException> {
+      store.addToExistingBatch(
+          accessionId = secondAccessionId,
+          batchId = batchId,
+          germinatingQuantity = -1,
+      )
+    }
+  }
+}

--- a/src/test/kotlin/com/terraformation/backend/nursery/db/batchStore/BatchStoreCreateBatchTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/nursery/db/batchStore/BatchStoreCreateBatchTest.kt
@@ -167,6 +167,19 @@ internal class BatchStoreCreateBatchTest : BatchStoreTest() {
   }
 
   @Test
+  fun `records accession ID in initial quantity history row`() {
+    val seedBankFacilityId = insertFacility(type = FacilityType.SeedBank)
+    val accessionId = insertAccession(facilityId = seedBankFacilityId)
+
+    val batchId = store.create(makeNewBatchModel().copy(accessionId = accessionId)).id
+
+    assertEquals(
+        listOf(accessionId),
+        batchQuantityHistoryDao.fetchByBatchId(batchId).map { it.accessionId },
+    )
+  }
+
+  @Test
   fun `includes facility number in batch number`() {
     val secondFacilityId = insertFacility(type = FacilityType.Nursery, facilityNumber = 2)
 

--- a/src/test/kotlin/com/terraformation/backend/nursery/db/batchStore/BatchStorePermissionTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/nursery/db/batchStore/BatchStorePermissionTest.kt
@@ -3,6 +3,7 @@ package com.terraformation.backend.nursery.db.batchStore
 import com.terraformation.backend.db.SpeciesNotFoundException
 import com.terraformation.backend.db.nursery.BatchId
 import com.terraformation.backend.db.nursery.BatchQuantityHistoryType
+import com.terraformation.backend.db.seedbank.AccessionId
 import com.terraformation.backend.nursery.db.BatchNotFoundException
 import io.mockk.every
 import org.junit.jupiter.api.Test
@@ -16,6 +17,21 @@ internal class BatchStorePermissionTest : BatchStoreTest() {
     every { user.canReadFacility(facilityId) } returns true
 
     assertThrows<AccessDeniedException> { store.create(makeNewBatchModel()) }
+  }
+
+  @Test
+  fun `addToExistingBatch throws exception if no permission to update batch`() {
+    val batchId = BatchId(1)
+
+    every { user.canUpdateBatch(batchId) } returns false
+
+    assertThrows<AccessDeniedException> {
+      store.addToExistingBatch(
+          accessionId = AccessionId(1),
+          batchId = batchId,
+          germinatingQuantity = 1,
+      )
+    }
   }
 
   @Test

--- a/src/test/kotlin/com/terraformation/backend/seedbank/AccessionServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/AccessionServiceTest.kt
@@ -15,6 +15,8 @@ import com.terraformation.backend.db.seedbank.AccessionState
 import com.terraformation.backend.db.seedbank.ViabilityTestType
 import com.terraformation.backend.db.seedbank.WithdrawalId
 import com.terraformation.backend.mockUser
+import com.terraformation.backend.nursery.db.BatchAtWrongFacilityException
+import com.terraformation.backend.nursery.db.BatchSpeciesMismatchException
 import com.terraformation.backend.nursery.db.BatchStore
 import com.terraformation.backend.nursery.db.CrossOrganizationNurseryTransferNotAllowedException
 import com.terraformation.backend.nursery.model.ExistingBatchModel
@@ -249,8 +251,22 @@ internal class AccessionServiceTest : DatabaseTest(), RunsAsUser {
             speciesId = SpeciesId(1),
         )
 
+    private val existingBatchId = BatchId(2)
+    private val existingBatchAccessionId = AccessionId(2)
+
     private val accessionSlot: CapturingSlot<AccessionModel> = slot()
     private val batchSlot: CapturingSlot<NewBatchModel> = slot()
+
+    private val transferredBatch =
+        NewBatchModel(
+            addedDate = LocalDate.EPOCH.plusDays(1),
+            facilityId = nurseryFacilityId,
+            germinatingQuantity = 10,
+            activeGrowthQuantity = 0,
+            readyQuantity = 0,
+            hardeningOffQuantity = 0,
+            speciesId = null,
+        )
 
     @BeforeEach
     fun setUp() {
@@ -289,6 +305,7 @@ internal class AccessionServiceTest : DatabaseTest(), RunsAsUser {
 
       every { user.canCreateBatch(nurseryFacilityId) } returns true
       every { user.canReadFacility(nurseryFacilityId) } returns true
+      every { user.canUpdateBatch(existingBatchId) } returns true
     }
 
     @Test
@@ -379,6 +396,72 @@ internal class AccessionServiceTest : DatabaseTest(), RunsAsUser {
           )
 
       assertEquals(grams(initialGrams - gramsPerSeed * (1 + 2 + 3 + 4)), accession.remaining)
+    }
+
+    @Test
+    fun `adds seeds to existing batch if batch ID is specified`() {
+      val existingBatch = makeExistingBatch()
+      val updatedBatch =
+          existingBatch.copy(
+              germinatingQuantity = 11,
+              activeGrowthQuantity = 22,
+              hardeningOffQuantity = 44,
+              readyQuantity = 33,
+              version = 2,
+          )
+
+      every { batchStore.fetchOneById(existingBatchId) } returns existingBatch
+      every {
+        batchStore.addToExistingBatch(
+            accessionId = accessionId,
+            batchId = existingBatchId,
+            germinatingQuantity = 10,
+        )
+      } returns updatedBatch
+
+      val (updatedAccession, batch) =
+          service.createNurseryTransfer(accessionId, transferredBatch, batchId = existingBatchId)
+
+      assertEquals(updatedBatch, batch, "Returned batch")
+      assertEquals(
+          existingBatchAccessionId,
+          batch.accessionId,
+          "Accession ID of batch should not have changed",
+      )
+      assertEquals(seeds(0), updatedAccession.remaining, "Seeds remaining")
+      assertEquals(existingBatchId, updatedAccession.withdrawals.single().batchId, "Batch ID")
+
+      verify(exactly = 0) { batchStore.create(any()) }
+    }
+
+    @Test
+    fun `throws exception if existing batch is at a different facility`() {
+      every { batchStore.fetchOneById(existingBatchId) } returns
+          makeExistingBatch(facilityId = FacilityId(3))
+
+      assertThrows<BatchAtWrongFacilityException> {
+        service.createNurseryTransfer(accessionId, transferredBatch, batchId = existingBatchId)
+      }
+    }
+
+    @Test
+    fun `throws exception if existing batch is of a different species`() {
+      every { batchStore.fetchOneById(existingBatchId) } returns
+          makeExistingBatch(speciesId = SpeciesId(1000))
+
+      assertThrows<BatchSpeciesMismatchException> {
+        service.createNurseryTransfer(accessionId, transferredBatch, batchId = existingBatchId)
+      }
+    }
+
+    @Test
+    fun `throws exception if no permission to update existing batch`() {
+      every { user.canReadBatch(existingBatchId) } returns true
+      every { user.canUpdateBatch(existingBatchId) } returns false
+
+      assertThrows<AccessDeniedException> {
+        service.createNurseryTransfer(accessionId, transferredBatch, batchId = existingBatchId)
+      }
     }
 
     @Test
@@ -479,5 +562,30 @@ internal class AccessionServiceTest : DatabaseTest(), RunsAsUser {
         )
       }
     }
+
+    private fun makeExistingBatch(
+        facilityId: FacilityId = nurseryFacilityId,
+        speciesId: SpeciesId = accession.speciesId!!,
+    ) =
+        ExistingBatchModel(
+            accessionId = existingBatchAccessionId,
+            activeGrowthQuantity = 20,
+            addedDate = LocalDate.EPOCH,
+            batchNumber = "2",
+            facilityId = facilityId,
+            germinatingQuantity = 10,
+            hardeningOffQuantity = 40,
+            id = existingBatchId,
+            latestObservedActiveGrowthQuantity = 20,
+            latestObservedGerminatingQuantity = 10,
+            latestObservedHardeningOffQuantity = 40,
+            latestObservedReadyQuantity = 30,
+            latestObservedTime = Instant.EPOCH,
+            organizationId = organizationId,
+            readyQuantity = 30,
+            speciesId = speciesId,
+            totalWithdrawn = 0,
+            version = 1,
+        )
   }
 }

--- a/src/test/kotlin/com/terraformation/backend/tracking/model/StratumModelTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/model/StratumModelTest.kt
@@ -563,6 +563,7 @@ class StratumModelTest {
       val square = stratum.findUnusedSquare(siteOrigin, 30)
       assertNotNull(square, "Unused square")
 
+      assertThat("foobar").contains("bar", "foo")
       assertThat(square!!.intersection(targetArea).area)
           .describedAs(
               "Area of the part of the square that is inside the only region the square should " +


### PR DESCRIPTION
Update the seedbank nursery transfer API to take an optional batch ID
value. If present, the server will add seeds to the germinating quantity
of the specified batch rather than creating a new batch.

Since seeds can now come from multiple accessions, the batch quantity
history table now tracks an optional accession ID with each entry. A
later change will expose the accession ID to clients in the history API.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>