### PR TITLE
SW-8773 Include accession IDs in batch history API

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/nursery/api/BatchesHistoryController.kt
+++ b/src/main/kotlin/com/terraformation/backend/nursery/api/BatchesHistoryController.kt
@@ -30,7 +30,9 @@ import com.terraformation.backend.db.nursery.tables.pojos.BatchDetailsHistorySub
 import com.terraformation.backend.db.nursery.tables.pojos.BatchQuantityHistoryRow
 import com.terraformation.backend.db.nursery.tables.pojos.BatchWithdrawalsRow
 import com.terraformation.backend.db.nursery.tables.pojos.WithdrawalsRow
+import com.terraformation.backend.db.seedbank.AccessionId
 import com.terraformation.backend.log.perClassLogger
+import com.terraformation.backend.seedbank.db.AccessionStore
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.media.Schema
 import java.time.Instant
@@ -44,6 +46,7 @@ import org.springframework.web.bind.annotation.RestController
 @RestController
 @RequestMapping("/api/v1/nursery/batches/{batchId}/history")
 class BatchesHistoryController(
+    private val accessionStore: AccessionStore,
     private val batchDetailsHistoryDao: BatchDetailsHistoryDao,
     private val batchDetailsHistorySubLocationsDao: BatchDetailsHistorySubLocationsDao,
     private val batchPhotosDao: BatchPhotosDao,
@@ -93,6 +96,9 @@ class BatchesHistoryController(
         }
 
     val quantityHistory = batchQuantityHistoryDao.fetchByBatchId(batchId)
+    val accessionNumbers =
+        accessionStore.fetchAccessionNumbers(quantityHistory.mapNotNull { it.accessionId })
+
     val quantityPayloads = quantityHistory.map { quantityHistoryRow ->
       val withdrawalId = quantityHistoryRow.withdrawalId
       val incomingBatchWithdrawal = incomingBatchWithdrawals[withdrawalId]
@@ -103,6 +109,14 @@ class BatchesHistoryController(
           outgoingBatchWithdrawal?.withdrawalId?.let { outgoingWithdrawals[it] }
 
       when {
+        quantityHistoryRow.historyTypeId == BatchQuantityHistoryType.Computed &&
+            quantityHistoryRow.accessionId != null -> {
+          BatchHistoryAddedFromAccessionPayload(
+              quantityHistoryRow,
+              accessionNumbers.getValue(quantityHistoryRow.accessionId!!),
+          )
+        }
+
         incomingBatchWithdrawal != null && incomingWithdrawal != null -> {
           BatchHistoryIncomingWithdrawalPayload(
               quantityHistoryRow,
@@ -173,6 +187,7 @@ sealed interface BatchHistoryPayloadCommonProps {
     allOf = [BatchHistoryPayloadCommonProps::class],
     oneOf =
         [
+            BatchHistoryAddedFromAccessionPayload::class,
             BatchHistoryDetailsEditedPayload::class,
             BatchHistoryIncomingWithdrawalPayload::class,
             BatchHistoryOutgoingWithdrawalPayload::class,
@@ -328,6 +343,35 @@ data class BatchHistoryStatusChangedPayload(
 
   val type
     @Schema(allowableValues = ["StatusChanged"]) get() = "StatusChanged"
+}
+
+@JsonTypeName("AddedFromAccession")
+@Schema(
+    allOf = [BatchHistoryPayloadCommonProps::class],
+    description = "A transfer from a seed bank that added germinating seedlings to this batch.",
+)
+data class BatchHistoryAddedFromAccessionPayload(
+    val accessionId: AccessionId,
+    val accessionNumber: String,
+    override val createdBy: UserId,
+    override val createdTime: Instant,
+    val germinatingQuantity: Int,
+    override val version: Int,
+) : BatchHistoryPayload, BatchHistoryPayloadCommonProps {
+  constructor(
+      historyRow: BatchQuantityHistoryRow,
+      accessionNumber: String,
+  ) : this(
+      accessionId = historyRow.accessionId!!,
+      accessionNumber = accessionNumber,
+      createdBy = historyRow.createdBy!!,
+      createdTime = historyRow.createdTime!!,
+      germinatingQuantity = historyRow.germinatingQuantity!!,
+      version = historyRow.version!!,
+  )
+
+  val type
+    @Schema(allowableValues = ["AddedFromAccession"]) get() = "AddedFromAccession"
 }
 
 @JsonTypeName("IncomingWithdrawal")

--- a/src/main/kotlin/com/terraformation/backend/seedbank/db/AccessionStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/seedbank/db/AccessionStore.kt
@@ -618,6 +618,44 @@ class AccessionStore(
     }
   }
 
+  fun fetchAccessionNumbers(accessionIds: Collection<AccessionId>): Map<AccessionId, String> {
+    if (accessionIds.isEmpty()) {
+      return emptyMap()
+    }
+
+    // The point of this taking a list of IDs is to avoid N+1 fetching, so we check permissions
+    // at the org level rather than at the individual accession level.
+    val organizationIdsAndNumbers =
+        dslContext
+            .select(
+                ACCESSIONS.ID,
+                ACCESSIONS.NUMBER,
+                ACCESSIONS.facilities.ORGANIZATION_ID,
+            )
+            .from(ACCESSIONS)
+            .where(ACCESSIONS.ID.`in`(accessionIds))
+            .fetch()
+    val organizationIds = organizationIdsAndNumbers.map { it.value3()!! }.distinct()
+    when (organizationIds.size) {
+      0 -> throw AccessionNotFoundException(accessionIds.first())
+      1 -> requirePermissions { readOrganization(organizationIds.single()) }
+      else ->
+          throw IllegalArgumentException(
+              "Cannot fetch accession numbers across multiple organizations"
+          )
+    }
+
+    val result = organizationIdsAndNumbers.associate { it.value1()!! to it.value2()!! }
+
+    accessionIds.forEach { accessionId ->
+      if (accessionId !in result) {
+        throw AccessionNotFoundException(accessionId)
+      }
+    }
+
+    return result
+  }
+
   fun fetchHistory(accessionId: AccessionId): List<AccessionHistoryModel> {
     requirePermissions { readAccession(accessionId) }
 

--- a/src/test/kotlin/com/terraformation/backend/seedbank/db/accessionStore/AccessionStoreFetchAccessionNumbersTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/db/accessionStore/AccessionStoreFetchAccessionNumbersTest.kt
@@ -1,0 +1,93 @@
+package com.terraformation.backend.seedbank.db.accessionStore
+
+import com.terraformation.backend.db.AccessionNotFoundException
+import com.terraformation.backend.db.OrganizationNotFoundException
+import com.terraformation.backend.db.seedbank.AccessionId
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+internal class AccessionStoreFetchAccessionNumbersTest : AccessionStoreTest() {
+  @Test
+  fun `returns numbers of requested accessions`() {
+    val accessionId1 = insertAccession(number = "ABC")
+    val accessionId2 = insertAccession(number = "DEF")
+    insertAccession(number = "GHI")
+
+    assertEquals(
+        mapOf(accessionId1 to "ABC", accessionId2 to "DEF"),
+        store.fetchAccessionNumbers(listOf(accessionId1, accessionId2)),
+    )
+  }
+
+  @Test
+  fun `returns numbers of accessions in different facilities in the same organization`() {
+    val accessionId1 = insertAccession(number = "ABC")
+    insertFacility()
+    val accessionId2 = insertAccession(number = "DEF")
+
+    assertEquals(
+        mapOf(accessionId1 to "ABC", accessionId2 to "DEF"),
+        store.fetchAccessionNumbers(listOf(accessionId1, accessionId2)),
+    )
+  }
+
+  @Test
+  fun `returns one entry per accession if the same ID is requested more than once`() {
+    val accessionId = insertAccession(number = "ABC")
+
+    assertEquals(
+        mapOf(accessionId to "ABC"),
+        store.fetchAccessionNumbers(listOf(accessionId, accessionId)),
+    )
+  }
+
+  @Test
+  fun `returns empty map if no accession IDs are requested`() {
+    assertEquals(emptyMap<AccessionId, String>(), store.fetchAccessionNumbers(emptyList()))
+  }
+
+  @Test
+  fun `throws exception if an accession does not exist`() {
+    val accessionId = insertAccession()
+    val nonexistentId = AccessionId(accessionId.value + 1)
+
+    assertThrows<AccessionNotFoundException> {
+      store.fetchAccessionNumbers(listOf(accessionId, nonexistentId))
+    }
+  }
+
+  @Test
+  fun `throws exception if none of the accessions exist`() {
+    val accessionId = insertAccession()
+
+    assertThrows<AccessionNotFoundException> {
+      store.fetchAccessionNumbers(listOf(AccessionId(accessionId.value + 1)))
+    }
+  }
+
+  @Test
+  fun `throws exception if accessions are in different organizations`() {
+    val accessionId = insertAccession()
+
+    insertOrganization()
+    insertOrganizationUser()
+    insertFacility()
+    val otherOrgAccessionId = insertAccession()
+
+    assertThrows<IllegalArgumentException> {
+      store.fetchAccessionNumbers(listOf(accessionId, otherOrgAccessionId))
+    }
+  }
+
+  @Test
+  fun `throws exception if no permission to read organization`() {
+    val accessionId = insertAccession()
+
+    deleteOrganizationUser()
+
+    assertThrows<OrganizationNotFoundException> {
+      store.fetchAccessionNumbers(listOf(accessionId))
+    }
+  }
+}


### PR DESCRIPTION
Add a new batch history entry payload class for transfers of additional
seeds from accessions.