### PR TITLE
Add admin page to visualize geometry SQL queries

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/admin/AdminController.kt
+++ b/src/main/kotlin/com/terraformation/backend/admin/AdminController.kt
@@ -109,6 +109,7 @@ class AdminController(
     model.addAttribute("canUpdateDefaultVoters", currentUser().canUpdateDefaultVoters())
     model.addAttribute("canUpdateDeviceTemplates", currentUser().canUpdateDeviceTemplates())
     model.addAttribute("canUpdateGlobalRoles", currentUser().canUpdateGlobalRoles())
+    model.addAttribute("canViewSqlMap", GlobalRole.SuperAdmin in currentUser().globalRoles)
     model.addAttribute("organizations", organizations)
     model.addAttribute("roles", Role.entries.map { it to it.getDisplayName(Locale.ENGLISH) })
     model.addAttribute("splatterEnabled", config.splatter.enabled)

--- a/src/main/kotlin/com/terraformation/backend/admin/AdminSqlMapController.kt
+++ b/src/main/kotlin/com/terraformation/backend/admin/AdminSqlMapController.kt
@@ -1,0 +1,61 @@
+package com.terraformation.backend.admin
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.terraformation.backend.api.RequireGlobalRole
+import com.terraformation.backend.config.TerrawareServerConfig
+import com.terraformation.backend.db.default_schema.GlobalRole
+import com.terraformation.backend.log.perClassLogger
+import com.terraformation.backend.tracking.mapbox.MapboxService
+import org.jooq.exception.DataAccessException
+import org.springframework.stereotype.Controller
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.servlet.mvc.support.RedirectAttributes
+
+@Controller
+@RequestMapping("/admin/sqlMap")
+@RequireGlobalRole([GlobalRole.SuperAdmin])
+class AdminSqlMapController(
+    private val config: TerrawareServerConfig,
+    private val mapboxService: MapboxService,
+    private val objectMapper: ObjectMapper,
+    private val sqlMapQueryService: SqlMapQueryService,
+) {
+  private val log = perClassLogger()
+
+  @GetMapping
+  fun getSqlMap(): String {
+    return "/admin/sqlMap"
+  }
+
+  @PostMapping
+  fun runSqlMap(@RequestParam query: String, redirectAttributes: RedirectAttributes): String {
+    redirectAttributes.addFlashAttribute("query", query)
+
+    try {
+      val result = sqlMapQueryService.runQuery(query)
+
+      redirectAttributes.addFlashAttribute(
+          "featureCollection",
+          objectMapper.valueToTree(result.featureCollection),
+      )
+      redirectAttributes.addFlashAttribute("mapboxToken", mapboxService.generateTemporaryToken())
+      redirectAttributes.addFlashAttribute("rowCount", result.rowCount)
+      redirectAttributes.addFlashAttribute(
+          "skippedNullGeometryCount",
+          result.skippedNullGeometryCount,
+      )
+      redirectAttributes.addFlashAttribute("rowLimitReached", result.rowLimitReached)
+    } catch (e: DataAccessException) {
+      log.info("SQL map query failed", e)
+      redirectAttributes.addFlashAttribute("errorMessage", "Query failed: ${e.cause?.message}")
+    } catch (e: Exception) {
+      log.info("SQL map query failed", e)
+      redirectAttributes.addFlashAttribute("errorMessage", "Query failed: ${e.message}")
+    }
+
+    return "redirect:/admin/sqlMap"
+  }
+}

--- a/src/main/kotlin/com/terraformation/backend/admin/SqlMapQueryService.kt
+++ b/src/main/kotlin/com/terraformation/backend/admin/SqlMapQueryService.kt
@@ -1,0 +1,156 @@
+package com.terraformation.backend.admin
+
+import com.terraformation.backend.db.GeometryBinding
+import jakarta.inject.Named
+import java.sql.Connection
+import java.sql.ResultSetMetaData
+import org.jooq.DSLContext
+import org.locationtech.jts.geom.Geometry
+import org.postgresql.util.PGobject
+
+/**
+ * Runs an arbitrary read-only SQL query and turns its geometry column into map features.
+ *
+ * The query is executed with plain JDBC because the community edition of jOOQ can't convert PostGIS
+ * `GEOMETRY` values in ad-hoc query results.
+ */
+@Named
+class SqlMapQueryService(private val dslContext: DSLContext) {
+  fun runQuery(sql: String): SqlMapResult {
+    validateQuery(sql)
+
+    val rawResult = dslContext.transactionResult { config ->
+      config.dsl().connectionResult { connection -> readRows(connection, sql) }
+    }
+
+    return buildResult(rawResult)
+  }
+
+  private fun validateQuery(sql: String) {
+    val parsed = dslContext.parser().parse(sql)
+    when (parsed.queries().size) {
+      0 -> throw IllegalArgumentException("No SQL query found")
+      1 -> Unit
+      else -> throw IllegalArgumentException("Cannot include multiple SQL statements in query")
+    }
+  }
+
+  private fun readRows(connection: Connection, sql: String): RawQueryResult {
+    connection.createStatement().use { statement ->
+      statement.execute("set transaction read only")
+      statement.execute("set local statement_timeout = $STATEMENT_TIMEOUT_MS")
+    }
+
+    return connection.prepareStatement(sql).use { statement ->
+      statement.maxRows = ROW_LIMIT
+
+      statement.executeQuery().use { resultSet ->
+        val metaData = resultSet.metaData
+        val columnCount = metaData.columnCount
+        val columnNames = (1..columnCount).map { metaData.getColumnLabel(it) }
+        val rows = buildList {
+          while (resultSet.next()) {
+            add((1..columnCount).map { resultSet.getObject(it) })
+          }
+        }
+
+        RawQueryResult(columnNames, resultSet.metaData, rows)
+      }
+    }
+  }
+
+  private fun buildResult(rawResult: RawQueryResult): SqlMapResult {
+    val columnNames = rawResult.columnNames
+
+    val geometryColumn =
+        columnNames.indices.firstOrNull { columnIndex ->
+          rawResult.metaData.getColumnTypeName(columnIndex + 1) == "geometry"
+        } ?: throw IllegalArgumentException("Query result has no geometry column.")
+
+    val rows = rawResult.rows
+
+    if (rows.isEmpty()) {
+      return SqlMapResult(
+          featureCollection = SqlMapFeatureCollection(emptyList()),
+          rowCount = 0,
+          skippedNullGeometryCount = 0,
+          rowLimitReached = false,
+      )
+    }
+
+    val labelColumns = columnNames.indices.filter { it != geometryColumn }
+
+    var skippedNullGeometryCount = 0
+    val features = rows.mapNotNull { row ->
+      val geometry = toGeometry(row[geometryColumn])
+      if (geometry == null) {
+        skippedNullGeometryCount++
+        null
+      } else {
+        SqlMapFeature(
+            geometry,
+            labelColumns.associate { columnNames[it] to row[it]?.toString() },
+        )
+      }
+    }
+
+    return SqlMapResult(
+        featureCollection = SqlMapFeatureCollection(features),
+        rowCount = features.size,
+        skippedNullGeometryCount = skippedNullGeometryCount,
+        rowLimitReached = rows.size == ROW_LIMIT,
+    )
+  }
+
+  /**
+   * Converts a raw JDBC column value to a JTS [Geometry] if it is a PostGIS geometry, or returns
+   * null otherwise. PostGIS geometry columns are returned by the JDBC driver as [PGobject]s whose
+   * value is the geometry in hex-encoded WKB form.
+   */
+  private fun toGeometry(value: Any?): Geometry? =
+      if (value is PGobject && value.type == "geometry") {
+        val hexValue: String? = value.getValue()
+        hexValue?.let { GeometryBinding.geometryFromWkbHex(it) }
+      } else {
+        null
+      }
+
+  private class RawQueryResult(
+      val columnNames: List<String>,
+      val metaData: ResultSetMetaData,
+      val rows: List<List<Any?>>,
+  )
+
+  data class SqlMapFeature(
+      val geometry: Geometry,
+      val properties: Map<String, String?>,
+  ) {
+    val type
+      get() = "Feature"
+  }
+
+  data class SqlMapFeatureCollection(val features: List<SqlMapFeature>) {
+    val type
+      get() = "FeatureCollection"
+  }
+
+  /**
+   * Result of running a SQL map query.
+   *
+   * @param featureCollection GeoJSON FeatureCollection.
+   * @param rowCount Number of features in the collection (rows with a non-null geometry).
+   * @param skippedNullGeometryCount Number of result rows whose geometry value was null.
+   * @param rowLimitReached True if the query hit the [ROW_LIMIT] cap.
+   */
+  data class SqlMapResult(
+      val featureCollection: SqlMapFeatureCollection,
+      val rowCount: Int,
+      val skippedNullGeometryCount: Int,
+      val rowLimitReached: Boolean,
+  )
+
+  companion object {
+    const val ROW_LIMIT = 10_000
+    const val STATEMENT_TIMEOUT_MS = 30_000
+  }
+}

--- a/src/main/kotlin/com/terraformation/backend/db/GeometryBinding.kt
+++ b/src/main/kotlin/com/terraformation/backend/db/GeometryBinding.kt
@@ -49,7 +49,7 @@ class GeometryBinding : Binding<JooqGeometry, Geometry> {
       // Geometry values are returned in WKB (Well Known Binary) form, encoded in hexadecimal.
       val wkb = databaseObject?.data() ?: return null
 
-      return WKBReader(geometryFactory).read(WKBReader.hexToBytes(wkb))
+      return geometryFromWkbHex(wkb)
     }
 
     /**
@@ -107,5 +107,14 @@ class GeometryBinding : Binding<JooqGeometry, Geometry> {
 
     /** DataType that can be used when constructing custom fields in queries. */
     val dataType = SQLDataType.GEOMETRY.asConvertedDataType(GeometryBinding())
+
+    /**
+     * Decodes a hex-encoded WKB (Well Known Binary) geometry value, as returned by PostGIS, into a
+     * JTS [Geometry]. A new [WKBReader] is created per call because [WKBReader] is not thread-safe.
+     */
+    fun geometryFromWkbHex(hex: String): Geometry {
+      val geometryFactory = GeometryFactory(PrecisionModel(), SRID.LONG_LAT)
+      return WKBReader(geometryFactory).read(WKBReader.hexToBytes(hex))
+    }
   }
 }

--- a/src/main/resources/templates/admin/index.html
+++ b/src/main/resources/templates/admin/index.html
@@ -88,27 +88,33 @@
 
 </details>
 
-<details id="testing" class="section" th:if="${canSetTestClock}">
+<details id="testing" class="section" th:if="${canSetTestClock || canViewSqlMap}">
     <summary>Test Utilities</summary>
 
-    <p>
-        <a href="/admin/testClock">Test clock adjustment</a>
-    </p>
+    <th:block th:if="${canSetTestClock}">
+        <p>
+            <a href="/admin/testClock">Test clock adjustment</a>
+        </p>
 
-    <p>
-        <a href="/admin/convertApi">ConvertAPI integration</a>
-    </p>
+        <p>
+            <a href="/admin/convertApi">ConvertAPI integration</a>
+        </p>
 
-    <p>
-        <a href="/admin/mux">Mux integration</a>
-    </p>
+        <p>
+            <a href="/admin/mux">Mux integration</a>
+        </p>
 
-    <p>
-        <a href="/admin/eventLog">Event log</a>
-    </p>
+        <p>
+            <a href="/admin/eventLog">Event log</a>
+        </p>
 
-    <p th:if="${splatterEnabled}">
-        <a href="/admin/splats">Splats</a>
+        <p th:if="${splatterEnabled}">
+            <a href="/admin/splats">Splats</a>
+        </p>
+    </th:block>
+
+    <p th:if="${canViewSqlMap}">
+        <a href="/admin/sqlMap">SQL query map</a>
     </p>
 </details>
 

--- a/src/main/resources/templates/admin/sqlMap.html
+++ b/src/main/resources/templates/admin/sqlMap.html
@@ -1,0 +1,247 @@
+<!DOCTYPE HTML>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+    <title>SQL Query Map</title>
+    <style>
+        html, body {
+            height: 100%;
+            margin: 0;
+        }
+
+        .container {
+            display: flex;
+            flex-flow: column;
+            height: 100%;
+        }
+
+        .controls {
+            flex: 0 0 auto;
+            padding: 8px;
+        }
+
+        .controls textarea {
+            width: 100%;
+            box-sizing: border-box;
+            font-family: monospace;
+        }
+
+        #map {
+            flex: 1 1 auto;
+        }
+
+        .error {
+            color: red;
+        }
+    </style>
+
+    <link href="https://api.mapbox.com/mapbox-gl-js/v3.29.0/mapbox-gl.css" rel="stylesheet">
+    <script src="https://api.mapbox.com/mapbox-gl-js/v3.29.0/mapbox-gl.js"></script>
+</head>
+
+<body>
+
+<div class="container">
+    <div class="controls">
+        <p>
+            Enter a SQL query that returns a geometry column and optionally other columns.
+            Additional columns appear in an on-click popup. Use a column alias of <code>label</code>
+            to label the map features.
+            <a id="populateExample" href="#">Example</a>
+        </p>
+
+        <form method="post" action="/admin/sqlMap">
+            <textarea id="query" name="query" rows="6" th:text="${query}"></textarea>
+            <br/>
+            <button type="submit">Run query</button>
+            <button type="button" id="cycleStyles">Light/Dark</button>
+        </form>
+
+        <p class="error" th:if="${errorMessage}" th:text="${errorMessage}">Error message</p>
+        <p th:if="${featureCollection != null}">
+            <span th:text="|${rowCount} feature(s).|">0 feature(s).</span>
+            <span th:if="${skippedNullGeometryCount > 0}"
+                  th:text="|${skippedNullGeometryCount} row(s) had a null geometry and were skipped.|"></span>
+            <span th:if="${rowLimitReached}">Row limit reached; results may be truncated.</span>
+        </p>
+    </div>
+
+    <div id="map" th:if="${featureCollection != null}"></div>
+
+    <script th:if="${featureCollection != null}" th:inline="javascript">
+        /*<![CDATA[*/
+        mapboxgl.accessToken = /*[[${mapboxToken}]]*/;
+
+        const featureCollection = /*[[${featureCollection}]]*/;
+
+        const styles = [
+            {base: 'mapbox://styles/mapbox/satellite-streets-v12', outlineColor: 'black'},
+            {base: 'mapbox://styles/mapbox/dark-v11'},
+        ];
+
+        let styleNumber = 0;
+        let currentStyle = styles[styleNumber];
+        let selectedFeatureId = null;
+
+        const map = new mapboxgl.Map({
+            container: 'map',
+            style: currentStyle.base,
+            center: [0, 0],
+            zoom: 1,
+        });
+
+        function fitMapToData() {
+            const bounds = new mapboxgl.LngLatBounds();
+            let hasCoordinates = false;
+
+            const extend = (coords) => {
+                if (typeof coords[0] === 'number') {
+                    const lng = coords[0];
+                    const lat = coords[1];
+                    if (Number.isFinite(lng) && Number.isFinite(lat)) {
+                        bounds.extend([lng, lat]);
+                        hasCoordinates = true;
+                    }
+                } else if (Array.isArray(coords)) {
+                    coords.forEach(extend);
+                }
+            };
+
+            featureCollection.features.forEach((feature) => {
+                if (feature.geometry && feature.geometry.coordinates) {
+                    extend(feature.geometry.coordinates);
+                }
+            });
+
+            if (hasCoordinates && !bounds.isEmpty()) {
+                map.fitBounds(bounds, {padding: 20, maxZoom: 16, duration: 0});
+            }
+        }
+
+        function initializeMapLayers() {
+            map.addSource('results', {
+                type: 'geojson',
+                data: featureCollection,
+                tolerance: 0,
+                generateId: true,
+            });
+
+            map.addLayer({
+                id: 'polygons',
+                type: 'fill',
+                source: 'results',
+                filter: ['==', ['geometry-type'], 'Polygon'],
+                paint: {
+                    'fill-color': ['case', ['boolean', ['feature-state', 'selected'], false], '#33ffff', '#22aaaa'],
+                    'fill-opacity': ['case', ['boolean', ['feature-state', 'selected'], false], 0.8, 0.6],
+                    'fill-outline-color': currentStyle.outlineColor ?? '#33cccc',
+                },
+            });
+
+            map.addLayer({
+                id: 'lines',
+                type: 'line',
+                source: 'results',
+                filter: ['==', ['geometry-type'], 'LineString'],
+                paint: {
+                    'line-color': ['case', ['boolean', ['feature-state', 'selected'], false], '#33ffff', currentStyle.outlineColor ?? 'yellow'],
+                    'line-width': ['case', ['boolean', ['feature-state', 'selected'], false], 4, 2],
+                },
+            });
+
+            map.addLayer({
+                id: 'points',
+                type: 'circle',
+                source: 'results',
+                filter: ['==', ['geometry-type'], 'Point'],
+                paint: {
+                    'circle-color': ['case', ['boolean', ['feature-state', 'selected'], false], '#33ffff', 'orange'],
+                    'circle-radius': ['case', ['boolean', ['feature-state', 'selected'], false], 8, 5],
+                    'circle-stroke-color': currentStyle.outlineColor ?? 'orange',
+                    'circle-stroke-width': 1,
+                },
+            });
+
+            map.addLayer({
+                id: 'labels',
+                type: 'symbol',
+                source: 'results',
+                filter: ['has', 'label'],
+                layout: {
+                    'text-field': ['get', 'label'],
+                    'text-size': 12,
+                },
+                paint: {
+                    'text-color': 'white',
+                    'text-halo-color': 'black',
+                    'text-halo-width': 2,
+                },
+            });
+
+            const clickHandler = (e) => {
+                const feature = e.features[0];
+
+                if (selectedFeatureId !== null) {
+                    map.setFeatureState({
+                        source: 'results',
+                        id: selectedFeatureId
+                    }, {selected: false});
+                }
+                selectedFeatureId = feature.id;
+                map.setFeatureState({source: 'results', id: selectedFeatureId}, {selected: true});
+
+                const popupContent = document.createElement('div');
+
+                Object.entries(feature.properties).forEach(([key, value]) => {
+                    const row = document.createElement('div');
+                    row.textContent = `${key}: ${value}`;
+                    popupContent.appendChild(row);
+                });
+
+                new mapboxgl.Popup()
+                        .setLngLat(e.lngLat)
+                        .setDOMContent(popupContent)
+                        .addTo(map);
+            };
+
+            ['polygons', 'lines', 'points'].forEach((layerId) => {
+                map.on('click', layerId, clickHandler);
+                map.on('mouseenter', layerId, () => {
+                    map.getCanvas().style.cursor = 'pointer';
+                });
+                map.on('mouseleave', layerId, () => {
+                    map.getCanvas().style.cursor = '';
+                });
+            });
+        }
+
+        map.on('style.load', () => {
+            selectedFeatureId = null;
+            initializeMapLayers();
+        });
+
+        map.on('load', () => {
+            map.resize();
+            fitMapToData();
+        });
+
+        document.getElementById('cycleStyles').addEventListener('click', () => {
+            styleNumber = (styleNumber + 1) % styles.length;
+            currentStyle = styles[styleNumber];
+            map.setStyle(currentStyle.base);
+        });
+        /*]]>*/
+    </script>
+
+    <script>
+        document.getElementById('populateExample').addEventListener('click', () => {
+            document.getElementById('query').value =
+                    'SELECT boundary, id, name AS label, organization_id\n' +
+                    'FROM tracking.planting_sites\n' +
+                    'ORDER BY created_time DESC\n' +
+                    'LIMIT 1';
+        });
+    </script>
+</div>
+
+</body>
+</html>

--- a/src/test/kotlin/com/terraformation/backend/admin/SqlMapQueryServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/admin/SqlMapQueryServiceTest.kt
@@ -1,0 +1,69 @@
+package com.terraformation.backend.admin
+
+import com.terraformation.backend.RunsAsUser
+import com.terraformation.backend.assertGeometryEquals
+import com.terraformation.backend.customer.model.TerrawareUser
+import com.terraformation.backend.db.DatabaseTest
+import com.terraformation.backend.mockUser
+import com.terraformation.backend.rectangle
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+internal class SqlMapQueryServiceTest : DatabaseTest(), RunsAsUser {
+  override val user: TerrawareUser = mockUser()
+
+  private val service: SqlMapQueryService by lazy { SqlMapQueryService(dslContext) }
+
+  @BeforeEach
+  fun setUp() {
+    insertOrganization()
+  }
+
+  @Test
+  fun `converts geometry column to a JTS geometry feature`() {
+    val boundary = rectangle(10)
+    insertPlantingSite(boundary = boundary)
+
+    val result = service.runQuery("select boundary from tracking.planting_sites")
+
+    assertEquals(1, result.rowCount, "row count")
+
+    val features = result.featureCollection.features
+    assertEquals(1, features.size, "feature count")
+    assertGeometryEquals(boundary, features[0].geometry)
+  }
+
+  @Test
+  fun `uses non-geometry columns as feature properties`() {
+    val plantingSiteId = insertPlantingSite(name = "Test Site")
+
+    val result = service.runQuery("select boundary, name, id from tracking.planting_sites; ")
+
+    val features = result.featureCollection.features
+    assertEquals(
+        mapOf(
+            "id" to "$plantingSiteId",
+            "name" to "Test Site",
+        ),
+        features[0].properties,
+    )
+  }
+
+  @Test
+  fun `rejects attempts to bypass read-only protection`() {
+    assertThrows<IllegalArgumentException> {
+      service.runQuery("commit; update users set first_name = 'blah'; commit")
+    }
+  }
+
+  @Test
+  fun `throws exception when the result has no geometry column`() {
+    insertPlantingSite()
+
+    assertThrows<IllegalArgumentException> {
+      service.runQuery("select name from tracking.planting_sites")
+    }
+  }
+}


### PR DESCRIPTION
When we're working on debugging planting site issues, it's often
helpful to view information about the site on a map. Currently, we
have to manually query the database, turn the result into GeoJSON,
and copy-paste it into something like geojson.io.

Add a super-admin-only page to the admin UI that lets an admin enter
an arbitrary SQL query whose output includes a geometry column. The
geometries will be shown on a Mapbox map, and if the query includes
any other columns, they'll be viewable as attributes when clicking
on the map. If a query contains a column named `label`, it will be
used to label the geometry on the map.

The query runs in a read-only transaction and with a timeout.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>