### PR TITLE
Send splat additional files to splatter

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/splat/Models.kt
+++ b/src/main/kotlin/com/terraformation/backend/splat/Models.kt
@@ -205,3 +205,9 @@ data class SplatGenerationParams(
     val restartAt: String? = null,
     val stepArgs: Map<String, List<String>> = emptyMap(),
 )
+
+/**
+ * Identifies the role a non-video file plays in a splat generation request, e.g., `imu` or
+ * `session-meta`. Derived from the file's content type suffix and passed through to splatter.
+ */
+typealias SplatAdditionalFileType = String

--- a/src/main/kotlin/com/terraformation/backend/splat/SplatService.kt
+++ b/src/main/kotlin/com/terraformation/backend/splat/SplatService.kt
@@ -11,11 +11,13 @@ import com.terraformation.backend.db.default_schema.AssetStatus
 import com.terraformation.backend.db.default_schema.FileBatchType
 import com.terraformation.backend.db.default_schema.FileId
 import com.terraformation.backend.db.default_schema.OrganizationId
+import com.terraformation.backend.db.default_schema.SplatAdditionalFileType
 import com.terraformation.backend.db.default_schema.tables.references.BIRDNET_RESULTS
 import com.terraformation.backend.db.default_schema.tables.references.FILES
 import com.terraformation.backend.db.default_schema.tables.references.FILE_BATCHES
 import com.terraformation.backend.db.default_schema.tables.references.ORGANIZATION_MEDIA_FILES
 import com.terraformation.backend.db.default_schema.tables.references.SPLATS
+import com.terraformation.backend.db.default_schema.tables.references.SPLAT_ADDITIONAL_FILES
 import com.terraformation.backend.db.default_schema.tables.references.SPLAT_ANNOTATIONS
 import com.terraformation.backend.db.default_schema.tables.references.SPLAT_ANNOTATION_MEDIA
 import com.terraformation.backend.db.tracking.MonitoringPlotId
@@ -159,10 +161,11 @@ class SplatService(
       force: Boolean = false,
       params: SplatGenerationParams = SplatGenerationParams(),
       runBirdnet: Boolean = true,
+      additionalFiles: Map<FileId, SplatAdditionalFileType> = emptyMap(),
   ) {
     ensureOrganizationMediaFile(organizationId, fileId)
 
-    generateSplat(organizationId, fileId, force, params, runBirdnet)
+    generateSplat(organizationId, fileId, force, params, runBirdnet, additionalFiles)
   }
 
   fun readOrganizationSplat(organizationId: OrganizationId, fileId: FileId): SizedInputStream {
@@ -407,6 +410,7 @@ class SplatService(
       force: Boolean = false,
       params: SplatGenerationParams,
       runBirdnet: Boolean = false,
+      additionalFiles: Map<FileId, SplatAdditionalFileType> = emptyMap(),
   ) {
     val videoUrl =
         dslContext.fetchValue(FILES.STORAGE_URL, FILES.ID.eq(fileId))
@@ -482,9 +486,25 @@ class SplatService(
       }
 
       if (rowsInserted == 1 || force) {
+        if (additionalFiles.isNotEmpty()) {
+          with(SPLAT_ADDITIONAL_FILES) {
+            dslContext.deleteFrom(SPLAT_ADDITIONAL_FILES).where(SPLAT_FILE_ID.eq(fileId)).execute()
+
+            additionalFiles.forEach { (additionalFileId, type) ->
+              dslContext
+                  .insertInto(SPLAT_ADDITIONAL_FILES)
+                  .set(FILE_ID, additionalFileId)
+                  .set(SPLAT_FILE_ID, fileId)
+                  .set(TYPE_ID, type)
+                  .execute()
+            }
+          }
+        }
+
         val requestMessage =
             SplatterRequestMessage(
                 abortAfter = params.abortAfter,
+                additionalFiles = listAdditionalFileLocations(fileId),
                 birdnetOutput = birdnetOutputLocation,
                 input =
                     SplatterRequestFileLocation(
@@ -513,6 +533,30 @@ class SplatService(
             "Splat record already exists for file $fileId; ignoring additional generation request"
         )
       }
+    }
+  }
+
+  private fun splatAdditionalFileType(fileName: String): SplatAdditionalFileType? {
+    val baseName = fileName.substringBeforeLast('.').lowercase()
+    return SplatAdditionalFileType.entries.firstOrNull { it.jsonValue == baseName }
+  }
+
+  private fun listAdditionalFileLocations(fileId: FileId): List<SplatterRequestFileLocation> {
+    return with(SPLAT_ADDITIONAL_FILES) {
+      dslContext
+          .select(FILES.STORAGE_URL, TYPE_ID)
+          .from(SPLAT_ADDITIONAL_FILES)
+          .join(FILES)
+          .on(FILE_ID.eq(FILES.ID))
+          .where(SPLAT_FILE_ID.eq(fileId))
+          .orderBy(FILE_ID)
+          .fetch { record ->
+            SplatterRequestFileLocation(
+                s3BucketName,
+                record[FILES.STORAGE_URL]!!.path.trimStart('/'),
+                record[TYPE_ID]!!,
+            )
+          }
     }
   }
 
@@ -553,7 +597,7 @@ class SplatService(
 
     val batchFiles =
         dslContext
-            .select(FILES.ID, FILES.CONTENT_TYPE)
+            .select(FILES.ID, FILES.CONTENT_TYPE, FILES.FILE_NAME)
             .from(FILES)
             .where(FILES.FILE_BATCH_ID.eq(event.fileBatchId))
             .fetch()
@@ -575,8 +619,26 @@ class SplatService(
             .where(ORGANIZATION_MEDIA_FILES.FILE_ID.eq(videoFileId))
             .fetchOne(ORGANIZATION_MEDIA_FILES.ORGANIZATION_ID) ?: return
 
+    val additionalFiles =
+        batchFiles
+            .filter { it[FILES.ID] != videoFileId }
+            .mapNotNull { record ->
+              val fileName = record[FILES.FILE_NAME]!!
+              val type = splatAdditionalFileType(fileName)
+              if (type == null) {
+                log.warn(
+                    "File batch ${event.fileBatchId} contains file $fileName with no recognized " +
+                        "splat additional file type; ignoring"
+                )
+                null
+              } else {
+                record[FILES.ID]!! to type
+              }
+            }
+            .toMap()
+
     try {
-      generateOrganizationMediaSplat(organizationId, videoFileId)
+      generateOrganizationMediaSplat(organizationId, videoFileId, additionalFiles = additionalFiles)
     } catch (e: Exception) {
       log.error(
           "Failed to auto-generate splat for file $videoFileId in batch ${event.fileBatchId}",

--- a/src/main/kotlin/com/terraformation/backend/splat/SplatService.kt
+++ b/src/main/kotlin/com/terraformation/backend/splat/SplatService.kt
@@ -160,7 +160,7 @@ class SplatService(
       force: Boolean = false,
       params: SplatGenerationParams = SplatGenerationParams(),
       runBirdnet: Boolean = true,
-      additionalFiles: Map<FileId, String> = emptyMap(),
+      additionalFiles: Map<FileId, SplatAdditionalFileType> = emptyMap(),
   ) {
     ensureOrganizationMediaFile(organizationId, fileId)
 
@@ -409,7 +409,7 @@ class SplatService(
       force: Boolean = false,
       params: SplatGenerationParams,
       runBirdnet: Boolean = false,
-      additionalFiles: Map<FileId, String> = emptyMap(),
+      additionalFiles: Map<FileId, SplatAdditionalFileType> = emptyMap(),
   ) {
     val videoUrl =
         dslContext.fetchValue(FILES.STORAGE_URL, FILES.ID.eq(fileId))
@@ -536,7 +536,15 @@ class SplatService(
     }
   }
 
-  private fun splatAdditionalFileType(fileContentType: String): String =
+  /**
+   * Returns the additional file type from a content type's structured syntax suffix, or an empty
+   * string if it doesn't have one. For example, `application/json+sessionMeta` becomes
+   * `session-meta`.
+   *
+   * Suffixes may be camel case; the regexes convert them to hyphen-delimited lowercase. Note that
+   * multiple sequential uppercase letters are kept together intentionally.
+   */
+  private fun splatAdditionalFileType(fileContentType: String): SplatAdditionalFileType =
       fileContentType
           .substringBefore(';')
           .trim()

--- a/src/main/kotlin/com/terraformation/backend/splat/SplatService.kt
+++ b/src/main/kotlin/com/terraformation/backend/splat/SplatService.kt
@@ -537,7 +537,12 @@ class SplatService(
   }
 
   private fun splatAdditionalFileType(fileName: String): SplatAdditionalFileType? {
-    val baseName = fileName.substringBeforeLast('.').lowercase()
+    val baseName =
+        fileName
+            .substringAfterLast('/')
+            .substringAfterLast('\\')
+            .substringBeforeLast('.')
+            .lowercase()
     return SplatAdditionalFileType.entries.firstOrNull { it.jsonValue == baseName }
   }
 
@@ -633,6 +638,18 @@ class SplatService(
                 null
               } else {
                 record[FILES.ID]!! to type
+              }
+            }
+            .groupBy({ it.second }, { it.first })
+            .mapNotNull { (type, fileIds) ->
+              if (fileIds.size > 1) {
+                log.warn(
+                    "File batch ${event.fileBatchId} contains ${fileIds.size} files of splat " +
+                        "additional file type ${type.jsonValue}; ignoring all of them"
+                )
+                null
+              } else {
+                fileIds.first() to type
               }
             }
             .toMap()

--- a/src/main/kotlin/com/terraformation/backend/splat/SplatService.kt
+++ b/src/main/kotlin/com/terraformation/backend/splat/SplatService.kt
@@ -11,7 +11,6 @@ import com.terraformation.backend.db.default_schema.AssetStatus
 import com.terraformation.backend.db.default_schema.FileBatchType
 import com.terraformation.backend.db.default_schema.FileId
 import com.terraformation.backend.db.default_schema.OrganizationId
-import com.terraformation.backend.db.default_schema.SplatAdditionalFileType
 import com.terraformation.backend.db.default_schema.tables.references.BIRDNET_RESULTS
 import com.terraformation.backend.db.default_schema.tables.references.FILES
 import com.terraformation.backend.db.default_schema.tables.references.FILE_BATCHES
@@ -161,7 +160,7 @@ class SplatService(
       force: Boolean = false,
       params: SplatGenerationParams = SplatGenerationParams(),
       runBirdnet: Boolean = true,
-      additionalFiles: Map<FileId, SplatAdditionalFileType> = emptyMap(),
+      additionalFiles: Map<FileId, String> = emptyMap(),
   ) {
     ensureOrganizationMediaFile(organizationId, fileId)
 
@@ -410,7 +409,7 @@ class SplatService(
       force: Boolean = false,
       params: SplatGenerationParams,
       runBirdnet: Boolean = false,
-      additionalFiles: Map<FileId, SplatAdditionalFileType> = emptyMap(),
+      additionalFiles: Map<FileId, String> = emptyMap(),
   ) {
     val videoUrl =
         dslContext.fetchValue(FILES.STORAGE_URL, FILES.ID.eq(fileId))
@@ -488,6 +487,7 @@ class SplatService(
       if (rowsInserted == 1 || force) {
         if (additionalFiles.isNotEmpty()) {
           with(SPLAT_ADDITIONAL_FILES) {
+            // TODO delete files too
             dslContext.deleteFrom(SPLAT_ADDITIONAL_FILES).where(SPLAT_FILE_ID.eq(fileId)).execute()
 
             additionalFiles.forEach { (additionalFileId, type) ->
@@ -495,7 +495,7 @@ class SplatService(
                   .insertInto(SPLAT_ADDITIONAL_FILES)
                   .set(FILE_ID, additionalFileId)
                   .set(SPLAT_FILE_ID, fileId)
-                  .set(TYPE_ID, type)
+                  .set(TYPE, type)
                   .execute()
             }
           }
@@ -536,20 +536,19 @@ class SplatService(
     }
   }
 
-  private fun splatAdditionalFileType(fileName: String): SplatAdditionalFileType? {
-    val baseName =
-        fileName
-            .substringAfterLast('/')
-            .substringAfterLast('\\')
-            .substringBeforeLast('.')
-            .lowercase()
-    return SplatAdditionalFileType.entries.firstOrNull { it.jsonValue == baseName }
-  }
+  private fun splatAdditionalFileType(fileContentType: String): String =
+      fileContentType
+          .substringBefore(';')
+          .trim()
+          .substringAfterLast('+', missingDelimiterValue = "")
+          .replace(Regex("([A-Z]+)([A-Z][a-z])"), "$1-$2")
+          .replace(Regex("([a-z0-9])([A-Z])"), "$1-$2")
+          .lowercase()
 
   private fun listAdditionalFileLocations(fileId: FileId): List<SplatterRequestFileLocation> {
     return with(SPLAT_ADDITIONAL_FILES) {
       dslContext
-          .select(FILES.STORAGE_URL, TYPE_ID)
+          .select(FILES.STORAGE_URL, TYPE)
           .from(SPLAT_ADDITIONAL_FILES)
           .join(FILES)
           .on(FILE_ID.eq(FILES.ID))
@@ -559,7 +558,7 @@ class SplatService(
             SplatterRequestFileLocation(
                 s3BucketName,
                 record[FILES.STORAGE_URL]!!.path.trimStart('/'),
-                record[TYPE_ID]!!,
+                record[TYPE]!!,
             )
           }
     }
@@ -629,11 +628,12 @@ class SplatService(
             .filter { it[FILES.ID] != videoFileId }
             .mapNotNull { record ->
               val fileName = record[FILES.FILE_NAME]!!
-              val type = splatAdditionalFileType(fileName)
-              if (type == null) {
+              val fileContentType = record[FILES.CONTENT_TYPE]!!
+              val type = splatAdditionalFileType(fileContentType)
+              if (type == "") {
                 log.warn(
-                    "File batch ${event.fileBatchId} contains file $fileName with no recognized " +
-                        "splat additional file type; ignoring"
+                    "File batch ${event.fileBatchId} contains file $fileName of content type " +
+                        "$fileContentType with no recognized splat additional file type; ignoring"
                 )
                 null
               } else {
@@ -645,7 +645,7 @@ class SplatService(
               if (fileIds.size > 1) {
                 log.warn(
                     "File batch ${event.fileBatchId} contains ${fileIds.size} files of splat " +
-                        "additional file type ${type.jsonValue}; ignoring all of them"
+                        "additional file type ${type}; ignoring all of them"
                 )
                 null
               } else {

--- a/src/main/kotlin/com/terraformation/backend/splat/sqs/SplatterRequestMessage.kt
+++ b/src/main/kotlin/com/terraformation/backend/splat/sqs/SplatterRequestMessage.kt
@@ -1,12 +1,11 @@
 package com.terraformation.backend.splat.sqs
 
-import com.terraformation.backend.db.default_schema.SplatAdditionalFileType
 import java.net.URI
 
 data class SplatterRequestFileLocation(
     val bucket: String,
     val key: String,
-    val type: SplatAdditionalFileType? = null,
+    val type: String? = null,
 )
 
 data class SplatterRequestMessage(

--- a/src/main/kotlin/com/terraformation/backend/splat/sqs/SplatterRequestMessage.kt
+++ b/src/main/kotlin/com/terraformation/backend/splat/sqs/SplatterRequestMessage.kt
@@ -1,14 +1,17 @@
 package com.terraformation.backend.splat.sqs
 
+import com.terraformation.backend.db.default_schema.SplatAdditionalFileType
 import java.net.URI
 
 data class SplatterRequestFileLocation(
     val bucket: String,
     val key: String,
+    val type: SplatAdditionalFileType? = null,
 )
 
 data class SplatterRequestMessage(
     val abortAfter: String? = null,
+    val additionalFiles: List<SplatterRequestFileLocation> = emptyList(),
     val birdnetOutput: SplatterRequestFileLocation? = null,
     val input: SplatterRequestFileLocation,
     val jobId: String,

--- a/src/test/kotlin/com/terraformation/backend/db/DatabaseBackedTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/db/DatabaseBackedTest.kt
@@ -167,6 +167,7 @@ import com.terraformation.backend.db.default_schema.SeedTreatment
 import com.terraformation.backend.db.default_schema.SpeciesId
 import com.terraformation.backend.db.default_schema.SpeciesNativeCategory
 import com.terraformation.backend.db.default_schema.SpeciesNativity
+import com.terraformation.backend.db.default_schema.SplatAdditionalFileType
 import com.terraformation.backend.db.default_schema.SplatAnnotationId
 import com.terraformation.backend.db.default_schema.SubLocationId
 import com.terraformation.backend.db.default_schema.SuccessionalGroup
@@ -270,6 +271,7 @@ import com.terraformation.backend.db.default_schema.tables.references.SPECIES_GR
 import com.terraformation.backend.db.default_schema.tables.references.SPECIES_PLANT_MATERIAL_SOURCING_METHODS
 import com.terraformation.backend.db.default_schema.tables.references.SPECIES_SUCCESSIONAL_GROUPS
 import com.terraformation.backend.db.default_schema.tables.references.SPLATS
+import com.terraformation.backend.db.default_schema.tables.references.SPLAT_ADDITIONAL_FILES
 import com.terraformation.backend.db.default_schema.tables.references.SPLAT_ANNOTATIONS
 import com.terraformation.backend.db.default_schema.tables.references.SPLAT_ANNOTATION_MEDIA
 import com.terraformation.backend.db.default_schema.tables.references.SUB_LOCATIONS
@@ -3683,6 +3685,21 @@ abstract class DatabaseBackedTest {
           .set(SKY_COLOR, skyColor)
           .set(AVERAGE_CAMERA_HEIGHT, averageCameraHeight)
           .set(SPLAT_STORAGE_URL, splatStorageUrl)
+          .execute()
+    }
+  }
+
+  fun insertSplatAdditionalFile(
+      splatFileId: FileId = inserted.fileId,
+      fileId: FileId = inserted.fileId,
+      type: SplatAdditionalFileType = SplatAdditionalFileType.Frames,
+  ) {
+    with(SPLAT_ADDITIONAL_FILES) {
+      dslContext
+          .insertInto(SPLAT_ADDITIONAL_FILES)
+          .set(SPLAT_FILE_ID, splatFileId)
+          .set(FILE_ID, fileId)
+          .set(TYPE_ID, type)
           .execute()
     }
   }

--- a/src/test/kotlin/com/terraformation/backend/db/DatabaseBackedTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/db/DatabaseBackedTest.kt
@@ -170,6 +170,7 @@ import com.terraformation.backend.db.default_schema.SpeciesNativity
 import com.terraformation.backend.db.default_schema.SpeciesProblemField
 import com.terraformation.backend.db.default_schema.SpeciesProblemId
 import com.terraformation.backend.db.default_schema.SpeciesProblemType
+import com.terraformation.backend.db.default_schema.SplatAdditionalFileType
 import com.terraformation.backend.db.default_schema.SplatAnnotationId
 import com.terraformation.backend.db.default_schema.SubLocationId
 import com.terraformation.backend.db.default_schema.SuccessionalGroup
@@ -274,6 +275,7 @@ import com.terraformation.backend.db.default_schema.tables.references.SPECIES_GR
 import com.terraformation.backend.db.default_schema.tables.references.SPECIES_PLANT_MATERIAL_SOURCING_METHODS
 import com.terraformation.backend.db.default_schema.tables.references.SPECIES_SUCCESSIONAL_GROUPS
 import com.terraformation.backend.db.default_schema.tables.references.SPLATS
+import com.terraformation.backend.db.default_schema.tables.references.SPLAT_ADDITIONAL_FILES
 import com.terraformation.backend.db.default_schema.tables.references.SPLAT_ANNOTATIONS
 import com.terraformation.backend.db.default_schema.tables.references.SPLAT_ANNOTATION_MEDIA
 import com.terraformation.backend.db.default_schema.tables.references.SUB_LOCATIONS
@@ -3747,6 +3749,21 @@ abstract class DatabaseBackedTest {
           .set(SKY_COLOR, skyColor)
           .set(AVERAGE_CAMERA_HEIGHT, averageCameraHeight)
           .set(SPLAT_STORAGE_URL, splatStorageUrl)
+          .execute()
+    }
+  }
+
+  fun insertSplatAdditionalFile(
+      splatFileId: FileId = inserted.fileId,
+      fileId: FileId = inserted.fileId,
+      type: SplatAdditionalFileType = SplatAdditionalFileType.Frames,
+  ) {
+    with(SPLAT_ADDITIONAL_FILES) {
+      dslContext
+          .insertInto(SPLAT_ADDITIONAL_FILES)
+          .set(SPLAT_FILE_ID, splatFileId)
+          .set(FILE_ID, fileId)
+          .set(TYPE_ID, type)
           .execute()
     }
   }

--- a/src/test/kotlin/com/terraformation/backend/db/DatabaseBackedTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/db/DatabaseBackedTest.kt
@@ -170,7 +170,6 @@ import com.terraformation.backend.db.default_schema.SpeciesNativity
 import com.terraformation.backend.db.default_schema.SpeciesProblemField
 import com.terraformation.backend.db.default_schema.SpeciesProblemId
 import com.terraformation.backend.db.default_schema.SpeciesProblemType
-import com.terraformation.backend.db.default_schema.SplatAdditionalFileType
 import com.terraformation.backend.db.default_schema.SplatAnnotationId
 import com.terraformation.backend.db.default_schema.SubLocationId
 import com.terraformation.backend.db.default_schema.SuccessionalGroup
@@ -3756,14 +3755,14 @@ abstract class DatabaseBackedTest {
   fun insertSplatAdditionalFile(
       splatFileId: FileId = inserted.fileId,
       fileId: FileId = inserted.fileId,
-      type: SplatAdditionalFileType = SplatAdditionalFileType.Frames,
+      type: String = "frames",
   ) {
     with(SPLAT_ADDITIONAL_FILES) {
       dslContext
           .insertInto(SPLAT_ADDITIONAL_FILES)
           .set(SPLAT_FILE_ID, splatFileId)
           .set(FILE_ID, fileId)
-          .set(TYPE_ID, type)
+          .set(TYPE, type)
           .execute()
     }
   }

--- a/src/test/kotlin/com/terraformation/backend/splat/SplatServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/splat/SplatServiceTest.kt
@@ -2146,6 +2146,110 @@ class SplatServiceTest : DatabaseTest(), RunsAsDatabaseUser {
     }
 
     @Test
+    fun `ignores batch files whose types are ambiguous`() {
+      val fileBatchId = insertFileBatch()
+      val videoFileId =
+          insertFile(
+              contentType = "video/mp4",
+              fileBatchId = fileBatchId,
+              fileName = "video.mp4",
+              storageUrl = "s3://bucket/video.mp4",
+          )
+      insertOrganizationMediaFile(fileId = videoFileId)
+      insertFile(
+          contentType = "application/json",
+          fileBatchId = fileBatchId,
+          fileName = "imu.json",
+          storageUrl = "s3://bucket/imu.json",
+      )
+      insertFile(
+          contentType = "text/csv",
+          fileBatchId = fileBatchId,
+          fileName = "imu.csv",
+          storageUrl = "s3://bucket/imu.csv",
+      )
+      val framesFileId =
+          insertFile(
+              contentType = "application/json",
+              fileBatchId = fileBatchId,
+              fileName = "frames.jsonl",
+              storageUrl = "s3://bucket/frames.jsonl",
+          )
+
+      val messageSlot = slot<SplatterRequestMessage>()
+      every { sqsTemplate.send(any<String>(), capture(messageSlot)) } returns mockk(relaxed = true)
+
+      service.on(FileBatchFinishedUploadingEvent(fileBatchId))
+
+      dslContext.fetchSingle(SPLATS, SPLATS.FILE_ID.eq(videoFileId))
+      assertTableEquals(
+          SplatAdditionalFilesRecord(
+              fileId = framesFileId,
+              splatFileId = videoFileId,
+              typeId = SplatAdditionalFileType.Frames,
+          )
+      )
+      assertEquals(
+          listOf(
+              SplatterRequestFileLocation(
+                  "bucket",
+                  "frames.jsonl",
+                  SplatAdditionalFileType.Frames,
+              )
+          ),
+          messageSlot.captured.additionalFiles,
+          "Request additional files",
+      )
+    }
+
+    @Test
+    fun `detects additional file types in names with directory components`() {
+      val fileBatchId = insertFileBatch()
+      val videoFileId =
+          insertFile(
+              contentType = "video/mp4",
+              fileBatchId = fileBatchId,
+              fileName = "video.mp4",
+              storageUrl = "s3://bucket/video.mp4",
+          )
+      insertOrganizationMediaFile(fileId = videoFileId)
+      val imuFileId =
+          insertFile(
+              contentType = "application/json",
+              fileBatchId = fileBatchId,
+              fileName = "C:\\fakepath\\imu.json",
+              storageUrl = "s3://bucket/imu.json",
+          )
+      val framesFileId =
+          insertFile(
+              contentType = "application/json",
+              fileBatchId = fileBatchId,
+              fileName = "capture/frames.jsonl",
+              storageUrl = "s3://bucket/frames.jsonl",
+          )
+
+      every { sqsTemplate.send(any<String>(), any<SplatterRequestMessage>()) } returns
+          mockk(relaxed = true)
+
+      service.on(FileBatchFinishedUploadingEvent(fileBatchId))
+
+      assertTableEquals(
+          listOf(
+              SplatAdditionalFilesRecord(
+                  fileId = imuFileId,
+                  splatFileId = videoFileId,
+                  typeId = SplatAdditionalFileType.Imu,
+              ),
+              SplatAdditionalFilesRecord(
+                  fileId = framesFileId,
+                  splatFileId = videoFileId,
+                  typeId = SplatAdditionalFileType.Frames,
+              ),
+          )
+      )
+    }
+
+    @Test
     fun `does nothing when batch has no organization video`() {
       val fileBatchId = insertFileBatch()
       insertFile(contentType = "application/json", fileBatchId = fileBatchId)

--- a/src/test/kotlin/com/terraformation/backend/splat/SplatServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/splat/SplatServiceTest.kt
@@ -15,7 +15,6 @@ import com.terraformation.backend.db.default_schema.FileBatchType
 import com.terraformation.backend.db.default_schema.FileId
 import com.terraformation.backend.db.default_schema.OrganizationId
 import com.terraformation.backend.db.default_schema.Role
-import com.terraformation.backend.db.default_schema.SplatAdditionalFileType
 import com.terraformation.backend.db.default_schema.tables.records.BirdnetResultsRecord
 import com.terraformation.backend.db.default_schema.tables.records.SplatAdditionalFilesRecord
 import com.terraformation.backend.db.default_schema.tables.records.SplatAnnotationsRecord
@@ -57,6 +56,8 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.CsvSource
 
 class SplatServiceTest : DatabaseTest(), RunsAsDatabaseUser {
   override lateinit var user: TerrawareUser
@@ -1434,12 +1435,12 @@ class SplatServiceTest : DatabaseTest(), RunsAsDatabaseUser {
       insertSplatAdditionalFile(
           splatFileId = orgFileId,
           fileId = insertFile(storageUrl = "s3://bucket/frames.zip"),
-          type = SplatAdditionalFileType.Frames,
+          type = "frames",
       )
       insertSplatAdditionalFile(
           splatFileId = orgFileId,
           fileId = insertFile(storageUrl = "s3://bucket/imu.json"),
-          type = SplatAdditionalFileType.Imu,
+          type = "imu",
       )
 
       val messageSlot = slot<SplatterRequestMessage>()
@@ -1454,8 +1455,8 @@ class SplatServiceTest : DatabaseTest(), RunsAsDatabaseUser {
 
       assertEquals(
           listOf(
-              SplatterRequestFileLocation("bucket", "frames.zip", SplatAdditionalFileType.Frames),
-              SplatterRequestFileLocation("bucket", "imu.json", SplatAdditionalFileType.Imu),
+              SplatterRequestFileLocation("bucket", "frames.zip", "frames"),
+              SplatterRequestFileLocation("bucket", "imu.json", "imu"),
           ),
           messageSlot.captured.additionalFiles,
           "Request additional files",
@@ -1468,7 +1469,7 @@ class SplatServiceTest : DatabaseTest(), RunsAsDatabaseUser {
       insertSplatAdditionalFile(
           splatFileId = orgFileId,
           fileId = insertFile(fileName = "imu.json", storageUrl = "s3://bucket/old-imu.json"),
-          type = SplatAdditionalFileType.Imu,
+          type = "imu",
       )
       val newImuFileId = insertFile(fileName = "imu.json", storageUrl = "s3://bucket/new-imu.json")
 
@@ -1480,20 +1481,18 @@ class SplatServiceTest : DatabaseTest(), RunsAsDatabaseUser {
           fileId = orgFileId,
           force = true,
           runBirdnet = false,
-          additionalFiles = mapOf(newImuFileId to SplatAdditionalFileType.Imu),
+          additionalFiles = mapOf(newImuFileId to "imu"),
       )
 
       assertTableEquals(
           SplatAdditionalFilesRecord(
               fileId = newImuFileId,
               splatFileId = orgFileId,
-              typeId = SplatAdditionalFileType.Imu,
+              type = "imu",
           )
       )
       assertEquals(
-          listOf(
-              SplatterRequestFileLocation("bucket", "new-imu.json", SplatAdditionalFileType.Imu)
-          ),
+          listOf(SplatterRequestFileLocation("bucket", "new-imu.json", "imu")),
           messageSlot.captured.additionalFiles,
           "Request additional files",
       )
@@ -2038,24 +2037,24 @@ class SplatServiceTest : DatabaseTest(), RunsAsDatabaseUser {
       insertOrganizationMediaFile(fileId = videoFileId)
       val framesFileId =
           insertFile(
-              contentType = "application/json",
+              contentType = "application/json+frames",
               fileBatchId = fileBatchId,
               fileName = "frames.jsonl",
               storageUrl = "s3://bucket/frames.jsonl",
           )
       val imuFileId =
           insertFile(
-              contentType = "application/json",
+              contentType = "application/json+imu",
               fileBatchId = fileBatchId,
               fileName = "imu.json",
               storageUrl = "s3://bucket/imu.json",
           )
       val sessionMetaFileId =
           insertFile(
-              contentType = "application/json",
+              contentType = "application/json+sessionMeta",
               fileBatchId = fileBatchId,
-              fileName = "session-meta.json",
-              storageUrl = "s3://bucket/session-meta.json",
+              fileName = "sessionMeta.json",
+              storageUrl = "s3://bucket/sessionMeta.json",
           )
 
       val messageSlot = slot<SplatterRequestMessage>()
@@ -2080,17 +2079,17 @@ class SplatServiceTest : DatabaseTest(), RunsAsDatabaseUser {
               SplatAdditionalFilesRecord(
                   fileId = framesFileId,
                   splatFileId = videoFileId,
-                  typeId = SplatAdditionalFileType.Frames,
+                  type = "frames",
               ),
               SplatAdditionalFilesRecord(
                   fileId = imuFileId,
                   splatFileId = videoFileId,
-                  typeId = SplatAdditionalFileType.Imu,
+                  type = "imu",
               ),
               SplatAdditionalFilesRecord(
                   fileId = sessionMetaFileId,
                   splatFileId = videoFileId,
-                  typeId = SplatAdditionalFileType.SessionMeta,
+                  type = "session-meta",
               ),
           )
       )
@@ -2104,13 +2103,13 @@ class SplatServiceTest : DatabaseTest(), RunsAsDatabaseUser {
               SplatterRequestFileLocation(
                   "bucket",
                   "frames.jsonl",
-                  SplatAdditionalFileType.Frames,
+                  "frames",
               ),
-              SplatterRequestFileLocation("bucket", "imu.json", SplatAdditionalFileType.Imu),
+              SplatterRequestFileLocation("bucket", "imu.json", "imu"),
               SplatterRequestFileLocation(
                   "bucket",
-                  "session-meta.json",
-                  SplatAdditionalFileType.SessionMeta,
+                  "sessionMeta.json",
+                  "session-meta",
               ),
           ),
           messageSlot.captured.additionalFiles,
@@ -2119,7 +2118,7 @@ class SplatServiceTest : DatabaseTest(), RunsAsDatabaseUser {
     }
 
     @Test
-    fun `ignores batch files whose names are not additional file types`() {
+    fun `ignores batch files whose content types have no additional file type suffix`() {
       val fileBatchId = insertFileBatch()
       val videoFileId =
           insertFile(
@@ -2130,6 +2129,16 @@ class SplatServiceTest : DatabaseTest(), RunsAsDatabaseUser {
           )
       insertOrganizationMediaFile(fileId = videoFileId)
       insertFile(contentType = "text/plain", fileBatchId = fileBatchId, fileName = "notes.txt")
+      insertFile(
+          contentType = "application/json+",
+          fileBatchId = fileBatchId,
+          fileName = "imu.json",
+      )
+      insertFile(
+          contentType = "text/plain; charset=utf-8",
+          fileBatchId = fileBatchId,
+          fileName = "readme.txt",
+      )
 
       val messageSlot = slot<SplatterRequestMessage>()
       every { sqsTemplate.send(any<String>(), capture(messageSlot)) } returns mockk(relaxed = true)
@@ -2157,20 +2166,20 @@ class SplatServiceTest : DatabaseTest(), RunsAsDatabaseUser {
           )
       insertOrganizationMediaFile(fileId = videoFileId)
       insertFile(
-          contentType = "application/json",
+          contentType = "application/json+unknown",
           fileBatchId = fileBatchId,
           fileName = "imu.json",
           storageUrl = "s3://bucket/imu.json",
       )
       insertFile(
-          contentType = "text/csv",
+          contentType = "text/csv+unknown",
           fileBatchId = fileBatchId,
           fileName = "imu.csv",
           storageUrl = "s3://bucket/imu.csv",
       )
       val framesFileId =
           insertFile(
-              contentType = "application/json",
+              contentType = "application/json+frames",
               fileBatchId = fileBatchId,
               fileName = "frames.jsonl",
               storageUrl = "s3://bucket/frames.jsonl",
@@ -2186,7 +2195,7 @@ class SplatServiceTest : DatabaseTest(), RunsAsDatabaseUser {
           SplatAdditionalFilesRecord(
               fileId = framesFileId,
               splatFileId = videoFileId,
-              typeId = SplatAdditionalFileType.Frames,
+              type = "frames",
           )
       )
       assertEquals(
@@ -2194,7 +2203,7 @@ class SplatServiceTest : DatabaseTest(), RunsAsDatabaseUser {
               SplatterRequestFileLocation(
                   "bucket",
                   "frames.jsonl",
-                  SplatAdditionalFileType.Frames,
+                  "frames",
               )
           ),
           messageSlot.captured.additionalFiles,
@@ -2202,8 +2211,60 @@ class SplatServiceTest : DatabaseTest(), RunsAsDatabaseUser {
       )
     }
 
+    @CsvSource(
+        "application/json+imu,imu",
+        "application/json+sessionMeta,session-meta",
+        "application/json+IMUData,imu-data",
+        "application/json+cameraIMU,camera-imu",
+        "application/json+GPS,gps",
+        "application/json+already-kebab,already-kebab",
+        "application/vnd.custom+json+imu,imu",
+        "application/json+imu; charset=utf-8,imu",
+        "application/json+sessionMeta ;charset=utf-8,session-meta",
+    )
+    @ParameterizedTest(name = "{0} -> {1}")
+    fun `derives additional file type from content type suffix`(
+        contentType: String,
+        expectedType: String,
+    ) {
+      val fileBatchId = insertFileBatch()
+      val videoFileId =
+          insertFile(
+              contentType = "video/mp4",
+              fileBatchId = fileBatchId,
+              fileName = "video.mp4",
+              storageUrl = "s3://bucket/video.mp4",
+          )
+      insertOrganizationMediaFile(fileId = videoFileId)
+      val additionalFileId =
+          insertFile(
+              contentType = contentType,
+              fileBatchId = fileBatchId,
+              fileName = "additional.json",
+              storageUrl = "s3://bucket/additional.json",
+          )
+
+      val messageSlot = slot<SplatterRequestMessage>()
+      every { sqsTemplate.send(any<String>(), capture(messageSlot)) } returns mockk(relaxed = true)
+
+      service.on(FileBatchFinishedUploadingEvent(fileBatchId))
+
+      assertTableEquals(
+          SplatAdditionalFilesRecord(
+              fileId = additionalFileId,
+              splatFileId = videoFileId,
+              type = expectedType,
+          )
+      )
+      assertEquals(
+          listOf(SplatterRequestFileLocation("bucket", "additional.json", expectedType)),
+          messageSlot.captured.additionalFiles,
+          "Request additional files",
+      )
+    }
+
     @Test
-    fun `detects additional file types in names with directory components`() {
+    fun `derives additional file types from content types rather than file names`() {
       val fileBatchId = insertFileBatch()
       val videoFileId =
           insertFile(
@@ -2215,21 +2276,18 @@ class SplatServiceTest : DatabaseTest(), RunsAsDatabaseUser {
       insertOrganizationMediaFile(fileId = videoFileId)
       val imuFileId =
           insertFile(
-              contentType = "application/json",
-              fileBatchId = fileBatchId,
-              fileName = "C:\\fakepath\\imu.json",
-              storageUrl = "s3://bucket/imu.json",
-          )
-      val framesFileId =
-          insertFile(
-              contentType = "application/json",
+              contentType = "application/json+imu",
               fileBatchId = fileBatchId,
               fileName = "capture/frames.jsonl",
               storageUrl = "s3://bucket/frames.jsonl",
           )
-
-      every { sqsTemplate.send(any<String>(), any<SplatterRequestMessage>()) } returns
-          mockk(relaxed = true)
+      val framesFileId =
+          insertFile(
+              contentType = "application/json+frames",
+              fileBatchId = fileBatchId,
+              fileName = "C:\\fakepath\\imu.json",
+              storageUrl = "s3://bucket/imu.json",
+          )
 
       service.on(FileBatchFinishedUploadingEvent(fileBatchId))
 
@@ -2238,14 +2296,52 @@ class SplatServiceTest : DatabaseTest(), RunsAsDatabaseUser {
               SplatAdditionalFilesRecord(
                   fileId = imuFileId,
                   splatFileId = videoFileId,
-                  typeId = SplatAdditionalFileType.Imu,
+                  type = "imu",
               ),
               SplatAdditionalFilesRecord(
                   fileId = framesFileId,
                   splatFileId = videoFileId,
-                  typeId = SplatAdditionalFileType.Frames,
+                  type = "frames",
               ),
           )
+      )
+    }
+
+    @Test
+    fun `ignores batch files whose content types normalize to the same type`() {
+      val fileBatchId = insertFileBatch()
+      val videoFileId =
+          insertFile(
+              contentType = "video/mp4",
+              fileBatchId = fileBatchId,
+              fileName = "video.mp4",
+              storageUrl = "s3://bucket/video.mp4",
+          )
+      insertOrganizationMediaFile(fileId = videoFileId)
+      insertFile(
+          contentType = "application/json+sessionMeta",
+          fileBatchId = fileBatchId,
+          fileName = "sessionMeta.json",
+          storageUrl = "s3://bucket/sessionMeta.json",
+      )
+      insertFile(
+          contentType = "application/json+session-meta",
+          fileBatchId = fileBatchId,
+          fileName = "session-meta.json",
+          storageUrl = "s3://bucket/session-meta.json",
+      )
+
+      val messageSlot = slot<SplatterRequestMessage>()
+      every { sqsTemplate.send(any<String>(), capture(messageSlot)) } returns mockk(relaxed = true)
+
+      service.on(FileBatchFinishedUploadingEvent(fileBatchId))
+
+      dslContext.fetchSingle(SPLATS, SPLATS.FILE_ID.eq(videoFileId))
+      assertTableEmpty(SPLAT_ADDITIONAL_FILES)
+      assertEquals(
+          emptyList<SplatterRequestFileLocation>(),
+          messageSlot.captured.additionalFiles,
+          "Request additional files",
       )
     }
 

--- a/src/test/kotlin/com/terraformation/backend/splat/SplatServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/splat/SplatServiceTest.kt
@@ -2053,8 +2053,8 @@ class SplatServiceTest : DatabaseTest(), RunsAsDatabaseUser {
           insertFile(
               contentType = "application/json+sessionMeta",
               fileBatchId = fileBatchId,
-              fileName = "sessionMeta.json",
-              storageUrl = "s3://bucket/sessionMeta.json",
+              fileName = "capture-3.json",
+              storageUrl = "s3://bucket/capture-3.json",
           )
 
       val messageSlot = slot<SplatterRequestMessage>()
@@ -2108,7 +2108,7 @@ class SplatServiceTest : DatabaseTest(), RunsAsDatabaseUser {
               SplatterRequestFileLocation("bucket", "imu.json", "imu"),
               SplatterRequestFileLocation(
                   "bucket",
-                  "sessionMeta.json",
+                  "capture-3.json",
                   "session-meta",
               ),
           ),
@@ -2260,50 +2260,6 @@ class SplatServiceTest : DatabaseTest(), RunsAsDatabaseUser {
           listOf(SplatterRequestFileLocation("bucket", "additional.json", expectedType)),
           messageSlot.captured.additionalFiles,
           "Request additional files",
-      )
-    }
-
-    @Test
-    fun `derives additional file types from content types rather than file names`() {
-      val fileBatchId = insertFileBatch()
-      val videoFileId =
-          insertFile(
-              contentType = "video/mp4",
-              fileBatchId = fileBatchId,
-              fileName = "video.mp4",
-              storageUrl = "s3://bucket/video.mp4",
-          )
-      insertOrganizationMediaFile(fileId = videoFileId)
-      val imuFileId =
-          insertFile(
-              contentType = "application/json+imu",
-              fileBatchId = fileBatchId,
-              fileName = "capture/frames.jsonl",
-              storageUrl = "s3://bucket/frames.jsonl",
-          )
-      val framesFileId =
-          insertFile(
-              contentType = "application/json+frames",
-              fileBatchId = fileBatchId,
-              fileName = "C:\\fakepath\\imu.json",
-              storageUrl = "s3://bucket/imu.json",
-          )
-
-      service.on(FileBatchFinishedUploadingEvent(fileBatchId))
-
-      assertTableEquals(
-          listOf(
-              SplatAdditionalFilesRecord(
-                  fileId = imuFileId,
-                  splatFileId = videoFileId,
-                  type = "imu",
-              ),
-              SplatAdditionalFilesRecord(
-                  fileId = framesFileId,
-                  splatFileId = videoFileId,
-                  type = "frames",
-              ),
-          )
       )
     }
 

--- a/src/test/kotlin/com/terraformation/backend/splat/SplatServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/splat/SplatServiceTest.kt
@@ -15,11 +15,14 @@ import com.terraformation.backend.db.default_schema.FileBatchType
 import com.terraformation.backend.db.default_schema.FileId
 import com.terraformation.backend.db.default_schema.OrganizationId
 import com.terraformation.backend.db.default_schema.Role
+import com.terraformation.backend.db.default_schema.SplatAdditionalFileType
 import com.terraformation.backend.db.default_schema.tables.records.BirdnetResultsRecord
+import com.terraformation.backend.db.default_schema.tables.records.SplatAdditionalFilesRecord
 import com.terraformation.backend.db.default_schema.tables.records.SplatAnnotationsRecord
 import com.terraformation.backend.db.default_schema.tables.records.SplatsRecord
 import com.terraformation.backend.db.default_schema.tables.references.BIRDNET_RESULTS
 import com.terraformation.backend.db.default_schema.tables.references.SPLATS
+import com.terraformation.backend.db.default_schema.tables.references.SPLAT_ADDITIONAL_FILES
 import com.terraformation.backend.db.default_schema.tables.references.SPLAT_ANNOTATIONS
 import com.terraformation.backend.db.tracking.ObservationId
 import com.terraformation.backend.db.tracking.ObservationState
@@ -1426,6 +1429,95 @@ class SplatServiceTest : DatabaseTest(), RunsAsDatabaseUser {
     }
 
     @Test
+    fun `includes additional files and their types in SQS message`() {
+      insertSplat(fileId = orgFileId, assetStatus = AssetStatus.Ready)
+      insertSplatAdditionalFile(
+          splatFileId = orgFileId,
+          fileId = insertFile(storageUrl = "s3://bucket/frames.zip"),
+          type = SplatAdditionalFileType.Frames,
+      )
+      insertSplatAdditionalFile(
+          splatFileId = orgFileId,
+          fileId = insertFile(storageUrl = "s3://bucket/imu.json"),
+          type = SplatAdditionalFileType.Imu,
+      )
+
+      val messageSlot = slot<SplatterRequestMessage>()
+      every { sqsTemplate.send(any<String>(), capture(messageSlot)) } returns mockk(relaxed = true)
+
+      service.generateOrganizationMediaSplat(
+          organizationId = organizationId,
+          fileId = orgFileId,
+          force = true,
+          runBirdnet = false,
+      )
+
+      assertEquals(
+          listOf(
+              SplatterRequestFileLocation("bucket", "frames.zip", SplatAdditionalFileType.Frames),
+              SplatterRequestFileLocation("bucket", "imu.json", SplatAdditionalFileType.Imu),
+          ),
+          messageSlot.captured.additionalFiles,
+          "Request additional files",
+      )
+    }
+
+    @Test
+    fun `replaces the stored additional file of a type`() {
+      insertSplat(fileId = orgFileId, assetStatus = AssetStatus.Ready)
+      insertSplatAdditionalFile(
+          splatFileId = orgFileId,
+          fileId = insertFile(fileName = "imu.json", storageUrl = "s3://bucket/old-imu.json"),
+          type = SplatAdditionalFileType.Imu,
+      )
+      val newImuFileId = insertFile(fileName = "imu.json", storageUrl = "s3://bucket/new-imu.json")
+
+      val messageSlot = slot<SplatterRequestMessage>()
+      every { sqsTemplate.send(any<String>(), capture(messageSlot)) } returns mockk(relaxed = true)
+
+      service.generateOrganizationMediaSplat(
+          organizationId = organizationId,
+          fileId = orgFileId,
+          force = true,
+          runBirdnet = false,
+          additionalFiles = mapOf(newImuFileId to SplatAdditionalFileType.Imu),
+      )
+
+      assertTableEquals(
+          SplatAdditionalFilesRecord(
+              fileId = newImuFileId,
+              splatFileId = orgFileId,
+              typeId = SplatAdditionalFileType.Imu,
+          )
+      )
+      assertEquals(
+          listOf(
+              SplatterRequestFileLocation("bucket", "new-imu.json", SplatAdditionalFileType.Imu)
+          ),
+          messageSlot.captured.additionalFiles,
+          "Request additional files",
+      )
+    }
+
+    @Test
+    fun `sends no additional files when splat has none`() {
+      val messageSlot = slot<SplatterRequestMessage>()
+      every { sqsTemplate.send(any<String>(), capture(messageSlot)) } returns mockk(relaxed = true)
+
+      service.generateOrganizationMediaSplat(
+          organizationId = organizationId,
+          fileId = orgFileId,
+          runBirdnet = false,
+      )
+
+      assertEquals(
+          emptyList<SplatterRequestFileLocation>(),
+          messageSlot.captured.additionalFiles,
+          "Request additional files",
+      )
+    }
+
+    @Test
     fun `throws exception when user is not a member of the organization`() {
       deleteOrganizationUser()
 
@@ -1934,15 +2026,37 @@ class SplatServiceTest : DatabaseTest(), RunsAsDatabaseUser {
     }
 
     @Test
-    fun `generates splat for a video that is part of a batch`() {
+    fun `generates splat with the additional files in a batch`() {
       val fileBatchId = insertFileBatch()
       val videoFileId =
           insertFile(
               contentType = "video/mp4",
               fileBatchId = fileBatchId,
+              fileName = "video.mp4",
               storageUrl = "s3://bucket/video.mp4",
           )
       insertOrganizationMediaFile(fileId = videoFileId)
+      val framesFileId =
+          insertFile(
+              contentType = "application/json",
+              fileBatchId = fileBatchId,
+              fileName = "frames.jsonl",
+              storageUrl = "s3://bucket/frames.jsonl",
+          )
+      val imuFileId =
+          insertFile(
+              contentType = "application/json",
+              fileBatchId = fileBatchId,
+              fileName = "imu.json",
+              storageUrl = "s3://bucket/imu.json",
+          )
+      val sessionMetaFileId =
+          insertFile(
+              contentType = "application/json",
+              fileBatchId = fileBatchId,
+              fileName = "session-meta.json",
+              storageUrl = "s3://bucket/session-meta.json",
+          )
 
       val messageSlot = slot<SplatterRequestMessage>()
       every { sqsTemplate.send(any<String>(), capture(messageSlot)) } returns mockk(relaxed = true)
@@ -1950,10 +2064,75 @@ class SplatServiceTest : DatabaseTest(), RunsAsDatabaseUser {
       service.on(FileBatchFinishedUploadingEvent(fileBatchId))
 
       dslContext.fetchSingle(SPLATS, SPLATS.FILE_ID.eq(videoFileId))
+
+      assertTableEquals(
+          listOf(
+              SplatAdditionalFilesRecord(
+                  fileId = framesFileId,
+                  splatFileId = videoFileId,
+                  typeId = SplatAdditionalFileType.Frames,
+              ),
+              SplatAdditionalFilesRecord(
+                  fileId = imuFileId,
+                  splatFileId = videoFileId,
+                  typeId = SplatAdditionalFileType.Imu,
+              ),
+              SplatAdditionalFilesRecord(
+                  fileId = sessionMetaFileId,
+                  splatFileId = videoFileId,
+                  typeId = SplatAdditionalFileType.SessionMeta,
+              ),
+          )
+      )
+
       assertEquals(
           SplatterRequestFileLocation("bucket", "video.mp4"),
           messageSlot.captured.input,
           "Request input file location",
+      )
+      assertEquals(
+          listOf(
+              SplatterRequestFileLocation(
+                  "bucket",
+                  "frames.jsonl",
+                  SplatAdditionalFileType.Frames,
+              ),
+              SplatterRequestFileLocation("bucket", "imu.json", SplatAdditionalFileType.Imu),
+              SplatterRequestFileLocation(
+                  "bucket",
+                  "session-meta.json",
+                  SplatAdditionalFileType.SessionMeta,
+              ),
+          ),
+          messageSlot.captured.additionalFiles,
+          "Request additional files",
+      )
+    }
+
+    @Test
+    fun `ignores batch files whose names are not additional file types`() {
+      val fileBatchId = insertFileBatch()
+      val videoFileId =
+          insertFile(
+              contentType = "video/mp4",
+              fileBatchId = fileBatchId,
+              fileName = "video.mp4",
+              storageUrl = "s3://bucket/video.mp4",
+          )
+      insertOrganizationMediaFile(fileId = videoFileId)
+      insertFile(contentType = "text/plain", fileBatchId = fileBatchId, fileName = "notes.txt")
+
+      val messageSlot = slot<SplatterRequestMessage>()
+      every { sqsTemplate.send(any<String>(), capture(messageSlot)) } returns mockk(relaxed = true)
+
+      service.on(FileBatchFinishedUploadingEvent(fileBatchId))
+
+      dslContext.fetchSingle(SPLATS, SPLATS.FILE_ID.eq(videoFileId))
+      assertTableEmpty(SPLAT_ADDITIONAL_FILES)
+      assertEquals(
+          emptyList<SplatterRequestFileLocation>(),
+          messageSlot.captured.additionalFiles,
+          "Request additional files",
       )
     }
 

--- a/src/test/kotlin/com/terraformation/backend/splat/SplatServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/splat/SplatServiceTest.kt
@@ -15,11 +15,14 @@ import com.terraformation.backend.db.default_schema.FileBatchType
 import com.terraformation.backend.db.default_schema.FileId
 import com.terraformation.backend.db.default_schema.OrganizationId
 import com.terraformation.backend.db.default_schema.Role
+import com.terraformation.backend.db.default_schema.SplatAdditionalFileType
 import com.terraformation.backend.db.default_schema.tables.records.BirdnetResultsRecord
+import com.terraformation.backend.db.default_schema.tables.records.SplatAdditionalFilesRecord
 import com.terraformation.backend.db.default_schema.tables.records.SplatAnnotationsRecord
 import com.terraformation.backend.db.default_schema.tables.records.SplatsRecord
 import com.terraformation.backend.db.default_schema.tables.references.BIRDNET_RESULTS
 import com.terraformation.backend.db.default_schema.tables.references.SPLATS
+import com.terraformation.backend.db.default_schema.tables.references.SPLAT_ADDITIONAL_FILES
 import com.terraformation.backend.db.default_schema.tables.references.SPLAT_ANNOTATIONS
 import com.terraformation.backend.db.tracking.ObservationId
 import com.terraformation.backend.db.tracking.ObservationState
@@ -1426,6 +1429,95 @@ class SplatServiceTest : DatabaseTest(), RunsAsDatabaseUser {
     }
 
     @Test
+    fun `includes additional files and their types in SQS message`() {
+      insertSplat(fileId = orgFileId, assetStatus = AssetStatus.Ready)
+      insertSplatAdditionalFile(
+          splatFileId = orgFileId,
+          fileId = insertFile(storageUrl = "s3://bucket/frames.zip"),
+          type = SplatAdditionalFileType.Frames,
+      )
+      insertSplatAdditionalFile(
+          splatFileId = orgFileId,
+          fileId = insertFile(storageUrl = "s3://bucket/imu.json"),
+          type = SplatAdditionalFileType.Imu,
+      )
+
+      val messageSlot = slot<SplatterRequestMessage>()
+      every { sqsTemplate.send(any<String>(), capture(messageSlot)) } returns mockk(relaxed = true)
+
+      service.generateOrganizationMediaSplat(
+          organizationId = organizationId,
+          fileId = orgFileId,
+          force = true,
+          runBirdnet = false,
+      )
+
+      assertEquals(
+          listOf(
+              SplatterRequestFileLocation("bucket", "frames.zip", SplatAdditionalFileType.Frames),
+              SplatterRequestFileLocation("bucket", "imu.json", SplatAdditionalFileType.Imu),
+          ),
+          messageSlot.captured.additionalFiles,
+          "Request additional files",
+      )
+    }
+
+    @Test
+    fun `replaces the stored additional file of a type`() {
+      insertSplat(fileId = orgFileId, assetStatus = AssetStatus.Ready)
+      insertSplatAdditionalFile(
+          splatFileId = orgFileId,
+          fileId = insertFile(fileName = "imu.json", storageUrl = "s3://bucket/old-imu.json"),
+          type = SplatAdditionalFileType.Imu,
+      )
+      val newImuFileId = insertFile(fileName = "imu.json", storageUrl = "s3://bucket/new-imu.json")
+
+      val messageSlot = slot<SplatterRequestMessage>()
+      every { sqsTemplate.send(any<String>(), capture(messageSlot)) } returns mockk(relaxed = true)
+
+      service.generateOrganizationMediaSplat(
+          organizationId = organizationId,
+          fileId = orgFileId,
+          force = true,
+          runBirdnet = false,
+          additionalFiles = mapOf(newImuFileId to SplatAdditionalFileType.Imu),
+      )
+
+      assertTableEquals(
+          SplatAdditionalFilesRecord(
+              fileId = newImuFileId,
+              splatFileId = orgFileId,
+              typeId = SplatAdditionalFileType.Imu,
+          )
+      )
+      assertEquals(
+          listOf(
+              SplatterRequestFileLocation("bucket", "new-imu.json", SplatAdditionalFileType.Imu)
+          ),
+          messageSlot.captured.additionalFiles,
+          "Request additional files",
+      )
+    }
+
+    @Test
+    fun `sends no additional files when splat has none`() {
+      val messageSlot = slot<SplatterRequestMessage>()
+      every { sqsTemplate.send(any<String>(), capture(messageSlot)) } returns mockk(relaxed = true)
+
+      service.generateOrganizationMediaSplat(
+          organizationId = organizationId,
+          fileId = orgFileId,
+          runBirdnet = false,
+      )
+
+      assertEquals(
+          emptyList<SplatterRequestFileLocation>(),
+          messageSlot.captured.additionalFiles,
+          "Request additional files",
+      )
+    }
+
+    @Test
     fun `throws exception when user is not a member of the organization`() {
       deleteOrganizationUser()
 
@@ -1934,15 +2026,37 @@ class SplatServiceTest : DatabaseTest(), RunsAsDatabaseUser {
     }
 
     @Test
-    fun `generates splat for a video that is part of a batch`() {
+    fun `generates splat with the additional files in a batch`() {
       val fileBatchId = insertFileBatch()
       val videoFileId =
           insertFile(
               contentType = "video/mp4",
               fileBatchId = fileBatchId,
+              fileName = "video.mp4",
               storageUrl = "s3://bucket/video.mp4",
           )
       insertOrganizationMediaFile(fileId = videoFileId)
+      val framesFileId =
+          insertFile(
+              contentType = "application/json",
+              fileBatchId = fileBatchId,
+              fileName = "frames.jsonl",
+              storageUrl = "s3://bucket/frames.jsonl",
+          )
+      val imuFileId =
+          insertFile(
+              contentType = "application/json",
+              fileBatchId = fileBatchId,
+              fileName = "imu.json",
+              storageUrl = "s3://bucket/imu.json",
+          )
+      val sessionMetaFileId =
+          insertFile(
+              contentType = "application/json",
+              fileBatchId = fileBatchId,
+              fileName = "session-meta.json",
+              storageUrl = "s3://bucket/session-meta.json",
+          )
 
       val messageSlot = slot<SplatterRequestMessage>()
       every { sqsTemplate.send(any<String>(), capture(messageSlot)) } returns mockk(relaxed = true)
@@ -1960,10 +2074,74 @@ class SplatServiceTest : DatabaseTest(), RunsAsDatabaseUser {
               splatStorageUrl = URI("s3://bucket/video.sog"),
           )
       )
+
+      assertTableEquals(
+          listOf(
+              SplatAdditionalFilesRecord(
+                  fileId = framesFileId,
+                  splatFileId = videoFileId,
+                  typeId = SplatAdditionalFileType.Frames,
+              ),
+              SplatAdditionalFilesRecord(
+                  fileId = imuFileId,
+                  splatFileId = videoFileId,
+                  typeId = SplatAdditionalFileType.Imu,
+              ),
+              SplatAdditionalFilesRecord(
+                  fileId = sessionMetaFileId,
+                  splatFileId = videoFileId,
+                  typeId = SplatAdditionalFileType.SessionMeta,
+              ),
+          )
+      )
       assertEquals(
           SplatterRequestFileLocation("bucket", "video.mp4"),
           messageSlot.captured.input,
           "Request input file location",
+      )
+      assertEquals(
+          listOf(
+              SplatterRequestFileLocation(
+                  "bucket",
+                  "frames.jsonl",
+                  SplatAdditionalFileType.Frames,
+              ),
+              SplatterRequestFileLocation("bucket", "imu.json", SplatAdditionalFileType.Imu),
+              SplatterRequestFileLocation(
+                  "bucket",
+                  "session-meta.json",
+                  SplatAdditionalFileType.SessionMeta,
+              ),
+          ),
+          messageSlot.captured.additionalFiles,
+          "Request additional files",
+      )
+    }
+
+    @Test
+    fun `ignores batch files whose names are not additional file types`() {
+      val fileBatchId = insertFileBatch()
+      val videoFileId =
+          insertFile(
+              contentType = "video/mp4",
+              fileBatchId = fileBatchId,
+              fileName = "video.mp4",
+              storageUrl = "s3://bucket/video.mp4",
+          )
+      insertOrganizationMediaFile(fileId = videoFileId)
+      insertFile(contentType = "text/plain", fileBatchId = fileBatchId, fileName = "notes.txt")
+
+      val messageSlot = slot<SplatterRequestMessage>()
+      every { sqsTemplate.send(any<String>(), capture(messageSlot)) } returns mockk(relaxed = true)
+
+      service.on(FileBatchFinishedUploadingEvent(fileBatchId))
+
+      dslContext.fetchSingle(SPLATS, SPLATS.FILE_ID.eq(videoFileId))
+      assertTableEmpty(SPLAT_ADDITIONAL_FILES)
+      assertEquals(
+          emptyList<SplatterRequestFileLocation>(),
+          messageSlot.captured.additionalFiles,
+          "Request additional files",
       )
     }
 

--- a/src/test/kotlin/com/terraformation/backend/splat/SplatServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/splat/SplatServiceTest.kt
@@ -2137,6 +2137,110 @@ class SplatServiceTest : DatabaseTest(), RunsAsDatabaseUser {
     }
 
     @Test
+    fun `ignores batch files whose types are ambiguous`() {
+      val fileBatchId = insertFileBatch()
+      val videoFileId =
+          insertFile(
+              contentType = "video/mp4",
+              fileBatchId = fileBatchId,
+              fileName = "video.mp4",
+              storageUrl = "s3://bucket/video.mp4",
+          )
+      insertOrganizationMediaFile(fileId = videoFileId)
+      insertFile(
+          contentType = "application/json",
+          fileBatchId = fileBatchId,
+          fileName = "imu.json",
+          storageUrl = "s3://bucket/imu.json",
+      )
+      insertFile(
+          contentType = "text/csv",
+          fileBatchId = fileBatchId,
+          fileName = "imu.csv",
+          storageUrl = "s3://bucket/imu.csv",
+      )
+      val framesFileId =
+          insertFile(
+              contentType = "application/json",
+              fileBatchId = fileBatchId,
+              fileName = "frames.jsonl",
+              storageUrl = "s3://bucket/frames.jsonl",
+          )
+
+      val messageSlot = slot<SplatterRequestMessage>()
+      every { sqsTemplate.send(any<String>(), capture(messageSlot)) } returns mockk(relaxed = true)
+
+      service.on(FileBatchFinishedUploadingEvent(fileBatchId))
+
+      dslContext.fetchSingle(SPLATS, SPLATS.FILE_ID.eq(videoFileId))
+      assertTableEquals(
+          SplatAdditionalFilesRecord(
+              fileId = framesFileId,
+              splatFileId = videoFileId,
+              typeId = SplatAdditionalFileType.Frames,
+          )
+      )
+      assertEquals(
+          listOf(
+              SplatterRequestFileLocation(
+                  "bucket",
+                  "frames.jsonl",
+                  SplatAdditionalFileType.Frames,
+              )
+          ),
+          messageSlot.captured.additionalFiles,
+          "Request additional files",
+      )
+    }
+
+    @Test
+    fun `detects additional file types in names with directory components`() {
+      val fileBatchId = insertFileBatch()
+      val videoFileId =
+          insertFile(
+              contentType = "video/mp4",
+              fileBatchId = fileBatchId,
+              fileName = "video.mp4",
+              storageUrl = "s3://bucket/video.mp4",
+          )
+      insertOrganizationMediaFile(fileId = videoFileId)
+      val imuFileId =
+          insertFile(
+              contentType = "application/json",
+              fileBatchId = fileBatchId,
+              fileName = "C:\\fakepath\\imu.json",
+              storageUrl = "s3://bucket/imu.json",
+          )
+      val framesFileId =
+          insertFile(
+              contentType = "application/json",
+              fileBatchId = fileBatchId,
+              fileName = "capture/frames.jsonl",
+              storageUrl = "s3://bucket/frames.jsonl",
+          )
+
+      every { sqsTemplate.send(any<String>(), any<SplatterRequestMessage>()) } returns
+          mockk(relaxed = true)
+
+      service.on(FileBatchFinishedUploadingEvent(fileBatchId))
+
+      assertTableEquals(
+          listOf(
+              SplatAdditionalFilesRecord(
+                  fileId = imuFileId,
+                  splatFileId = videoFileId,
+                  typeId = SplatAdditionalFileType.Imu,
+              ),
+              SplatAdditionalFilesRecord(
+                  fileId = framesFileId,
+                  splatFileId = videoFileId,
+                  typeId = SplatAdditionalFileType.Frames,
+              ),
+          )
+      )
+    }
+
+    @Test
     fun `does nothing when batch has no organization video`() {
       val fileBatchId = insertFileBatch()
       insertFile(contentType = "application/json", fileBatchId = fileBatchId)


### PR DESCRIPTION
When a file batch finishes uploading for a splat video, include the rest of the batch files as part of the payload. Use the file names as their types.
If a filename/type doesn't exist yet, warn and continue with the rest to allow new files to be ready before splatter is ready to consume them.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>