### PR TITLE
SW-8811 Don't suggest colliding species renames

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/species/db/SpeciesChecker.kt
+++ b/src/main/kotlin/com/terraformation/backend/species/db/SpeciesChecker.kt
@@ -32,7 +32,12 @@ class SpeciesChecker(
   }
 
   private fun createProblems(model: ExistingSpeciesModel) {
-    val problems = listOfNotNull(gbifStore.checkScientificName(model.scientificName))
+    val problems =
+        listOfNotNull(gbifStore.checkScientificName(model.scientificName)).filter { problem ->
+          // Don't suggest names that would collide with existing species names.
+          problem.suggestedValue == null ||
+              !speciesStore.exists(model.organizationId, problem.suggestedValue!!)
+        }
 
     speciesStore.updateProblems(model.id, problems)
   }

--- a/src/main/kotlin/com/terraformation/backend/species/db/SpeciesStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/species/db/SpeciesStore.kt
@@ -345,6 +345,14 @@ class SpeciesStore(
     )
   }
 
+  fun exists(organizationId: OrganizationId, scientificName: String): Boolean {
+    return dslContext.fetchExists(
+        SPECIES,
+        SPECIES.ORGANIZATION_ID.eq(organizationId),
+        SPECIES.SCIENTIFIC_NAME.eq(scientificName),
+    )
+  }
+
   /**
    * Returns a list of IDs of species that haven't yet been checked for possible suggested edits.
    */

--- a/src/test/kotlin/com/terraformation/backend/species/db/SpeciesCheckerTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/species/db/SpeciesCheckerTest.kt
@@ -33,7 +33,9 @@ internal class SpeciesCheckerTest : DatabaseTest(), RunsAsDatabaseUser {
         speciesProblemsDao,
     )
   }
-  private val checker: SpeciesChecker by lazy { SpeciesChecker(gbifStore, speciesStore) }
+  private val checker: SpeciesChecker by lazy {
+    SpeciesChecker(gbifStore, speciesStore)
+  }
 
   private lateinit var organizationId: OrganizationId
 
@@ -95,6 +97,17 @@ internal class SpeciesCheckerTest : DatabaseTest(), RunsAsDatabaseUser {
       checker.checkSpecies(speciesId)
 
       assertTableEquals(expectedSpecies)
+      assertTableEmpty(SPECIES_PROBLEMS)
+    }
+
+    @Test
+    fun `does not suggest rename that would collide with existing species`() {
+      insertGbifTaxon(scientificName = "Correct species")
+      insertSpecies(scientificName = "Correct species")
+      val speciesId = insertSpecies("Correc species")
+
+      checker.checkSpecies(speciesId)
+
       assertTableEmpty(SPECIES_PROBLEMS)
     }
   }


### PR DESCRIPTION
We don't allow organizations to have two species with the same
scientific name, meaning you can't rename a species to a name that's
already on your species list. Our species name checker was
suggesting colliding renames, and the suggestions were impossible to
accept. Change the checker to filter out the collisions.

This will leave the incorrect names in place, but short of
implementing a species merge feature, it's the best we can do.