### PR TITLE
SW-8811 Remove existing colliding suggestions

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/species/SpeciesService.kt
+++ b/src/main/kotlin/com/terraformation/backend/species/SpeciesService.kt
@@ -71,6 +71,10 @@ class SpeciesService(
           model.copy(commonNameSource = commonNameSource, familyNameSource = familyNameSource)
 
       val speciesId = speciesStore.createSpecies(populatedModel)
+      speciesStore.removeCollidingSuggestedNames(
+          model.organizationId,
+          populatedModel.scientificName,
+      )
       speciesChecker.checkSpecies(speciesId)
 
       if (model.projectIds.isNotEmpty()) {
@@ -90,6 +94,7 @@ class SpeciesService(
       val modelWithSources = freshenNameSources(existingRow, model)
 
       val updatedRow = speciesStore.updateSpecies(modelWithSources)
+      speciesStore.removeCollidingSuggestedNames(existingRow.organizationId, model.scientificName)
       speciesChecker.recheckSpecies(existingRow, updatedRow)
       resetNativitiesIfRenamed(existingRow, updatedRow)
       val checkedRow = speciesStore.fetchSpeciesById(updatedRow.id)

--- a/src/main/kotlin/com/terraformation/backend/species/db/SpeciesStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/species/db/SpeciesStore.kt
@@ -613,6 +613,7 @@ class SpeciesStore(
       if (existingIdByCurrentName != null) {
         if (overwriteExisting || existingByCurrentName[DELETED_TIME] != null) {
           updateExisting(existingIdByCurrentName)
+          removeCollidingSuggestedNames(model.organizationId, model.scientificName)
         }
         existingIdByCurrentName
       } else {
@@ -662,6 +663,7 @@ class SpeciesStore(
           updateGrowthForms(newSpeciesId, model.growthForms)
           updatePlantMaterialSourcingMethods(newSpeciesId, model.plantMaterialSourcingMethods)
           updateSuccessionalGroups(newSpeciesId, model.successionalGroups)
+          removeCollidingSuggestedNames(model.organizationId, model.scientificName)
 
           newSpeciesId
         } else {
@@ -877,6 +879,22 @@ class SpeciesStore(
           .update(SPECIES)
           .set(SPECIES.CHECKED_TIME, clock.instant())
           .where(SPECIES.ID.eq(speciesId))
+          .execute()
+    }
+  }
+
+  fun removeCollidingSuggestedNames(organizationId: OrganizationId, scientificName: String) {
+    with(SPECIES_PROBLEMS) {
+      dslContext
+          .deleteFrom(SPECIES_PROBLEMS)
+          .where(
+              SPECIES_ID.`in`(
+                  DSL.select(SPECIES.ID)
+                      .from(SPECIES)
+                      .where(SPECIES.ORGANIZATION_ID.eq(organizationId))
+              )
+          )
+          .and(SUGGESTED_VALUE.eq(scientificName))
           .execute()
     }
   }

--- a/src/test/kotlin/com/terraformation/backend/db/DatabaseBackedTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/db/DatabaseBackedTest.kt
@@ -167,6 +167,9 @@ import com.terraformation.backend.db.default_schema.SeedTreatment
 import com.terraformation.backend.db.default_schema.SpeciesId
 import com.terraformation.backend.db.default_schema.SpeciesNativeCategory
 import com.terraformation.backend.db.default_schema.SpeciesNativity
+import com.terraformation.backend.db.default_schema.SpeciesProblemField
+import com.terraformation.backend.db.default_schema.SpeciesProblemId
+import com.terraformation.backend.db.default_schema.SpeciesProblemType
 import com.terraformation.backend.db.default_schema.SplatAnnotationId
 import com.terraformation.backend.db.default_schema.SubLocationId
 import com.terraformation.backend.db.default_schema.SuccessionalGroup
@@ -250,6 +253,7 @@ import com.terraformation.backend.db.default_schema.tables.records.ExternalDatas
 import com.terraformation.backend.db.default_schema.tables.records.GriisResourcesRecord
 import com.terraformation.backend.db.default_schema.tables.records.GriisTaxaRecord
 import com.terraformation.backend.db.default_schema.tables.records.ProjectSpeciesRecord
+import com.terraformation.backend.db.default_schema.tables.records.SpeciesProblemsRecord
 import com.terraformation.backend.db.default_schema.tables.records.WcvpDistributionsRecord
 import com.terraformation.backend.db.default_schema.tables.records.WcvpTaxaRecord
 import com.terraformation.backend.db.default_schema.tables.references.AUTOMATIONS
@@ -1692,6 +1696,27 @@ abstract class DatabaseBackedTest {
         )
         .attach(dslContext)
         .insert()
+  }
+
+  fun insertSpeciesProblem(
+      speciesId: SpeciesId = inserted.speciesId,
+      type: SpeciesProblemType = SpeciesProblemType.NameNotFound,
+      suggestedValue: String? = null,
+      createdTime: Instant = Instant.EPOCH,
+  ): SpeciesProblemId {
+    val record =
+        SpeciesProblemsRecord(
+                createdTime = createdTime,
+                fieldId = SpeciesProblemField.ScientificName,
+                speciesId = speciesId,
+                suggestedValue = suggestedValue,
+                typeId = type,
+            )
+            .attach(dslContext)
+
+    record.insert()
+
+    return record.id!!.also { inserted.speciesProblemIds.add(it) }
   }
 
   fun insertSubmission(

--- a/src/test/kotlin/com/terraformation/backend/db/InsertedDatabaseIds.kt
+++ b/src/test/kotlin/com/terraformation/backend/db/InsertedDatabaseIds.kt
@@ -27,6 +27,7 @@ import com.terraformation.backend.db.default_schema.OrganizationId
 import com.terraformation.backend.db.default_schema.ProjectId
 import com.terraformation.backend.db.default_schema.SeedFundReportId
 import com.terraformation.backend.db.default_schema.SpeciesId
+import com.terraformation.backend.db.default_schema.SpeciesProblemId
 import com.terraformation.backend.db.default_schema.SplatAnnotationId
 import com.terraformation.backend.db.default_schema.SubLocationId
 import com.terraformation.backend.db.default_schema.TimeseriesId
@@ -117,6 +118,7 @@ class InsertedDatabaseIds {
   val seedbankWithdrawalIds = mutableListOf<WithdrawalId>()
   val seedFundReportIds = mutableListOf<SeedFundReportId>()
   val speciesIds = mutableListOf<SpeciesId>()
+  val speciesProblemIds = mutableListOf<SpeciesProblemId>()
   val splatAnnotationIds = mutableListOf<SplatAnnotationId>()
   val stratumHistoryIds = mutableListOf<StratumHistoryId>()
   val stratumHistoryIdsByStratumId = mutableMapOf<StratumId, MutableList<StratumHistoryId>>()
@@ -275,6 +277,9 @@ class InsertedDatabaseIds {
 
   val speciesId
     get() = speciesIds.last()
+
+  val speciesProblemId
+    get() = speciesProblemIds.last()
 
   val splatAnnotationId
     get() = splatAnnotationIds.last()

--- a/src/test/kotlin/com/terraformation/backend/species/SpeciesServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/species/SpeciesServiceTest.kt
@@ -21,6 +21,7 @@ import com.terraformation.backend.db.default_schema.SpeciesProblemType
 import com.terraformation.backend.db.default_schema.tables.pojos.SpeciesProblemsRow
 import com.terraformation.backend.db.default_schema.tables.records.ProjectSpeciesRecord
 import com.terraformation.backend.db.default_schema.tables.references.PROJECT_SPECIES
+import com.terraformation.backend.db.default_schema.tables.references.SPECIES_PROBLEMS
 import com.terraformation.backend.mockUser
 import com.terraformation.backend.species.db.ExternalDatasetStore
 import com.terraformation.backend.species.db.GbifStore
@@ -215,6 +216,25 @@ internal class SpeciesServiceTest : DatabaseTest(), RunsAsUser {
           )
       )
     }
+
+    @Test
+    fun `removes suggested rename of existing species that would collide with new one`() {
+      insertSpecies(scientificName = "Other species")
+      insertSpeciesProblem()
+      val expectedProblems = dslContext.fetch(SPECIES_PROBLEMS)
+
+      insertSpecies(scientificName = "Correc name")
+      insertSpeciesProblem(
+          type = SpeciesProblemType.NameMisspelled,
+          suggestedValue = "Correct name",
+      )
+
+      service.createSpecies(
+          NewSpeciesModel(organizationId = organizationId, scientificName = "Correct name")
+      )
+
+      assertTableEquals(expectedProblems)
+    }
   }
 
   @Nested
@@ -391,6 +411,25 @@ internal class SpeciesServiceTest : DatabaseTest(), RunsAsUser {
               speciesId = speciesId,
           )
       )
+    }
+
+    @Test
+    fun `removes suggestions that would collide with updated species name`() {
+      insertSpecies(scientificName = "Other name")
+      insertSpeciesProblem()
+      val expectedProblems = dslContext.fetch(SPECIES_PROBLEMS)
+
+      insertSpecies(scientificName = "Correc name")
+      insertSpeciesProblem(
+          type = SpeciesProblemType.NameMisspelled,
+          suggestedValue = "Correct name",
+      )
+      val speciesId = insertSpecies(scientificName = "Original name")
+
+      val initial = speciesStore.fetchSpeciesById(speciesId)
+      service.updateSpecies(initial.copy(scientificName = "Correct name"))
+
+      assertTableEquals(expectedProblems)
     }
   }
 

--- a/src/test/kotlin/com/terraformation/backend/species/db/SpeciesImporterTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/species/db/SpeciesImporterTest.kt
@@ -11,6 +11,7 @@ import com.terraformation.backend.db.default_schema.GrowthForm
 import com.terraformation.backend.db.default_schema.OrganizationId
 import com.terraformation.backend.db.default_schema.PlantMaterialSourcingMethod
 import com.terraformation.backend.db.default_schema.SeedStorageBehavior
+import com.terraformation.backend.db.default_schema.SpeciesProblemType
 import com.terraformation.backend.db.default_schema.SuccessionalGroup
 import com.terraformation.backend.db.default_schema.UploadId
 import com.terraformation.backend.db.default_schema.UploadProblemType
@@ -26,6 +27,7 @@ import com.terraformation.backend.db.default_schema.tables.records.SpeciesSucces
 import com.terraformation.backend.db.default_schema.tables.references.SPECIES
 import com.terraformation.backend.db.default_schema.tables.references.SPECIES_ECOSYSTEM_TYPES
 import com.terraformation.backend.db.default_schema.tables.references.SPECIES_GROWTH_FORMS
+import com.terraformation.backend.db.default_schema.tables.references.SPECIES_PROBLEMS
 import com.terraformation.backend.db.default_schema.tables.references.UPLOADS
 import com.terraformation.backend.db.default_schema.tables.references.UPLOAD_PROBLEMS
 import com.terraformation.backend.file.FileStore
@@ -718,6 +720,30 @@ internal class SpeciesImporterTest : DatabaseTest(), RunsAsUser {
     )
 
     assertStatus(UploadStatus.Completed)
+  }
+
+  @Test
+  fun `importCsv removes suggested renames that would collide with newly-imported names`() {
+    insertSpecies(scientificName = "Noncolliding species")
+    insertSpeciesProblem()
+    val expectedProblems = dslContext.fetch(SPECIES_PROBLEMS)
+
+    insertGbifTaxon(scientificName = "Correct name")
+    insertSpecies(scientificName = "Correct nam")
+    insertSpeciesProblem(type = SpeciesProblemType.NameMisspelled, suggestedValue = "Correct name")
+
+    every { fileStore.read(storageUrl) } returns
+        sizedInputStream("$header\nCorrect name,Common,Family,,true,Shrub,Recalcitrant,,,,,,,")
+    val uploadId =
+        insertUpload(
+            organizationId = organizationId,
+            status = UploadStatus.AwaitingProcessing,
+            storageUrl = storageUrl,
+        )
+
+    importer.importCsv(uploadId, false)
+
+    assertTableEquals(expectedProblems)
   }
 
   @Test


### PR DESCRIPTION
Commit 792fc223 fixed the case where a suggested species rename collides
with the name of an existing species, but it didn't address the case
where the species with the correct name is created after the misspelled
one (at which point the rename suggestion will have already been 
generated). Search for colliding suggestions on species creation and
rename and remove them if present.