### PR TITLE
Split request ID tagging into a separate, earlier filter

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/auth/RequestIdFilter.kt
+++ b/src/main/kotlin/com/terraformation/backend/auth/RequestIdFilter.kt
@@ -1,0 +1,47 @@
+package com.terraformation.backend.auth
+
+import jakarta.servlet.Filter
+import jakarta.servlet.FilterChain
+import jakarta.servlet.ServletRequest
+import jakarta.servlet.ServletResponse
+import java.nio.ByteBuffer
+import java.util.UUID
+import org.apache.commons.codec.binary.Base32
+import org.slf4j.MDC
+
+/**
+ * Adds a unique identifier for each incoming request to the logging context and the request
+ * attributes. This is included in log messages and can be retrieved by any other code that needs to
+ * know which request triggered it.
+ *
+ * This should come early in the filter chain.
+ */
+class RequestIdFilter : Filter {
+  /**
+   * Prefix to include in request IDs. [ServletRequest.getRequestId] doesn't return globally unique
+   * request IDs, and it's useful to be able to search for logs from a specific request.
+   */
+  private val requestIdPrefix: String by lazy {
+    val uuid = UUID.randomUUID()
+    val buffer = ByteBuffer.allocate(16)
+
+    buffer.putLong(uuid.mostSignificantBits)
+    buffer.putLong(uuid.leastSignificantBits)
+
+    Base32().encodeToString(buffer.array()).trimEnd('=')
+  }
+
+  override fun doFilter(request: ServletRequest, response: ServletResponse, chain: FilterChain) {
+    val oldMdc = MDC.getCopyOfContextMap()
+    val requestId = "${requestIdPrefix}_${request.requestId}"
+
+    try {
+      MDC.put("requestId", requestId)
+      request.setAttribute("terrawareRequestId", requestId)
+
+      chain.doFilter(request, response)
+    } finally {
+      oldMdc?.let { MDC.setContextMap(it) } ?: MDC.clear()
+    }
+  }
+}

--- a/src/main/kotlin/com/terraformation/backend/auth/RequestResponseLoggingFilter.kt
+++ b/src/main/kotlin/com/terraformation/backend/auth/RequestResponseLoggingFilter.kt
@@ -14,11 +14,8 @@ import jakarta.servlet.ServletResponse
 import jakarta.servlet.http.HttpServletRequest
 import jakarta.servlet.http.HttpServletResponse
 import jakarta.ws.rs.core.MediaType
-import java.nio.ByteBuffer
 import java.nio.charset.StandardCharsets
-import java.util.UUID
 import kotlin.math.min
-import org.apache.commons.codec.binary.Base32
 import org.slf4j.MDC
 import org.springframework.web.util.ContentCachingRequestWrapper
 import org.springframework.web.util.ContentCachingResponseWrapper
@@ -49,29 +46,12 @@ class RequestResponseLoggingFilter(
           MediaType.MULTIPART_FORM_DATA,
       )
 
-  /**
-   * Prefix to include in request IDs. [ServletRequest.getRequestId] doesn't return globally unique
-   * request IDs, and it's useful to be able to search for logs from a specific request.
-   */
-  private val requestIdPrefix: String by lazy {
-    val uuid = UUID.randomUUID()
-    val buffer = ByteBuffer.allocate(16)
-
-    buffer.putLong(uuid.mostSignificantBits)
-    buffer.putLong(uuid.leastSignificantBits)
-
-    Base32().encodeToString(buffer.array()).trimEnd('=')
-  }
-
   override fun doFilter(request: ServletRequest, response: ServletResponse, chain: FilterChain) {
     val user = CurrentUserHolder.getCurrentUser()
     val oldMdc = MDC.getCopyOfContextMap()
-    val requestId = "${requestIdPrefix}_${request.requestId}"
 
     try {
       mdcPut("authId", user?.authId)
-      mdcPut("requestId", requestId)
-      request.setAttribute("terrawareRequestId", requestId)
 
       if (user is IndividualUser || user is FunderUser) {
         mdcPut("email", user.email)

--- a/src/main/kotlin/com/terraformation/backend/auth/SecurityConfig.kt
+++ b/src/main/kotlin/com/terraformation/backend/auth/SecurityConfig.kt
@@ -19,6 +19,7 @@ import org.springframework.security.oauth2.client.registration.ClientRegistratio
 import org.springframework.security.oauth2.server.resource.web.authentication.BearerTokenAuthenticationFilter
 import org.springframework.security.web.SecurityFilterChain
 import org.springframework.security.web.authentication.HttpStatusEntryPoint
+import org.springframework.security.web.context.SecurityContextHolderFilter
 import org.springframework.security.web.header.writers.StaticHeadersWriter
 import org.springframework.security.web.util.matcher.MediaTypeRequestMatcher
 import org.springframework.web.cors.CorsConfiguration
@@ -144,6 +145,10 @@ class SecurityConfig(
 
       // Allow clients to authenticate using JWT-encoded access tokens.
       oauth2ResourceServer { jwt {} }
+
+      // Add request ID to the logging context before any filters that would query the database so
+      // we can tag database queries with request IDs.
+      addFilterBefore<SecurityContextHolderFilter>(RequestIdFilter())
 
       // Add a request handling filter that uses the user ID from the OAuth2 authentication data to
       // look up a TerrawareUser. This needs to come after Spring has had a chance to authenticate


### PR DESCRIPTION
To allow correlating database queries with request IDs, move the code
that populates the request context with a random request ID to a
separate filter that runs earlier in the filter chain. This way the
request ID can be included with any database queries done by other
filters (such as authentication).