### PR TITLE
SW-8718 Tag database queries with request ID

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/db/CorrelationLoggingDataSource.kt
+++ b/src/main/kotlin/com/terraformation/backend/db/CorrelationLoggingDataSource.kt
@@ -1,0 +1,34 @@
+package com.terraformation.backend.db
+
+import com.zaxxer.hikari.HikariConfig
+import com.zaxxer.hikari.HikariDataSource
+import java.sql.Connection
+import org.slf4j.MDC
+
+/**
+ * DataSource implementation that tells the database which request or job ID is responsible for each
+ * database query. This is done using the `application_name` session variable, which is included in
+ * the logging configuration on the database side.
+ */
+class CorrelationLoggingDataSource(config: HikariConfig) : HikariDataSource(config) {
+  override fun getConnection(): Connection {
+    val conn = super.getConnection()
+
+    try {
+      val appName =
+          MDC.get("requestId")?.let { "request:$it" }
+              ?: MDC.get("jobrunr.jobId")?.let { "job:$it" }
+              ?: "terraware-server"
+
+      conn.prepareStatement("SELECT set_config('application_name', ?, false)").use { ps ->
+        ps.setString(1, appName)
+        ps.execute()
+      }
+
+      return conn
+    } catch (e: Exception) {
+      conn.close()
+      throw e
+    }
+  }
+}

--- a/src/main/kotlin/com/terraformation/backend/db/DataSourceConfig.kt
+++ b/src/main/kotlin/com/terraformation/backend/db/DataSourceConfig.kt
@@ -1,0 +1,37 @@
+package com.terraformation.backend.db
+
+import com.zaxxer.hikari.HikariConfig
+import com.zaxxer.hikari.HikariDataSource
+import javax.sql.DataSource
+import org.springframework.boot.autoconfigure.jdbc.DataSourceProperties
+import org.springframework.boot.context.properties.ConfigurationProperties
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+/** Configures the application to use [CorrelationLoggingDataSource] as its connection pool. */
+@Configuration
+class DataSourceConfig {
+  /**
+   * Returns the pool configuration. Spring will populate this configuration with additional
+   * connection pool properties from the application config.
+   */
+  @Bean
+  @ConfigurationProperties("spring.datasource.hikari")
+  fun hikariConfig(properties: DataSourceProperties): HikariConfig {
+    return HikariConfig().apply {
+      jdbcUrl = properties.determineUrl()
+      username = properties.determineUsername()
+      password = properties.determinePassword()
+      driverClassName = properties.determineDriverClassName()
+    }
+  }
+
+  @Bean
+  fun dataSource(hikariConfig: HikariConfig): DataSource {
+    if ("postgres" in hikariConfig.jdbcUrl) {
+      return CorrelationLoggingDataSource(hikariConfig)
+    } else {
+      return HikariDataSource(hikariConfig)
+    }
+  }
+}


### PR DESCRIPTION
We want to pass request and JobRunr job IDs to the database via the
"application name" setting, which is per-session, meaning we'll need to
set it each time the server gets a connection from the connection pool.

Introduce a custom subclass of `HikariDataSource` that sets the
application name, and a custom configuration class that tells Spring
Boot how to create the data source.