### PR TITLE
Remove "is required" field from sublists

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/search/SearchFieldPath.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/SearchFieldPath.kt
@@ -46,15 +46,6 @@ data class SearchFieldPrefix(
       return sublists.isNotEmpty() && sublists.first().isFlattened
     }
 
-  /**
-   * True if the sublist represented by this prefix is guaranteed to have at least one value if the
-   * root has a value. For example, if the root namespace is `sites`, then a prefix with a prefix of
-   * `project` and `organization` is required because every site must have a project and every
-   * project must have an organization.
-   */
-  val isRequired: Boolean
-    get() = isRoot || sublists.all { it.isRequired }
-
   /** Which sublist this prefix refers to, or null if this is a root prefix. */
   val sublistField: SublistField?
     get() = sublists.lastOrNull()

--- a/src/main/kotlin/com/terraformation/backend/search/SearchTable.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/SearchTable.kt
@@ -198,14 +198,12 @@ abstract class SearchTable {
   fun asSingleValueSublist(
       name: String,
       conditionForMultiset: Condition,
-      isRequired: Boolean = true,
       isTraversedForGetAllFields: Boolean = false,
   ): SublistField {
     return SublistField(
         name = name,
         searchTable = this,
         isMultiValue = false,
-        isRequired = isRequired,
         conditionForMultiset = conditionForMultiset,
         isTraversedForGetAllFields = isTraversedForGetAllFields,
     )

--- a/src/main/kotlin/com/terraformation/backend/search/SublistField.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/SublistField.kt
@@ -58,13 +58,6 @@ data class SublistField(
     val isFlattened: Boolean = false,
 
     /**
-     * If true, this sublist always contains a value. For example, this is true for a single-value
-     * sublist that represents a parent-child relationship from the child's point of view. It is
-     * used to determine whether fields are nullable.
-     */
-    val isRequired: Boolean = false,
-
-    /**
      * True if this sublist represents a direct parent-to-child relationship. This value is used to
      * whether this sublist is traversed when enumerating all possible fields.
      *

--- a/src/main/kotlin/com/terraformation/backend/search/table/AcceleratorReportsTable.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/table/AcceleratorReportsTable.kt
@@ -39,11 +39,7 @@ class AcceleratorReportsTable(tables: SearchTables) : SearchTable() {
               "projectIndicators",
               REPORTS.ID.eq(REPORT_PROJECT_INDICATORS.REPORT_ID),
           ),
-          users.asSingleValueSublist(
-              "submittedBy",
-              REPORTS.SUBMITTED_BY.eq(USERS.ID),
-              isRequired = false,
-          ),
+          users.asSingleValueSublist("submittedBy", REPORTS.SUBMITTED_BY.eq(USERS.ID)),
       )
     }
   }

--- a/src/main/kotlin/com/terraformation/backend/search/table/AccessionsTable.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/table/AccessionsTable.kt
@@ -43,7 +43,6 @@ class AccessionsTable(private val tables: SearchTables, private val clock: Clock
           countries.asSingleValueSublist(
               "collectionSiteCountry",
               ACCESSIONS.COLLECTION_SITE_COUNTRY_CODE.eq(COUNTRIES.CODE),
-              isRequired = false,
           ),
           accessionCollectors.asMultiValueSublist(
               "collectors",
@@ -55,20 +54,11 @@ class AccessionsTable(private val tables: SearchTables, private val clock: Clock
               "geolocations",
               ACCESSIONS.ID.eq(GEOLOCATIONS.ACCESSION_ID),
           ),
-          projects.asSingleValueSublist(
-              "project",
-              ACCESSIONS.PROJECT_ID.eq(PROJECTS.ID),
-              isRequired = false,
-          ),
-          species.asSingleValueSublist(
-              "species",
-              ACCESSIONS.SPECIES_ID.eq(SPECIES.ID),
-              isRequired = false,
-          ),
+          projects.asSingleValueSublist("project", ACCESSIONS.PROJECT_ID.eq(PROJECTS.ID)),
+          species.asSingleValueSublist("species", ACCESSIONS.SPECIES_ID.eq(SPECIES.ID)),
           subLocations.asSingleValueSublist(
               "subLocation",
               ACCESSIONS.SUB_LOCATION_ID.eq(SUB_LOCATIONS.ID),
-              isRequired = false,
           ),
           viabilityTests.asMultiValueSublist(
               "viabilityTests",

--- a/src/main/kotlin/com/terraformation/backend/search/table/BatchWithdrawalsTable.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/table/BatchWithdrawalsTable.kt
@@ -24,7 +24,6 @@ class BatchWithdrawalsTable(private val tables: SearchTables) : SearchTable() {
           batches.asSingleValueSublist(
               "destinationBatch",
               BATCH_WITHDRAWALS.DESTINATION_BATCH_ID.eq(BATCHES.ID),
-              isRequired = false,
           ),
           nurseryWithdrawals.asSingleValueSublist(
               "withdrawal",

--- a/src/main/kotlin/com/terraformation/backend/search/table/BatchesTable.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/table/BatchesTable.kt
@@ -26,17 +26,9 @@ class BatchesTable(private val tables: SearchTables) : SearchTable() {
   override val sublists: List<SublistField> by lazy {
     with(tables) {
       listOf(
-          accessions.asSingleValueSublist(
-              "accession",
-              BATCHES.ACCESSION_ID.eq(ACCESSIONS.ID),
-              isRequired = false,
-          ),
+          accessions.asSingleValueSublist("accession", BATCHES.ACCESSION_ID.eq(ACCESSIONS.ID)),
           facilities.asSingleValueSublist("facility", BATCHES.FACILITY_ID.eq(FACILITIES.ID)),
-          projects.asSingleValueSublist(
-              "project",
-              BATCHES.PROJECT_ID.eq(PROJECTS.ID),
-              isRequired = false,
-          ),
+          projects.asSingleValueSublist("project", BATCHES.PROJECT_ID.eq(PROJECTS.ID)),
           species.asSingleValueSublist("species", BATCHES.SPECIES_ID.eq(SPECIES.ID)),
           batchSubLocations.asMultiValueSublist(
               "subLocations",

--- a/src/main/kotlin/com/terraformation/backend/search/table/DraftPlantingSitesTable.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/table/DraftPlantingSitesTable.kt
@@ -28,11 +28,7 @@ class DraftPlantingSitesTable(tables: SearchTables) : SearchTable() {
               "organization",
               DRAFT_PLANTING_SITES.ORGANIZATION_ID.eq(ORGANIZATIONS.ID),
           ),
-          projects.asSingleValueSublist(
-              "project",
-              DRAFT_PLANTING_SITES.PROJECT_ID.eq(PROJECTS.ID),
-              isRequired = false,
-          ),
+          projects.asSingleValueSublist("project", DRAFT_PLANTING_SITES.PROJECT_ID.eq(PROJECTS.ID)),
       )
     }
   }

--- a/src/main/kotlin/com/terraformation/backend/search/table/MediaFilesTable.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/table/MediaFilesTable.kt
@@ -84,13 +84,8 @@ class MediaFilesTable(tables: SearchTables) : SearchTable() {
           monitoringPlots.asSingleValueSublist(
               "monitoringPlot",
               monitoringPlotIdColumn.eq(MONITORING_PLOTS.ID),
-              isRequired = false,
           ),
-          observations.asSingleValueSublist(
-              "observation",
-              observationIdColumn.eq(OBSERVATIONS.ID),
-              isRequired = false,
-          ),
+          observations.asSingleValueSublist("observation", observationIdColumn.eq(OBSERVATIONS.ID)),
           organizations.asSingleValueSublist(
               "organization",
               organizationIdColumn.eq(ORGANIZATIONS.ID),

--- a/src/main/kotlin/com/terraformation/backend/search/table/NurseryWithdrawalsTable.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/table/NurseryWithdrawalsTable.kt
@@ -33,7 +33,6 @@ class NurseryWithdrawalsTable(private val tables: SearchTables) : SearchTable() 
           deliveries.asSingleValueSublist(
               "delivery",
               WITHDRAWAL_SUMMARIES.DELIVERY_ID.eq(DELIVERIES.ID),
-              isRequired = false,
           ),
           facilities.asSingleValueSublist(
               "facility",

--- a/src/main/kotlin/com/terraformation/backend/search/table/ObservationBiomassSpeciesTable.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/table/ObservationBiomassSpeciesTable.kt
@@ -45,7 +45,6 @@ class ObservationBiomassSpeciesTable(private val tables: SearchTables) : SearchT
           species.asSingleValueSublist(
               "species",
               OBSERVATION_BIOMASS_SPECIES.SPECIES_ID.eq(SPECIES.ID),
-              isRequired = false,
           ),
       )
     }

--- a/src/main/kotlin/com/terraformation/backend/search/table/ObservationPlotsTable.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/table/ObservationPlotsTable.kt
@@ -27,7 +27,6 @@ class ObservationPlotsTable(private val tables: SearchTables) : SearchTable() {
               OBSERVATION_PLOTS.OBSERVATION_PLOT_ID.eq(
                   OBSERVATION_BIOMASS_DETAILS.OBSERVATION_PLOT_ID
               ),
-              isRequired = false,
           ),
           observationPlotConditions.asMultiValueSublist(
               "conditions",

--- a/src/main/kotlin/com/terraformation/backend/search/table/ObservationStratumResultTable.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/table/ObservationStratumResultTable.kt
@@ -29,12 +29,10 @@ class ObservationStratumResultTable(private val tables: SearchTables) : SearchTa
           strata.asSingleValueSublist(
               "stratum",
               OBSERVATION_STRATUM_RESULTS.STRATUM_ID.eq(STRATA.ID),
-              isRequired = false,
           ),
           stratumHistories.asSingleValueSublist(
               "stratumHistory",
               OBSERVATION_STRATUM_RESULTS.STRATUM_HISTORY_ID.eq(STRATUM_HISTORIES.ID),
-              isRequired = false,
           ),
           observationSubstratumResult.asMultiValueSublist(
               "substratumResults",

--- a/src/main/kotlin/com/terraformation/backend/search/table/ObservationSubstratumResultTable.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/table/ObservationSubstratumResultTable.kt
@@ -29,7 +29,6 @@ class ObservationSubstratumResultTable(private val tables: SearchTables) : Searc
           substrata.asSingleValueSublist(
               "substratum",
               OBSERVATION_SUBSTRATUM_RESULTS.SUBSTRATUM_ID.eq(SUBSTRATA.ID),
-              isRequired = false,
           ),
           substratumHistories.asSingleValueSublist(
               "substratumHistory",

--- a/src/main/kotlin/com/terraformation/backend/search/table/ObservationsTable.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/table/ObservationsTable.kt
@@ -39,7 +39,6 @@ class ObservationsTable(private val tables: SearchTables) : SearchTable() {
           observationSiteResult.asSingleValueSublist(
               "siteResult",
               OBSERVATIONS.ID.eq(OBSERVATION_SITE_RESULTS.OBSERVATION_ID),
-              isRequired = false,
           ),
           observationStratumResult.asMultiValueSublist(
               "stratumResults",

--- a/src/main/kotlin/com/terraformation/backend/search/table/OrganizationsTable.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/table/OrganizationsTable.kt
@@ -39,15 +39,10 @@ class OrganizationsTable(tables: SearchTables) : SearchTable() {
               "botanicalCountry",
               ORGANIZATIONS.BOTANICAL_COUNTRY_CODE.eq(BOTANICAL_COUNTRIES.LEVEL3_CODE),
           ),
-          countries.asSingleValueSublist(
-              "country",
-              ORGANIZATIONS.COUNTRY_CODE.eq(COUNTRIES.CODE),
-              isRequired = false,
-          ),
+          countries.asSingleValueSublist("country", ORGANIZATIONS.COUNTRY_CODE.eq(COUNTRIES.CODE)),
           countrySubdivisions.asSingleValueSublist(
               "countrySubdivision",
               ORGANIZATIONS.COUNTRY_SUBDIVISION_CODE.eq(COUNTRY_SUBDIVISIONS.CODE),
-              isRequired = false,
           ),
           draftPlantingSites.asMultiValueSublist(
               "draftPlantingSites",

--- a/src/main/kotlin/com/terraformation/backend/search/table/PlantingSitesTable.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/table/PlantingSitesTable.kt
@@ -78,7 +78,6 @@ class PlantingSitesTable(tables: SearchTables) : SearchTable() {
           projects.asSingleValueSublist(
               "project",
               PLANTING_SITE_SUMMARIES.PROJECT_ID.eq(PROJECTS.ID),
-              isRequired = false,
           ),
           strata.asMultiValueSublist(
               "plantingZones",

--- a/src/main/kotlin/com/terraformation/backend/search/table/ProjectsTable.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/table/ProjectsTable.kt
@@ -72,7 +72,6 @@ class ProjectsTable(tables: SearchTables) : SearchTable() {
           projectAcceleratorDetails.asSingleValueSublist(
               "acceleratorDetails",
               PROJECTS.ID.eq(PROJECT_ACCELERATOR_DETAILS.PROJECT_ID),
-              isRequired = false,
           ),
           projectDeliverables.asMultiValueSublist(
               "projectDeliverables",

--- a/src/main/kotlin/com/terraformation/backend/search/table/SeedFundReportsTable.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/table/SeedFundReportsTable.kt
@@ -24,16 +24,8 @@ class SeedFundReportsTable(tables: SearchTables) : SearchTable() {
               "organization",
               SEED_FUND_REPORTS.ORGANIZATION_ID.eq(ORGANIZATIONS.ID),
           ),
-          users.asSingleValueSublist(
-              "lockedBy",
-              SEED_FUND_REPORTS.LOCKED_BY.eq(USERS.ID),
-              isRequired = false,
-          ),
-          users.asSingleValueSublist(
-              "submittedBy",
-              SEED_FUND_REPORTS.SUBMITTED_BY.eq(USERS.ID),
-              isRequired = false,
-          ),
+          users.asSingleValueSublist("lockedBy", SEED_FUND_REPORTS.LOCKED_BY.eq(USERS.ID)),
+          users.asSingleValueSublist("submittedBy", SEED_FUND_REPORTS.SUBMITTED_BY.eq(USERS.ID)),
       )
     }
   }

--- a/src/main/kotlin/com/terraformation/backend/search/table/SpeciesTable.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/table/SpeciesTable.kt
@@ -38,7 +38,6 @@ class SpeciesTable(tables: SearchTables) : SearchTable() {
               "inventory",
               SPECIES.ORGANIZATION_ID.eq(INVENTORIES.ORGANIZATION_ID)
                   .and(SPECIES.ID.eq(INVENTORIES.SPECIES_ID)),
-              isRequired = false,
           ),
           nurserySpeciesProjects.asMultiValueSublist(
               "nurseryProjects",


### PR DESCRIPTION
We stopped using the "is required" flag on single-value sublists a while
ago, but we were still populating it in the table definitions. Remove it
entirely.