### PR TITLE
SW-8773 Return all accessions in batch details

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/nursery/api/BatchesController.kt
+++ b/src/main/kotlin/com/terraformation/backend/nursery/api/BatchesController.kt
@@ -230,20 +230,32 @@ class BatchesController(
   }
 }
 
+data class BatchAccessionPayload(
+    val accessionId: AccessionId?,
+    val accessionNumber: String?,
+)
+
 @JsonInclude(JsonInclude.Include.NON_NULL)
 data class BatchPayload(
     @Schema(
+        deprecated = true,
         description =
             "If this batch was created via a seed withdrawal, the ID of the seed accession it " +
-                "came from."
+                "came from. Use \"accessions\" instead of this.",
     )
     val accessionId: AccessionId?,
     @Schema(
+        deprecated = true,
         description =
             "If this batch was created via a seed withdrawal, the accession number associated to " +
-                "the seed accession it came from."
+                "the seed accession it came from. Use \"accessions\" instead of this.",
     )
     val accessionNumber: String?,
+    @Schema(
+        description =
+            "If this batch was created via a seed withdrawal, the list of accessions it came from."
+    )
+    val accessions: List<BatchAccessionPayload>,
     val activeGrowthQuantity: Int,
     val addedDate: LocalDate,
     val batchNumber: String,
@@ -284,8 +296,9 @@ data class BatchPayload(
   constructor(
       model: ExistingBatchModel
   ) : this(
-      accessionId = model.accessionId,
-      accessionNumber = model.accessionNumber,
+      accessionId = model.accessionNumbers.keys.firstOrNull(),
+      accessionNumber = model.accessionNumbers.values.firstOrNull(),
+      accessions = model.accessionNumbers.map { BatchAccessionPayload(it.key, it.value) },
       activeGrowthQuantity = model.activeGrowthQuantity,
       addedDate = model.addedDate,
       batchNumber = model.batchNumber,

--- a/src/main/kotlin/com/terraformation/backend/nursery/db/BatchStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/nursery/db/BatchStore.kt
@@ -134,12 +134,11 @@ class BatchStore(
     requirePermissions { readBatch(batchId) }
 
     val batchesRow = batchesDao.fetchOneById(batchId) ?: throw BatchNotFoundException(batchId)
+    val accessionNumbers = fetchAccessionNumbers(batchId)
     val subLocationIds = fetchSubLocationIds(batchId)
     val totalWithdrawn = getTotalWithdrawn(batchId)
 
-    val accessionNumber = batchesRow.accessionId?.let { fetchAccessionNumber(it) }
-
-    return ExistingBatchModel(batchesRow, subLocationIds, totalWithdrawn, accessionNumber)
+    return ExistingBatchModel(batchesRow, subLocationIds, totalWithdrawn, accessionNumbers)
   }
 
   fun fetchWithdrawalById(withdrawalId: WithdrawalId): ExistingWithdrawalModel {
@@ -307,7 +306,7 @@ class BatchStore(
         row = rowWithDefaults,
         subLocationIds = newModel.subLocationIds,
         totalWithdrawn = 0,
-        accessionNumber = rowWithDefaults.accessionId?.let { fetchAccessionNumber(it) },
+        accessionNumbers = fetchAccessionNumbers(rowWithDefaults.id!!),
     )
   }
 
@@ -1329,12 +1328,17 @@ class BatchStore(
         .fetchSet(BATCH_SUB_LOCATIONS.SUB_LOCATION_ID.asNonNullable())
   }
 
-  private fun fetchAccessionNumber(accessionId: AccessionId): String? {
+  private fun fetchAccessionNumbers(batchId: BatchId): Map<AccessionId, String> {
     return dslContext
-        .select(ACCESSIONS.NUMBER)
-        .from(ACCESSIONS)
-        .where(ACCESSIONS.ID.eq(accessionId))
-        .fetchOne(ACCESSIONS.NUMBER)
+        .select(ACCESSIONS.ID.asNonNullable(), ACCESSIONS.NUMBER.asNonNullable())
+        .from(BATCH_QUANTITY_HISTORY)
+        .join(ACCESSIONS)
+        .on(BATCH_QUANTITY_HISTORY.ACCESSION_ID.eq(ACCESSIONS.ID))
+        .where(BATCH_QUANTITY_HISTORY.BATCH_ID.eq(batchId))
+        .orderBy(BATCH_QUANTITY_HISTORY.ID)
+        .fetch()
+        .distinct()
+        .associate { it.value1() to it.value2() }
   }
 
   private fun updateSubLocations(

--- a/src/main/kotlin/com/terraformation/backend/nursery/model/BatchModel.kt
+++ b/src/main/kotlin/com/terraformation/backend/nursery/model/BatchModel.kt
@@ -67,8 +67,7 @@ data class NewBatchModel(
 }
 
 data class ExistingBatchModel(
-    val accessionId: AccessionId? = null,
-    val accessionNumber: String? = null,
+    val accessionNumbers: Map<AccessionId, String>,
     val activeGrowthQuantity: Int,
     val addedDate: LocalDate,
     val batchNumber: String,
@@ -104,10 +103,9 @@ data class ExistingBatchModel(
       row: BatchesRow,
       subLocationIds: Set<SubLocationId> = emptySet(),
       totalWithdrawn: Int,
-      accessionNumber: String? = null,
+      accessionNumbers: Map<AccessionId, String> = emptyMap(),
   ) : this(
-      accessionId = row.accessionId,
-      accessionNumber = accessionNumber,
+      accessionNumbers = accessionNumbers,
       addedDate = row.addedDate!!,
       batchNumber = row.batchNumber!!,
       facilityId = row.facilityId!!,

--- a/src/main/kotlin/com/terraformation/backend/seedbank/AccessionService.kt
+++ b/src/main/kotlin/com/terraformation/backend/seedbank/AccessionService.kt
@@ -174,7 +174,11 @@ class AccessionService(
           )
       val updatedAccession = createWithdrawal(withdrawal)
 
-      updatedAccession to updatedBatch
+      updatedAccession to
+          updatedBatch.copy(
+              accessionNumbers =
+                  updatedBatch.accessionNumbers + mapOf(accessionId to accession.accessionNumber!!)
+          )
     }
   }
 

--- a/src/test/kotlin/com/terraformation/backend/db/DatabaseBackedTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/db/DatabaseBackedTest.kt
@@ -392,6 +392,8 @@ import com.terraformation.backend.db.funder.tables.references.PUBLISHED_REPORTS
 import com.terraformation.backend.db.funder.tables.references.PUBLISHED_REPORT_ACHIEVEMENTS
 import com.terraformation.backend.db.funder.tables.references.PUBLISHED_REPORT_CHALLENGES
 import com.terraformation.backend.db.nursery.BatchId
+import com.terraformation.backend.db.nursery.BatchQuantityHistoryId
+import com.terraformation.backend.db.nursery.BatchQuantityHistoryType
 import com.terraformation.backend.db.nursery.WithdrawalId
 import com.terraformation.backend.db.nursery.WithdrawalPurpose
 import com.terraformation.backend.db.nursery.keys.BATCHES_PKEY
@@ -408,6 +410,7 @@ import com.terraformation.backend.db.nursery.tables.pojos.BatchWithdrawalsRow
 import com.terraformation.backend.db.nursery.tables.pojos.BatchesRow
 import com.terraformation.backend.db.nursery.tables.pojos.WithdrawalPhotosRow
 import com.terraformation.backend.db.nursery.tables.pojos.WithdrawalsRow
+import com.terraformation.backend.db.nursery.tables.records.BatchQuantityHistoryRecord
 import com.terraformation.backend.db.seedbank.AccessionId
 import com.terraformation.backend.db.seedbank.AccessionState
 import com.terraformation.backend.db.seedbank.BagId
@@ -2320,6 +2323,42 @@ abstract class DatabaseBackedTest {
         )
 
     batchSubLocationsDao.insert(row)
+  }
+
+  fun insertBatchQuantityHistory(
+      accessionId: AccessionId? = null,
+      activeGrowthQuantity: Int = 0,
+      batchId: BatchId = inserted.batchId,
+      createdBy: UserId = inserted.userId,
+      createdTime: Instant = Instant.EPOCH,
+      germinatingQuantity: Int = 0,
+      hardeningOffQuantity: Int = 0,
+      historyType: BatchQuantityHistoryType = BatchQuantityHistoryType.Observed,
+      notes: String? = null,
+      readyQuantity: Int = 0,
+      version: Int = 1,
+      withdrawalId: WithdrawalId? = null,
+  ): BatchQuantityHistoryId {
+    val record =
+        BatchQuantityHistoryRecord(
+                accessionId = accessionId,
+                activeGrowthQuantity = activeGrowthQuantity,
+                batchId = batchId,
+                createdBy = createdBy,
+                createdTime = createdTime,
+                germinatingQuantity = germinatingQuantity,
+                hardeningOffQuantity = hardeningOffQuantity,
+                historyTypeId = historyType,
+                notes = notes,
+                readyQuantity = readyQuantity,
+                version = version,
+                withdrawalId = withdrawalId,
+            )
+            .attach(dslContext)
+
+    record.insert()
+
+    return record.id!!.also { inserted.batchQuantityHistoryIds.add(it) }
   }
 
   fun insertNurseryWithdrawal(

--- a/src/test/kotlin/com/terraformation/backend/db/InsertedDatabaseIds.kt
+++ b/src/test/kotlin/com/terraformation/backend/db/InsertedDatabaseIds.kt
@@ -42,6 +42,7 @@ import com.terraformation.backend.db.docprod.VariableValueId
 import com.terraformation.backend.db.docprod.VariableWorkflowHistoryId
 import com.terraformation.backend.db.funder.FundingEntityId
 import com.terraformation.backend.db.nursery.BatchId
+import com.terraformation.backend.db.nursery.BatchQuantityHistoryId
 import com.terraformation.backend.db.seedbank.AccessionId
 import com.terraformation.backend.db.seedbank.BagId
 import com.terraformation.backend.db.seedbank.ViabilityTestId
@@ -75,6 +76,7 @@ class InsertedDatabaseIds {
   val automationIds = mutableListOf<AutomationId>()
   val bagsIds = mutableListOf<BagId>()
   val batchIds = mutableListOf<BatchId>()
+  val batchQuantityHistoryIds = mutableListOf<BatchQuantityHistoryId>()
   val biomassSpeciesIds = mutableListOf<BiomassSpeciesId>()
   val botanicalCountryCodes = mutableListOf<String>()
   val commonIndicatorIds = mutableListOf<CommonIndicatorId>()
@@ -163,6 +165,9 @@ class InsertedDatabaseIds {
 
   val batchId
     get() = batchIds.last()
+
+  val batchQuantityHistoryId
+    get() = batchQuantityHistoryIds.last()
 
   val biomassSpeciesId
     get() = biomassSpeciesIds.last()

--- a/src/test/kotlin/com/terraformation/backend/nursery/db/batchStore/BatchStoreAddToExistingBatchTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/nursery/db/batchStore/BatchStoreAddToExistingBatchTest.kt
@@ -23,8 +23,8 @@ internal class BatchStoreAddToExistingBatchTest : BatchStoreTest() {
   @BeforeEach
   fun setUpTestBatch() {
     insertFacility(type = FacilityType.SeedBank)
-    originalAccessionId = insertAccession()
-    secondAccessionId = insertAccession()
+    originalAccessionId = insertAccession(number = "1")
+    secondAccessionId = insertAccession(number = "2")
 
     batch =
         store.create(
@@ -47,6 +47,7 @@ internal class BatchStoreAddToExistingBatchTest : BatchStoreTest() {
 
     assertEquals(
         batch.copy(
+            accessionNumbers = mapOf(originalAccessionId to "1", secondAccessionId to "2"),
             germinatingQuantity = 110,
             lossRate = null,
             version = 2,

--- a/src/test/kotlin/com/terraformation/backend/nursery/db/batchStore/BatchStoreFetchTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/nursery/db/batchStore/BatchStoreFetchTest.kt
@@ -1,6 +1,7 @@
 package com.terraformation.backend.nursery.db.batchStore
 
 import com.terraformation.backend.db.default_schema.SeedTreatment
+import com.terraformation.backend.db.nursery.BatchQuantityHistoryType
 import com.terraformation.backend.db.nursery.BatchSubstrate
 import com.terraformation.backend.db.nursery.WithdrawalPurpose
 import com.terraformation.backend.db.nursery.tables.pojos.BatchesRow
@@ -16,13 +17,15 @@ import org.junit.jupiter.api.Test
 internal class BatchStoreFetchTest : BatchStoreTest() {
   @Test
   fun `returns model from database row`() {
-    val accessionNumber = "2023-01-01"
-    val accessionId = insertAccession(facilityId = facilityId, number = accessionNumber)
+    val accessionNumber1 = "2023-01-01"
+    val accessionNumber2 = "2023-01-02"
+    val accessionId1 = insertAccession(facilityId = facilityId, number = accessionNumber1)
+    val accessionId2 = insertAccession(facilityId = facilityId, number = accessionNumber2)
 
     val batchId =
         insertBatch(
             BatchesRow(
-                accessionId = accessionId,
+                accessionId = accessionId1,
                 germinationStartedDate = LocalDate.of(2023, 5, 15),
                 notes = "Notes",
                 seedsSownDate = LocalDate.of(2023, 5, 10),
@@ -39,6 +42,27 @@ internal class BatchStoreFetchTest : BatchStoreTest() {
             readyQuantity = 256,
             speciesId = speciesId,
         )
+
+    insertSeedbankWithdrawal(
+        accessionId = accessionId1,
+        purpose = com.terraformation.backend.db.seedbank.WithdrawalPurpose.Nursery,
+        batchId = batchId,
+    )
+    insertBatchQuantityHistory(
+        accessionId = accessionId1,
+        historyType = BatchQuantityHistoryType.Computed,
+        version = 1,
+    )
+    insertSeedbankWithdrawal(
+        accessionId = accessionId2,
+        purpose = com.terraformation.backend.db.seedbank.WithdrawalPurpose.Nursery,
+        batchId = batchId,
+    )
+    insertBatchQuantityHistory(
+        accessionId = accessionId2,
+        historyType = BatchQuantityHistoryType.Computed,
+        version = 2,
+    )
 
     val subLocationId1 = insertSubLocation()
     insertBatchSubLocation()
@@ -62,8 +86,8 @@ internal class BatchStoreFetchTest : BatchStoreTest() {
 
     val expected =
         ExistingBatchModel(
-            accessionId = accessionId,
-            accessionNumber = accessionNumber,
+            accessionNumbers =
+                mapOf(accessionId1 to accessionNumber1, accessionId2 to accessionNumber2),
             addedDate = LocalDate.EPOCH,
             batchNumber = "23-2-1-008",
             facilityId = facilityId,

--- a/src/test/kotlin/com/terraformation/backend/seedbank/AccessionServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/AccessionServiceTest.kt
@@ -242,6 +242,7 @@ internal class AccessionServiceTest : DatabaseTest(), RunsAsUser {
 
     private val accession =
         AccessionModel(
+            accessionNumber = "26-1-1-001",
             clock = clock,
             id = accessionId,
             facilityId = seedBankFacilityId,
@@ -278,7 +279,8 @@ internal class AccessionServiceTest : DatabaseTest(), RunsAsUser {
       every { batchStore.create(capture(batchSlot)) } answers
           {
             ExistingBatchModel(
-                accessionId = batchSlot.captured.accessionId,
+                accessionNumbers =
+                    batchSlot.captured.accessionId?.let { mapOf(it to "dummy") } ?: emptyMap(),
                 addedDate = batchSlot.captured.addedDate,
                 batchNumber = "1",
                 facilityId = batchSlot.captured.facilityId,
@@ -354,7 +356,7 @@ internal class AccessionServiceTest : DatabaseTest(), RunsAsUser {
       val (accession, batch) = service.createNurseryTransfer(accessionId, newBatch)
 
       // Verify that the accession values were propagated correctly
-      assertEquals(accessionId, batch.accessionId)
+      assertEquals(mapOf(accessionId to accession.accessionNumber), batch.accessionNumbers)
       assertEquals(accession.projectId, batch.projectId)
       assertEquals(accession.speciesId, batch.speciesId)
 
@@ -403,6 +405,11 @@ internal class AccessionServiceTest : DatabaseTest(), RunsAsUser {
       val existingBatch = makeExistingBatch()
       val updatedBatch =
           existingBatch.copy(
+              accessionNumbers =
+                  mapOf(
+                      existingBatchAccessionId to "dummy",
+                      accessionId to accession.accessionNumber!!,
+                  ),
               germinatingQuantity = 11,
               activeGrowthQuantity = 22,
               hardeningOffQuantity = 44,
@@ -424,9 +431,9 @@ internal class AccessionServiceTest : DatabaseTest(), RunsAsUser {
 
       assertEquals(updatedBatch, batch, "Returned batch")
       assertEquals(
-          existingBatchAccessionId,
-          batch.accessionId,
-          "Accession ID of batch should not have changed",
+          mapOf(existingBatchAccessionId to "dummy", accession.id to accession.accessionNumber),
+          batch.accessionNumbers,
+          "New accession ID/number should have been added to batch",
       )
       assertEquals(seeds(0), updatedAccession.remaining, "Seeds remaining")
       assertEquals(existingBatchId, updatedAccession.withdrawals.single().batchId, "Batch ID")
@@ -568,7 +575,7 @@ internal class AccessionServiceTest : DatabaseTest(), RunsAsUser {
         speciesId: SpeciesId = accession.speciesId!!,
     ) =
         ExistingBatchModel(
-            accessionId = existingBatchAccessionId,
+            accessionNumbers = mapOf(existingBatchAccessionId to "dummy"),
             activeGrowthQuantity = 20,
             addedDate = LocalDate.EPOCH,
             batchNumber = "2",


### PR DESCRIPTION
A nursery batch can now come from more than one accession, but we were
only returning the first accession ID and number in the batch details
API. Add a list of accessions, with the existing ID/number fields
derived from the list for backward compatibility.