### PR TITLE
Add multi-value sublist for withdrawal deliveries

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/search/table/NurseryWithdrawalsTable.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/table/NurseryWithdrawalsTable.kt
@@ -30,6 +30,13 @@ class NurseryWithdrawalsTable(private val tables: SearchTables) : SearchTable() 
               "batchWithdrawals",
               WITHDRAWAL_SUMMARIES.ID.eq(BATCH_WITHDRAWALS.WITHDRAWAL_ID),
           ),
+          deliveries.asMultiValueSublist(
+              "deliveries",
+              WITHDRAWAL_SUMMARIES.ID.eq(DELIVERIES.WITHDRAWAL_ID),
+          ),
+          // TEMPORARY for backward compatibility; withdrawals can now have multiple deliveries
+          // so it's no longer correct to use a single-value sublist. This can be removed once
+          // clients are updated to use the "deliveries" sublist instead.
           deliveries.asSingleValueSublist(
               "delivery",
               WITHDRAWAL_SUMMARIES.DELIVERY_ID.eq(DELIVERIES.ID),

--- a/src/test/kotlin/com/terraformation/backend/nursery/NurserySearchTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/nursery/NurserySearchTest.kt
@@ -704,7 +704,7 @@ internal class NurserySearchTest : DatabaseTest(), RunsAsUser {
       val fields =
           listOf(
                   "batchWithdrawals.batch_species_scientificName",
-                  "delivery_id",
+                  "deliveries.id",
                   "destinationFacilityId",
                   "destinationName",
                   "facility_name",
@@ -772,7 +772,10 @@ internal class NurserySearchTest : DatabaseTest(), RunsAsUser {
                                   "batch_species_scientificName" to "Species 2",
                               ),
                           ),
-                      "delivery_id" to "$deliveryId",
+                      "deliveries" to
+                          listOf(
+                              mapOf("id" to "$deliveryId"),
+                          ),
                       "destinationName" to "Site 1",
                       "facility_name" to "Nursery",
                       "hasReassignments" to "true",


### PR DESCRIPTION
With cross-site reassignments, it's now possible for a nursery withdrawal to have multiple deliveries, but the nursery withdrawals search table doesn't reflect that fact.

Add a new multi-value sublist that can fetch all the deliveries. Once clients are updated to use it, we can retire the old single-value sublist as well as the part of the `withdrawal_summaries` view that calculates which delivery ID to use.