### PR TITLE
SW-8840 Calculate nativities on species import

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/species/SpeciesService.kt
+++ b/src/main/kotlin/com/terraformation/backend/species/SpeciesService.kt
@@ -18,6 +18,7 @@ import com.terraformation.backend.species.db.ProjectSpeciesStore
 import com.terraformation.backend.species.db.SpeciesChecker
 import com.terraformation.backend.species.db.SpeciesStore
 import com.terraformation.backend.species.event.SpeciesEditedEvent
+import com.terraformation.backend.species.event.SpeciesImportedEvent
 import com.terraformation.backend.species.model.ExistingSpeciesModel
 import com.terraformation.backend.species.model.GbifTaxonModel
 import com.terraformation.backend.species.model.NewSpeciesModel
@@ -170,6 +171,13 @@ class SpeciesService(
             event.changedFrom.countryCode != event.changedTo.countryCode
     ) {
       projectSpeciesStore.recalculateNativities(event.projectId, autoAccept = true)
+    }
+  }
+
+  @EventListener
+  fun on(event: SpeciesImportedEvent) {
+    if (!event.alreadyExisted) {
+      projectSpeciesStore.resetNativities(event.speciesId)
     }
   }
 

--- a/src/main/kotlin/com/terraformation/backend/species/db/SpeciesStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/species/db/SpeciesStore.kt
@@ -41,6 +41,7 @@ import com.terraformation.backend.db.tracking.tables.references.RECORDED_PLANTS
 import com.terraformation.backend.db.tracking.tables.references.SUBSTRATA
 import com.terraformation.backend.log.perClassLogger
 import com.terraformation.backend.species.SpeciesService
+import com.terraformation.backend.species.event.SpeciesImportedEvent
 import com.terraformation.backend.species.model.ExistingSpeciesModel
 import com.terraformation.backend.species.model.ExistingSpeciesProjectModel
 import com.terraformation.backend.species.model.NewSpeciesModel
@@ -52,6 +53,7 @@ import org.jooq.Field
 import org.jooq.TableField
 import org.jooq.TableRecord
 import org.jooq.impl.DSL
+import org.springframework.context.ApplicationEventPublisher
 import org.springframework.dao.DuplicateKeyException
 import org.springframework.security.access.AccessDeniedException
 
@@ -59,6 +61,7 @@ import org.springframework.security.access.AccessDeniedException
 class SpeciesStore(
     private val clock: Clock,
     private val dslContext: DSLContext,
+    private val eventPublisher: ApplicationEventPublisher,
     private val speciesDao: SpeciesDao,
     private val speciesEcosystemTypesDao: SpeciesEcosystemTypesDao,
     private val speciesGrowthFormsDao: SpeciesGrowthFormsDao,
@@ -611,10 +614,14 @@ class SpeciesStore(
       val existingIdByCurrentName = existingByCurrentName?.get(ID)
 
       if (existingIdByCurrentName != null) {
-        if (overwriteExisting || existingByCurrentName[DELETED_TIME] != null) {
+        val wasDeleted = existingByCurrentName[DELETED_TIME] != null
+        if (overwriteExisting || wasDeleted) {
           updateExisting(existingIdByCurrentName)
           removeCollidingSuggestedNames(model.organizationId, model.scientificName)
         }
+        eventPublisher.publishEvent(
+            SpeciesImportedEvent(alreadyExisted = !wasDeleted, existingIdByCurrentName)
+        )
         existingIdByCurrentName
       } else {
         val existingIdByInitialName =
@@ -665,11 +672,18 @@ class SpeciesStore(
           updateSuccessionalGroups(newSpeciesId, model.successionalGroups)
           removeCollidingSuggestedNames(model.organizationId, model.scientificName)
 
+          eventPublisher.publishEvent(
+              SpeciesImportedEvent(alreadyExisted = false, speciesId = newSpeciesId)
+          )
+
           newSpeciesId
         } else {
           if (overwriteExisting) {
             updateExisting(existingIdByInitialName)
           }
+          eventPublisher.publishEvent(
+              SpeciesImportedEvent(alreadyExisted = true, speciesId = existingIdByInitialName)
+          )
           existingIdByInitialName
         }
       }

--- a/src/main/kotlin/com/terraformation/backend/species/event/SpeciesImportedEvent.kt
+++ b/src/main/kotlin/com/terraformation/backend/species/event/SpeciesImportedEvent.kt
@@ -1,0 +1,10 @@
+package com.terraformation.backend.species.event
+
+import com.terraformation.backend.db.default_schema.SpeciesId
+
+/** Published when a new species is created or updated via a bulk data import. */
+data class SpeciesImportedEvent(
+    /** True if this was an update to an existing, non-deleted species. */
+    val alreadyExisted: Boolean,
+    val speciesId: SpeciesId,
+)

--- a/src/test/kotlin/com/terraformation/backend/notification/NotificationServiceAppTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/notification/NotificationServiceAppTest.kt
@@ -254,6 +254,7 @@ internal class NotificationServiceAppTest : DatabaseTest(), RunsAsUser {
         SpeciesStore(
             clock,
             dslContext,
+            publisher,
             speciesDao,
             speciesEcosystemTypesDao,
             speciesGrowthFormsDao,

--- a/src/test/kotlin/com/terraformation/backend/nursery/db/BatchImporterTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/nursery/db/BatchImporterTest.kt
@@ -56,6 +56,7 @@ internal class BatchImporterTest : DatabaseTest(), RunsAsUser {
   override val user = mockUser()
 
   private val clock = TestClock()
+  private val eventPublisher = TestEventPublisher()
   private val fileStore: FileStore = mockk()
   private val scheduler: JobScheduler = mockk()
   private val uploadService: UploadService = mockk()
@@ -70,7 +71,7 @@ internal class BatchImporterTest : DatabaseTest(), RunsAsUser {
         batchWithdrawalsDao,
         clock,
         dslContext,
-        TestEventPublisher(),
+        eventPublisher,
         facilitiesDao,
         IdentifierGenerator(clock, dslContext),
         parentStore,
@@ -86,6 +87,7 @@ internal class BatchImporterTest : DatabaseTest(), RunsAsUser {
     SpeciesStore(
         clock,
         dslContext,
+        eventPublisher,
         speciesDao,
         speciesEcosystemTypesDao,
         speciesGrowthFormsDao,

--- a/src/test/kotlin/com/terraformation/backend/report/SeedFundReportServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/report/SeedFundReportServiceTest.kt
@@ -164,6 +164,7 @@ class SeedFundReportServiceTest : DatabaseTest(), RunsAsUser {
         SpeciesStore(
             clock,
             dslContext,
+            publisher,
             speciesDao,
             speciesEcosystemTypesDao,
             speciesGrowthFormsDao,

--- a/src/test/kotlin/com/terraformation/backend/seedbank/db/AccessionImporterTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/db/AccessionImporterTest.kt
@@ -127,6 +127,7 @@ internal class AccessionImporterTest : DatabaseTest(), RunsAsUser {
     SpeciesStore(
         clock,
         dslContext,
+        publisher,
         speciesDao,
         speciesEcosystemTypesDao,
         speciesGrowthFormsDao,

--- a/src/test/kotlin/com/terraformation/backend/seedbank/db/accessionStore/AccessionStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/db/accessionStore/AccessionStoreTest.kt
@@ -77,6 +77,7 @@ internal abstract class AccessionStoreTest : DatabaseTest(), RunsAsDatabaseUser 
         SpeciesStore(
             clock,
             dslContext,
+            publisher,
             speciesDao,
             speciesEcosystemTypesDao,
             speciesGrowthFormsDao,

--- a/src/test/kotlin/com/terraformation/backend/species/SpeciesServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/species/SpeciesServiceTest.kt
@@ -30,6 +30,7 @@ import com.terraformation.backend.species.db.SpeciesChecker
 import com.terraformation.backend.species.db.SpeciesNativityCalculator
 import com.terraformation.backend.species.db.SpeciesStore
 import com.terraformation.backend.species.event.SpeciesEditedEvent
+import com.terraformation.backend.species.event.SpeciesImportedEvent
 import com.terraformation.backend.species.model.ExistingSpeciesModel
 import com.terraformation.backend.species.model.NewSpeciesModel
 import com.terraformation.backend.species.model.SpeciesDataSourceModel
@@ -71,6 +72,7 @@ internal class SpeciesServiceTest : DatabaseTest(), RunsAsUser {
     SpeciesStore(
         clock,
         dslContext,
+        eventPublisher,
         speciesDao,
         speciesEcosystemTypesDao,
         speciesGrowthFormsDao,
@@ -623,6 +625,40 @@ internal class SpeciesServiceTest : DatabaseTest(), RunsAsUser {
       service.on(OrganizationLocationUpdatedEvent(null, null, organizationId))
 
       assertTableEquals(before)
+    }
+  }
+
+  @Nested
+  inner class OnSpeciesImportedEvent {
+    @Test
+    fun `resets nativities if species is newly imported`() {
+      insertBotanicalCountry(level3Code = "KEN")
+      organizationId =
+          insertOrganization(botanicalCountryCode = "KEN", countryCode = "KE", name = "Kenya Org")
+      val speciesId = insertSpecies()
+
+      service.on(SpeciesImportedEvent(alreadyExisted = false, speciesId = speciesId))
+
+      assertTableEquals(
+          ProjectSpeciesRecord(
+              organizationId = organizationId,
+              pendingNativityId = SpeciesNativity.Unknown,
+              speciesId = speciesId,
+          )
+      )
+
+      assertIsEventListener<SpeciesImportedEvent>(service)
+    }
+
+    @Test
+    fun `does not reset nativities on re-import of existing species`() {
+      insertBotanicalCountry(level3Code = "KEN")
+      insertOrganization(botanicalCountryCode = "KEN", countryCode = "KE", name = "Kenya Org")
+      val speciesId = insertSpecies()
+
+      service.on(SpeciesImportedEvent(alreadyExisted = true, speciesId = speciesId))
+
+      assertTableEmpty(PROJECT_SPECIES)
     }
   }
 

--- a/src/test/kotlin/com/terraformation/backend/species/db/SpeciesCheckerTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/species/db/SpeciesCheckerTest.kt
@@ -2,6 +2,7 @@ package com.terraformation.backend.species.db
 
 import com.terraformation.backend.RunsAsDatabaseUser
 import com.terraformation.backend.TestClock
+import com.terraformation.backend.TestEventPublisher
 import com.terraformation.backend.customer.model.TerrawareUser
 import com.terraformation.backend.db.DatabaseTest
 import com.terraformation.backend.db.default_schema.OrganizationId
@@ -27,6 +28,7 @@ internal class SpeciesCheckerTest : DatabaseTest(), RunsAsDatabaseUser {
     SpeciesStore(
         clock,
         dslContext,
+        TestEventPublisher(),
         speciesDao,
         speciesEcosystemTypesDao,
         speciesGrowthFormsDao,

--- a/src/test/kotlin/com/terraformation/backend/species/db/SpeciesImporterTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/species/db/SpeciesImporterTest.kt
@@ -2,6 +2,7 @@ package com.terraformation.backend.species.db
 
 import com.terraformation.backend.RunsAsUser
 import com.terraformation.backend.TestClock
+import com.terraformation.backend.TestEventPublisher
 import com.terraformation.backend.customer.db.UserStore
 import com.terraformation.backend.db.DatabaseTest
 import com.terraformation.backend.db.UploadNotAwaitingActionException
@@ -39,6 +40,7 @@ import com.terraformation.backend.i18n.Messages
 import com.terraformation.backend.i18n.toGibberish
 import com.terraformation.backend.i18n.use
 import com.terraformation.backend.mockUser
+import com.terraformation.backend.species.event.SpeciesImportedEvent
 import io.mockk.Runs
 import io.mockk.every
 import io.mockk.just
@@ -63,6 +65,7 @@ internal class SpeciesImporterTest : DatabaseTest(), RunsAsUser {
   override val user = mockUser()
 
   private val clock = TestClock()
+  private val eventPublisher = TestEventPublisher()
   private val fileStore: FileStore = mockk()
   private val messages = Messages()
   private val scheduler: JobScheduler = mockk()
@@ -71,6 +74,7 @@ internal class SpeciesImporterTest : DatabaseTest(), RunsAsUser {
     SpeciesStore(
         clock,
         dslContext,
+        eventPublisher,
         speciesDao,
         speciesEcosystemTypesDao,
         speciesGrowthFormsDao,
@@ -349,6 +353,10 @@ internal class SpeciesImporterTest : DatabaseTest(), RunsAsUser {
 
     val newSpeciesId = speciesDao.findAll().map { it.id!! }.maxOf { it }
 
+    eventPublisher.assertExactEventsPublished(
+        listOf(SpeciesImportedEvent(alreadyExisted = false, speciesId = newSpeciesId))
+    )
+
     assertTableEquals(
         listOf(
             SpeciesRecord(
@@ -596,12 +604,14 @@ internal class SpeciesImporterTest : DatabaseTest(), RunsAsUser {
             status = UploadStatus.AwaitingProcessing,
             storageUrl = storageUrl,
         )
-    insertSpecies(
-        scientificName = "Existing name",
-        growthForms = setOf(GrowthForm.Shrub),
-        ecosystemTypes = setOf(EcosystemType.Mangroves),
-    )
-    insertSpecies(scientificName = "New name", initialScientificName = "Initial name")
+    val existingSpeciesId =
+        insertSpecies(
+            scientificName = "Existing name",
+            growthForms = setOf(GrowthForm.Shrub),
+            ecosystemTypes = setOf(EcosystemType.Mangroves),
+        )
+    val renamedSpeciesId =
+        insertSpecies(scientificName = "New name", initialScientificName = "Initial name")
 
     clock.instant = Instant.EPOCH + Duration.ofDays(1)
 
@@ -616,6 +626,13 @@ internal class SpeciesImporterTest : DatabaseTest(), RunsAsUser {
     assertTableEquals(expectedGrowthForms)
 
     assertStatus(UploadStatus.Completed)
+
+    eventPublisher.assertEventsPublished(
+        setOf(
+            SpeciesImportedEvent(alreadyExisted = true, speciesId = existingSpeciesId),
+            SpeciesImportedEvent(alreadyExisted = true, speciesId = renamedSpeciesId),
+        )
+    )
   }
 
   @Test
@@ -665,6 +682,10 @@ internal class SpeciesImporterTest : DatabaseTest(), RunsAsUser {
     assertTableEquals(SpeciesGrowthFormsRecord(speciesId1, GrowthForm.Shrub))
 
     assertStatus(UploadStatus.Completed)
+
+    eventPublisher.assertEventPublished(
+        SpeciesImportedEvent(alreadyExisted = false, speciesId = speciesId1)
+    )
   }
 
   @Test

--- a/src/test/kotlin/com/terraformation/backend/species/db/SpeciesStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/species/db/SpeciesStoreTest.kt
@@ -2,6 +2,7 @@ package com.terraformation.backend.species.db
 
 import com.terraformation.backend.RunsAsUser
 import com.terraformation.backend.TestClock
+import com.terraformation.backend.TestEventPublisher
 import com.terraformation.backend.customer.model.TerrawareUser
 import com.terraformation.backend.db.DatabaseTest
 import com.terraformation.backend.db.OrganizationNotFoundException
@@ -65,6 +66,7 @@ internal class SpeciesStoreTest : DatabaseTest(), RunsAsUser {
         SpeciesStore(
             clock,
             dslContext,
+            TestEventPublisher(),
             speciesDao,
             speciesEcosystemTypesDao,
             speciesGrowthFormsDao,


### PR DESCRIPTION
When species were created via CSV import of a species list, accession
list, or nursery batch list, we weren't calculating their nativities
like we did if they were created via the web UI. Add logic to calculate
nativities of newly-imported species.