### PR TITLE
Delete splat additional files from the file store when they are replaced

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/splat/SplatService.kt
+++ b/src/main/kotlin/com/terraformation/backend/splat/SplatService.kt
@@ -556,7 +556,8 @@ class SplatService(
 
   /**
    * Removes a splat's additional files from the database and, unless they're still needed, from the
-   * file store.
+   * file store. Additional files are uploaded as organization media, so their organization media
+   * rows are deleted too; otherwise they would keep the files alive in the file store.
    *
    * @param retainedFileIds Files that are about to be inserted as additional files of the same
    *   splat again. Their rows are still deleted, but the files themselves are left alone.
@@ -574,9 +575,16 @@ class SplatService(
               .fetch(FILE_ID.asNonNullable())
         }
 
-    deletedFileIds
-        .filterNot { it in retainedFileIds }
-        .forEach { eventPublisher.publishEvent(FileReferenceDeletedEvent(it)) }
+    val unreferencedFileIds = deletedFileIds.filterNot { it in retainedFileIds }
+
+    if (unreferencedFileIds.isNotEmpty()) {
+      dslContext
+          .deleteFrom(ORGANIZATION_MEDIA_FILES)
+          .where(ORGANIZATION_MEDIA_FILES.FILE_ID.`in`(unreferencedFileIds))
+          .execute()
+
+      unreferencedFileIds.forEach { eventPublisher.publishEvent(FileReferenceDeletedEvent(it)) }
+    }
   }
 
   private fun listAdditionalFileLocations(fileId: FileId): List<SplatterRequestFileLocation> {

--- a/src/main/kotlin/com/terraformation/backend/splat/SplatService.kt
+++ b/src/main/kotlin/com/terraformation/backend/splat/SplatService.kt
@@ -568,8 +568,7 @@ class SplatService(
 
   /**
    * Removes a splat's additional files from the database. Additional files are uploaded as
-   * organization media, so their organization media rows are deleted too; otherwise they would keep
-   * the files alive in the file store.
+   * organization media, so their organization media rows are deleted too.
    *
    * @param retainedFileIds Files that are about to be inserted as additional files of the same
    *   splat again. Their rows are still deleted, but the files themselves are left alone.

--- a/src/main/kotlin/com/terraformation/backend/splat/SplatService.kt
+++ b/src/main/kotlin/com/terraformation/backend/splat/SplatService.kt
@@ -435,7 +435,7 @@ class SplatService(
       SplatterRequestFileLocation(s3BucketName, birdnetKey)
     }
 
-    dslContext.transaction { _ ->
+    val replacedFileIds = dslContext.transactionResult { _ ->
       val rowsInserted =
           with(SPLATS) {
             dslContext
@@ -487,20 +487,26 @@ class SplatService(
       }
 
       if (rowsInserted == 1 || force) {
-        if (additionalFiles.isNotEmpty()) {
-          deleteAdditionalFiles(fileId, retainedFileIds = additionalFiles.keys)
+        val replacedFileIds =
+            if (additionalFiles.isNotEmpty()) {
+              val unreferencedFileIds =
+                  deleteAdditionalFiles(fileId, retainedFileIds = additionalFiles.keys)
 
-          with(SPLAT_ADDITIONAL_FILES) {
-            additionalFiles.forEach { (additionalFileId, type) ->
-              dslContext
-                  .insertInto(SPLAT_ADDITIONAL_FILES)
-                  .set(FILE_ID, additionalFileId)
-                  .set(SPLAT_FILE_ID, fileId)
-                  .set(TYPE, type)
-                  .execute()
+              with(SPLAT_ADDITIONAL_FILES) {
+                additionalFiles.forEach { (additionalFileId, type) ->
+                  dslContext
+                      .insertInto(SPLAT_ADDITIONAL_FILES)
+                      .set(FILE_ID, additionalFileId)
+                      .set(SPLAT_FILE_ID, fileId)
+                      .set(TYPE, type)
+                      .execute()
+                }
+              }
+
+              unreferencedFileIds
+            } else {
+              emptyList()
             }
-          }
-        }
 
         val requestMessage =
             SplatterRequestMessage(
@@ -529,12 +535,18 @@ class SplatService(
         log.info(
             "Requested splat generation for file $fileId${if (runBirdnet) " with BirdNet" else ""}"
         )
+
+        replacedFileIds
       } else {
         log.info(
             "Splat record already exists for file $fileId; ignoring additional generation request"
         )
+
+        emptyList()
       }
     }
+
+    replacedFileIds.forEach { eventPublisher.publishEvent(FileReferenceDeletedEvent(it)) }
   }
 
   /**
@@ -555,17 +567,20 @@ class SplatService(
           .lowercase()
 
   /**
-   * Removes a splat's additional files from the database and, unless they're still needed, from the
-   * file store. Additional files are uploaded as organization media, so their organization media
-   * rows are deleted too; otherwise they would keep the files alive in the file store.
+   * Removes a splat's additional files from the database. Additional files are uploaded as
+   * organization media, so their organization media rows are deleted too; otherwise they would keep
+   * the files alive in the file store.
    *
    * @param retainedFileIds Files that are about to be inserted as additional files of the same
    *   splat again. Their rows are still deleted, but the files themselves are left alone.
+   * @return The files that nothing refers to any more. The caller must publish
+   *   [FileReferenceDeletedEvent] for each of them, but only once its transaction has committed:
+   *   the handler deletes the files from the file store, which a rollback can't undo.
    */
   private fun deleteAdditionalFiles(
       splatFileId: FileId,
       retainedFileIds: Set<FileId> = emptySet(),
-  ) {
+  ): List<FileId> {
     val deletedFileIds =
         with(SPLAT_ADDITIONAL_FILES) {
           dslContext
@@ -582,9 +597,9 @@ class SplatService(
           .deleteFrom(ORGANIZATION_MEDIA_FILES)
           .where(ORGANIZATION_MEDIA_FILES.FILE_ID.`in`(unreferencedFileIds))
           .execute()
-
-      unreferencedFileIds.forEach { eventPublisher.publishEvent(FileReferenceDeletedEvent(it)) }
     }
+
+    return unreferencedFileIds
   }
 
   private fun listAdditionalFileLocations(fileId: FileId): List<SplatterRequestFileLocation> {

--- a/src/main/kotlin/com/terraformation/backend/splat/SplatService.kt
+++ b/src/main/kotlin/com/terraformation/backend/splat/SplatService.kt
@@ -416,138 +416,162 @@ class SplatService(
     val videoUrl =
         dslContext.fetchValue(FILES.STORAGE_URL, FILES.ID.eq(fileId))
             ?: throw FileNotFoundException(fileId)
-    val videoKey = videoUrl.path.trimStart('/')
-    val videoPath = fileStore.getPath(videoUrl)
-    val splatPath = Path(videoPath.pathString.substringBeforeLast('.') + splatFileExtension)
-    val splatUrl = fileStore.getUrl(splatPath)
-    val splatKey = splatUrl.path.trimStart('/')
-
+    val outputPathPrefix = fileStore.getPath(videoUrl).pathString.substringBeforeLast('.')
+    val splatUrl = fileStore.getUrl(Path(outputPathPrefix + splatFileExtension))
     val birdnetUrl =
         if (runBirdnet) {
-          val birdnetPath = Path(videoPath.pathString.substringBeforeLast('.') + "_birdnet.json")
-          fileStore.getUrl(birdnetPath)
+          fileStore.getUrl(Path(outputPathPrefix + "_birdnet.json"))
         } else {
           null
         }
 
-    val birdnetOutputLocation = birdnetUrl?.let {
-      val birdnetKey = it.path.trimStart('/')
-      SplatterRequestFileLocation(s3BucketName, birdnetKey)
-    }
-
     val replacedFileIds = dslContext.transactionResult { _ ->
-      val rowsInserted =
-          with(SPLATS) {
-            dslContext
-                .insertInto(SPLATS)
-                .set(ASSET_STATUS_ID, AssetStatus.Preparing)
-                .set(CREATED_BY, currentUser().userId)
-                .set(CREATED_TIME, clock.instant())
-                .set(FILE_ID, fileId)
-                .set(NEEDS_ATTENTION, false)
-                .set(ORGANIZATION_ID, organizationId)
-                .set(SPLAT_STORAGE_URL, splatUrl)
-                .onConflictDoNothing()
-                .execute()
-          }
+      val splatIsNew = insertOrRestartSplat(fileId, organizationId, splatUrl, force)
 
-      if (rowsInserted == 0 && force) {
-        with(SPLATS) {
-          dslContext
-              .update(SPLATS)
-              .set(ASSET_STATUS_ID, AssetStatus.Preparing)
-              .where(FILE_ID.eq(fileId))
-              .execute()
-        }
+      if (birdnetUrl != null) {
+        insertOrRestartBirdnetResult(fileId, birdnetUrl, force)
       }
 
-      if (runBirdnet && birdnetUrl != null) {
-        val birdnetRowsInserted =
-            with(BIRDNET_RESULTS) {
-              dslContext
-                  .insertInto(BIRDNET_RESULTS)
-                  .set(ASSET_STATUS_ID, AssetStatus.Preparing)
-                  .set(CREATED_BY, currentUser().userId)
-                  .set(CREATED_TIME, clock.instant())
-                  .set(FILE_ID, fileId)
-                  .set(RESULTS_STORAGE_URL, birdnetUrl)
-                  .onConflictDoNothing()
-                  .execute()
-            }
-
-        if (birdnetRowsInserted == 0 && force) {
-          with(BIRDNET_RESULTS) {
-            dslContext
-                .update(BIRDNET_RESULTS)
-                .set(ASSET_STATUS_ID, AssetStatus.Preparing)
-                .where(FILE_ID.eq(fileId))
-                .execute()
-          }
-        }
-      }
-
-      if (rowsInserted == 1 || force) {
-        val replacedFileIds =
-            if (additionalFiles.isNotEmpty()) {
-              val unreferencedFileIds =
-                  deleteAdditionalFiles(fileId, retainedFileIds = additionalFiles.keys)
-
-              with(SPLAT_ADDITIONAL_FILES) {
-                additionalFiles.forEach { (additionalFileId, type) ->
-                  dslContext
-                      .insertInto(SPLAT_ADDITIONAL_FILES)
-                      .set(FILE_ID, additionalFileId)
-                      .set(SPLAT_FILE_ID, fileId)
-                      .set(TYPE, type)
-                      .execute()
-                }
-              }
-
-              unreferencedFileIds
-            } else {
-              emptyList()
-            }
-
-        val requestMessage =
-            SplatterRequestMessage(
-                abortAfter = params.abortAfter,
-                additionalFiles = listAdditionalFileLocations(fileId),
-                birdnetOutput = birdnetOutputLocation,
-                input =
-                    SplatterRequestFileLocation(
-                        s3BucketName,
-                        videoKey,
-                    ),
-                jobId = fileId.toString(),
-                output =
-                    SplatterRequestFileLocation(
-                        s3BucketName,
-                        splatKey,
-                    ),
-                responseQueueUrl = responseQueueUrl,
-                restartAt = params.restartAt,
-                restoreJob = params.restartAt != null,
-                stepArgs = params.stepArgs,
-            )
-
-        sqsTemplate.send(requestQueueUrl, requestMessage)
-
-        log.info(
-            "Requested splat generation for file $fileId${if (runBirdnet) " with BirdNet" else ""}"
-        )
-
-        replacedFileIds
-      } else {
+      if (!splatIsNew && !force) {
         log.info(
             "Splat record already exists for file $fileId; ignoring additional generation request"
         )
 
-        emptyList()
+        return@transactionResult emptyList()
       }
+
+      val replacedFileIds = replaceAdditionalFiles(fileId, additionalFiles)
+
+      sqsTemplate.send(
+          requestQueueUrl,
+          SplatterRequestMessage(
+              abortAfter = params.abortAfter,
+              additionalFiles = listAdditionalFileLocations(fileId),
+              birdnetOutput = birdnetUrl?.let { fileLocation(it) },
+              input = fileLocation(videoUrl),
+              jobId = fileId.toString(),
+              output = fileLocation(splatUrl),
+              responseQueueUrl = responseQueueUrl,
+              restartAt = params.restartAt,
+              restoreJob = params.restartAt != null,
+              stepArgs = params.stepArgs,
+          ),
+      )
+
+      log.info(
+          "Requested splat generation for file $fileId${if (runBirdnet) " with BirdNet" else ""}"
+      )
+
+      replacedFileIds
     }
 
     publishAdditionalFilesDeleted(replacedFileIds)
   }
+
+  /**
+   * Inserts a splat row, or moves an existing one back to [AssetStatus.Preparing] if [force] is
+   * true.
+   *
+   * @return True if there was no splat row for the file yet.
+   */
+  private fun insertOrRestartSplat(
+      fileId: FileId,
+      organizationId: OrganizationId,
+      splatUrl: URI,
+      force: Boolean,
+  ): Boolean {
+    val rowsInserted =
+        with(SPLATS) {
+          dslContext
+              .insertInto(SPLATS)
+              .set(ASSET_STATUS_ID, AssetStatus.Preparing)
+              .set(CREATED_BY, currentUser().userId)
+              .set(CREATED_TIME, clock.instant())
+              .set(FILE_ID, fileId)
+              .set(NEEDS_ATTENTION, false)
+              .set(ORGANIZATION_ID, organizationId)
+              .set(SPLAT_STORAGE_URL, splatUrl)
+              .onConflictDoNothing()
+              .execute()
+        }
+
+    if (rowsInserted == 0 && force) {
+      with(SPLATS) {
+        dslContext
+            .update(SPLATS)
+            .set(ASSET_STATUS_ID, AssetStatus.Preparing)
+            .where(FILE_ID.eq(fileId))
+            .execute()
+      }
+    }
+
+    return rowsInserted == 1
+  }
+
+  /**
+   * Inserts a BirdNet result row, or moves an existing one back to [AssetStatus.Preparing] if
+   * [force] is true.
+   */
+  private fun insertOrRestartBirdnetResult(fileId: FileId, birdnetUrl: URI, force: Boolean) {
+    val rowsInserted =
+        with(BIRDNET_RESULTS) {
+          dslContext
+              .insertInto(BIRDNET_RESULTS)
+              .set(ASSET_STATUS_ID, AssetStatus.Preparing)
+              .set(CREATED_BY, currentUser().userId)
+              .set(CREATED_TIME, clock.instant())
+              .set(FILE_ID, fileId)
+              .set(RESULTS_STORAGE_URL, birdnetUrl)
+              .onConflictDoNothing()
+              .execute()
+        }
+
+    if (rowsInserted == 0 && force) {
+      with(BIRDNET_RESULTS) {
+        dslContext
+            .update(BIRDNET_RESULTS)
+            .set(ASSET_STATUS_ID, AssetStatus.Preparing)
+            .where(FILE_ID.eq(fileId))
+            .execute()
+      }
+    }
+  }
+
+  /**
+   * Makes [additionalFiles] the full set of additional files for a splat, replacing any previous
+   * ones. Does nothing if [additionalFiles] is empty.
+   *
+   * @return The previous additional files that nothing refers to any more; see
+   *   [deleteAdditionalFiles] for how the caller must dispose of them.
+   */
+  private fun replaceAdditionalFiles(
+      splatFileId: FileId,
+      additionalFiles: Map<FileId, SplatAdditionalFileType>,
+  ): List<FileId> {
+    if (additionalFiles.isEmpty()) {
+      return emptyList()
+    }
+
+    val replacedFileIds = deleteAdditionalFiles(splatFileId, retainedFileIds = additionalFiles.keys)
+
+    with(SPLAT_ADDITIONAL_FILES) {
+      additionalFiles.forEach { (additionalFileId, type) ->
+        dslContext
+            .insertInto(SPLAT_ADDITIONAL_FILES)
+            .set(FILE_ID, additionalFileId)
+            .set(SPLAT_FILE_ID, splatFileId)
+            .set(TYPE, type)
+            .onDuplicateKeyUpdate()
+            .set(TYPE, type)
+            .execute()
+      }
+    }
+
+    return replacedFileIds
+  }
+
+  private fun fileLocation(url: URI, type: SplatAdditionalFileType? = null) =
+      SplatterRequestFileLocation(s3BucketName, url.path.trimStart('/'), type)
 
   /**
    * Returns the additional file type from a content type's structured syntax suffix, or an empty
@@ -589,7 +613,7 @@ class SplatService(
    * organization media, so their organization media rows are deleted too.
    *
    * @param retainedFileIds Files that are about to be inserted as additional files of the same
-   *   splat again. Their rows are still deleted, but the files themselves are left alone.
+   *   splat again. Their rows are left in place for the insert to update.
    * @return The files that nothing refers to any more. The caller must publish
    *   [FileReferenceDeletedEvent] for each of them, but only once its transaction has committed:
    *   the handler deletes the files from the file store, which a rollback can't undo.
@@ -603,20 +627,19 @@ class SplatService(
           dslContext
               .deleteFrom(SPLAT_ADDITIONAL_FILES)
               .where(SPLAT_FILE_ID.eq(splatFileId))
+              .and(FILE_ID.notIn(retainedFileIds))
               .returning(FILE_ID)
               .fetch(FILE_ID.asNonNullable())
         }
 
-    val unreferencedFileIds = deletedFileIds.filterNot { it in retainedFileIds }
-
-    if (unreferencedFileIds.isNotEmpty()) {
+    if (deletedFileIds.isNotEmpty()) {
       dslContext
           .deleteFrom(ORGANIZATION_MEDIA_FILES)
-          .where(ORGANIZATION_MEDIA_FILES.FILE_ID.`in`(unreferencedFileIds))
+          .where(ORGANIZATION_MEDIA_FILES.FILE_ID.`in`(deletedFileIds))
           .execute()
     }
 
-    return unreferencedFileIds
+    return deletedFileIds
   }
 
   private fun listAdditionalFileLocations(fileId: FileId): List<SplatterRequestFileLocation> {
@@ -628,13 +651,7 @@ class SplatService(
           .on(FILE_ID.eq(FILES.ID))
           .where(SPLAT_FILE_ID.eq(fileId))
           .orderBy(FILE_ID)
-          .fetch { record ->
-            SplatterRequestFileLocation(
-                s3BucketName,
-                record[FILES.STORAGE_URL]!!.path.trimStart('/'),
-                record[TYPE]!!,
-            )
-          }
+          .fetch { record -> fileLocation(record[FILES.STORAGE_URL]!!, record[TYPE]!!) }
     }
   }
 

--- a/src/main/kotlin/com/terraformation/backend/splat/SplatService.kt
+++ b/src/main/kotlin/com/terraformation/backend/splat/SplatService.kt
@@ -546,7 +546,7 @@ class SplatService(
       }
     }
 
-    replacedFileIds.forEach { eventPublisher.publishEvent(FileReferenceDeletedEvent(it)) }
+    publishAdditionalFilesDeleted(replacedFileIds)
   }
 
   /**
@@ -565,6 +565,24 @@ class SplatService(
           .replace(Regex("([A-Z]+)([A-Z][a-z])"), "$1-$2")
           .replace(Regex("([a-z0-9])([A-Z])"), "$1-$2")
           .lowercase()
+
+  /**
+   * Announces that additional files are no longer referenced, which causes them to be deleted from
+   * the file store. Must be called after the database changes that dropped the references have
+   * committed, since deleting a file from the file store can't be rolled back.
+   *
+   * Each file is announced independently: the references are already gone, so a file store failure
+   * for one of them must not stop the others from being cleaned up.
+   */
+  private fun publishAdditionalFilesDeleted(fileIds: Collection<FileId>) {
+    fileIds.forEach { fileId ->
+      try {
+        eventPublisher.publishEvent(FileReferenceDeletedEvent(fileId))
+      } catch (e: Exception) {
+        log.error("Unable to delete splat additional file $fileId", e)
+      }
+    }
+  }
 
   /**
    * Removes a splat's additional files from the database. Additional files are uploaded as

--- a/src/main/kotlin/com/terraformation/backend/splat/SplatService.kt
+++ b/src/main/kotlin/com/terraformation/backend/splat/SplatService.kt
@@ -7,6 +7,7 @@ import com.terraformation.backend.customer.event.OrganizationVideoUploadedEvent
 import com.terraformation.backend.customer.model.requirePermissions
 import com.terraformation.backend.db.FileBatchNotFoundException
 import com.terraformation.backend.db.FileNotFoundException
+import com.terraformation.backend.db.asNonNullable
 import com.terraformation.backend.db.default_schema.AssetStatus
 import com.terraformation.backend.db.default_schema.FileBatchType
 import com.terraformation.backend.db.default_schema.FileId
@@ -26,6 +27,7 @@ import com.terraformation.backend.file.S3FileStore
 import com.terraformation.backend.file.SizedInputStream
 import com.terraformation.backend.file.event.FileBatchFinishedUploadingEvent
 import com.terraformation.backend.file.event.FileDeletionStartedEvent
+import com.terraformation.backend.file.event.FileReferenceDeletedEvent
 import com.terraformation.backend.log.perClassLogger
 import com.terraformation.backend.splat.event.SplatDeletedEvent
 import com.terraformation.backend.splat.event.SplatGenerationCompletedEvent
@@ -486,10 +488,9 @@ class SplatService(
 
       if (rowsInserted == 1 || force) {
         if (additionalFiles.isNotEmpty()) {
-          with(SPLAT_ADDITIONAL_FILES) {
-            // TODO delete files too
-            dslContext.deleteFrom(SPLAT_ADDITIONAL_FILES).where(SPLAT_FILE_ID.eq(fileId)).execute()
+          deleteAdditionalFiles(fileId, retainedFileIds = additionalFiles.keys)
 
+          with(SPLAT_ADDITIONAL_FILES) {
             additionalFiles.forEach { (additionalFileId, type) ->
               dslContext
                   .insertInto(SPLAT_ADDITIONAL_FILES)
@@ -552,6 +553,31 @@ class SplatService(
           .replace(Regex("([A-Z]+)([A-Z][a-z])"), "$1-$2")
           .replace(Regex("([a-z0-9])([A-Z])"), "$1-$2")
           .lowercase()
+
+  /**
+   * Removes a splat's additional files from the database and, unless they're still needed, from the
+   * file store.
+   *
+   * @param retainedFileIds Files that are about to be inserted as additional files of the same
+   *   splat again. Their rows are still deleted, but the files themselves are left alone.
+   */
+  private fun deleteAdditionalFiles(
+      splatFileId: FileId,
+      retainedFileIds: Set<FileId> = emptySet(),
+  ) {
+    val deletedFileIds =
+        with(SPLAT_ADDITIONAL_FILES) {
+          dslContext
+              .deleteFrom(SPLAT_ADDITIONAL_FILES)
+              .where(SPLAT_FILE_ID.eq(splatFileId))
+              .returning(FILE_ID)
+              .fetch(FILE_ID.asNonNullable())
+        }
+
+    deletedFileIds
+        .filterNot { it in retainedFileIds }
+        .forEach { eventPublisher.publishEvent(FileReferenceDeletedEvent(it)) }
+  }
 
   private fun listAdditionalFileLocations(fileId: FileId): List<SplatterRequestFileLocation> {
     return with(SPLAT_ADDITIONAL_FILES) {

--- a/src/test/kotlin/com/terraformation/backend/splat/SplatServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/splat/SplatServiceTest.kt
@@ -16,6 +16,7 @@ import com.terraformation.backend.db.default_schema.FileId
 import com.terraformation.backend.db.default_schema.OrganizationId
 import com.terraformation.backend.db.default_schema.Role
 import com.terraformation.backend.db.default_schema.tables.records.BirdnetResultsRecord
+import com.terraformation.backend.db.default_schema.tables.records.OrganizationMediaFilesRecord
 import com.terraformation.backend.db.default_schema.tables.records.SplatAdditionalFilesRecord
 import com.terraformation.backend.db.default_schema.tables.records.SplatAnnotationsRecord
 import com.terraformation.backend.db.default_schema.tables.records.SplatsRecord
@@ -1468,8 +1469,10 @@ class SplatServiceTest : DatabaseTest(), RunsAsDatabaseUser {
     fun `replaces the stored additional file of a type`() {
       insertSplat(fileId = orgFileId, assetStatus = AssetStatus.Ready)
       val oldImuFileId = insertFile(fileName = "imu.json", storageUrl = "s3://bucket/old-imu.json")
+      insertOrganizationMediaFile(fileId = oldImuFileId)
       insertSplatAdditionalFile(splatFileId = orgFileId, fileId = oldImuFileId, type = "imu")
       val newImuFileId = insertFile(fileName = "imu.json", storageUrl = "s3://bucket/new-imu.json")
+      insertOrganizationMediaFile(fileId = newImuFileId)
 
       val messageSlot = slot<SplatterRequestMessage>()
       every { sqsTemplate.send(any<String>(), capture(messageSlot)) } returns mockk(relaxed = true)
@@ -1495,6 +1498,13 @@ class SplatServiceTest : DatabaseTest(), RunsAsDatabaseUser {
           "Request additional files",
       )
 
+      assertTableEquals(
+          listOf(
+              OrganizationMediaFilesRecord(fileId = orgFileId, organizationId = organizationId),
+              OrganizationMediaFilesRecord(fileId = newImuFileId, organizationId = organizationId),
+          )
+      )
+
       eventPublisher.assertEventPublished(FileReferenceDeletedEvent(oldImuFileId))
     }
 
@@ -1502,6 +1512,7 @@ class SplatServiceTest : DatabaseTest(), RunsAsDatabaseUser {
     fun `does not delete an additional file that is still used by the splat`() {
       insertSplat(fileId = orgFileId, assetStatus = AssetStatus.Ready)
       val imuFileId = insertFile(fileName = "imu.json", storageUrl = "s3://bucket/imu.json")
+      insertOrganizationMediaFile(fileId = imuFileId)
       insertSplatAdditionalFile(splatFileId = orgFileId, fileId = imuFileId, type = "imu")
 
       every { sqsTemplate.send(any<String>(), any<SplatterRequestMessage>()) } returns
@@ -1520,6 +1531,13 @@ class SplatServiceTest : DatabaseTest(), RunsAsDatabaseUser {
               fileId = imuFileId,
               splatFileId = orgFileId,
               type = "imu",
+          )
+      )
+
+      assertTableEquals(
+          listOf(
+              OrganizationMediaFilesRecord(fileId = orgFileId, organizationId = organizationId),
+              OrganizationMediaFilesRecord(fileId = imuFileId, organizationId = organizationId),
           )
       )
 

--- a/src/test/kotlin/com/terraformation/backend/splat/SplatServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/splat/SplatServiceTest.kt
@@ -1509,6 +1509,36 @@ class SplatServiceTest : DatabaseTest(), RunsAsDatabaseUser {
     }
 
     @Test
+    fun `keeps deleting replaced additional files after one of them fails`() {
+      insertSplat(fileId = orgFileId, assetStatus = AssetStatus.Ready)
+      val oldImuFileId = insertOrganizationMediaFile(fileId = insertFile())
+      insertSplatAdditionalFile(splatFileId = orgFileId, fileId = oldImuFileId, type = "imu")
+      val oldFramesFileId = insertOrganizationMediaFile(fileId = insertFile())
+      insertSplatAdditionalFile(splatFileId = orgFileId, fileId = oldFramesFileId, type = "frames")
+      val newImuFileId = insertOrganizationMediaFile(fileId = insertFile())
+
+      val attemptedFileIds = mutableListOf<FileId>()
+      eventPublisher.register<FileReferenceDeletedEvent> { event ->
+        attemptedFileIds.add(event.fileId)
+        throw RuntimeException("File store unavailable")
+      }
+
+      service.generateOrganizationMediaSplat(
+          organizationId = organizationId,
+          fileId = orgFileId,
+          force = true,
+          runBirdnet = false,
+          additionalFiles = mapOf(newImuFileId to "imu"),
+      )
+
+      assertEquals(
+          setOf(oldImuFileId, oldFramesFileId),
+          attemptedFileIds.toSet(),
+          "Files whose deletion was attempted",
+      )
+    }
+
+    @Test
     fun `does not delete replaced additional files if the generation request fails`() {
       insertSplat(fileId = orgFileId, assetStatus = AssetStatus.Ready)
       val oldImuFileId = insertFile(fileName = "imu.json", storageUrl = "s3://bucket/old-imu.json")

--- a/src/test/kotlin/com/terraformation/backend/splat/SplatServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/splat/SplatServiceTest.kt
@@ -1509,6 +1509,40 @@ class SplatServiceTest : DatabaseTest(), RunsAsDatabaseUser {
     }
 
     @Test
+    fun `does not delete replaced additional files if the generation request fails`() {
+      insertSplat(fileId = orgFileId, assetStatus = AssetStatus.Ready)
+      val oldImuFileId = insertFile(fileName = "imu.json", storageUrl = "s3://bucket/old-imu.json")
+      insertOrganizationMediaFile(fileId = oldImuFileId)
+      insertSplatAdditionalFile(splatFileId = orgFileId, fileId = oldImuFileId, type = "imu")
+      val newImuFileId = insertFile(fileName = "imu.json", storageUrl = "s3://bucket/new-imu.json")
+      insertOrganizationMediaFile(fileId = newImuFileId)
+
+      every { sqsTemplate.send(any<String>(), any<SplatterRequestMessage>()) } throws
+          RuntimeException("Request queue unavailable")
+
+      assertThrows<RuntimeException> {
+        service.generateOrganizationMediaSplat(
+            organizationId = organizationId,
+            fileId = orgFileId,
+            force = true,
+            runBirdnet = false,
+            additionalFiles = mapOf(newImuFileId to "imu"),
+        )
+      }
+
+      assertTableEquals(
+          SplatAdditionalFilesRecord(
+              fileId = oldImuFileId,
+              splatFileId = orgFileId,
+              type = "imu",
+          ),
+          "Additional file should be restored by the rollback",
+      )
+
+      eventPublisher.assertEventNotPublished(FileReferenceDeletedEvent(oldImuFileId))
+    }
+
+    @Test
     fun `does not delete an additional file that is still used by the splat`() {
       insertSplat(fileId = orgFileId, assetStatus = AssetStatus.Ready)
       val imuFileId = insertFile(fileName = "imu.json", storageUrl = "s3://bucket/imu.json")

--- a/src/test/kotlin/com/terraformation/backend/splat/SplatServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/splat/SplatServiceTest.kt
@@ -29,6 +29,7 @@ import com.terraformation.backend.file.S3FileStore
 import com.terraformation.backend.file.SizedInputStream
 import com.terraformation.backend.file.event.FileBatchFinishedUploadingEvent
 import com.terraformation.backend.file.event.FileDeletionStartedEvent
+import com.terraformation.backend.file.event.FileReferenceDeletedEvent
 import com.terraformation.backend.point
 import com.terraformation.backend.splat.event.SplatDeletedEvent
 import com.terraformation.backend.splat.event.SplatGenerationCompletedEvent
@@ -1466,11 +1467,8 @@ class SplatServiceTest : DatabaseTest(), RunsAsDatabaseUser {
     @Test
     fun `replaces the stored additional file of a type`() {
       insertSplat(fileId = orgFileId, assetStatus = AssetStatus.Ready)
-      insertSplatAdditionalFile(
-          splatFileId = orgFileId,
-          fileId = insertFile(fileName = "imu.json", storageUrl = "s3://bucket/old-imu.json"),
-          type = "imu",
-      )
+      val oldImuFileId = insertFile(fileName = "imu.json", storageUrl = "s3://bucket/old-imu.json")
+      insertSplatAdditionalFile(splatFileId = orgFileId, fileId = oldImuFileId, type = "imu")
       val newImuFileId = insertFile(fileName = "imu.json", storageUrl = "s3://bucket/new-imu.json")
 
       val messageSlot = slot<SplatterRequestMessage>()
@@ -1496,6 +1494,36 @@ class SplatServiceTest : DatabaseTest(), RunsAsDatabaseUser {
           messageSlot.captured.additionalFiles,
           "Request additional files",
       )
+
+      eventPublisher.assertEventPublished(FileReferenceDeletedEvent(oldImuFileId))
+    }
+
+    @Test
+    fun `does not delete an additional file that is still used by the splat`() {
+      insertSplat(fileId = orgFileId, assetStatus = AssetStatus.Ready)
+      val imuFileId = insertFile(fileName = "imu.json", storageUrl = "s3://bucket/imu.json")
+      insertSplatAdditionalFile(splatFileId = orgFileId, fileId = imuFileId, type = "imu")
+
+      every { sqsTemplate.send(any<String>(), any<SplatterRequestMessage>()) } returns
+          mockk(relaxed = true)
+
+      service.generateOrganizationMediaSplat(
+          organizationId = organizationId,
+          fileId = orgFileId,
+          force = true,
+          runBirdnet = false,
+          additionalFiles = mapOf(imuFileId to "frames"),
+      )
+
+      assertTableEquals(
+          SplatAdditionalFilesRecord(
+              fileId = imuFileId,
+              splatFileId = orgFileId,
+              type = "frames",
+          )
+      )
+
+      eventPublisher.assertEventNotPublished(FileReferenceDeletedEvent(imuFileId))
     }
 
     @Test

--- a/src/test/kotlin/com/terraformation/backend/splat/SplatServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/splat/SplatServiceTest.kt
@@ -1512,14 +1512,14 @@ class SplatServiceTest : DatabaseTest(), RunsAsDatabaseUser {
           fileId = orgFileId,
           force = true,
           runBirdnet = false,
-          additionalFiles = mapOf(imuFileId to "frames"),
+          additionalFiles = mapOf(imuFileId to "imu"),
       )
 
       assertTableEquals(
           SplatAdditionalFilesRecord(
               fileId = imuFileId,
               splatFileId = orgFileId,
-              type = "frames",
+              type = "imu",
           )
       )
 


### PR DESCRIPTION
Publish FileReferenceDeletedEvent for each splat_additional_files row
that is removed, so the underlying file is deleted from the file store
and the files table once nothing else refers to it.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>