### PR TITLE
Delete a splat's additional files when the splat is deleted

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/splat/SplatService.kt
+++ b/src/main/kotlin/com/terraformation/backend/splat/SplatService.kt
@@ -246,12 +246,16 @@ class SplatService(
   private fun deleteSplatRows(fileId: FileId, organizationId: OrganizationId) {
     val splatRecord = dslContext.fetchSingle(SPLATS, SPLATS.FILE_ID.eq(fileId))
 
-    dslContext.transaction { _ ->
-      deleteAdditionalFiles(fileId)
+    val additionalFileIds = dslContext.transactionResult { _ ->
+      val unreferencedFileIds = deleteAdditionalFiles(fileId)
       dslContext.deleteFrom(SPLAT_ANNOTATIONS).where(SPLAT_ANNOTATIONS.FILE_ID.eq(fileId)).execute()
       dslContext.deleteFrom(BIRDNET_RESULTS).where(BIRDNET_RESULTS.FILE_ID.eq(fileId)).execute()
       dslContext.deleteFrom(SPLATS).where(SPLATS.FILE_ID.eq(fileId)).execute()
+
+      unreferencedFileIds
     }
+
+    additionalFileIds.forEach { eventPublisher.publishEvent(FileReferenceDeletedEvent(it)) }
 
     eventPublisher.publishEvent(
         SplatDeletedEvent(
@@ -674,8 +678,10 @@ class SplatService(
           // Not an error if there wasn't a job archive for the splat.
         }
 
-        deleteAdditionalFiles(event.fileId)
+        val additionalFileIds = deleteAdditionalFiles(event.fileId)
         splatsRecord.delete()
+
+        additionalFileIds.forEach { eventPublisher.publishEvent(FileReferenceDeletedEvent(it)) }
       }
     } catch (e: Exception) {
       log.error("Unable to delete splat for file ${event.fileId}", e)

--- a/src/main/kotlin/com/terraformation/backend/splat/SplatService.kt
+++ b/src/main/kotlin/com/terraformation/backend/splat/SplatService.kt
@@ -255,7 +255,7 @@ class SplatService(
       unreferencedFileIds
     }
 
-    additionalFileIds.forEach { eventPublisher.publishEvent(FileReferenceDeletedEvent(it)) }
+    publishAdditionalFilesDeleted(additionalFileIds)
 
     eventPublisher.publishEvent(
         SplatDeletedEvent(
@@ -681,7 +681,7 @@ class SplatService(
         val additionalFileIds = deleteAdditionalFiles(event.fileId)
         splatsRecord.delete()
 
-        additionalFileIds.forEach { eventPublisher.publishEvent(FileReferenceDeletedEvent(it)) }
+        publishAdditionalFilesDeleted(additionalFileIds)
       }
     } catch (e: Exception) {
       log.error("Unable to delete splat for file ${event.fileId}", e)

--- a/src/main/kotlin/com/terraformation/backend/splat/SplatService.kt
+++ b/src/main/kotlin/com/terraformation/backend/splat/SplatService.kt
@@ -247,6 +247,7 @@ class SplatService(
     val splatRecord = dslContext.fetchSingle(SPLATS, SPLATS.FILE_ID.eq(fileId))
 
     dslContext.transaction { _ ->
+      deleteAdditionalFiles(fileId)
       dslContext.deleteFrom(SPLAT_ANNOTATIONS).where(SPLAT_ANNOTATIONS.FILE_ID.eq(fileId)).execute()
       dslContext.deleteFrom(BIRDNET_RESULTS).where(BIRDNET_RESULTS.FILE_ID.eq(fileId)).execute()
       dslContext.deleteFrom(SPLATS).where(SPLATS.FILE_ID.eq(fileId)).execute()
@@ -673,6 +674,7 @@ class SplatService(
           // Not an error if there wasn't a job archive for the splat.
         }
 
+        deleteAdditionalFiles(event.fileId)
         splatsRecord.delete()
       }
     } catch (e: Exception) {

--- a/src/test/kotlin/com/terraformation/backend/splat/SplatServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/splat/SplatServiceTest.kt
@@ -21,6 +21,7 @@ import com.terraformation.backend.db.default_schema.tables.records.SplatAddition
 import com.terraformation.backend.db.default_schema.tables.records.SplatAnnotationsRecord
 import com.terraformation.backend.db.default_schema.tables.records.SplatsRecord
 import com.terraformation.backend.db.default_schema.tables.references.BIRDNET_RESULTS
+import com.terraformation.backend.db.default_schema.tables.references.ORGANIZATION_MEDIA_FILES
 import com.terraformation.backend.db.default_schema.tables.references.SPLATS
 import com.terraformation.backend.db.default_schema.tables.references.SPLAT_ADDITIONAL_FILES
 import com.terraformation.backend.db.default_schema.tables.references.SPLAT_ANNOTATIONS
@@ -513,6 +514,19 @@ class SplatServiceTest : DatabaseTest(), RunsAsDatabaseUser {
     }
 
     @Test
+    fun `removes additional files from database and file store`() {
+      val additionalFileId = insertOrganizationMediaFile(fileId = insertFile())
+      insertSplatAdditionalFile(splatFileId = fileId, fileId = additionalFileId, type = "imu")
+
+      service.deleteObservationSplat(observationId, fileId)
+
+      assertTableEmpty(SPLAT_ADDITIONAL_FILES)
+      assertTableEmpty(ORGANIZATION_MEDIA_FILES)
+
+      eventPublisher.assertEventPublished(FileReferenceDeletedEvent(additionalFileId))
+    }
+
+    @Test
     fun `throws exception if splat does not exist for file`() {
       val fileWithoutSplat = insertFile()
       insertObservationMediaFile(fileId = fileWithoutSplat)
@@ -573,6 +587,21 @@ class SplatServiceTest : DatabaseTest(), RunsAsDatabaseUser {
               videoUploadedTime = Instant.EPOCH,
           )
       )
+    }
+
+    @Test
+    fun `removes additional files from database and file store`() {
+      val additionalFileId = insertOrganizationMediaFile(fileId = insertFile())
+      insertSplatAdditionalFile(splatFileId = orgFileId, fileId = additionalFileId, type = "imu")
+
+      service.deleteOrganizationSplat(organizationId, orgFileId)
+
+      assertTableEmpty(SPLAT_ADDITIONAL_FILES)
+      assertTableEquals(
+          OrganizationMediaFilesRecord(fileId = orgFileId, organizationId = organizationId)
+      )
+
+      eventPublisher.assertEventPublished(FileReferenceDeletedEvent(additionalFileId))
     }
 
     @Test
@@ -1290,6 +1319,25 @@ class SplatServiceTest : DatabaseTest(), RunsAsDatabaseUser {
       verify(exactly = 1) { fileStore.delete(jobArchiveUrl) }
 
       assertTableEmpty(SPLATS)
+    }
+
+    @Test
+    fun `deletes additional files when media file is deleted`() {
+      val url = URI("s3://bucket/file.sog")
+
+      every { fileStore.delete(any()) } just Runs
+
+      insertSplat(splatStorageUrl = url)
+      val additionalFileId = insertOrganizationMediaFile(fileId = insertFile())
+      insertSplatAdditionalFile(splatFileId = fileId, fileId = additionalFileId, type = "imu")
+
+      service.on(FileDeletionStartedEvent(fileId, "video/quicktime"))
+
+      assertTableEmpty(SPLATS)
+      assertTableEmpty(SPLAT_ADDITIONAL_FILES)
+      assertTableEmpty(ORGANIZATION_MEDIA_FILES)
+
+      eventPublisher.assertEventPublished(FileReferenceDeletedEvent(additionalFileId))
     }
   }
 

--- a/src/test/kotlin/com/terraformation/backend/splat/SplatServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/splat/SplatServiceTest.kt
@@ -605,6 +605,38 @@ class SplatServiceTest : DatabaseTest(), RunsAsDatabaseUser {
     }
 
     @Test
+    fun `keeps deleting additional files after one of them fails`() {
+      val imuFileId = insertOrganizationMediaFile(fileId = insertFile())
+      insertSplatAdditionalFile(splatFileId = orgFileId, fileId = imuFileId, type = "imu")
+      val framesFileId = insertOrganizationMediaFile(fileId = insertFile())
+      insertSplatAdditionalFile(splatFileId = orgFileId, fileId = framesFileId, type = "frames")
+
+      val attemptedFileIds = mutableListOf<FileId>()
+      eventPublisher.register<FileReferenceDeletedEvent> { event ->
+        attemptedFileIds.add(event.fileId)
+        throw RuntimeException("File store unavailable")
+      }
+
+      service.deleteOrganizationSplat(organizationId, orgFileId)
+
+      assertEquals(
+          setOf(imuFileId, framesFileId),
+          attemptedFileIds.toSet(),
+          "Files whose deletion was attempted",
+      )
+
+      eventPublisher.assertEventPublished(
+          SplatDeletedEvent(
+              deletedByUserId = user.userId,
+              fileId = orgFileId,
+              organizationId = organizationId,
+              uploadedByUserId = user.userId,
+              videoUploadedTime = Instant.EPOCH,
+          )
+      )
+    }
+
+    @Test
     fun `throws exception if file does not belong to organization`() {
       val unassociatedFileId = insertFile()
       insertSplat(fileId = unassociatedFileId)


### PR DESCRIPTION
Remove the splat_additional_files rows before the splats row goes away
in both deletion paths, and publish FileReferenceDeletedEvent for each
one so the files are deleted from the file store and the files table.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>