### PR TITLE
Don't let an existing splat supply additional files

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/splat/Exceptions.kt
+++ b/src/main/kotlin/com/terraformation/backend/splat/Exceptions.kt
@@ -2,6 +2,9 @@ package com.terraformation.backend.splat
 
 import com.terraformation.backend.db.default_schema.FileId
 
+data class SplatAdditionalFilesExistException(val fileId: FileId) :
+    RuntimeException("Splat for file $fileId already has additional files")
+
 data class SplatGenerationFailedException(val fileId: FileId) :
     Exception("Failed to generate splat for file $fileId")
 

--- a/src/main/kotlin/com/terraformation/backend/splat/SplatService.kt
+++ b/src/main/kotlin/com/terraformation/backend/splat/SplatService.kt
@@ -548,9 +548,7 @@ class SplatService(
           SPLAT_ADDITIONAL_FILES.SPLAT_FILE_ID.eq(splatFileId),
       )
 
-  /**
-   * Attaches [additionalFiles] to a splat. These are immutable for the splat's lifetime.
-   */
+  /** Attaches [additionalFiles] to a splat. These are immutable for the splat's lifetime. */
   private fun insertAdditionalFiles(
       splatFileId: FileId,
       additionalFiles: Map<FileId, SplatAdditionalFileType>,

--- a/src/main/kotlin/com/terraformation/backend/splat/SplatService.kt
+++ b/src/main/kotlin/com/terraformation/backend/splat/SplatService.kt
@@ -430,7 +430,11 @@ class SplatService(
           null
         }
 
-    val replacedFileIds = dslContext.transactionResult { _ ->
+    dslContext.transaction { _ ->
+      if (additionalFiles.isNotEmpty() && hasAdditionalFiles(fileId)) {
+        throw SplatAdditionalFilesExistException(fileId)
+      }
+
       val splatIsNew = insertOrRestartSplat(fileId, organizationId, splatUrl, force)
 
       if (birdnetUrl != null) {
@@ -442,10 +446,10 @@ class SplatService(
             "Splat record already exists for file $fileId; ignoring additional generation request"
         )
 
-        return@transactionResult emptyList()
+        return@transaction
       }
 
-      val replacedFileIds = replaceAdditionalFiles(fileId, additionalFiles)
+      insertAdditionalFiles(fileId, additionalFiles)
 
       sqsTemplate.send(
           requestQueueUrl,
@@ -466,11 +470,7 @@ class SplatService(
       log.info(
           "Requested splat generation for file $fileId${if (runBirdnet) " with BirdNet" else ""}"
       )
-
-      replacedFileIds
     }
-
-    publishAdditionalFilesDeleted(replacedFileIds)
   }
 
   /**
@@ -542,23 +542,19 @@ class SplatService(
     }
   }
 
+  private fun hasAdditionalFiles(splatFileId: FileId): Boolean =
+      dslContext.fetchExists(
+          SPLAT_ADDITIONAL_FILES,
+          SPLAT_ADDITIONAL_FILES.SPLAT_FILE_ID.eq(splatFileId),
+      )
+
   /**
-   * Makes [additionalFiles] the full set of additional files for a splat, replacing any previous
-   * ones. Does nothing if [additionalFiles] is empty.
-   *
-   * @return The previous additional files that nothing refers to any more; see
-   *   [deleteAdditionalFiles] for how the caller must dispose of them.
+   * Attaches [additionalFiles] to a splat. These are immutable for the splat's lifetime.
    */
-  private fun replaceAdditionalFiles(
+  private fun insertAdditionalFiles(
       splatFileId: FileId,
       additionalFiles: Map<FileId, SplatAdditionalFileType>,
-  ): List<FileId> {
-    if (additionalFiles.isEmpty()) {
-      return emptyList()
-    }
-
-    val replacedFileIds = deleteAdditionalFiles(splatFileId, retainedFileIds = additionalFiles.keys)
-
+  ) {
     with(SPLAT_ADDITIONAL_FILES) {
       additionalFiles.forEach { (additionalFileId, type) ->
         dslContext
@@ -566,13 +562,9 @@ class SplatService(
             .set(FILE_ID, additionalFileId)
             .set(SPLAT_FILE_ID, splatFileId)
             .set(TYPE, type)
-            .onDuplicateKeyUpdate()
-            .set(TYPE, type)
             .execute()
       }
     }
-
-    return replacedFileIds
   }
 
   private fun fileLocation(url: URI, type: SplatAdditionalFileType? = null) =
@@ -617,22 +609,16 @@ class SplatService(
    * Removes a splat's additional files from the database. Additional files are uploaded as
    * organization media, so their organization media rows are deleted too.
    *
-   * @param retainedFileIds Files that are about to be inserted as additional files of the same
-   *   splat again. Their rows are left in place for the insert to update.
    * @return The files that nothing refers to any more. The caller must publish
    *   [FileReferenceDeletedEvent] for each of them, but only once its transaction has committed:
    *   the handler deletes the files from the file store, which a rollback can't undo.
    */
-  private fun deleteAdditionalFiles(
-      splatFileId: FileId,
-      retainedFileIds: Set<FileId> = emptySet(),
-  ): List<FileId> {
+  private fun deleteAdditionalFiles(splatFileId: FileId): List<FileId> {
     val deletedFileIds =
         with(SPLAT_ADDITIONAL_FILES) {
           dslContext
               .deleteFrom(SPLAT_ADDITIONAL_FILES)
               .where(SPLAT_FILE_ID.eq(splatFileId))
-              .and(FILE_ID.notIn(retainedFileIds))
               .returning(FILE_ID)
               .fetch(FILE_ID.asNonNullable())
         }

--- a/src/main/kotlin/com/terraformation/backend/splat/SplatService.kt
+++ b/src/main/kotlin/com/terraformation/backend/splat/SplatService.kt
@@ -431,11 +431,14 @@ class SplatService(
         }
 
     dslContext.transaction { _ ->
+      val splatIsNew = insertOrRestartSplat(fileId, organizationId, splatUrl, force)
+
+      // Concurrent generation requests for the same file all contend for the same splats row, so by
+      // the time this runs, a competing request has either committed its additional files or rolled
+      // them back; checking any earlier could let two requests each add a disjoint set of files.
       if (additionalFiles.isNotEmpty() && hasAdditionalFiles(fileId)) {
         throw SplatAdditionalFilesExistException(fileId)
       }
-
-      val splatIsNew = insertOrRestartSplat(fileId, organizationId, splatUrl, force)
 
       if (birdnetUrl != null) {
         insertOrRestartBirdnetResult(fileId, birdnetUrl, force)

--- a/src/test/kotlin/com/terraformation/backend/splat/SplatServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/splat/SplatServiceTest.kt
@@ -1546,7 +1546,7 @@ class SplatServiceTest : DatabaseTest(), RunsAsDatabaseUser {
     }
 
     @Test
-    fun `replaces the stored additional file of a type`() {
+    fun `throws exception when splat already has additional files`() {
       insertSplat(fileId = orgFileId, assetStatus = AssetStatus.Ready)
       val oldImuFileId = insertFile(fileName = "imu.json", storageUrl = "s3://bucket/old-imu.json")
       insertOrganizationMediaFile(fileId = oldImuFileId)
@@ -1554,83 +1554,7 @@ class SplatServiceTest : DatabaseTest(), RunsAsDatabaseUser {
       val newImuFileId = insertFile(fileName = "imu.json", storageUrl = "s3://bucket/new-imu.json")
       insertOrganizationMediaFile(fileId = newImuFileId)
 
-      val messageSlot = slot<SplatterRequestMessage>()
-      every { sqsTemplate.send(any<String>(), capture(messageSlot)) } returns mockk(relaxed = true)
-
-      service.generateOrganizationMediaSplat(
-          organizationId = organizationId,
-          fileId = orgFileId,
-          force = true,
-          runBirdnet = false,
-          additionalFiles = mapOf(newImuFileId to "imu"),
-      )
-
-      assertTableEquals(
-          SplatAdditionalFilesRecord(
-              fileId = newImuFileId,
-              splatFileId = orgFileId,
-              type = "imu",
-          )
-      )
-      assertEquals(
-          listOf(SplatterRequestFileLocation("bucket", "new-imu.json", "imu")),
-          messageSlot.captured.additionalFiles,
-          "Request additional files",
-      )
-
-      assertTableEquals(
-          listOf(
-              OrganizationMediaFilesRecord(fileId = orgFileId, organizationId = organizationId),
-              OrganizationMediaFilesRecord(fileId = newImuFileId, organizationId = organizationId),
-          )
-      )
-
-      eventPublisher.assertEventPublished(FileReferenceDeletedEvent(oldImuFileId))
-    }
-
-    @Test
-    fun `keeps deleting replaced additional files after one of them fails`() {
-      insertSplat(fileId = orgFileId, assetStatus = AssetStatus.Ready)
-      val oldImuFileId = insertOrganizationMediaFile(fileId = insertFile())
-      insertSplatAdditionalFile(splatFileId = orgFileId, fileId = oldImuFileId, type = "imu")
-      val oldFramesFileId = insertOrganizationMediaFile(fileId = insertFile())
-      insertSplatAdditionalFile(splatFileId = orgFileId, fileId = oldFramesFileId, type = "frames")
-      val newImuFileId = insertOrganizationMediaFile(fileId = insertFile())
-
-      val attemptedFileIds = mutableListOf<FileId>()
-      eventPublisher.register<FileReferenceDeletedEvent> { event ->
-        attemptedFileIds.add(event.fileId)
-        throw RuntimeException("File store unavailable")
-      }
-
-      service.generateOrganizationMediaSplat(
-          organizationId = organizationId,
-          fileId = orgFileId,
-          force = true,
-          runBirdnet = false,
-          additionalFiles = mapOf(newImuFileId to "imu"),
-      )
-
-      assertEquals(
-          setOf(oldImuFileId, oldFramesFileId),
-          attemptedFileIds.toSet(),
-          "Files whose deletion was attempted",
-      )
-    }
-
-    @Test
-    fun `does not delete replaced additional files if the generation request fails`() {
-      insertSplat(fileId = orgFileId, assetStatus = AssetStatus.Ready)
-      val oldImuFileId = insertFile(fileName = "imu.json", storageUrl = "s3://bucket/old-imu.json")
-      insertOrganizationMediaFile(fileId = oldImuFileId)
-      insertSplatAdditionalFile(splatFileId = orgFileId, fileId = oldImuFileId, type = "imu")
-      val newImuFileId = insertFile(fileName = "imu.json", storageUrl = "s3://bucket/new-imu.json")
-      insertOrganizationMediaFile(fileId = newImuFileId)
-
-      every { sqsTemplate.send(any<String>(), any<SplatterRequestMessage>()) } throws
-          RuntimeException("Request queue unavailable")
-
-      assertThrows<RuntimeException> {
+      assertThrows<SplatAdditionalFilesExistException> {
         service.generateOrganizationMediaSplat(
             organizationId = organizationId,
             fileId = orgFileId,
@@ -1646,21 +1570,29 @@ class SplatServiceTest : DatabaseTest(), RunsAsDatabaseUser {
               splatFileId = orgFileId,
               type = "imu",
           ),
-          "Additional file should be restored by the rollback",
+          "Existing additional files",
+      )
+
+      assertTableEquals(
+          listOf(
+              OrganizationMediaFilesRecord(fileId = orgFileId, organizationId = organizationId),
+              OrganizationMediaFilesRecord(fileId = oldImuFileId, organizationId = organizationId),
+              OrganizationMediaFilesRecord(fileId = newImuFileId, organizationId = organizationId),
+          )
       )
 
       eventPublisher.assertEventNotPublished(FileReferenceDeletedEvent(oldImuFileId))
+      verify(exactly = 0) { sqsTemplate.send(any<String>(), any<SplatterRequestMessage>()) }
     }
 
     @Test
-    fun `does not delete an additional file that is still used by the splat`() {
+    fun `adds additional files to an existing splat that has none`() {
       insertSplat(fileId = orgFileId, assetStatus = AssetStatus.Ready)
       val imuFileId = insertFile(fileName = "imu.json", storageUrl = "s3://bucket/imu.json")
       insertOrganizationMediaFile(fileId = imuFileId)
-      insertSplatAdditionalFile(splatFileId = orgFileId, fileId = imuFileId, type = "imu")
 
-      every { sqsTemplate.send(any<String>(), any<SplatterRequestMessage>()) } returns
-          mockk(relaxed = true)
+      val messageSlot = slot<SplatterRequestMessage>()
+      every { sqsTemplate.send(any<String>(), capture(messageSlot)) } returns mockk(relaxed = true)
 
       service.generateOrganizationMediaSplat(
           organizationId = organizationId,
@@ -1678,14 +1610,33 @@ class SplatServiceTest : DatabaseTest(), RunsAsDatabaseUser {
           )
       )
 
-      assertTableEquals(
-          listOf(
-              OrganizationMediaFilesRecord(fileId = orgFileId, organizationId = organizationId),
-              OrganizationMediaFilesRecord(fileId = imuFileId, organizationId = organizationId),
-          )
+      assertEquals(
+          listOf(SplatterRequestFileLocation("bucket", "imu.json", "imu")),
+          messageSlot.captured.additionalFiles,
+          "Request additional files",
       )
+    }
 
-      eventPublisher.assertEventNotPublished(FileReferenceDeletedEvent(imuFileId))
+    @Test
+    fun `does not add additional files if the generation request fails`() {
+      insertSplat(fileId = orgFileId, assetStatus = AssetStatus.Ready)
+      val imuFileId = insertFile(fileName = "imu.json", storageUrl = "s3://bucket/imu.json")
+      insertOrganizationMediaFile(fileId = imuFileId)
+
+      every { sqsTemplate.send(any<String>(), any<SplatterRequestMessage>()) } throws
+          RuntimeException("Request queue unavailable")
+
+      assertThrows<RuntimeException> {
+        service.generateOrganizationMediaSplat(
+            organizationId = organizationId,
+            fileId = orgFileId,
+            force = true,
+            runBirdnet = false,
+            additionalFiles = mapOf(imuFileId to "imu"),
+        )
+      }
+
+      assertTableEmpty(SPLAT_ADDITIONAL_FILES)
     }
 
     @Test


### PR DESCRIPTION
Make a splat's set of additional files fixed once it has been created.
Generating a splat with additional files throws an exception.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>