### PR TITLE
Use file extension as fallback in storage paths

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/file/FileService.kt
+++ b/src/main/kotlin/com/terraformation/backend/file/FileService.kt
@@ -145,7 +145,13 @@ class FileService(
         }
 
     return storageStream.use {
-      val storageUrl = fileStore.newUrl(clock.instant(), category, newFileMetadata.contentType)
+      val storageUrl =
+          fileStore.newUrl(
+              clock.instant(),
+              category,
+              newFileMetadata.contentType,
+              newFileMetadata.filenameWithoutPath,
+          )
 
       try {
         fileStore.write(storageUrl, storageStream)

--- a/src/main/kotlin/com/terraformation/backend/file/FileStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/file/FileStore.kt
@@ -83,6 +83,14 @@ interface FileStore {
    *
    * This will typically delegate the construction of the relative path to
    * [PathGenerator.generatePath].
+   *
+   * @param filename The name of the file as supplied by the client, if any. Used to determine the
+   *   file extension for content types that don't have standard extensions.
    */
-  fun newUrl(timestamp: Instant, category: String, contentType: String): URI
+  fun newUrl(
+      timestamp: Instant,
+      category: String,
+      contentType: String,
+      filename: String? = null,
+  ): URI
 }

--- a/src/main/kotlin/com/terraformation/backend/file/LocalFileStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/file/LocalFileStore.kt
@@ -80,8 +80,13 @@ class LocalFileStore(
     return Path(url.path.trimStart('/'))
   }
 
-  override fun newUrl(timestamp: Instant, category: String, contentType: String): URI {
-    return getUrl(pathGenerator.generatePath(timestamp, category, contentType))
+  override fun newUrl(
+      timestamp: Instant,
+      category: String,
+      contentType: String,
+      filename: String?,
+  ): URI {
+    return getUrl(pathGenerator.generatePath(timestamp, category, contentType, filename))
   }
 
   private fun getFullPath(url: URI): Path {

--- a/src/main/kotlin/com/terraformation/backend/file/PathGenerator.kt
+++ b/src/main/kotlin/com/terraformation/backend/file/PathGenerator.kt
@@ -19,8 +19,9 @@ import org.apache.tika.mime.MimeTypes
  * - `hhmmss` is the time part of the file's creation timestamp in UTC timezone.
  * - `random` is a 16-character-long random hexadecimal string. (See [generateBaseName] for
  *   details.)
- * - `.ext` is a file extension based on the file's MIME type, or `.bin` if the file's type doesn't
- *   have a standard file extension. For example, for JPEG files, the extension is `.jpg`.
+ * - `.ext` is a file extension based on the file's MIME type, or on the name of the uploaded file
+ *   if the MIME type doesn't have a standard extension, or `.bin` if neither of those yields an
+ *   extension. For example, for JPEG files, the extension is `.jpg`.
  */
 @Named
 class PathGenerator(private val random: Random = Random.Default) {
@@ -32,13 +33,23 @@ class PathGenerator(private val random: Random = Random.Default) {
   /**
    * Returns a unique path for a new file. This would typically be passed to [FileStore.getUrl].
    *
-   * @param contentType The MIME type of the file. This is used to determine the file extension. If
-   *   the MIME type is unknown, a default extension of `.bin` will be used.
+   * @param contentType The MIME type of the file. This is used to determine the file extension.
+   * @param filename The name of the file as supplied by the client, if any. Its extension is used
+   *   when [contentType] isn't a MIME type with a standard extension, which is the case for the
+   *   `+`-suffixed types that identify additional splat inputs. A default extension of `.bin` is
+   *   used if the filename has no usable extension either.
    */
-  fun generatePath(timestamp: Instant, category: String, contentType: String): Path {
+  fun generatePath(
+      timestamp: Instant,
+      category: String,
+      contentType: String,
+      filename: String? = null,
+  ): Path {
     val baseName = generateBaseName(timestamp)
     val extension =
-        MimeTypes.getDefaultMimeTypes().getRegisteredMimeType(contentType)?.extension ?: ".bin"
+        MimeTypes.getDefaultMimeTypes().getRegisteredMimeType(contentType)?.extension
+            ?: filenameExtension(filename)
+            ?: DEFAULT_EXTENSION
 
     return Path(
         yearFormatter.format(timestamp),
@@ -48,6 +59,18 @@ class PathGenerator(private val random: Random = Random.Default) {
         "$baseName$extension",
     )
   }
+
+  /**
+   * Returns the extension of a filename, including the leading `.`, or null if it doesn't have one.
+   * Since the extension becomes part of a storage path, extensions that aren't plain alphanumeric
+   * strings are rejected rather than sanitized.
+   */
+  private fun filenameExtension(filename: String?): String? =
+      filename
+          ?.substringAfterLast('.', missingDelimiterValue = "")
+          ?.lowercase()
+          ?.takeIf { extensionRegex.matches(it) }
+          ?.let { ".$it" }
 
   /**
    * Returns a unique string for use as the base part of the filename. The string is a 6-digit
@@ -63,4 +86,9 @@ class PathGenerator(private val random: Random = Random.Default) {
 
   private fun dateTimeFormatter(pattern: String) =
       DateTimeFormatter.ofPattern(pattern).withZone(ZoneOffset.UTC)!!
+
+  companion object {
+    private const val DEFAULT_EXTENSION = ".bin"
+    private val extensionRegex = Regex("[a-z0-9]{1,10}")
+  }
 }

--- a/src/main/kotlin/com/terraformation/backend/file/PathGenerator.kt
+++ b/src/main/kotlin/com/terraformation/backend/file/PathGenerator.kt
@@ -21,10 +21,15 @@ import org.apache.tika.mime.MimeTypes
  *   details.)
  * - `.ext` is a file extension based on the file's MIME type, or on the name of the uploaded file
  *   if the MIME type doesn't have a standard extension, or `.bin` if neither of those yields an
- *   extension. For example, for JPEG files, the extension is `.jpg`.
+ *   extension.
  */
 @Named
 class PathGenerator(private val random: Random = Random.Default) {
+  companion object {
+    private const val DEFAULT_EXTENSION = ".bin"
+    private val extensionRegex = Regex("[a-z0-9]{1,10}")
+  }
+
   private val yearFormatter = dateTimeFormatter("yyyy")
   private val monthFormatter = dateTimeFormatter("MM")
   private val dayFormatter = dateTimeFormatter("dd")
@@ -35,9 +40,8 @@ class PathGenerator(private val random: Random = Random.Default) {
    *
    * @param contentType The MIME type of the file. This is used to determine the file extension.
    * @param filename The name of the file as supplied by the client, if any. Its extension is used
-   *   when [contentType] isn't a MIME type with a standard extension, which is the case for the
-   *   `+`-suffixed types that identify additional splat inputs. A default extension of `.bin` is
-   *   used if the filename has no usable extension either.
+   *   when [contentType] isn't a MIME type with a standard extension. A default extension of `.bin`
+   *   is used if the filename has no usable extension either.
    */
   fun generatePath(
       timestamp: Instant,
@@ -86,9 +90,4 @@ class PathGenerator(private val random: Random = Random.Default) {
 
   private fun dateTimeFormatter(pattern: String) =
       DateTimeFormatter.ofPattern(pattern).withZone(ZoneOffset.UTC)!!
-
-  companion object {
-    private const val DEFAULT_EXTENSION = ".bin"
-    private val extensionRegex = Regex("[a-z0-9]{1,10}")
-  }
 }

--- a/src/main/kotlin/com/terraformation/backend/file/S3FileStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/file/S3FileStore.kt
@@ -166,8 +166,13 @@ class S3FileStore(config: TerrawareServerConfig, private val pathGenerator: Path
     }
   }
 
-  override fun newUrl(timestamp: Instant, category: String, contentType: String): URI {
-    return getUrl(pathGenerator.generatePath(timestamp, category, contentType))
+  override fun newUrl(
+      timestamp: Instant,
+      category: String,
+      contentType: String,
+      filename: String?,
+  ): URI {
+    return getUrl(pathGenerator.generatePath(timestamp, category, contentType, filename))
   }
 
   /**

--- a/src/main/kotlin/com/terraformation/backend/file/UploadService.kt
+++ b/src/main/kotlin/com/terraformation/backend/file/UploadService.kt
@@ -49,7 +49,7 @@ class UploadService(
       facilityId: FacilityId? = null,
       successStatus: UploadStatus = UploadStatus.AwaitingValidation,
   ): UploadId {
-    val url = fileStore.newUrl(clock.instant(), type.name, contentType)
+    val url = fileStore.newUrl(clock.instant(), type.name, contentType, fileName)
     val uploadsRow =
         UploadsRow(
             contentType = contentType,

--- a/src/test/kotlin/com/terraformation/backend/file/FileServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/file/FileServiceTest.kt
@@ -145,6 +145,23 @@ class FileServiceTest : DatabaseTest(), RunsAsUser {
     }
 
     @Test
+    fun `uses filename extension in storage URL if content type has no standard extension`() {
+      val data = Random.nextBytes(10)
+
+      val fileId =
+          fileService.storeFile(
+              "category",
+              data.inputStream(),
+              FileMetadata.of("application/json+frames", "frames.jsonl", data.size.toLong()),
+          ) {}
+
+      assertEquals(
+          URI("file:///2021/02/03/category/040506-0123456789ABCDEF.jsonl"),
+          filesDao.fetchOneById(fileId)!!.storageUrl,
+      )
+    }
+
+    @Test
     fun `stores file that has no EXIF metadata`() {
       val data = Random.nextBytes(10)
       val size = data.size.toLong()

--- a/src/test/kotlin/com/terraformation/backend/file/InMemoryFileStore.kt
+++ b/src/test/kotlin/com/terraformation/backend/file/InMemoryFileStore.kt
@@ -110,9 +110,14 @@ class InMemoryFileStore(private val pathGenerator: PathGenerator? = null) :
     return Path(url.path.trimStart('/'))
   }
 
-  override fun newUrl(timestamp: Instant, category: String, contentType: String): URI {
+  override fun newUrl(
+      timestamp: Instant,
+      category: String,
+      contentType: String,
+      filename: String?,
+  ): URI {
     return if (pathGenerator != null) {
-      getUrl(pathGenerator.generatePath(timestamp, category, contentType))
+      getUrl(pathGenerator.generatePath(timestamp, category, contentType, filename))
     } else {
       URI("file:///$timestamp/$category/${counter++}")
     }

--- a/src/test/kotlin/com/terraformation/backend/file/PathGeneratorTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/file/PathGeneratorTest.kt
@@ -1,7 +1,7 @@
 package com.terraformation.backend.file
 
 import java.time.Instant
-import kotlin.io.path.extension
+import kotlin.io.path.Path
 import kotlin.random.Random
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.params.ParameterizedTest
@@ -11,12 +11,16 @@ class PathGeneratorTest {
   private val timestamp = Instant.parse("2024-03-15T12:34:56Z")
   private val pathGenerator = PathGenerator(Random(0))
 
+  /** Hexadecimal form of the first value from the generator's seeded random number source. */
+  private val randomValue = "8CB4C22C53FEAE50"
+
   @CsvSource(
       "content type extension     , image/jpeg              ,                 , jpg",
       "content type beats filename, image/jpeg              , photo.png       , jpg",
-      "filename extension         , application/json+frames , frames.json     , json",
+      "filename extension         , application/json+frames , frames.jsonl    , jsonl",
       "uppercase filename         , application/x-bogus     , DATA.JSON       , json",
       "no filename                , application/json+frames ,                 , bin",
+      "filename with multiple dots, application/json+frames , foo.bar.jsonx   , jsonx",
       "filename without extension , application/x-bogus     , frames          , bin",
       "unusable filename extension, application/x-bogus     , frames.j/../son , bin",
       ignoreLeadingAndTrailingWhitespace = true,
@@ -30,6 +34,6 @@ class PathGeneratorTest {
   ) {
     val path = pathGenerator.generatePath(timestamp, "category", contentType, filename)
 
-    assertEquals(expectedExtension, path.extension)
+    assertEquals(Path("2024/03/15/category/123456-$randomValue.$expectedExtension"), path)
   }
 }

--- a/src/test/kotlin/com/terraformation/backend/file/PathGeneratorTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/file/PathGeneratorTest.kt
@@ -1,0 +1,63 @@
+package com.terraformation.backend.file
+
+import java.time.Instant
+import kotlin.io.path.extension
+import kotlin.random.Random
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class PathGeneratorTest {
+  private val timestamp = Instant.parse("2024-03-15T12:34:56Z")
+  private val pathGenerator = PathGenerator(Random(0))
+
+  @Test
+  fun `uses extension of content type`() {
+    val path = pathGenerator.generatePath(timestamp, "category", "image/jpeg")
+
+    assertEquals("jpg", path.extension)
+  }
+
+  @Test
+  fun `uses extension of content type if it differs from filename extension`() {
+    val path = pathGenerator.generatePath(timestamp, "category", "image/jpeg", "photo.png")
+
+    assertEquals("jpg", path.extension)
+  }
+
+  @Test
+  fun `uses filename extension if content type has no extension`() {
+    val path =
+        pathGenerator.generatePath(timestamp, "category", "application/json+frames", "frames.json")
+
+    assertEquals("json", path.extension)
+  }
+
+  @Test
+  fun `converts filename extension to lowercase`() {
+    val path = pathGenerator.generatePath(timestamp, "category", "application/x-bogus", "DATA.JSON")
+
+    assertEquals("json", path.extension)
+  }
+
+  @Test
+  fun `uses default extension if content type has no extension and there is no filename`() {
+    val path = pathGenerator.generatePath(timestamp, "category", "application/json+frames")
+
+    assertEquals("bin", path.extension)
+  }
+
+  @Test
+  fun `uses default extension if filename has no extension`() {
+    val path = pathGenerator.generatePath(timestamp, "category", "application/x-bogus", "frames")
+
+    assertEquals("bin", path.extension)
+  }
+
+  @Test
+  fun `uses default extension if filename extension is not alphanumeric`() {
+    val path =
+        pathGenerator.generatePath(timestamp, "category", "application/x-bogus", "frames.j/../son")
+
+    assertEquals("bin", path.extension)
+  }
+}

--- a/src/test/kotlin/com/terraformation/backend/file/PathGeneratorTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/file/PathGeneratorTest.kt
@@ -4,60 +4,32 @@ import java.time.Instant
 import kotlin.io.path.extension
 import kotlin.random.Random
 import org.junit.jupiter.api.Assertions.assertEquals
-import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.CsvSource
 
 class PathGeneratorTest {
   private val timestamp = Instant.parse("2024-03-15T12:34:56Z")
   private val pathGenerator = PathGenerator(Random(0))
 
-  @Test
-  fun `uses extension of content type`() {
-    val path = pathGenerator.generatePath(timestamp, "category", "image/jpeg")
+  @CsvSource(
+      "content type extension     , image/jpeg              ,                 , jpg",
+      "content type beats filename, image/jpeg              , photo.png       , jpg",
+      "filename extension         , application/json+frames , frames.json     , json",
+      "uppercase filename         , application/x-bogus     , DATA.JSON       , json",
+      "no filename                , application/json+frames ,                 , bin",
+      "filename without extension , application/x-bogus     , frames          , bin",
+      "unusable filename extension, application/x-bogus     , frames.j/../son , bin",
+      ignoreLeadingAndTrailingWhitespace = true,
+  )
+  @ParameterizedTest(name = "{0}")
+  fun `uses extension of content type, falling back to extension of filename`(
+      name: String,
+      contentType: String,
+      filename: String?,
+      expectedExtension: String,
+  ) {
+    val path = pathGenerator.generatePath(timestamp, "category", contentType, filename)
 
-    assertEquals("jpg", path.extension)
-  }
-
-  @Test
-  fun `uses extension of content type if it differs from filename extension`() {
-    val path = pathGenerator.generatePath(timestamp, "category", "image/jpeg", "photo.png")
-
-    assertEquals("jpg", path.extension)
-  }
-
-  @Test
-  fun `uses filename extension if content type has no extension`() {
-    val path =
-        pathGenerator.generatePath(timestamp, "category", "application/json+frames", "frames.json")
-
-    assertEquals("json", path.extension)
-  }
-
-  @Test
-  fun `converts filename extension to lowercase`() {
-    val path = pathGenerator.generatePath(timestamp, "category", "application/x-bogus", "DATA.JSON")
-
-    assertEquals("json", path.extension)
-  }
-
-  @Test
-  fun `uses default extension if content type has no extension and there is no filename`() {
-    val path = pathGenerator.generatePath(timestamp, "category", "application/json+frames")
-
-    assertEquals("bin", path.extension)
-  }
-
-  @Test
-  fun `uses default extension if filename has no extension`() {
-    val path = pathGenerator.generatePath(timestamp, "category", "application/x-bogus", "frames")
-
-    assertEquals("bin", path.extension)
-  }
-
-  @Test
-  fun `uses default extension if filename extension is not alphanumeric`() {
-    val path =
-        pathGenerator.generatePath(timestamp, "category", "application/x-bogus", "frames.j/../son")
-
-    assertEquals("bin", path.extension)
+    assertEquals(expectedExtension, path.extension)
   }
 }

--- a/src/test/kotlin/com/terraformation/backend/file/UploadServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/file/UploadServiceTest.kt
@@ -61,7 +61,7 @@ internal class UploadServiceTest : DatabaseTest(), RunsAsUser {
     val contentType = "text/csv"
     val type = UploadType.SpeciesCSV
 
-    every { fileStore.newUrl(any(), any(), any()) } returns storageUrl
+    every { fileStore.newUrl(any(), any(), any(), any()) } returns storageUrl
     every { fileStore.write(storageUrl, any()) } just Runs
     val organizationId = insertOrganization()
 
@@ -88,7 +88,7 @@ internal class UploadServiceTest : DatabaseTest(), RunsAsUser {
 
   @Test
   fun `receive does not leave behind uploads row if file fails to transfer to store`() {
-    every { fileStore.newUrl(any(), any(), any()) } returns storageUrl
+    every { fileStore.newUrl(any(), any(), any(), any()) } returns storageUrl
     every { fileStore.delete(storageUrl) } just Runs
     every { fileStore.write(storageUrl, any()) } throws IOException("uh oh")
 

--- a/src/test/kotlin/com/terraformation/backend/report/SeedFundReportFileServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/report/SeedFundReportFileServiceTest.kt
@@ -87,7 +87,7 @@ class SeedFundReportFileServiceTest : DatabaseTest(), RunsAsUser {
     seedFundReportId = insertSeedFundReport()
 
     every { fileStore.delete(any()) } just Runs
-    every { fileStore.newUrl(any(), any(), any()) } answers { URI("${++storageUrlCount}") }
+    every { fileStore.newUrl(any(), any(), any(), any()) } answers { URI("${++storageUrlCount}") }
     every { fileStore.write(any(), any()) } just Runs
     every { user.canReadSeedFundReport(any()) } returns true
     every { user.canUpdateSeedFundReport(any()) } returns true
@@ -97,7 +97,7 @@ class SeedFundReportFileServiceTest : DatabaseTest(), RunsAsUser {
   inner class DeleteReport {
     @Test
     fun `report deletion triggers file and photo deletion`() {
-      excludeRecords { fileStore.newUrl(any(), any(), any()) }
+      excludeRecords { fileStore.newUrl(any(), any(), any(), any()) }
       excludeRecords { fileStore.write(any(), any()) }
 
       val fileId1 = storeFile(filename = "a.txt")


### PR DESCRIPTION
When a storage path gets created, if the mime type isn't found in the default list, use the file's original extension (optionally) to determine the storage path's extension.
If this doesn't exist, continue to fall back to .bin.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>