### PR TITLE
Add admin page for uploading a file batch

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/admin/AdminFileBatchesController.kt
+++ b/src/main/kotlin/com/terraformation/backend/admin/AdminFileBatchesController.kt
@@ -1,0 +1,105 @@
+package com.terraformation.backend.admin
+
+import com.terraformation.backend.api.RequireGlobalRole
+import com.terraformation.backend.customer.db.OrganizationStore
+import com.terraformation.backend.db.default_schema.FileBatchType
+import com.terraformation.backend.db.default_schema.GlobalRole
+import com.terraformation.backend.db.default_schema.OrganizationId
+import com.terraformation.backend.file.FileService
+import com.terraformation.backend.log.perClassLogger
+import com.terraformation.backend.tracking.OrganizationMediaService
+import org.springframework.stereotype.Controller
+import org.springframework.ui.Model
+import org.springframework.validation.annotation.Validated
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RequestPart
+import org.springframework.web.multipart.MultipartFile
+import org.springframework.web.servlet.mvc.support.RedirectAttributes
+
+@Controller
+@RequestMapping("/admin")
+@RequireGlobalRole([GlobalRole.SuperAdmin])
+@Validated
+class AdminFileBatchesController(
+    private val fileService: FileService,
+    private val organizationMediaService: OrganizationMediaService,
+    private val organizationStore: OrganizationStore,
+) {
+  private val log = perClassLogger()
+
+  @GetMapping("/fileBatches")
+  fun fileBatchesHome(model: Model): String {
+    model.addAttribute("organizations", organizationStore.fetchAll().sortedBy { it.id })
+    model.addAttribute("fileBatchTypes", FileBatchType.entries)
+
+    return "/admin/fileBatches"
+  }
+
+  /**
+   * Uploads a batch of organization media files. Each file may be given a content type that
+   * overrides the one the browser detected, which allows uploading files whose content types
+   * clients can't declare directly, such as the additional inputs for splat generation.
+   *
+   * The content type for a file is the element of [contentTypes] at the same position as the file
+   * in [files]; browsers submit an entry for every row of the form, including rows where no file
+   * was chosen, so the two lists stay aligned.
+   */
+  @PostMapping("/fileBatches")
+  fun uploadFileBatch(
+      @RequestParam organizationId: OrganizationId,
+      @RequestParam type: FileBatchType,
+      @RequestPart("files", required = false) files: List<MultipartFile>?,
+      @RequestParam("contentTypes", required = false) contentTypes: List<String>?,
+      redirectAttributes: RedirectAttributes,
+  ): String {
+    val fileList = files ?: emptyList()
+    val contentTypeList = contentTypes ?: emptyList()
+
+    if (fileList.size != contentTypeList.size) {
+      redirectAttributes.failureMessage =
+          "Got ${fileList.size} file(s) but ${contentTypeList.size} content type(s); can't tell " +
+              "which content type goes with which file."
+      return redirectToFileBatchesHome()
+    }
+
+    val uploads = fileList.zip(contentTypeList).filter { (file, _) -> !file.isEmpty }
+
+    if (uploads.isEmpty()) {
+      redirectAttributes.failureMessage = "No files were selected."
+      return redirectToFileBatchesHome()
+    }
+
+    try {
+      val fileBatchId = fileService.createFileBatch(type)
+
+      val details = uploads.map { (file, contentType) ->
+        val fileId =
+            organizationMediaService.upload(
+                organizationId = organizationId,
+                file = file,
+                caption = null,
+                fileBatchId = fileBatchId,
+                contentType = contentType.ifBlank { null },
+            )
+
+        "File $fileId: ${file.originalFilename} (${contentType.ifBlank { "detected" }})"
+      }
+
+      fileService.finishUploadingFileBatch(fileBatchId)
+
+      redirectAttributes.successMessage =
+          "Uploaded ${uploads.size} file(s) as $type batch $fileBatchId."
+      redirectAttributes.successDetails = details
+    } catch (e: Exception) {
+      log.error("Error uploading file batch", e)
+      redirectAttributes.failureMessage = "Failed to upload file batch: ${e.message}"
+    }
+
+    return redirectToFileBatchesHome()
+  }
+
+  private fun redirectToFileBatchesHome() = "redirect:/admin/fileBatches"
+}

--- a/src/main/kotlin/com/terraformation/backend/admin/AdminFileBatchesController.kt
+++ b/src/main/kotlin/com/terraformation/backend/admin/AdminFileBatchesController.kt
@@ -1,10 +1,10 @@
 package com.terraformation.backend.admin
 
 import com.terraformation.backend.api.RequireGlobalRole
+import com.terraformation.backend.customer.db.OrganizationStore
 import com.terraformation.backend.db.default_schema.FileBatchType
 import com.terraformation.backend.db.default_schema.GlobalRole
 import com.terraformation.backend.db.default_schema.OrganizationId
-import com.terraformation.backend.db.default_schema.tables.daos.OrganizationsDao
 import com.terraformation.backend.file.FileService
 import com.terraformation.backend.log.perClassLogger
 import com.terraformation.backend.tracking.OrganizationMediaService
@@ -26,13 +26,13 @@ import org.springframework.web.servlet.mvc.support.RedirectAttributes
 class AdminFileBatchesController(
     private val fileService: FileService,
     private val organizationMediaService: OrganizationMediaService,
-    private val organizationsDao: OrganizationsDao,
+    private val organizationStore: OrganizationStore,
 ) {
   private val log = perClassLogger()
 
   @GetMapping
   fun fileBatchesHome(model: Model): String {
-    model.addAttribute("organizations", organizationsDao.findAll().sortedBy { it.id })
+    model.addAttribute("organizations", organizationStore.fetchAll().sortedBy { it.id })
     model.addAttribute("fileBatchTypes", FileBatchType.entries)
 
     return "/admin/fileBatches"

--- a/src/main/kotlin/com/terraformation/backend/admin/AdminFileBatchesController.kt
+++ b/src/main/kotlin/com/terraformation/backend/admin/AdminFileBatchesController.kt
@@ -1,10 +1,10 @@
 package com.terraformation.backend.admin
 
 import com.terraformation.backend.api.RequireGlobalRole
-import com.terraformation.backend.customer.db.OrganizationStore
 import com.terraformation.backend.db.default_schema.FileBatchType
 import com.terraformation.backend.db.default_schema.GlobalRole
 import com.terraformation.backend.db.default_schema.OrganizationId
+import com.terraformation.backend.db.default_schema.tables.daos.OrganizationsDao
 import com.terraformation.backend.file.FileService
 import com.terraformation.backend.log.perClassLogger
 import com.terraformation.backend.tracking.OrganizationMediaService
@@ -20,19 +20,19 @@ import org.springframework.web.multipart.MultipartFile
 import org.springframework.web.servlet.mvc.support.RedirectAttributes
 
 @Controller
-@RequestMapping("/admin")
+@RequestMapping("/admin/fileBatches")
 @RequireGlobalRole([GlobalRole.SuperAdmin])
 @Validated
 class AdminFileBatchesController(
     private val fileService: FileService,
     private val organizationMediaService: OrganizationMediaService,
-    private val organizationStore: OrganizationStore,
+    private val organizationsDao: OrganizationsDao,
 ) {
   private val log = perClassLogger()
 
-  @GetMapping("/fileBatches")
+  @GetMapping
   fun fileBatchesHome(model: Model): String {
-    model.addAttribute("organizations", organizationStore.fetchAll().sortedBy { it.id })
+    model.addAttribute("organizations", organizationsDao.findAll().sortedBy { it.id })
     model.addAttribute("fileBatchTypes", FileBatchType.entries)
 
     return "/admin/fileBatches"
@@ -41,13 +41,13 @@ class AdminFileBatchesController(
   /**
    * Uploads a batch of organization media files. Each file may be given a content type that
    * overrides the one the browser detected, which allows uploading files whose content types
-   * clients can't declare directly, such as the additional inputs for splat generation.
+   * clients can't declare directly, such as the additional files for splat generation.
    *
    * The content type for a file is the element of [contentTypes] at the same position as the file
    * in [files]; browsers submit an entry for every row of the form, including rows where no file
    * was chosen, so the two lists stay aligned.
    */
-  @PostMapping("/fileBatches")
+  @PostMapping
   fun uploadFileBatch(
       @RequestParam organizationId: OrganizationId,
       @RequestParam type: FileBatchType,

--- a/src/main/kotlin/com/terraformation/backend/tracking/OrganizationMediaService.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/OrganizationMediaService.kt
@@ -38,13 +38,6 @@ class OrganizationMediaService(
 ) {
   private val log = perClassLogger()
 
-  /**
-   * Stores a media file for an organization.
-   *
-   * @param contentType Store the file with this content type rather than the one declared by the
-   *   client. The value is used as-is, so it may be a content type that wouldn't be accepted as an
-   *   upload, such as one of the `+`-suffixed types that identify additional splat inputs.
-   */
   fun upload(
       organizationId: OrganizationId,
       file: MultipartFile,

--- a/src/main/kotlin/com/terraformation/backend/tracking/OrganizationMediaService.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/OrganizationMediaService.kt
@@ -38,22 +38,30 @@ class OrganizationMediaService(
 ) {
   private val log = perClassLogger()
 
+  /**
+   * Stores a media file for an organization.
+   *
+   * @param contentType Store the file with this content type rather than the one declared by the
+   *   client. The value is used as-is, so it may be a content type that wouldn't be accepted as an
+   *   upload, such as one of the `+`-suffixed types that identify additional splat inputs.
+   */
   fun upload(
       organizationId: OrganizationId,
       file: MultipartFile,
       caption: String?,
       fileBatchId: FileBatchId? = null,
+      contentType: String? = null,
   ): FileId {
     requirePermissions { createOrganizationMedia(organizationId) }
 
-    val contentType = file.getPlainContentType(SUPPORTED_ADDITIONAL_MEDIA_TYPES)
+    val fileContentType = contentType ?: file.getPlainContentType(SUPPORTED_ADDITIONAL_MEDIA_TYPES)
     val filename = file.getFilename("media")
 
     val fileId =
         fileService.storeFile(
             "organizationMedia",
             file.inputStream,
-            FileMetadata.of(contentType, filename, file.size),
+            FileMetadata.of(fileContentType, filename, file.size),
             fileBatchId = fileBatchId,
         ) { (fileId, _) ->
           dslContext
@@ -66,7 +74,7 @@ class OrganizationMediaService(
 
     log.info("Stored media file $fileId for organization $organizationId")
 
-    if (contentType.startsWith("video/")) {
+    if (fileContentType.startsWith("video/")) {
       eventPublisher.publishEvent(
           OrganizationVideoUploadedEvent(fileId, organizationId, fileBatchId)
       )

--- a/src/main/kotlin/com/terraformation/backend/tracking/api/OrganizationMediaController.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/api/OrganizationMediaController.kt
@@ -135,9 +135,7 @@ data class UploadOrganizationMediaRequestPayload(
     val caption: String? = null,
     @Schema(
         description =
-            "Store the file with this content type rather than the one declared by the upload. " +
-                "Use this for content types a client can't declare directly, such as the " +
-                "\"+\"-suffixed types that identify additional splat inputs."
+            "Store the file with this content type rather than the one declared by the upload."
     )
     val contentType: String? = null,
     val fileBatchId: FileBatchId? = null,

--- a/src/main/kotlin/com/terraformation/backend/tracking/api/OrganizationMediaController.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/api/OrganizationMediaController.kt
@@ -16,6 +16,7 @@ import com.terraformation.backend.file.mux.MuxStreamModel
 import com.terraformation.backend.tracking.OrganizationMediaService
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.Parameter
+import io.swagger.v3.oas.annotations.media.Schema
 import org.locationtech.jts.geom.Point
 import org.springframework.http.MediaType
 import org.springframework.http.ResponseEntity
@@ -52,6 +53,7 @@ class OrganizationMediaController(
             file = file,
             caption = payload?.caption,
             fileBatchId = payload?.fileBatchId,
+            contentType = payload?.contentType,
         )
     return UploadOrganizationMediaResponsePayload(fileId)
   }
@@ -131,6 +133,13 @@ class OrganizationMediaController(
 
 data class UploadOrganizationMediaRequestPayload(
     val caption: String? = null,
+    @Schema(
+        description =
+            "Store the file with this content type rather than the one declared by the upload. " +
+                "Use this for content types a client can't declare directly, such as the " +
+                "\"+\"-suffixed types that identify additional splat inputs."
+    )
+    val contentType: String? = null,
     val fileBatchId: FileBatchId? = null,
 )
 

--- a/src/main/resources/templates/admin/fileBatches.html
+++ b/src/main/resources/templates/admin/fileBatches.html
@@ -37,11 +37,6 @@
     file for splat generation.
 </p>
 
-<p th:if="${#lists.isEmpty(organizations)}" style="background-color: red;">
-    You are not a member of any organizations, so you can't upload media files. Add yourself to an
-    organization first.
-</p>
-
 <form method="POST" action="/admin/fileBatches" enctype="multipart/form-data">
     <p>
         <label for="organizationId">Organization</label>

--- a/src/main/resources/templates/admin/fileBatches.html
+++ b/src/main/resources/templates/admin/fileBatches.html
@@ -32,10 +32,9 @@
 </p>
 
 <p>
-    You can set the content type of each file yourself. Leave it empty to use the content type
-    the browser detects, which must be one of the types the media upload API accepts. Fill it in
-    to store any content type you like, including ones a browser will never detect, such as
-    <code>application/json+cameraPoses</code>.
+    The content type of each file is detected from the file if left blank, or used directly.
+    An example would be <code>application/json+frames</code> for specifying the "frames" additional
+    file for splat generation.
 </p>
 
 <p th:if="${#lists.isEmpty(organizations)}" style="background-color: red;">

--- a/src/main/resources/templates/admin/fileBatches.html
+++ b/src/main/resources/templates/admin/fileBatches.html
@@ -25,10 +25,10 @@
 
 <p>
     Here you can upload a group of files as a single file batch. The files are stored as media
-    files for the organization you choose, and the batch is marked as finished uploading once
-    they have all been stored, which is what triggers any processing the batch type calls for.
-    A <code>Splat</code> batch generates a splat from the batch's video file, using the batch's
-    other files as additional inputs.
+    files for the organization you choose (only lists orgs you are a member of), and the batch is
+    marked as finished uploading once they have all been stored, which is what triggers any
+    processing the batch type calls for. A <code>Splat</code> batch generates a splat from the
+    batch's video file, using the batch's other files as additional inputs.
 </p>
 
 <p>

--- a/src/main/resources/templates/admin/fileBatches.html
+++ b/src/main/resources/templates/admin/fileBatches.html
@@ -1,0 +1,97 @@
+<!DOCTYPE HTML>
+<html xmlns:th="http://www.thymeleaf.org">
+<head th:replace="~{/admin/header :: head}">
+    <script th:fragment="additionalScript" type="application/javascript">
+        function addFileRow() {
+            const template = document.getElementById('fileRowTemplate');
+            const row = template.content.cloneNode(true);
+            document.getElementById('fileRows').appendChild(row);
+        }
+
+        function removeFileRow(button) {
+            button.closest('tr').remove();
+        }
+
+        document.addEventListener('DOMContentLoaded', addFileRow);
+    </script>
+</head>
+<body>
+
+<span th:replace="~{/admin/header :: top}"/>
+
+<a href="/admin/">Home</a>
+
+<h2>Upload File Batch</h2>
+
+<p>
+    Here you can upload a group of files as a single file batch. The files are stored as media
+    files for the organization you choose, and the batch is marked as finished uploading once
+    they have all been stored, which is what triggers any processing the batch type calls for.
+    A <code>Splat</code> batch generates a splat from the batch's video file, using the batch's
+    other files as additional inputs.
+</p>
+
+<p>
+    You can set the content type of each file yourself. Leave it empty to use the content type
+    the browser detects, which must be one of the types the media upload API accepts. Fill it in
+    to store any content type you like, including ones a browser will never detect, such as
+    <code>application/json+cameraPoses</code>.
+</p>
+
+<p th:if="${#lists.isEmpty(organizations)}" style="background-color: red;">
+    You are not a member of any organizations, so you can't upload media files. Add yourself to an
+    organization first.
+</p>
+
+<form method="POST" action="/admin/fileBatches" enctype="multipart/form-data">
+    <p>
+        <label for="organizationId">Organization</label>
+        <select id="organizationId" name="organizationId" required>
+            <option th:each="organization : ${organizations}" th:value="${organization.id}"
+                    th:text="|${organization.name} (${organization.id})|">
+                My Org (123)
+            </option>
+        </select>
+    </p>
+
+    <p>
+        <label for="type">Batch type</label>
+        <select id="type" name="type" required>
+            <option th:each="fileBatchType : ${fileBatchTypes}"
+                    th:value="${fileBatchType.jsonValue}"
+                    th:text="${fileBatchType.jsonValue}">
+                Splat
+            </option>
+        </select>
+    </p>
+
+    <table>
+        <thead>
+        <tr>
+            <th>File</th>
+            <th>Content type</th>
+            <th/>
+        </tr>
+        </thead>
+        <tbody id="fileRows"></tbody>
+    </table>
+
+    <p>
+        <button type="button" onclick="addFileRow()">Add another file</button>
+    </p>
+
+    <input type="submit" value="Upload Batch"/>
+</form>
+
+<template id="fileRowTemplate">
+    <tr>
+        <td><input type="file" name="files"/></td>
+        <td><input type="text" name="contentTypes" size="40" placeholder="Detect from file"/></td>
+        <td>
+            <button type="button" onclick="removeFileRow(this)">Remove</button>
+        </td>
+    </tr>
+</template>
+
+</body>
+</html>

--- a/src/main/resources/templates/admin/index.html
+++ b/src/main/resources/templates/admin/index.html
@@ -108,6 +108,10 @@
             <a href="/admin/eventLog">Event log</a>
         </p>
 
+        <p>
+            <a href="/admin/fileBatches">Upload file batch</a>
+        </p>
+
         <p th:if="${splatterEnabled}">
             <a href="/admin/splats">Splats</a>
         </p>

--- a/src/test/kotlin/com/terraformation/backend/tracking/OrganizationMediaServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/OrganizationMediaServiceTest.kt
@@ -135,18 +135,17 @@ internal class OrganizationMediaServiceTest : DatabaseTest(), RunsAsUser {
 
     @Test
     fun `stores caller-supplied content type that is not an accepted upload type`() {
-      val multipartFile =
-          MockMultipartFile("file", "poses.json", "application/octet-stream", ByteArray(1))
+      val multipartFile = MockMultipartFile("file", "imu.jsonl", "application/json", ByteArray(1))
 
       val fileId =
           service.upload(
               organizationId,
               multipartFile,
               "caption",
-              contentType = "application/json+cameraPoses",
+              contentType = "application/json+imu",
           )
 
-      assertEquals("application/json+cameraPoses", filesDao.fetchOneById(fileId)!!.contentType)
+      assertEquals("application/json+imu", filesDao.fetchOneById(fileId)!!.contentType)
     }
 
     @Test
@@ -163,7 +162,7 @@ internal class OrganizationMediaServiceTest : DatabaseTest(), RunsAsUser {
     @Test
     fun `rejects unsupported content type when caller does not supply one`() {
       val multipartFile =
-          MockMultipartFile("file", "poses.json", "application/octet-stream", ByteArray(1))
+          MockMultipartFile("file", "frames.jsonl", "application/octet-stream", ByteArray(1))
 
       assertThrows<NotSupportedException> {
         service.upload(organizationId, multipartFile, "caption")

--- a/src/test/kotlin/com/terraformation/backend/tracking/OrganizationMediaServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/OrganizationMediaServiceTest.kt
@@ -23,6 +23,7 @@ import com.terraformation.backend.mockUser
 import com.terraformation.backend.point
 import io.mockk.every
 import io.mockk.mockk
+import jakarta.ws.rs.NotSupportedException
 import java.io.ByteArrayInputStream
 import java.net.URI
 import org.junit.jupiter.api.Assertions.assertArrayEquals
@@ -130,6 +131,43 @@ internal class OrganizationMediaServiceTest : DatabaseTest(), RunsAsUser {
       eventPublisher.assertEventPublished(
           OrganizationVideoUploadedEvent(fileId, organizationId, fileBatchId)
       )
+    }
+
+    @Test
+    fun `stores caller-supplied content type that is not an accepted upload type`() {
+      val multipartFile =
+          MockMultipartFile("file", "poses.json", "application/octet-stream", ByteArray(1))
+
+      val fileId =
+          service.upload(
+              organizationId,
+              multipartFile,
+              "caption",
+              contentType = "application/json+cameraPoses",
+          )
+
+      assertEquals("application/json+cameraPoses", filesDao.fetchOneById(fileId)!!.contentType)
+    }
+
+    @Test
+    fun `publishes OrganizationVideoUploadedEvent based on caller-supplied content type`() {
+      val multipartFile =
+          MockMultipartFile("file", "clip.bin", "application/octet-stream", ByteArray(1))
+
+      val fileId =
+          service.upload(organizationId, multipartFile, "caption", contentType = "video/mp4")
+
+      eventPublisher.assertEventPublished(OrganizationVideoUploadedEvent(fileId, organizationId))
+    }
+
+    @Test
+    fun `rejects unsupported content type when caller does not supply one`() {
+      val multipartFile =
+          MockMultipartFile("file", "poses.json", "application/octet-stream", ByteArray(1))
+
+      assertThrows<NotSupportedException> {
+        service.upload(organizationId, multipartFile, "caption")
+      }
     }
   }
 

--- a/src/test/kotlin/com/terraformation/backend/tracking/OrganizationMediaServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/OrganizationMediaServiceTest.kt
@@ -149,7 +149,8 @@ internal class OrganizationMediaServiceTest : DatabaseTest(), RunsAsUser {
     }
 
     @Test
-    fun `publishes OrganizationVideoUploadedEvent based on caller-supplied content type`() {
+    fun `publishes OrganizationVideoUploadedEvent when overridden content type is video`() {
+      // any content type that starts with "video/" publishes this event.
       val multipartFile =
           MockMultipartFile("file", "clip.bin", "application/octet-stream", ByteArray(1))
 
@@ -157,6 +158,16 @@ internal class OrganizationMediaServiceTest : DatabaseTest(), RunsAsUser {
           service.upload(organizationId, multipartFile, "caption", contentType = "video/mp4")
 
       eventPublisher.assertEventPublished(OrganizationVideoUploadedEvent(fileId, organizationId))
+    }
+
+    @Test
+    fun `does not publish OrganizationVideoUploadedEvent when content type is overridden to non-video`() {
+      // any content type that starts with "video/" publishes this event.
+      val multipartFile = MockMultipartFile("file", "clip.bin", "video/mp4", ByteArray(1))
+
+      service.upload(organizationId, multipartFile, "caption", contentType = "not-video/mp4")
+
+      eventPublisher.assertEventNotPublished<OrganizationVideoUploadedEvent>()
     }
 
     @Test


### PR DESCRIPTION
Add a new admin page for uploading a file batch to an org's media.
Content type cna be overridden so that this page can be used for splats generated with arcore sidecar data files.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>