### PR TITLE
Don't save API request details on login redirect

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/auth/SecurityConfig.kt
+++ b/src/main/kotlin/com/terraformation/backend/auth/SecurityConfig.kt
@@ -7,6 +7,7 @@ import com.terraformation.backend.customer.model.DeviceManagerUser
 import com.terraformation.backend.customer.model.IndividualUser
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
+import org.springframework.http.HttpMethod
 import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
 import org.springframework.security.config.annotation.web.builders.HttpSecurity
@@ -21,7 +22,10 @@ import org.springframework.security.web.SecurityFilterChain
 import org.springframework.security.web.authentication.HttpStatusEntryPoint
 import org.springframework.security.web.context.SecurityContextHolderFilter
 import org.springframework.security.web.header.writers.StaticHeadersWriter
+import org.springframework.security.web.savedrequest.HttpSessionRequestCache
+import org.springframework.security.web.servlet.util.matcher.PathPatternRequestMatcher
 import org.springframework.security.web.util.matcher.MediaTypeRequestMatcher
+import org.springframework.security.web.util.matcher.OrRequestMatcher
 import org.springframework.web.cors.CorsConfiguration
 import org.springframework.web.cors.CorsConfigurationSource
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource
@@ -169,6 +173,21 @@ class SecurityConfig(
         matcher.setIgnoredMediaTypes(setOf(MediaType.ALL))
 
         defaultAuthenticationEntryPointFor(HttpStatusEntryPoint(HttpStatus.UNAUTHORIZED), matcher)
+      }
+
+      requestCache {
+        requestCache =
+            HttpSessionRequestCache().apply {
+              setRequestMatcher(
+                  OrRequestMatcher(
+                      listOf(
+                          PathPatternRequestMatcher.withDefaults()
+                              .matcher(HttpMethod.GET, "/api/v1/login"),
+                          PathPatternRequestMatcher.withDefaults().matcher("/admin/**"),
+                      )
+                  )
+              )
+            }
       }
     }
 


### PR DESCRIPTION
Configure Spring Security so that it only caches requests to the login
endpoint and the admin UI when a request is unauthenticated. This should
prevent a problem where a client could make multiple unauthenticated API
requests in rapid succession and end up getting redirected back to one
of those API endpoints rather than the redirect URI that was passed to
the `/api/v1/login` endpoint originally.