### PR TITLE
Report unmodified monitoring plots in map update dry run

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/admin/AdminPlantingSitesController.kt
+++ b/src/main/kotlin/com/terraformation/backend/admin/AdminPlantingSitesController.kt
@@ -781,17 +781,24 @@ class AdminPlantingSitesController(
     val substratumEdits =
         stratumEdit.substratumEdits.flatMap { describeSubstratumEdit(stratumEdit, it) }
 
+    val totalPermanent =
+        stratumEdit.monitoringPlotEdits.size +
+            stratumEdit.substratumEdits.sumOf { substratumEdit ->
+              substratumEdit.monitoringPlotEdits.count { it.permanentIndex != null }
+            }
+
     return listOf(
         if (existingModel != null) {
           if (desiredModel != null) {
             val overlapPercent = renderOverlapPercent(existingModel.boundary, desiredModel.boundary)
             val areaDifference = stratumEdit.areaHaDifference.toPlainString()
-            "$prefix Change in plantable area: ${areaDifference}ha, overlap $overlapPercent%"
+            "$prefix Change in plantable area: ${areaDifference}ha, overlap $overlapPercent%, " +
+                "$totalPermanent permanent plots"
           } else {
             "$prefix Delete (stable ID ${existingModel.stableId})"
           }
         } else {
-          "$prefix Create (stable ID ${desiredModel?.stableId})"
+          "$prefix Create (stable ID ${desiredModel?.stableId}), $totalPermanent permanent plots"
         }
     ) + monitoringPlotCreations + substratumEdits
   }
@@ -833,6 +840,12 @@ class AdminPlantingSitesController(
                   "$prefix Adopt plot ID $plotId without permanent index"
                 }
             is MonitoringPlotEdit.Eject -> "$prefix Eject plot ID $plotId"
+            is MonitoringPlotEdit.Accept ->
+                if (permanentIndex != null) {
+                  "$prefix Accept plot ID $plotId with permanent index $permanentIndex"
+                } else {
+                  "$prefix Accept plot ID $plotId without permanent index"
+                }
           }
         }
 

--- a/src/main/kotlin/com/terraformation/backend/tracking/ObservationService.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/ObservationService.kt
@@ -908,7 +908,9 @@ class ObservationService(
       // Abandon any active observations with incomplete plots in strata that are affected by the
       // edit.
       val affectedStratumIds =
-          event.plantingSiteEdit.stratumEdits.mapNotNull { it.existingModel?.id }
+          event.plantingSiteEdit.stratumEdits
+              .filterNot { it.isNoOp() }
+              .mapNotNull { it.existingModel?.id }
       val affectedObservationIds =
           observationStore.fetchActiveObservationIds(event.edited.id, affectedStratumIds)
 

--- a/src/main/kotlin/com/terraformation/backend/tracking/db/PlantingSiteStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/db/PlantingSiteStore.kt
@@ -590,7 +590,7 @@ class PlantingSiteStore(
       val replacementResults = mutableListOf<ReplacementResult>()
 
       if (
-          plantingSiteEdit.stratumEdits.isEmpty() &&
+          plantingSiteEdit.stratumEdits.all { it.isNoOp() } &&
               existing.boundary.equalsOrBothNull(plantingSiteEdit.desiredModel.boundary) &&
               existing.exclusion.equalsOrBothNull(plantingSiteEdit.desiredModel.exclusion)
       ) {
@@ -1062,6 +1062,8 @@ class PlantingSiteStore(
 
         ReplacementResult(emptySet(), setOf(edit.monitoringPlotId))
       }
+
+      is MonitoringPlotEdit.Accept -> ReplacementResult(emptySet(), emptySet())
     }
   }
 

--- a/src/main/kotlin/com/terraformation/backend/tracking/edit/MonitoringPlotEdit.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/edit/MonitoringPlotEdit.kt
@@ -70,4 +70,13 @@ sealed interface MonitoringPlotEdit {
     override val permanentIndex: Int?
       get() = null
   }
+
+  /**
+   * Represents a monitoring plot that is already in the correct substratum with the correct
+   * permanent index. This is just for reporting purposes; the plot won't be modified.
+   */
+  data class Accept(
+      override val monitoringPlotId: MonitoringPlotId,
+      override val permanentIndex: Int?,
+  ) : MonitoringPlotEdit
 }

--- a/src/main/kotlin/com/terraformation/backend/tracking/edit/PlantingSiteEditCalculator.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/edit/PlantingSiteEditCalculator.kt
@@ -262,14 +262,20 @@ class PlantingSiteEditCalculator(
                         desiredSubstrataByMonitoringPlotId[plotEdit.monitoringPlotId] ==
                             desiredSubstratum
                       }
-                      .filter { plotEdit ->
+                      .map { plotEdit ->
                         // If the plot is already in the right substratum with the right permanent
                         // index, no need to adopt it.
                         val monitoringPlotId = plotEdit.monitoringPlotId
                         val existingMonitoringPlot = existingMonitoringPlotsById[monitoringPlotId]
-                        existingSubstrataByMonitoringPlotId[monitoringPlotId] !=
-                            existingSubstratum ||
-                            existingMonitoringPlot?.permanentIndex != plotEdit.permanentIndex
+                        if (
+                            existingSubstrataByMonitoringPlotId[monitoringPlotId] !=
+                                existingSubstratum ||
+                                existingMonitoringPlot?.permanentIndex != plotEdit.permanentIndex
+                        ) {
+                          plotEdit
+                        } else {
+                          MonitoringPlotEdit.Accept(monitoringPlotId, plotEdit.permanentIndex)
+                        }
                       }
               val ejectEdits =
                   existingSubstratum.monitoringPlots

--- a/src/main/kotlin/com/terraformation/backend/tracking/edit/StratumEdit.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/edit/StratumEdit.kt
@@ -1,5 +1,6 @@
 package com.terraformation.backend.tracking.edit
 
+import com.fasterxml.jackson.annotation.JsonIgnore
 import com.terraformation.backend.tracking.model.AnyStratumModel
 import com.terraformation.backend.tracking.model.ExistingStratumModel
 import com.terraformation.backend.util.equalsIgnoreScale
@@ -48,6 +49,28 @@ sealed interface StratumEdit {
    * covered by the existing site's exclusion areas.
    */
   val removedRegion: MultiPolygon?
+
+  /** Returns true if this edit only reports unchanged monitoring plots. */
+  @JsonIgnore
+  fun isNoOp(): Boolean =
+      this is Update &&
+          areaHaDifference.equalsIgnoreScale(BigDecimal.ZERO) &&
+          addedRegion.isEmpty &&
+          removedRegion.isEmpty &&
+          existingModel.boundary.equalsOrBothNull(desiredModel.boundary) &&
+          existingModel.areaHa.equalsIgnoreScale(desiredModel.areaHa) &&
+          existingModel.name == desiredModel.name &&
+          existingModel.errorMargin.equalsIgnoreScale(desiredModel.errorMargin) &&
+          existingModel.initialPlantingDensity.equalsIgnoreScale(
+              desiredModel.initialPlantingDensity
+          ) &&
+          existingModel.numPermanentPlots == desiredModel.numPermanentPlots &&
+          existingModel.studentsT.equalsIgnoreScale(desiredModel.studentsT) &&
+          existingModel.variance.equalsIgnoreScale(desiredModel.variance) &&
+          monitoringPlotEdits.isEmpty() &&
+          substratumEdits.all { edit ->
+            edit.isNoOp() && existingModel.substrata.any { it.id == edit.existingModel?.id }
+          }
 
   fun equalsExact(other: StratumEdit, tolerance: Double = 0.0000001): Boolean =
       javaClass == other.javaClass &&

--- a/src/main/kotlin/com/terraformation/backend/tracking/edit/SubstratumEdit.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/edit/SubstratumEdit.kt
@@ -1,5 +1,6 @@
 package com.terraformation.backend.tracking.edit
 
+import com.fasterxml.jackson.annotation.JsonIgnore
 import com.terraformation.backend.tracking.model.AnySubstratumModel
 import com.terraformation.backend.tracking.model.ExistingSubstratumModel
 import com.terraformation.backend.util.equalsIgnoreScale
@@ -46,6 +47,22 @@ sealed interface SubstratumEdit {
    * covered by the existing site's exclusion areas.
    */
   val removedRegion: MultiPolygon?
+
+  /**
+   * Returns true if this edit only reports unchanged monitoring plots. Assumes the substratum stays
+   * in the same stratum.
+   */
+  @JsonIgnore
+  fun isNoOp(): Boolean =
+      this is Update &&
+          areaHaDifference.equalsIgnoreScale(BigDecimal.ZERO) &&
+          addedRegion.isEmpty &&
+          removedRegion.isEmpty &&
+          existingModel.boundary.equalsOrBothNull(desiredModel.boundary) &&
+          existingModel.areaHa.equalsIgnoreScale(desiredModel.areaHa) &&
+          existingModel.name == desiredModel.name &&
+          existingModel.fullName == desiredModel.fullName &&
+          monitoringPlotEdits.all { it is MonitoringPlotEdit.Accept }
 
   fun equalsExact(other: SubstratumEdit, tolerance: Double = 0.0000001): Boolean =
       javaClass == other.javaClass &&

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/plantingSiteStore/PlantingSiteStoreApplyEditTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/plantingSiteStore/PlantingSiteStoreApplyEditTest.kt
@@ -790,7 +790,7 @@ internal class PlantingSiteStoreApplyEditTest : BasePlantingSiteStoreTest() {
         )
       }
 
-      if (plantingSiteEdit.stratumEdits.isNotEmpty()) {
+      if (plantingSiteEdit.stratumEdits.any { !it.isNoOp() }) {
         assertHistories(existing, edited)
       }
 

--- a/src/test/kotlin/com/terraformation/backend/tracking/edit/PlantingSiteEditCalculatorTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/edit/PlantingSiteEditCalculatorTest.kt
@@ -42,7 +42,27 @@ class PlantingSiteEditCalculatorTest {
                             listOf(
                                 SubstratumEdit.Create(desiredModel = desired.strata[1].substrata[0])
                             ),
-                    )
+                    ),
+                    StratumEdit.Update(
+                        addedRegion = rectangle(0),
+                        areaHaDifference = BigDecimal.ZERO,
+                        desiredModel = desired.strata[0],
+                        existingModel = existing.strata[0],
+                        monitoringPlotEdits = emptyList(),
+                        substratumEdits =
+                            listOf(
+                                SubstratumEdit.Update(
+                                    addedRegion = rectangle(0),
+                                    areaHaDifference = BigDecimal.ZERO,
+                                    desiredModel = desired.strata[0].substrata[0],
+                                    existingModel = existing.strata[0].substrata[0],
+                                    monitoringPlotEdits =
+                                        listOf(MonitoringPlotEdit.Accept(MonitoringPlotId(1), 1)),
+                                    removedRegion = rectangle(0),
+                                )
+                            ),
+                        removedRegion = rectangle(0),
+                    ),
                 ),
         ),
         existing,
@@ -110,6 +130,7 @@ class PlantingSiteEditCalculatorTest {
                                     existingModel = existing.strata[0].substrata[0],
                                     monitoringPlotEdits =
                                         listOf(
+                                            MonitoringPlotEdit.Accept(MonitoringPlotId(1), 1),
                                             MonitoringPlotEdit.Adopt(MonitoringPlotId(2), 3),
                                         ),
                                     removedRegion = rectangle(0),
@@ -156,7 +177,27 @@ class PlantingSiteEditCalculatorTest {
                         desiredModel = desired.strata[0],
                         existingModel = existing.strata[0],
                         monitoringPlotEdits = emptyList(),
-                        substratumEdits = emptyList(),
+                        substratumEdits =
+                            listOf(
+                                SubstratumEdit.Update(
+                                    addedRegion = rectangle(0),
+                                    areaHaDifference = BigDecimal.ZERO,
+                                    desiredModel = desired.strata[0].substrata[0],
+                                    existingModel = existing.strata[0].substrata[0],
+                                    monitoringPlotEdits =
+                                        listOf(
+                                            MonitoringPlotEdit.Accept(MonitoringPlotId(1), 1),
+                                            MonitoringPlotEdit.Accept(MonitoringPlotId(2), 2),
+                                            MonitoringPlotEdit.Accept(MonitoringPlotId(3), 3),
+                                            MonitoringPlotEdit.Accept(MonitoringPlotId(4), 4),
+                                            MonitoringPlotEdit.Accept(MonitoringPlotId(5), 5),
+                                            MonitoringPlotEdit.Accept(MonitoringPlotId(6), 6),
+                                            MonitoringPlotEdit.Accept(MonitoringPlotId(7), 7),
+                                            MonitoringPlotEdit.Accept(MonitoringPlotId(8), 8),
+                                        ),
+                                    removedRegion = rectangle(0),
+                                )
+                            ),
                         removedRegion = rectangle(0),
                     )
                 ),
@@ -346,7 +387,18 @@ class PlantingSiteEditCalculatorTest {
                         desiredModel = desired.strata[0],
                         existingModel = existing.strata[0],
                         monitoringPlotEdits = emptyList(),
-                        substratumEdits = emptyList(),
+                        substratumEdits =
+                            listOf(
+                                SubstratumEdit.Update(
+                                    addedRegion = rectangle(0),
+                                    areaHaDifference = BigDecimal.ZERO,
+                                    desiredModel = desired.strata[0].substrata[0],
+                                    existingModel = existing.strata[0].substrata[0],
+                                    monitoringPlotEdits =
+                                        listOf(MonitoringPlotEdit.Accept(MonitoringPlotId(1), 1)),
+                                    removedRegion = rectangle(0),
+                                )
+                            ),
                         removedRegion = rectangle(x = 250, width = 250, height = 500),
                     ),
                 ),
@@ -397,7 +449,18 @@ class PlantingSiteEditCalculatorTest {
                         desiredModel = desired.strata[0],
                         existingModel = existing.strata[0],
                         monitoringPlotEdits = emptyList(),
-                        substratumEdits = emptyList(),
+                        substratumEdits =
+                            listOf(
+                                SubstratumEdit.Update(
+                                    addedRegion = rectangle(0),
+                                    areaHaDifference = BigDecimal.ZERO,
+                                    desiredModel = desired.strata[0].substrata[0],
+                                    existingModel = existing.strata[0].substrata[0],
+                                    monitoringPlotEdits =
+                                        listOf(MonitoringPlotEdit.Accept(MonitoringPlotId(1), 1)),
+                                    removedRegion = rectangle(0),
+                                )
+                            ),
                         removedRegion = rectangle(x = 250, width = 250, height = 500),
                     ),
                     StratumEdit.Update(
@@ -414,7 +477,19 @@ class PlantingSiteEditCalculatorTest {
                                     desiredModel = desired.strata[1].substrata[0],
                                     existingModel = existing.strata[0].substrata[1],
                                     monitoringPlotEdits =
-                                        listOf(MonitoringPlotEdit.Adopt(MonitoringPlotId(3), null)),
+                                        listOf(
+                                            MonitoringPlotEdit.Accept(MonitoringPlotId(2), 2),
+                                            MonitoringPlotEdit.Adopt(MonitoringPlotId(3), null),
+                                        ),
+                                    removedRegion = rectangle(0),
+                                ),
+                                SubstratumEdit.Update(
+                                    addedRegion = rectangle(0),
+                                    areaHaDifference = BigDecimal.ZERO,
+                                    desiredModel = desired.strata[1].substrata[1],
+                                    existingModel = existing.strata[1].substrata[0],
+                                    monitoringPlotEdits =
+                                        listOf(MonitoringPlotEdit.Accept(MonitoringPlotId(4), 1)),
                                     removedRegion = rectangle(0),
                                 ),
                             ),
@@ -712,10 +787,12 @@ class PlantingSiteEditCalculatorTest {
                                     areaHaDifference = BigDecimal("5.000"),
                                     desiredModel = desired.strata[0].substrata[0],
                                     existingModel = existing.strata[0].substrata[0],
-                                    // The unqualified plots are already in the correct substratum
-                                    // and already have null permanent indexes, so no need to update
-                                    // any of them.
-                                    monitoringPlotEdits = emptyList(),
+                                    monitoringPlotEdits =
+                                        listOf(
+                                            MonitoringPlotEdit.Accept(MonitoringPlotId(1), null),
+                                            MonitoringPlotEdit.Accept(MonitoringPlotId(2), null),
+                                            MonitoringPlotEdit.Accept(MonitoringPlotId(3), null),
+                                        ),
                                     removedRegion = rectangle(0),
                                 ),
                             ),
@@ -816,7 +893,21 @@ class PlantingSiteEditCalculatorTest {
                         existingModel = existing.strata[0],
                         monitoringPlotEdits =
                             listOf(MonitoringPlotEdit.Create(existing.boundary!!, 3)),
-                        substratumEdits = emptyList(),
+                        substratumEdits =
+                            listOf(
+                                SubstratumEdit.Update(
+                                    addedRegion = rectangle(0),
+                                    areaHaDifference = BigDecimal.ZERO,
+                                    desiredModel = desired.strata[0].substrata[0],
+                                    existingModel = existing.strata[0].substrata[0],
+                                    monitoringPlotEdits =
+                                        listOf(
+                                            MonitoringPlotEdit.Accept(MonitoringPlotId(1), 1),
+                                            MonitoringPlotEdit.Accept(MonitoringPlotId(2), 2),
+                                        ),
+                                    removedRegion = rectangle(0),
+                                )
+                            ),
                         removedRegion = rectangle(0),
                     )
                 ),
@@ -860,7 +951,11 @@ class PlantingSiteEditCalculatorTest {
                                     desiredModel = desired.strata[0].substrata[0],
                                     existingModel = existing.strata[0].substrata[0],
                                     monitoringPlotEdits =
-                                        listOf(MonitoringPlotEdit.Adopt(MonitoringPlotId(3), null)),
+                                        listOf(
+                                            MonitoringPlotEdit.Accept(MonitoringPlotId(1), 1),
+                                            MonitoringPlotEdit.Accept(MonitoringPlotId(2), 2),
+                                            MonitoringPlotEdit.Adopt(MonitoringPlotId(3), null),
+                                        ),
                                     removedRegion = rectangle(0),
                                 )
                             ),
@@ -889,6 +984,26 @@ class PlantingSiteEditCalculatorTest {
             existingModel = existing,
             stratumEdits =
                 listOf(
+                    StratumEdit.Update(
+                        addedRegion = rectangle(0),
+                        areaHaDifference = BigDecimal.ZERO,
+                        desiredModel = desired.strata[0],
+                        existingModel = existing.strata[0],
+                        monitoringPlotEdits = emptyList(),
+                        substratumEdits =
+                            listOf(
+                                SubstratumEdit.Update(
+                                    addedRegion = rectangle(0),
+                                    areaHaDifference = BigDecimal.ZERO,
+                                    desiredModel = desired.strata[0].substrata[0],
+                                    existingModel = existing.strata[0].substrata[0],
+                                    monitoringPlotEdits =
+                                        listOf(MonitoringPlotEdit.Accept(MonitoringPlotId(1), 1)),
+                                    removedRegion = rectangle(0),
+                                )
+                            ),
+                        removedRegion = rectangle(0),
+                    ),
                     StratumEdit.Delete(
                         existingModel = existing.strata[1],
                         substratumEdits =
@@ -899,7 +1014,7 @@ class PlantingSiteEditCalculatorTest {
                                         listOf(MonitoringPlotEdit.Eject(MonitoringPlotId(2))),
                                 )
                             ),
-                    )
+                    ),
                 ),
         ),
         existing,
@@ -991,7 +1106,8 @@ class PlantingSiteEditCalculatorTest {
                                     areaHaDifference = BigDecimal.ZERO,
                                     desiredModel = desired.strata[0].substrata[0],
                                     existingModel = existing.strata[0].substrata[0],
-                                    monitoringPlotEdits = emptyList(),
+                                    monitoringPlotEdits =
+                                        listOf(MonitoringPlotEdit.Accept(MonitoringPlotId(1), 1)),
                                     removedRegion = rectangle(0),
                                 )
                             ),
@@ -1010,7 +1126,8 @@ class PlantingSiteEditCalculatorTest {
                                     areaHaDifference = BigDecimal.ZERO,
                                     desiredModel = desired.strata[1].substrata[0],
                                     existingModel = existing.strata[1].substrata[0],
-                                    monitoringPlotEdits = emptyList(),
+                                    monitoringPlotEdits =
+                                        listOf(MonitoringPlotEdit.Accept(MonitoringPlotId(2), 1)),
                                     removedRegion = rectangle(0),
                                 )
                             ),
@@ -1058,10 +1175,31 @@ class PlantingSiteEditCalculatorTest {
                                     areaHaDifference = BigDecimal.ZERO,
                                     desiredModel = desired.strata[0].substrata[0],
                                     existingModel = existing.strata[0].substrata[0],
-                                    monitoringPlotEdits = emptyList(),
+                                    monitoringPlotEdits =
+                                        listOf(MonitoringPlotEdit.Accept(MonitoringPlotId(1), 1)),
                                     removedRegion = rectangle(0),
                                 )
                             ),
+                    ),
+                    StratumEdit.Update(
+                        addedRegion = rectangle(0),
+                        areaHaDifference = BigDecimal.ZERO,
+                        desiredModel = desired.strata[1],
+                        existingModel = existing.strata[1],
+                        monitoringPlotEdits = emptyList(),
+                        substratumEdits =
+                            listOf(
+                                SubstratumEdit.Update(
+                                    addedRegion = rectangle(0),
+                                    areaHaDifference = BigDecimal.ZERO,
+                                    desiredModel = desired.strata[1].substrata[0],
+                                    existingModel = existing.strata[1].substrata[0],
+                                    monitoringPlotEdits =
+                                        listOf(MonitoringPlotEdit.Accept(MonitoringPlotId(2), 1)),
+                                    removedRegion = rectangle(0),
+                                )
+                            ),
+                        removedRegion = rectangle(0),
                     ),
                     StratumEdit.Delete(existing.strata[0], emptyList()),
                 ),
@@ -1109,8 +1247,7 @@ class PlantingSiteEditCalculatorTest {
                                     monitoringPlotEdits =
                                         listOf(
                                             MonitoringPlotEdit.Eject(MonitoringPlotId(1)),
-                                            // Plot ID 2 is already in the correct substratum with
-                                            // the correct permanent index.
+                                            MonitoringPlotEdit.Accept(MonitoringPlotId(2), 1),
                                         ),
                                     removedRegion = rectangle(25),
                                 ),
@@ -1174,7 +1311,7 @@ class PlantingSiteEditCalculatorTest {
   }
 
   @Test
-  fun `returns empty list of edits if nothing changed`() {
+  fun `accepts existing monitoring plots if nothing changed`() {
     val existing = existingSite { stratum(numPermanent = 1) { substratum { permanent() } } }
     val desired = existing.toNew()
 
@@ -1183,7 +1320,29 @@ class PlantingSiteEditCalculatorTest {
             areaHaDifference = BigDecimal("0.0"),
             desiredModel = desired,
             existingModel = existing,
-            stratumEdits = emptyList(),
+            stratumEdits =
+                listOf(
+                    StratumEdit.Update(
+                        addedRegion = rectangle(0),
+                        areaHaDifference = BigDecimal.ZERO,
+                        desiredModel = desired.strata[0],
+                        existingModel = existing.strata[0],
+                        monitoringPlotEdits = emptyList(),
+                        substratumEdits =
+                            listOf(
+                                SubstratumEdit.Update(
+                                    addedRegion = rectangle(0),
+                                    areaHaDifference = BigDecimal.ZERO,
+                                    desiredModel = desired.strata[0].substrata[0],
+                                    existingModel = existing.strata[0].substrata[0],
+                                    monitoringPlotEdits =
+                                        listOf(MonitoringPlotEdit.Accept(MonitoringPlotId(1), 1)),
+                                    removedRegion = rectangle(0),
+                                )
+                            ),
+                        removedRegion = rectangle(0),
+                    )
+                ),
         ),
         existing,
         desired,


### PR DESCRIPTION
Previously, when you uploaded an updated shapefile for a planting site
and selected the "Dry Run" option, we would only show line items for
monitoring plots that needed to be updated; monitoring plots that were
already in the correct substrata and already had the correct permanent
indexes were omitted. The idea was to keep the dry run output concise.

The GIS team (the main consumer of this feature) wants more detailed
dry run outputs so they can compare the proposed lists of monitoring
plots with their expectations.

Change the edit calculation to include a new "Accept" monitoring plot
edit type, indicating that a plot will remain unchanged.