### PR TITLE
Eagerly create permanent plots on map update

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/tracking/db/PlantingSiteStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/db/PlantingSiteStore.kt
@@ -833,6 +833,10 @@ class PlantingSiteStore(
               now,
           )
         }
+
+        replacementResults.addAll(
+            applyPermanentPlotCreations(edit.monitoringPlotEdits, plantingSiteId, stratumId)
+        )
       }
       is StratumEdit.Delete -> {
         replacementResults.addAll(
@@ -915,27 +919,43 @@ class PlantingSiteStore(
           }
         }
 
-        // Need to create permanent plots using the updated substrata since we need their IDs.
-        val updatedSite = fetchSiteById(plantingSiteId, PlantingSiteDepth.Plot)
-        val updatedStratum = updatedSite.strata.single { it.id == edit.existingModel.id }
-
-        edit.monitoringPlotEdits
-            .filter { it.permanentIndex != null }
-            .groupBy { it.region }
-            .forEach { (region, plotEdits) ->
-              val newPlotIds =
-                  createPermanentPlots(
-                      updatedSite,
-                      updatedStratum,
-                      plotEdits.map { it.permanentIndex!! },
-                      region,
-                  )
-              replacementResults.add(ReplacementResult(newPlotIds.toSet(), emptySet()))
-            }
+        replacementResults.addAll(
+            applyPermanentPlotCreations(
+                edit.monitoringPlotEdits,
+                plantingSiteId,
+                edit.existingModel.id,
+            )
+        )
       }
     }
 
     return ReplacementResult.merge(replacementResults)
+  }
+
+  private fun applyPermanentPlotCreations(
+      edits: List<MonitoringPlotEdit.Create>,
+      plantingSiteId: PlantingSiteId,
+      stratumId: StratumId,
+  ): List<ReplacementResult> {
+    val plantingSite = fetchSiteById(plantingSiteId, PlantingSiteDepth.Plot)
+    val stratum = plantingSite.strata.single { it.id == stratumId }
+    val replacementResults = mutableListOf<ReplacementResult>()
+
+    edits
+        .filter { it.permanentIndex != null }
+        .groupBy { it.region }
+        .forEach { (region, plotEdits) ->
+          val newPlotIds =
+              createPermanentPlots(
+                  plantingSite,
+                  stratum,
+                  plotEdits.map { it.permanentIndex!! },
+                  region,
+              )
+          replacementResults.add(ReplacementResult(newPlotIds.toSet(), emptySet()))
+        }
+
+    return replacementResults
   }
 
   private fun applySubstratumEdit(

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/plantingSiteStore/PlantingSiteStoreApplyEditTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/plantingSiteStore/PlantingSiteStoreApplyEditTest.kt
@@ -570,10 +570,10 @@ internal class PlantingSiteStoreApplyEditTest : BasePlantingSiteStoreTest() {
       }
 
       val desired = newSite {
-        stratum(name = "A", stableId = StableId("B"), x = 250, width = 250) {
+        stratum(name = "A", stableId = StableId("B"), x = 250, width = 250, numPermanent = 3) {
           substratum(stableId = StableId("B-S2"))
         }
-        stratum(name = "B", stableId = StableId("A"), x = 0, width = 250) {
+        stratum(name = "B", stableId = StableId("A"), x = 0, width = 250, numPermanent = 4) {
           substratum(stableId = StableId("A-S1"))
         }
       }
@@ -589,6 +589,14 @@ internal class PlantingSiteStoreApplyEditTest : BasePlantingSiteStoreTest() {
           existing.strata.associate { it.stableId to it.id },
           edited.strata.associate { it.stableId to it.id },
           "Stratum IDs by stable ID after name swap",
+      )
+
+      assertEquals(
+          mapOf("A" to 3, "B" to 4),
+          edited.strata.associate { stratum ->
+            stratum.name to stratum.substrata.sumOf { it.monitoringPlots.size }
+          },
+          "Monitoring plots in each stratum",
       )
     }
 


### PR DESCRIPTION
Previously, when a map edit created a new stratum, we would adopt any
existing permanent plots that were in its boundary, but we wouldn't
create any additional permanent plots, instead relying on the fact that
permanent plots are created as needed at observation start time.

The GIS team has requested that we eagerly create plots in that case,
so they can do a more useful before-and-after comparison of an edited
site including its monitoring plot layout.