### PR TITLE
SW-8817 Place temporary plots in substrata with space

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/admin/AdminPlantingSitesController.kt
+++ b/src/main/kotlin/com/terraformation/backend/admin/AdminPlantingSitesController.kt
@@ -39,7 +39,6 @@ import com.terraformation.backend.tracking.model.NewObservationModel
 import com.terraformation.backend.tracking.model.PlantingSiteDepth
 import com.terraformation.backend.tracking.model.PlantingSiteModel
 import com.terraformation.backend.tracking.model.Shapefile
-import com.terraformation.backend.tracking.model.SubstratumFullException
 import com.terraformation.backend.util.nearlyCoveredBy
 import com.terraformation.backend.util.toMultiPolygon
 import io.swagger.v3.oas.annotations.Hidden
@@ -228,19 +227,15 @@ class AdminPlantingSitesController(
                 val numPermanent = stratum.numPermanentPlots
 
                 val temporaryPlotsAndIds: List<Pair<Polygon, MonitoringPlotId?>> =
-                    try {
-                      stratum
-                          .chooseTemporaryPlots(
-                              site.strata
-                                  .flatMap { stratum -> stratum.substrata.map { it.id } }
-                                  .toSet(),
-                              gridOrigin = site.gridOrigin!!,
-                              exclusion = site.exclusion,
-                          )
-                          .map { boundary -> boundary to stratum.findMonitoringPlot(boundary)?.id }
-                    } catch (e: SubstratumFullException) {
-                      emptyList()
-                    }
+                    stratum
+                        .chooseTemporaryPlots(
+                            site.strata
+                                .flatMap { stratum -> stratum.substrata.map { it.id } }
+                                .toSet(),
+                            gridOrigin = site.gridOrigin!!,
+                            exclusion = site.exclusion,
+                        )
+                        .map { boundary -> boundary to stratum.findMonitoringPlot(boundary)?.id }
                 val temporaryPlotIds = temporaryPlotsAndIds.mapNotNull { (_, id) -> id }.toSet()
 
                 // Temporary plots that, if this were the start of an actual observation, we would

--- a/src/main/kotlin/com/terraformation/backend/tracking/model/StratumModel.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/model/StratumModel.kt
@@ -75,9 +75,13 @@ data class StratumModel<
    * - Plots that are already selected as permanent plots aren't eligible.
    * - Plots that span substratum boundaries aren't eligible.
    * - Plots in substrata that were not requested for the observation aren't eligible.
-   * - Plots must be spread across substrata as evenly as possible: the number of temporary plots
-   *   can't vary by more than 1 between substrata. This even spreading doesn't take eligibility
-   *   into account.
+   * - Plots must be spread across substrata as evenly as possible: the quota assigned to each
+   *   substratum can't vary by more than 1 between substrata. This even spreading doesn't take
+   *   eligibility into account.
+   * - A requested substratum that doesn't have room for its whole quota passes the remainder to the
+   *   other requested substrata, one plot at a time so the plots stay as evenly spread as the
+   *   available space allows. Quotas belonging to unrequested substrata are dropped rather than
+   *   passed on.
    * - If plots can't be exactly evenly spread across substrata (that is, [numTemporaryPlots] is not
    *   a multiple of the number of substrata), the substrata for the remaining plots are determined
    *   using the following criteria in order (with the later criteria used as a tiebreaker if more
@@ -99,11 +103,10 @@ data class StratumModel<
    *   using the stratum's configured permanent plot count.
    * @return A collection of plot boundaries. These may or may not be the boundaries of plots that
    *   already exist in the database; callers can use [findMonitoringPlot] to check whether they
-   *   already exist.
+   *   already exist. Fewer boundaries than requested are returned if the substrata don't have room
+   *   for all of them.
    * @throws IllegalArgumentException The number of temporary plots hasn't been configured or the
    *   stratum has no substrata.
-   * @throws SubstratumFullException There weren't enough eligible plots available in a substratum
-   *   to choose the required number.
    */
   fun chooseTemporaryPlots(
       requestedSubstratumIds: Set<SubstratumId>,
@@ -122,47 +125,81 @@ data class StratumModel<
 
     // Any plots that can't be spread evenly will be placed in the substrata with the smallest
     // number of permanent plots, with priority given to substrata that are requested, and
-    // substratum ID
-    // used as a tie-breaker.
+    // substratum ID used as a tie-breaker.
     //
     // If we sort the substrata by those criteria, this means we can assign one extra plot each to
     // the first N substrata on that sorted list where N is the number of excess plots.
-    return substrata
-        .sortedWith(
-            compareBy { substratum: SubstratumModel<SSID> ->
-              substratum.monitoringPlots.count { plot -> isPermanent(plot, permanentPlotIds) }
-            }
-                .thenBy { if (it.id != null && it.id in requestedSubstratumIds) 0 else 1 }
-                .thenBy { it.id?.value ?: 0L }
-        )
-        .flatMapIndexed { index, substratum ->
-          if (substratum.id != null && substratum.id in requestedSubstratumIds) {
-            val numPlots =
-                if (index < numExcessPlots) {
-                  numEvenlySpreadPlotsPerSubstratum + 1
-                } else {
-                  numEvenlySpreadPlotsPerSubstratum
+    val quotas =
+        substrata
+            .sortedWith(
+                compareBy { substratum: SubstratumModel<SSID> ->
+                  substratum.monitoringPlots.count { plot -> isPermanent(plot, permanentPlotIds) }
                 }
+                    .thenBy { if (it.id != null && it.id in requestedSubstratumIds) 0 else 1 }
+                    .thenBy { it.id?.value ?: 0L }
+            )
+            .mapIndexed { index, substratum ->
+              val numPlots =
+                  if (index < numExcessPlots) {
+                    numEvenlySpreadPlotsPerSubstratum + 1
+                  } else {
+                    numEvenlySpreadPlotsPerSubstratum
+                  }
 
-            val squares =
-                findUnusedSquares(
-                    count = numPlots,
-                    exclusion = exclusion,
-                    gridOrigin = gridOrigin,
-                    searchBoundary = substratum.boundary,
-                    permanentPlotIds = permanentPlotIds,
-                )
-
-            if (squares.size < numPlots) {
-              throw SubstratumFullException(substratum.id, numPlots, squares.size)
+              substratum to numPlots
+            }
+            .filter { (substratum, _) ->
+              substratum.id != null && substratum.id in requestedSubstratumIds
             }
 
-            squares
-          } else {
-            // This substratum has no plants or wasn't requested, so it gets no temporary plots.
-            emptyList()
+    val chosenSquares = mutableListOf<Polygon>()
+
+    // Squares that have already been chosen are excluded from later searches.
+    var searchExclusion = exclusion
+
+    fun place(substratum: SubstratumModel<SSID>, numPlots: Int): Int {
+      val squares =
+          findUnusedSquares(
+              count = numPlots,
+              exclusion = searchExclusion,
+              gridOrigin = gridOrigin,
+              searchBoundary = substratum.boundary,
+              permanentPlotIds = permanentPlotIds,
+          )
+
+      searchExclusion =
+          squares.fold(searchExclusion) { acc, square ->
+            val triangle = middleTriangle(square)
+            (acc?.union(triangle) ?: triangle).toMultiPolygon()
           }
-        }
+
+      chosenSquares.addAll(squares)
+
+      return squares.size
+    }
+
+    // Substrata that didn't have room for their whole quotas pass the remainder to the ones that
+    // still have space, starting after any substrata that have already received excess plots due
+    // to the plot count not being a whole multiple of the substratum count.
+    var deficit = quotas.sumOf { (substratum, numPlots) -> numPlots - place(substratum, numPlots) }
+    var consecutiveFullSubstrata = 0
+    var quotaIndex = quotas.indexOfLast { it.second > numEvenlySpreadPlotsPerSubstratum } + 1
+
+    while (deficit > 0 && consecutiveFullSubstrata < quotas.size) {
+      val substratum = quotas[quotaIndex.rem(quotas.size)].first
+      val numPlaced = place(substratum, 1)
+
+      if (numPlaced > 0) {
+        consecutiveFullSubstrata = 0
+        deficit -= numPlaced
+      } else {
+        consecutiveFullSubstrata++
+      }
+
+      quotaIndex++
+    }
+
+    return chosenSquares
   }
 
   /**

--- a/src/test/kotlin/com/terraformation/backend/tracking/ObservationServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/ObservationServiceTest.kt
@@ -94,7 +94,6 @@ import com.terraformation.backend.tracking.event.ObservationMediaFileDeletedEven
 import com.terraformation.backend.tracking.event.ObservationMediaFileEditedEvent
 import com.terraformation.backend.tracking.event.ObservationMediaFileEditedEventValues
 import com.terraformation.backend.tracking.event.ObservationMediaFileUploadedEvent
-import com.terraformation.backend.tracking.event.ObservationNotStartedEvent
 import com.terraformation.backend.tracking.event.ObservationPlotReplacedEvent
 import com.terraformation.backend.tracking.event.ObservationRescheduledEvent
 import com.terraformation.backend.tracking.event.ObservationScheduledEvent
@@ -591,7 +590,7 @@ class ObservationServiceTest : DatabaseTest(), RunsAsDatabaseUser {
     }
 
     @Test
-    fun `deletes observation and publishes event if planting site is too small`() {
+    fun `starts observation with fewer plots if planting site is too small for all of them`() {
       val boundary = rectangle(MONITORING_PLOT_SIZE)
 
       insertStratum(boundary = boundary, numPermanentPlots = 1, numTemporaryPlots = 1)
@@ -602,9 +601,23 @@ class ObservationServiceTest : DatabaseTest(), RunsAsDatabaseUser {
 
       service.startObservation(observationId)
 
-      assertTableEmpty(OBSERVATIONS)
+      val observationPlots = observationPlotsDao.findAll()
 
-      eventPublisher.assertEventPublished(ObservationNotStartedEvent(observationId, plantingSiteId))
+      assertEquals(
+          listOf(true),
+          observationPlots.map { it.isPermanent },
+          "Should have only the one permanent plot; no room for a temporary plot",
+      )
+
+      assertEquals(
+          ObservationState.InProgress,
+          observationsDao.fetchOneById(observationId)!!.stateId,
+          "Observation state",
+      )
+
+      eventPublisher.assertEventPublished(
+          ObservationStartedEvent(observationStore.fetchObservationById(observationId))
+      )
     }
 
     @Test

--- a/src/test/kotlin/com/terraformation/backend/tracking/model/BaseStratumModelTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/model/BaseStratumModelTest.kt
@@ -78,12 +78,17 @@ abstract class BaseStratumModelTest {
 
   /**
    * Returns the boundary for a sample substratum. Substrata are arranged in a row from west to east
-   * and each one has room for 5 monitoring plots in the layout defined by [monitoringPlotBoundary],
-   * plus a 1-meter margin to account for floating-point inaccuracy.
+   * and each one has room for the requested number of monitoring plots in the layout defined by
+   * [monitoringPlotBoundary].
    */
   protected fun substratumBoundary(id: Int, numPlots: Int): MultiPolygon {
     return Turtle(siteOrigin).makeMultiPolygon {
       east(id * MONITORING_PLOT_SIZE * 2)
+
+      if (numPlots == 1) {
+        square(MONITORING_PLOT_SIZE)
+        return@makeMultiPolygon
+      }
 
       val southwest = currentPosition
 

--- a/src/test/kotlin/com/terraformation/backend/tracking/model/StratumModelTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/model/StratumModelTest.kt
@@ -2,15 +2,18 @@ package com.terraformation.backend.tracking.model
 
 import com.terraformation.backend.assertSetEquals
 import com.terraformation.backend.db.tracking.MonitoringPlotId
+import com.terraformation.backend.rectangle
 import com.terraformation.backend.util.Turtle
 import kotlin.random.Random
 import org.assertj.core.api.Assertions.assertThat
+import org.jooq.impl.DSL.square
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotEquals
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
+import org.locationtech.jts.geom.Polygon
 
 class StratumModelTest : BaseStratumModelTest() {
   @Nested
@@ -452,7 +455,7 @@ class StratumModelTest : BaseStratumModelTest() {
     }
 
     @Test
-    fun `throws exception if substratum has too few remaining plots`() {
+    fun `returns fewer plots if substratum does not have room for all of them`() {
       val model =
           stratumModel(
               numTemporaryPlots = 6,
@@ -460,9 +463,131 @@ class StratumModelTest : BaseStratumModelTest() {
                   listOf(substratumModel(plots = monitoringPlotModels(permanentIds = listOf(10)))),
           )
 
-      assertThrows<SubstratumFullException> {
-        model.chooseTemporaryPlots(substrataIds(1), siteOrigin)
-      }
+      assertEquals(
+          emptyList<Polygon>(),
+          model.chooseTemporaryPlots(substrataIds(1), siteOrigin).toList(),
+          "Should return no plots when the only position is taken by a permanent plot",
+      )
+    }
+
+    @Test
+    fun `spreads a full substratum's plots across the requested substrata that have room`() {
+      val model =
+          stratumModel(
+              numTemporaryPlots = 6,
+              substrata =
+                  listOf(
+                      // Full substratum
+                      substratumModel(
+                          id = 1,
+                          plots = monitoringPlotModels(permanentIds = listOf(10)),
+                      ),
+                      substratumModel(
+                          id = 2,
+                          plots = monitoringPlotModels(temporaryIds = listOf(20, 21, 22, 23, 24)),
+                      ),
+                      substratumModel(
+                          id = 3,
+                          plots = monitoringPlotModels(temporaryIds = listOf(30, 31, 32, 33, 34)),
+                      ),
+                      // Unrequested substratum
+                      substratumModel(
+                          id = 4,
+                          plots = monitoringPlotModels(temporaryIds = listOf(40, 41, 42)),
+                      ),
+                  ),
+          )
+
+      val availablePlotIds =
+          listOf(
+              monitoringPlotIds(10),
+              monitoringPlotIds(20, 21, 22, 23, 24),
+              monitoringPlotIds(30, 31, 32, 33, 34),
+              monitoringPlotIds(40, 41, 42),
+          )
+
+      val chosenIds =
+          model.chooseTemporaryPlots(substrataIds(1, 2, 3), siteOrigin).map {
+            model.findMonitoringPlot(it)?.id
+          }
+      val chosenIdSet = chosenIds.toSet()
+
+      val numChosenPerSubstratum = availablePlotIds.map { ids -> ids.intersect(chosenIdSet).size }
+
+      assertEquals(
+          listOf(0, 3, 2, 0),
+          numChosenPerSubstratum,
+          "Number of plots chosen in each substratum",
+      )
+
+      assertEquals(
+          chosenIds.distinct(),
+          chosenIds,
+          "Should not choose the same plot multiple times",
+      )
+    }
+
+    @Test
+    fun `redistributes remaining plots to substrata with fewest temporary plots`() {
+      val model =
+          stratumModel(
+              numTemporaryPlots = 4,
+              substrata =
+                  listOf(
+                      substratumModel(
+                          id = 1,
+                          plots = monitoringPlotModels(temporaryIds = listOf(10, 11, 12, 13)),
+                      ),
+                      substratumModel(
+                          id = 2,
+                          plots = monitoringPlotModels(temporaryIds = listOf(20, 21, 22, 23)),
+                      ),
+                      substratumModel(
+                          id = 3,
+                          plots = monitoringPlotModels(permanentIds = listOf(30)),
+                      ),
+                  ),
+          )
+
+      val chosenIds =
+          model.chooseTemporaryPlots(substrataIds(1, 2, 3), siteOrigin).map {
+            model.findMonitoringPlot(it)?.id
+          }
+      val numChosenPerSubstratum =
+          model.substrata.map { substratum ->
+            substratum.monitoringPlots.count { it.id in chosenIds }
+          }
+
+      assertEquals(
+          listOf(2, 2, 0),
+          numChosenPerSubstratum,
+          "Remaining plots should be spread evenly across substrata with space",
+      )
+    }
+
+    @Test
+    fun `returns fewer plots when no substratum has room for the remainder`() {
+      val model =
+          stratumModel(
+              numTemporaryPlots = 6,
+              substrata =
+                  listOf(
+                      substratumModel(
+                          id = 1,
+                          plots = monitoringPlotModels(temporaryIds = listOf(10, 11)),
+                      ),
+                      substratumModel(
+                          id = 2,
+                          plots = monitoringPlotModels(temporaryIds = listOf(20, 21)),
+                      ),
+                  ),
+          )
+
+      assertEquals(
+          4,
+          model.chooseTemporaryPlots(substrataIds(1, 2), siteOrigin).size,
+          "Should return as many plots as will fit",
+      )
     }
   }
 


### PR DESCRIPTION
Previously, if a stratum had a substratum that was too small for whatever
number of temporary plots it should contain according to the "spread
temporary plots evenly across substrata" rule, we treated it as a
failure and refused to start the observation.

Change the allocation code so that it instead tries to place the excess
plots in whichever other requested substrata have room for them. If no
requested substrata have room, don't treat it as a failure, but allow
the observation to start with a reduced plot count.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>