### PR TITLE
SW-8817 Add ratio-aware plot allocator

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/tracking/model/Exceptions.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/model/Exceptions.kt
@@ -1,5 +1,6 @@
 package com.terraformation.backend.tracking.model
 
+import com.terraformation.backend.db.tracking.StratumId
 import com.terraformation.backend.db.tracking.SubstratumId
 
 class SubstratumFullException(
@@ -11,3 +12,6 @@ class SubstratumFullException(
         "Substratum $substratumId needs $plotsNeeded temporary plots but only " +
             "$plotsRemaining available"
     )
+
+class StratumFullException(val stratumId: StratumId) :
+    IllegalStateException("Stratum $stratumId has no room for any monitoring plots")

--- a/src/main/kotlin/com/terraformation/backend/tracking/model/StratumModel.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/model/StratumModel.kt
@@ -256,8 +256,10 @@ data class StratumModel<
       sizeMeters: Number,
       exclusion: MultiPolygon? = null,
       searchBoundary: MultiPolygon = this.boundary,
+      predicate: (Polygon) -> Boolean = { true },
   ): Polygon? {
-    return UnusedSquareFinder(searchBoundary, gridOrigin, sizeMeters, exclusion).findUnusedSquare()
+    return UnusedSquareFinder(searchBoundary, gridOrigin, sizeMeters, exclusion, predicate)
+        .findUnusedSquare()
   }
 
   /**
@@ -286,6 +288,7 @@ data class StratumModel<
       exclusion: MultiPolygon? = null,
       searchBoundary: MultiPolygon = this.boundary,
       permanentPlotIds: Set<MonitoringPlotId>? = null,
+      predicate: (Polygon) -> Boolean = { true },
   ): List<Polygon> {
     // For purposes of checking whether or not a particular grid position is available, we treat
     // existing permanent plots as part of the exclusion area.
@@ -298,7 +301,13 @@ data class StratumModel<
 
     return (1..count).mapNotNull { squareNumber ->
       val square =
-          findUnusedSquare(gridOrigin, sizeMeters, exclusionWithAllocatedSquares, searchBoundary)
+          findUnusedSquare(
+              gridOrigin,
+              sizeMeters,
+              exclusionWithAllocatedSquares,
+              searchBoundary,
+              predicate,
+          )
 
       if (square != null && squareNumber < count) {
         // Prevent this square from being selected again by excluding an area in the middle of it.

--- a/src/main/kotlin/com/terraformation/backend/tracking/model/StratumPlotAllocator.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/model/StratumPlotAllocator.kt
@@ -1,0 +1,121 @@
+package com.terraformation.backend.tracking.model
+
+import com.terraformation.backend.db.tracking.MonitoringPlotId
+import com.terraformation.backend.db.tracking.SubstratumId
+import com.terraformation.backend.util.nearlyCoveredBy
+import kotlin.math.roundToInt
+import org.locationtech.jts.geom.MultiPolygon
+import org.locationtech.jts.geom.Point
+import org.locationtech.jts.geom.Polygon
+
+/**
+ * Chooses the monitoring plots for one stratum in one observation.
+ *
+ * A stratum can hold fewer plots than it is configured for. When that happens, 75% of the plots
+ * that fit are allocated as permanent, 25% as temporary. This can mean demoting a permanent plot to
+ * temporary even though its permanent index is less than [StratumModel.numPermanentPlots].
+ */
+class StratumPlotAllocator(
+    private val stratum: ExistingStratumModel,
+    private val gridOrigin: Point,
+    private val exclusion: MultiPolygon?,
+) {
+  /**
+   * Fraction of a stratum's plots that should be treated as permanent when there isn't room for the
+   * full number of configured plots.
+   */
+  private val permanentPlotFraction = 0.75
+
+  /**
+   * Allocates as many plots as possible (up to the configured limits) in the stratum.
+   *
+   * @throws StratumFullException The stratum has no room for any monitoring plots at all.
+   */
+  fun allocate(requestedSubstratumIds: Set<SubstratumId>): Allocation {
+    val numConfigured = stratum.numPermanentPlots + stratum.numTemporaryPlots
+
+    val existingPermanent =
+        stratum.substrata
+            .flatMap { it.monitoringPlots }
+            .filter { plot ->
+              plot.permanentIndex != null && plot.permanentIndex <= stratum.numPermanentPlots
+            }
+            .sortedBy { it.permanentIndex }
+
+    val numUnusedSquares =
+        stratum
+            .findUnusedSquares(
+                count = numConfigured - existingPermanent.size,
+                exclusion = exclusion,
+                gridOrigin = gridOrigin,
+                predicate = { squareBoundary ->
+                  stratum.substrata.any { squareBoundary.nearlyCoveredBy(it.boundary) }
+                },
+            )
+            .size
+
+    var numAllocated = existingPermanent.size + numUnusedSquares
+
+    if (numAllocated == 0) {
+      throw StratumFullException(stratum.id)
+    }
+
+    if (numAllocated >= numConfigured) {
+      return Allocation(
+          permanentPlotIds = stratum.choosePermanentPlots(requestedSubstratumIds),
+          temporaryPlotBoundaries =
+              stratum.chooseTemporaryPlots(requestedSubstratumIds, gridOrigin, exclusion),
+          numConfigured = numConfigured,
+          numAllocated = numAllocated,
+      )
+    }
+
+    var numPermanent = existingPermanent.size
+    while (numPermanent > (numAllocated * permanentPlotFraction).roundToInt()) {
+      val demotedPlot = existingPermanent[--numPermanent]
+
+      // A permanent plot can cross substratum boundaries, but a temporary plot must fit within
+      // one substratum. Losing such a plot reduces capacity and can require further demotions.
+      if (stratum.substrata.none { demotedPlot.boundary.nearlyCoveredBy(it.boundary) }) {
+        numAllocated--
+      }
+    }
+
+    val permanentPlotIds = existingPermanent.take(numPermanent).map { it.id }.toSet()
+
+    return Allocation(
+        permanentPlotIds =
+            permanentPlotIds.intersect(stratum.choosePermanentPlots(requestedSubstratumIds)),
+        temporaryPlotBoundaries =
+            stratum.chooseTemporaryPlots(
+                requestedSubstratumIds,
+                gridOrigin,
+                exclusion,
+                count = numAllocated - numPermanent,
+                permanentPlotIds = permanentPlotIds,
+            ),
+        numConfigured = numConfigured,
+        numAllocated = numAllocated,
+    )
+  }
+
+  /** The monitoring plots chosen for a stratum in an observation. */
+  data class Allocation(
+      val permanentPlotIds: Set<MonitoringPlotId>,
+      val temporaryPlotBoundaries: Collection<Polygon>,
+      /**
+       * Number of monitoring plots configured for the stratum. This is the sum of
+       * [StratumModel.numPermanentPlots] and [StratumModel.numTemporaryPlots].
+       */
+      val numConfigured: Int,
+      /**
+       * Number of monitoring plots that ultimately fit in the stratum. This is the stratum-wide
+       * total and includes plots that would have been allocated in unrequested substrata, so the
+       * actual number of plots in the observation may be less than this.
+       */
+      val numAllocated: Int,
+  ) {
+    val isShortfall: Boolean
+      get() = numAllocated < numConfigured
+  }
+}

--- a/src/main/kotlin/com/terraformation/backend/tracking/model/UnusedSquareFinder.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/model/UnusedSquareFinder.kt
@@ -23,6 +23,8 @@ class UnusedSquareFinder(
     private val sizeMeters: Number,
     /** Areas to exclude from the stratum, or null if the whole stratum is available. */
     exclusion: MultiPolygon? = null,
+    /** Only return squares matching this predicate. */
+    private val predicate: (Polygon) -> Boolean = { true },
 ) {
   private val geometryFactory = stratumBoundary.factory
   private val boundaryCrs = CRS.decode("EPSG:${stratumBoundary.srid}", true)
@@ -147,7 +149,7 @@ class UnusedSquareFinder(
     if (regionWidth < gridInterval && regionHeight < gridInterval) {
       val polygon = gridAlignedSquare(southwest.x, southwest.y)
 
-      return if (coveredByStratum(polygon)) {
+      return if (coveredByStratum(polygon) && predicate(polygon)) {
         polygon
       } else {
         null
@@ -164,7 +166,7 @@ class UnusedSquareFinder(
               Random.nextDouble(southwest.y, northeast.y),
           )
 
-      if (coveredByStratum(polygon)) {
+      if (coveredByStratum(polygon) && predicate(polygon)) {
         return polygon
       }
     }

--- a/src/test/kotlin/com/terraformation/backend/tracking/model/StratumPlotAllocatorTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/model/StratumPlotAllocatorTest.kt
@@ -1,0 +1,247 @@
+package com.terraformation.backend.tracking.model
+
+import com.terraformation.backend.db.tracking.MonitoringPlotId
+import com.terraformation.backend.util.toMultiPolygon
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.CsvSource
+import org.locationtech.jts.geom.Envelope
+
+class StratumPlotAllocatorTest : BaseStratumModelTest() {
+  private fun fullStratum(numPlots: Int = 4, numPermanentPlots: Int = 6): ExistingStratumModel =
+      stratumModel(
+          numPermanentPlots = numPermanentPlots,
+          numTemporaryPlots = 2,
+          substrata =
+              listOf(
+                  substratumModel(
+                      plots =
+                          List(numPlots) { monitoringPlotModel(10 + it, permanentIndex = it + 1) }
+                  )
+              ),
+      )
+
+  @Test
+  fun `uses StratumModel allocator when there is room for all the plots`() {
+    val stratum =
+        stratumModel(
+            numPermanentPlots = 1,
+            numTemporaryPlots = 1,
+            substrata =
+                listOf(
+                    substratumModel(
+                        id = 1,
+                        plots = listOf(monitoringPlotModel(10, permanentIndex = 1)),
+                        boundary = substratumBoundary(1, 2),
+                    )
+                ),
+        )
+
+    val allocation =
+        StratumPlotAllocator(
+                stratum,
+                siteOrigin,
+                exclusion = null,
+            )
+            .allocate(substrataIds(1))
+
+    assertEquals(2, allocation.numConfigured, "Configured plots")
+    assertEquals(2, allocation.numAllocated, "Allocated plots")
+    assertFalse(allocation.isShortfall, "Should not be a shortfall")
+    assertEquals(setOf(MonitoringPlotId(10)), allocation.permanentPlotIds, "Permanent plots")
+    assertEquals(1, allocation.temporaryPlotBoundaries.size, "Number of temporary plots")
+  }
+
+  @ParameterizedTest
+  @CsvSource("2,6,2", "4,6,3", "6,8,5")
+  fun `tries to allocate 75 percent of plots as permanent`(
+      capacity: Int,
+      configuredPermanent: Int,
+      expectedPermanent: Int,
+  ) {
+    val stratum = fullStratum(capacity, configuredPermanent)
+
+    val allocation =
+        StratumPlotAllocator(stratum, siteOrigin, exclusion = null).allocate(substrataIds(1))
+
+    assertEquals(configuredPermanent + 2, allocation.numConfigured, "Configured plots")
+    assertEquals(capacity, allocation.numAllocated, "Allocated plots")
+    assertTrue(allocation.isShortfall, "Should be a shortfall")
+    assertEquals(
+        (0..<expectedPermanent).map { MonitoringPlotId(it.toLong() + 10) }.toSet(),
+        allocation.permanentPlotIds,
+        "Should keep the lowest permanent indexes",
+    )
+    assertEquals(
+        capacity - expectedPermanent,
+        allocation.temporaryPlotBoundaries.size,
+        "Number of temporary plots",
+    )
+  }
+
+  @Test
+  fun `does not turn permanent plots that cross substratum boundaries into temporary plots`() {
+    val boundary = substratumBoundary(1, 4)
+    val envelope = boundary.envelopeInternal
+    val splitX = envelope.minX + envelope.width / 4
+    val westBoundary =
+        boundary
+            .intersection(
+                geometryFactory.toGeometry(
+                    Envelope(envelope.minX, splitX, envelope.minY, envelope.maxY)
+                )
+            )
+            .toMultiPolygon()
+    val eastBoundary = boundary.difference(westBoundary).toMultiPolygon()
+
+    // Plots 10 and 12 cross the substratum boundary; plots 11 and 13 fit within the east
+    // substratum. Plot 12 has the highest permanent index, making it a candidate for demotion.
+    val stratum =
+        stratumModel(
+            numPermanentPlots = 6,
+            numTemporaryPlots = 2,
+            boundary = boundary,
+            substrata =
+                listOf(
+                    substratumModel(id = 1, boundary = westBoundary),
+                    substratumModel(
+                        id = 2,
+                        boundary = eastBoundary,
+                        plots =
+                            listOf(
+                                monitoringPlotModel(10, permanentIndex = 1),
+                                monitoringPlotModel(11, permanentIndex = 2),
+                                monitoringPlotModel(13, permanentIndex = 3),
+                                monitoringPlotModel(12, permanentIndex = 4),
+                            ),
+                    ),
+                ),
+        )
+
+    val requestedSubstratumIds = substrataIds(1, 2)
+    val allocation =
+        StratumPlotAllocator(stratum, siteOrigin, exclusion = null).allocate(requestedSubstratumIds)
+
+    assertEquals(8, allocation.numConfigured, "Configured plots")
+    assertEquals(3, allocation.numAllocated, "Allocated count should span the whole stratum")
+    assertTrue(allocation.isShortfall, "Should be a shortfall")
+    assertEquals(
+        monitoringPlotIds(10, 11),
+        allocation.permanentPlotIds,
+        "Should keep the lowest permanent indexes at the reduced capacity",
+    )
+    assertEquals(1, allocation.temporaryPlotBoundaries.size, "Number of temporary plots")
+  }
+
+  @Test
+  fun `does not allocate permanent plots with indexes greater than numPermanentPlots`() {
+    val stratum =
+        stratumModel(
+            numPermanentPlots = 1,
+            numTemporaryPlots = 7,
+            substrata =
+                listOf(
+                    substratumModel(
+                        id = 1,
+                        plots =
+                            listOf(
+                                monitoringPlotModel(10, permanentIndex = 1),
+                                // These might be plots from an older version of the stratum when
+                                // numPermanentPlots was higher.
+                                monitoringPlotModel(11, permanentIndex = 2),
+                                monitoringPlotModel(12, permanentIndex = 3),
+                                monitoringPlotModel(13, permanentIndex = 4),
+                            ),
+                        boundary = substratumBoundary(1, 4),
+                    )
+                ),
+        )
+
+    val allocation =
+        StratumPlotAllocator(
+                stratum,
+                siteOrigin,
+                exclusion = null,
+            )
+            .allocate(substrataIds(1))
+
+    assertEquals(4, allocation.numAllocated, "Allocated plots")
+    assertEquals(setOf(MonitoringPlotId(10)), allocation.permanentPlotIds, "Permanent plots")
+    assertEquals(3, allocation.temporaryPlotBoundaries.size, "Temporary plots")
+  }
+
+  @Test
+  fun `throws exception if the stratum has no room for any plots at all`() {
+    val stratum =
+        stratumModel(
+            numPermanentPlots = 1,
+            numTemporaryPlots = 0,
+            substrata =
+                listOf(
+                    substratumModel(
+                        id = 1,
+                        plots = listOf(monitoringPlotModel(10, isAvailable = false)),
+                        boundary = substratumBoundary(1, 1),
+                    )
+                ),
+        )
+
+    assertThrows<StratumFullException> {
+      StratumPlotAllocator(
+              stratum,
+              siteOrigin,
+              exclusion = null,
+          )
+          .allocate(substrataIds(1))
+    }
+  }
+
+  @Test
+  fun `only returns plots in requested substrata`() {
+    val stratum =
+        stratumModel(
+            numPermanentPlots = 6,
+            numTemporaryPlots = 2,
+            substrata =
+                listOf(
+                    substratumModel(
+                        id = 1,
+                        plots =
+                            listOf(
+                                monitoringPlotModel(10, permanentIndex = 1),
+                                monitoringPlotModel(11, permanentIndex = 2),
+                            ),
+                        boundary = substratumBoundary(1, 2),
+                    ),
+                    substratumModel(
+                        id = 2,
+                        plots =
+                            listOf(
+                                monitoringPlotModel(20, permanentIndex = 3),
+                                monitoringPlotModel(21, permanentIndex = 4),
+                            ),
+                        boundary = substratumBoundary(2, 2),
+                    ),
+                ),
+        )
+
+    val allocation =
+        StratumPlotAllocator(
+                stratum,
+                siteOrigin,
+                exclusion = null,
+            )
+            .allocate(substrataIds(1))
+
+    assertEquals(4, allocation.numAllocated, "Allocated count should span the whole stratum")
+    assertEquals(
+        setOf(MonitoringPlotId(10), MonitoringPlotId(11)),
+        allocation.permanentPlotIds,
+        "Only plots in the requested substratum should be returned",
+    )
+  }
+}


### PR DESCRIPTION
In cases where a stratum is too small to hold the configured number of
monitoring plots, we want to allocate as many plots as we can, in the
ratio of 75% permanent to 25% temporary. StratumModel is already getting
a little long, so put the new logic in its own helper class.

Nothing calls this yet; that'll happen in a later change.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>