### PR TITLE
SW-8817 Preserve observed permanent plots when allocating reduced plot counts

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/tracking/db/ObservationStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/db/ObservationStore.kt
@@ -1732,6 +1732,23 @@ class ObservationStore(
     }
   }
 
+  /**
+   * Returns the IDs of a planting site's monitoring plots that have been included in observations
+   * as permanent plots. Includes plots from observations that haven't been completed.
+   */
+  fun fetchObservedPermanentPlotIds(plantingSiteId: PlantingSiteId): Set<MonitoringPlotId> {
+    requirePermissions { readPlantingSite(plantingSiteId) }
+
+    return dslContext
+        .selectDistinct(OBSERVATION_PLOTS.MONITORING_PLOT_ID)
+        .from(OBSERVATION_PLOTS)
+        .join(MONITORING_PLOTS)
+        .on(OBSERVATION_PLOTS.MONITORING_PLOT_ID.eq(MONITORING_PLOTS.ID))
+        .where(MONITORING_PLOTS.PLANTING_SITE_ID.eq(plantingSiteId))
+        .and(OBSERVATION_PLOTS.IS_PERMANENT)
+        .fetchSet(OBSERVATION_PLOTS.MONITORING_PLOT_ID.asNonNullable())
+  }
+
   /** Recalculates the stratum- and site-level survival rates for an observation. */
   fun recalculateSurvivalRates(
       observationId: ObservationId,

--- a/src/main/kotlin/com/terraformation/backend/tracking/model/StratumPlotAllocator.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/model/StratumPlotAllocator.kt
@@ -14,11 +14,18 @@ import org.locationtech.jts.geom.Polygon
  * A stratum can hold fewer plots than it is configured for. When that happens, 75% of the plots
  * that fit are allocated as permanent, 25% as temporary. This can mean demoting a permanent plot to
  * temporary even though its permanent index is less than [StratumModel.numPermanentPlots].
+ *
+ * A permanent plot that has already been observed is never demoted, even if that pushes the split
+ * away from the target ratio.
  */
 class StratumPlotAllocator(
     private val stratum: ExistingStratumModel,
     private val gridOrigin: Point,
     private val exclusion: MultiPolygon?,
+    /**
+     * Plots that have already been observed as permanent. May include plots outside this stratum.
+     */
+    private val observedPermanentPlotIds: Set<MonitoringPlotId>,
 ) {
   /**
    * Fraction of a stratum's plots that should be treated as permanent when there isn't room for the
@@ -70,9 +77,15 @@ class StratumPlotAllocator(
       )
     }
 
-    var numPermanent = existingPermanent.size
-    while (numPermanent > (numAllocated * permanentPlotFraction).roundToInt()) {
-      val demotedPlot = existingPermanent[--numPermanent]
+    val (observed, unobserved) = existingPermanent.partition { it.id in observedPermanentPlotIds }
+    val availablePermanent = observed + unobserved
+    var numPermanent = availablePermanent.size
+
+    while (
+        numPermanent > observed.size &&
+            numPermanent > (numAllocated * permanentPlotFraction).roundToInt()
+    ) {
+      val demotedPlot = availablePermanent[--numPermanent]
 
       // A permanent plot can cross substratum boundaries, but a temporary plot must fit within
       // one substratum. Losing such a plot reduces capacity and can require further demotions.
@@ -81,11 +94,15 @@ class StratumPlotAllocator(
       }
     }
 
-    val permanentPlotIds = existingPermanent.take(numPermanent).map { it.id }.toSet()
+    val permanentPlotIds =
+        availablePermanent
+            .take(numPermanent)
+            .map { it.id }
+            .toSet()
+            .intersect(stratum.choosePermanentPlots(requestedSubstratumIds))
 
     return Allocation(
-        permanentPlotIds =
-            permanentPlotIds.intersect(stratum.choosePermanentPlots(requestedSubstratumIds)),
+        permanentPlotIds = permanentPlotIds,
         temporaryPlotBoundaries =
             stratum.chooseTemporaryPlots(
                 requestedSubstratumIds,

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/observationStore/ObservationStoreFetchObservedPermanentPlotIdsTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/observationStore/ObservationStoreFetchObservedPermanentPlotIdsTest.kt
@@ -1,0 +1,25 @@
+package com.terraformation.backend.tracking.db.observationStore
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class ObservationStoreFetchObservedPermanentPlotIdsTest : BaseObservationStoreTest() {
+  @Test
+  fun `returns only plots that were observed as permanent`() {
+    insertStratum()
+    insertSubstratum()
+    val permanentPlotId = insertMonitoringPlot(permanentIndex = 1, x = 0, y = 0)
+    val temporaryPlotId = insertMonitoringPlot(permanentIndex = 2, x = 1, y = 0)
+    insertMonitoringPlot(permanentIndex = 3, x = 2, y = 0)
+
+    insertObservation()
+    insertObservationPlot(monitoringPlotId = permanentPlotId, isPermanent = true)
+    insertObservationPlot(monitoringPlotId = temporaryPlotId, isPermanent = false)
+
+    assertEquals(
+        setOf(permanentPlotId),
+        store.fetchObservedPermanentPlotIds(plantingSiteId),
+        "Observed permanent plots",
+    )
+  }
+}

--- a/src/test/kotlin/com/terraformation/backend/tracking/model/StratumPlotAllocatorTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/model/StratumPlotAllocatorTest.kt
@@ -46,6 +46,7 @@ class StratumPlotAllocatorTest : BaseStratumModelTest() {
                 stratum,
                 siteOrigin,
                 exclusion = null,
+                observedPermanentPlotIds = emptySet(),
             )
             .allocate(substrataIds(1))
 
@@ -66,7 +67,13 @@ class StratumPlotAllocatorTest : BaseStratumModelTest() {
     val stratum = fullStratum(capacity, configuredPermanent)
 
     val allocation =
-        StratumPlotAllocator(stratum, siteOrigin, exclusion = null).allocate(substrataIds(1))
+        StratumPlotAllocator(
+                stratum,
+                siteOrigin,
+                exclusion = null,
+                observedPermanentPlotIds = emptySet(),
+            )
+            .allocate(substrataIds(1))
 
     assertEquals(configuredPermanent + 2, allocation.numConfigured, "Configured plots")
     assertEquals(capacity, allocation.numAllocated, "Allocated plots")
@@ -83,8 +90,13 @@ class StratumPlotAllocatorTest : BaseStratumModelTest() {
     )
   }
 
-  @Test
-  fun `does not turn permanent plots that cross substratum boundaries into temporary plots`() {
+  @ParameterizedTest
+  @CsvSource("0,3,2", "3,3,3", "4,4,4")
+  fun `does not turn permanent plots that cross substratum boundaries into temporary plots`(
+      numObserved: Int,
+      expectedAllocated: Int,
+      expectedPermanent: Int,
+  ) {
     val boundary = substratumBoundary(1, 4)
     val envelope = boundary.envelopeInternal
     val splitX = envelope.minX + envelope.width / 4
@@ -122,19 +134,71 @@ class StratumPlotAllocatorTest : BaseStratumModelTest() {
                 ),
         )
 
+    val permanentPlotIds = listOf(10, 11, 13, 12).map { MonitoringPlotId(it.toLong()) }
     val requestedSubstratumIds = substrataIds(1, 2)
     val allocation =
-        StratumPlotAllocator(stratum, siteOrigin, exclusion = null).allocate(requestedSubstratumIds)
+        StratumPlotAllocator(
+                stratum,
+                siteOrigin,
+                exclusion = null,
+                observedPermanentPlotIds = permanentPlotIds.take(numObserved).toSet(),
+            )
+            .allocate(requestedSubstratumIds)
 
     assertEquals(8, allocation.numConfigured, "Configured plots")
-    assertEquals(3, allocation.numAllocated, "Allocated count should span the whole stratum")
+    assertEquals(
+        expectedAllocated,
+        allocation.numAllocated,
+        "Allocated count should span the whole stratum",
+    )
     assertTrue(allocation.isShortfall, "Should be a shortfall")
     assertEquals(
-        monitoringPlotIds(10, 11),
+        permanentPlotIds.take(expectedPermanent).toSet(),
         allocation.permanentPlotIds,
         "Should keep the lowest permanent indexes at the reduced capacity",
     )
-    assertEquals(1, allocation.temporaryPlotBoundaries.size, "Number of temporary plots")
+    assertEquals(
+        expectedAllocated - expectedPermanent,
+        allocation.temporaryPlotBoundaries.size,
+        "Number of temporary plots",
+    )
+  }
+
+  @Test
+  fun `keeps an observed permanent plot permanent instead of using one with a lower index`() {
+    val stratum = fullStratum()
+
+    val allocation =
+        StratumPlotAllocator(
+                stratum,
+                siteOrigin,
+                exclusion = null,
+                observedPermanentPlotIds = setOf(MonitoringPlotId(13)),
+            )
+            .allocate(substrataIds(1))
+
+    assertEquals(
+        setOf(MonitoringPlotId(10), MonitoringPlotId(11), MonitoringPlotId(13)),
+        allocation.permanentPlotIds,
+        "Observed plot should displace the highest unobserved one",
+    )
+  }
+
+  @Test
+  fun `exceeds the target permanent-temporary ratio when too many plots are previously observed`() {
+    val stratum = fullStratum()
+
+    val allocation =
+        StratumPlotAllocator(
+                stratum,
+                siteOrigin,
+                exclusion = null,
+                observedPermanentPlotIds = monitoringPlotIds(10, 11, 12, 13),
+            )
+            .allocate(substrataIds(1))
+
+    assertEquals(4, allocation.permanentPlotIds.size, "All observed plots stay permanent")
+    assertEquals(0, allocation.temporaryPlotBoundaries.size, "No room left for temporary plots")
   }
 
   @Test
@@ -166,6 +230,7 @@ class StratumPlotAllocatorTest : BaseStratumModelTest() {
                 stratum,
                 siteOrigin,
                 exclusion = null,
+                observedPermanentPlotIds = emptySet(),
             )
             .allocate(substrataIds(1))
 
@@ -195,6 +260,7 @@ class StratumPlotAllocatorTest : BaseStratumModelTest() {
               stratum,
               siteOrigin,
               exclusion = null,
+              observedPermanentPlotIds = emptySet(),
           )
           .allocate(substrataIds(1))
     }
@@ -234,6 +300,7 @@ class StratumPlotAllocatorTest : BaseStratumModelTest() {
                 stratum,
                 siteOrigin,
                 exclusion = null,
+                observedPermanentPlotIds = emptySet(),
             )
             .allocate(substrataIds(1))
 


### PR DESCRIPTION
When there isn't enough room for the configured number of monitoring
plots in a stratum, we try to use 75% of the available plots as
permanent and 25% as temporary, even if some of the temporary plots
had permanent indexes.

But we want to maintain continuity of monitoring of permanent plots.
Update the allocator such that it will never demote a permanent plot
that has already been included in an observation.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>