### PR TITLE
SW-8817 Start observations with reduced plots counts if needed

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/tracking/ObservationService.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/ObservationService.kt
@@ -63,6 +63,7 @@ import com.terraformation.backend.tracking.event.ObservationMediaFileEditedEvent
 import com.terraformation.backend.tracking.event.ObservationMediaFileUploadedEvent
 import com.terraformation.backend.tracking.event.ObservationNotStartedEvent
 import com.terraformation.backend.tracking.event.ObservationPlotReplacedEvent
+import com.terraformation.backend.tracking.event.ObservationPlotsUnderallocatedEvent
 import com.terraformation.backend.tracking.event.ObservationRescheduledEvent
 import com.terraformation.backend.tracking.event.ObservationScheduledEvent
 import com.terraformation.backend.tracking.event.ObservationStartedEvent
@@ -76,7 +77,8 @@ import com.terraformation.backend.tracking.model.NotificationCriteria
 import com.terraformation.backend.tracking.model.PlantingSiteDepth
 import com.terraformation.backend.tracking.model.ReplacementDuration
 import com.terraformation.backend.tracking.model.ReplacementResult
-import com.terraformation.backend.tracking.model.SubstratumFullException
+import com.terraformation.backend.tracking.model.StratumFullException
+import com.terraformation.backend.tracking.model.StratumPlotAllocator
 import jakarta.inject.Named
 import java.io.InputStream
 import java.time.Instant
@@ -144,29 +146,41 @@ class ObservationService(
         log.info("Starting observation")
 
         try {
+          val observedPermanentPlotIds =
+              observationStore.fetchObservedPermanentPlotIds(observation.plantingSiteId)
+          val shortfalls = mutableListOf<ObservationPlotsUnderallocatedEvent.Shortfall>()
+
           plantingSite.strata.forEach { stratum ->
             log.withMDC("stratumId" to stratum.id) {
               if (stratum.substrata.any { it.id in observation.requestedSubstratumIds }) {
-                val permanentPlotIds =
-                    stratum.choosePermanentPlots(observation.requestedSubstratumIds)
-                val temporaryPlotIds =
-                    stratum
-                        .chooseTemporaryPlots(
-                            observation.requestedSubstratumIds,
+                val allocation =
+                    StratumPlotAllocator(
+                            stratum,
                             gridOrigin,
                             plantingSite.exclusion,
+                            observedPermanentPlotIds,
                         )
-                        .map { plotBoundary ->
-                          plantingSiteStore.createTemporaryPlot(
-                              plantingSite.id,
-                              stratum.id,
-                              plotBoundary,
-                          )
-                        }
+                        .allocate(observation.requestedSubstratumIds)
+
+                if (
+                    allocation.permanentPlotIds.isEmpty() &&
+                        allocation.temporaryPlotBoundaries.isEmpty()
+                ) {
+                  throw StratumFullException(stratum.id)
+                }
+
+                val temporaryPlotIds =
+                    allocation.temporaryPlotBoundaries.map { plotBoundary ->
+                      plantingSiteStore.createTemporaryPlot(
+                          plantingSite.id,
+                          stratum.id,
+                          plotBoundary,
+                      )
+                    }
 
                 observationStore.addPlotsToObservation(
                     observationId,
-                    permanentPlotIds,
+                    allocation.permanentPlotIds,
                     isPermanent = true,
                 )
                 observationStore.addPlotsToObservation(
@@ -175,9 +189,20 @@ class ObservationService(
                     isPermanent = false,
                 )
 
+                if (allocation.isShortfall) {
+                  shortfalls.add(
+                      ObservationPlotsUnderallocatedEvent.Shortfall(
+                          numAllocated = allocation.numAllocated,
+                          numConfigured = allocation.numConfigured,
+                          stratumId = stratum.id,
+                          stratumName = stratum.name,
+                      )
+                  )
+                }
+
                 log.info(
-                    "Added ${permanentPlotIds.size} permanent and ${temporaryPlotIds.size} " +
-                        "temporary plots"
+                    "Added ${allocation.permanentPlotIds.size} permanent and " +
+                        "${temporaryPlotIds.size} temporary plots"
                 )
               } else {
                 log.info("Skipping stratum because it has no reported plants")
@@ -188,7 +213,17 @@ class ObservationService(
           val startedObservation = observationStore.recordObservationStart(observationId)
 
           eventPublisher.publishEvent(ObservationStartedEvent(startedObservation))
-        } catch (e: SubstratumFullException) {
+
+          if (shortfalls.isNotEmpty()) {
+            eventPublisher.publishEvent(
+                ObservationPlotsUnderallocatedEvent(
+                    observationId,
+                    observation.plantingSiteId,
+                    shortfalls,
+                )
+            )
+          }
+        } catch (e: StratumFullException) {
           log.info("Unable to start observation $observationId", e)
 
           eventPublisher.publishEvent(

--- a/src/main/kotlin/com/terraformation/backend/tracking/event/Events.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/event/Events.kt
@@ -106,6 +106,28 @@ data class ObservationNotStartedEvent(
     val plantingSiteId: PlantingSiteId,
 ) : ObservationSchedulingNotificationEvent
 
+/**
+ * Published when an observation started with fewer monitoring plots than its strata are configured
+ * for because the strata didn't have room for all of them. Only strata that fell short are
+ * included.
+ */
+data class ObservationPlotsUnderallocatedEvent(
+    val observationId: ObservationId,
+    val plantingSiteId: PlantingSiteId,
+    val shortfalls: List<Shortfall>,
+) {
+  /**
+   * How many monitoring plots a stratum was configured for and how many it had room for. Both
+   * counts cover the whole stratum and don't take requested substrata into account.
+   */
+  data class Shortfall(
+      val numAllocated: Int,
+      val numConfigured: Int,
+      val stratumId: StratumId,
+      val stratumName: String,
+  )
+}
+
 data class ObservationStateUpdatedEvent(
     val observationId: ObservationId,
     val newState: ObservationState,

--- a/src/main/kotlin/com/terraformation/backend/tracking/model/Exceptions.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/model/Exceptions.kt
@@ -1,17 +1,6 @@
 package com.terraformation.backend.tracking.model
 
 import com.terraformation.backend.db.tracking.StratumId
-import com.terraformation.backend.db.tracking.SubstratumId
-
-class SubstratumFullException(
-    val substratumId: SubstratumId,
-    val plotsNeeded: Int,
-    val plotsRemaining: Int,
-) :
-    IllegalStateException(
-        "Substratum $substratumId needs $plotsNeeded temporary plots but only " +
-            "$plotsRemaining available"
-    )
 
 class StratumFullException(val stratumId: StratumId) :
     IllegalStateException("Stratum $stratumId has no room for any monitoring plots")

--- a/src/test/kotlin/com/terraformation/backend/tracking/ObservationServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/ObservationServiceTest.kt
@@ -94,7 +94,9 @@ import com.terraformation.backend.tracking.event.ObservationMediaFileDeletedEven
 import com.terraformation.backend.tracking.event.ObservationMediaFileEditedEvent
 import com.terraformation.backend.tracking.event.ObservationMediaFileEditedEventValues
 import com.terraformation.backend.tracking.event.ObservationMediaFileUploadedEvent
+import com.terraformation.backend.tracking.event.ObservationNotStartedEvent
 import com.terraformation.backend.tracking.event.ObservationPlotReplacedEvent
+import com.terraformation.backend.tracking.event.ObservationPlotsUnderallocatedEvent
 import com.terraformation.backend.tracking.event.ObservationRescheduledEvent
 import com.terraformation.backend.tracking.event.ObservationScheduledEvent
 import com.terraformation.backend.tracking.event.ObservationStartedEvent
@@ -618,6 +620,38 @@ class ObservationServiceTest : DatabaseTest(), RunsAsDatabaseUser {
       eventPublisher.assertEventPublished(
           ObservationStartedEvent(observationStore.fetchObservationById(observationId))
       )
+    }
+
+    @Test
+    fun `does not start observation if only unrequested substrata have capacity`() {
+      val requestedBoundary = rectangle(MONITORING_PLOT_SIZE)
+      plantingSiteId =
+          insertPlantingSite(
+              width = 4,
+              height = 1,
+              gridOrigin = point(1),
+              exclusion = rectangle(width = 10, height = 10, x = 10, y = 10),
+          )
+      insertStratum(
+          width = 4,
+          height = 1,
+          numPermanentPlots = 1,
+          numTemporaryPlots = 1,
+      )
+      val requestedSubstratumId = insertSubstratum(boundary = requestedBoundary)
+      insertSubstratum(x = 1, width = 3, height = 1)
+      insertPermanentPlot(1, x = 1, y = 0)
+
+      val observationId = insertObservation(state = ObservationState.Upcoming)
+      insertObservationRequestedSubstratum(substratumId = requestedSubstratumId)
+
+      service.startObservation(observationId)
+
+      eventPublisher.assertEventPublished(ObservationNotStartedEvent(observationId, plantingSiteId))
+      eventPublisher.assertEventNotPublished<ObservationStartedEvent>()
+      eventPublisher.assertEventNotPublished<ObservationPlotsUnderallocatedEvent>()
+
+      assertTableEmpty(OBSERVATIONS, "Observation should have been deleted")
     }
 
     @Test

--- a/src/test/kotlin/com/terraformation/backend/tracking/PlotAssignmentTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/PlotAssignmentTest.kt
@@ -16,6 +16,8 @@ import com.terraformation.backend.tracking.db.ObservationStore
 import com.terraformation.backend.tracking.db.PlantingSiteImporter
 import com.terraformation.backend.tracking.db.PlantingSiteNotificationStore
 import com.terraformation.backend.tracking.db.PlantingSiteStore
+import com.terraformation.backend.tracking.event.ObservationNotStartedEvent
+import com.terraformation.backend.tracking.event.ObservationPlotsUnderallocatedEvent
 import com.terraformation.backend.tracking.model.ExistingPlantingSiteModel
 import com.terraformation.backend.tracking.model.PlantingSiteDepth
 import com.terraformation.backend.tracking.model.Shapefile
@@ -28,6 +30,7 @@ import org.jobrunr.scheduling.JobScheduler
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.RepeatedTest
+import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.fail
 
 class PlotAssignmentTest : DatabaseTest(), RunsAsUser {
@@ -115,6 +118,98 @@ class PlotAssignmentTest : DatabaseTest(), RunsAsUser {
     every { user.canReadSubstratum(any()) } returns true
     every { user.canUpdateObservation(any()) } returns true
     every { user.canUpdatePlantingSite(any()) } returns true
+  }
+
+  @Test
+  fun `publishes event when not all configured plots fit in a stratum`() {
+    val smallBoundary = gen.multiRectangle(0 to 0, 91 to 31)
+    val smallFeature =
+        gen.substratumFeature(
+            smallBoundary,
+            name = "Sub1",
+            stratum = "S1",
+            permanentPlots = 6,
+            temporaryPlots = 2,
+        )
+
+    val largeBoundary = gen.multiRectangle(200 to 0, 531 to 121)
+    val largeFeature =
+        gen.substratumFeature(
+            largeBoundary,
+            name = "Sub2",
+            stratum = "S2",
+            permanentPlots = 2,
+            temporaryPlots = 2,
+        )
+
+    val plantingSite = importSite(listOf(smallFeature, largeFeature))
+    val smallStratum = plantingSite.strata.first { it.name == "S1" }
+    val largeStratum = plantingSite.strata.first { it.name == "S2" }
+    val smallSubstratum = smallStratum.substrata.first { it.name == "Sub1" }
+    val largeSubstratum = largeStratum.substrata.first { it.name == "Sub2" }
+
+    val observationId =
+        insertObservation(plantingSiteId = plantingSite.id, state = ObservationState.Upcoming)
+    insertObservationRequestedSubstratum(substratumId = smallSubstratum.id)
+    insertObservationRequestedSubstratum(substratumId = largeSubstratum.id)
+
+    observationService.startObservation(observationId)
+
+    val observationPlots = observationStore.fetchObservationPlotDetails(observationId)
+
+    assertEquals(7, observationPlots.size, "Total plots in observation")
+    assertEquals(
+        4, // 2 in S1, 2 in S2
+        observationPlots.count { it.model.isPermanent },
+        "Permanent plots in observation",
+    )
+
+    eventPublisher.assertEventPublished(
+        ObservationPlotsUnderallocatedEvent(
+            observationId,
+            plantingSite.id,
+            listOf(
+                ObservationPlotsUnderallocatedEvent.Shortfall(
+                    numAllocated = 3,
+                    numConfigured = 8,
+                    stratumId = smallStratum.id,
+                    stratumName = smallStratum.name,
+                )
+            ),
+        )
+    )
+  }
+
+  @Test
+  fun `abandons the observation when a stratum has no room for any plots at all`() {
+    val substratumBoundary = gen.multiRectangle(0 to 0, 91 to 31)
+    val feature =
+        gen.substratumFeature(
+            substratumBoundary,
+            stratum = "S1",
+            permanentPlots = 6,
+            temporaryPlots = 2,
+        )
+
+    val plantingSite = importSite(listOf(feature))
+    val substratum = plantingSite.strata.single().substrata.single()
+
+    // Fill the substratum with unavailable plots.
+    plantingSiteStore.ensurePermanentPlotsExist(plantingSite.id)
+    monitoringPlotsDao.findAll().forEach { plantingSiteStore.makePlotUnavailable(it.id!!) }
+
+    val observationId =
+        insertObservation(plantingSiteId = plantingSite.id, state = ObservationState.Upcoming)
+    insertObservationRequestedSubstratum(substratumId = substratum.id)
+
+    observationService.startObservation(observationId)
+
+    eventPublisher.assertEventPublished(ObservationNotStartedEvent(observationId, plantingSite.id))
+    assertEquals(
+        emptyList<Any>(),
+        observationStore.fetchObservationPlotDetails(observationId),
+        "Abandoned observation should have no plots",
+    )
   }
 
   // Run test 10 times to exercise different random selections. 10 is somewhat arbitrary but given
@@ -207,6 +302,8 @@ class PlotAssignmentTest : DatabaseTest(), RunsAsUser {
         assertEquals("between 0 and 2", "$numPermanentPlots", "Number of permanent plots")
       }
     }
+
+    eventPublisher.assertEventNotPublished<ObservationPlotsUnderallocatedEvent>()
   }
 
   /**


### PR DESCRIPTION
Use the new ratio-aware plot allocator when starting observations. If
there isn't enough room for the configured number of plots in one or
more of the observed strata, publish an event describing the shortfall.
A future change will use this event to generate a notification.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>