### PR TITLE
Move OpenAPI comparison to its own Buildkite step

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -120,12 +120,18 @@ steps:
       TEST_S3_BUCKET_NAME: "terraformation-buildkite-test"
 
   - <<: *use-existing-checkout
-    label: ":python: Check scripts"
-    key: "check-scripts"
+    label: ":gradle: Compare OpenAPI schema to staging"
+    key: "compare-openapi"
     depends_on:
       - step: "run-tests"
       - step: "external-tests"
         allow_failure: true
+    command: ".buildkite/scripts/compare-openapi.sh"
+
+  - <<: *use-existing-checkout
+    label: ":python: Check scripts"
+    key: "check-scripts"
+    depends_on: "compare-openapi"
     if_changed: "scripts/**"
     plugins:
       - cache#v1.11.1:
@@ -138,10 +144,8 @@ steps:
     label: ":junit: Annotate build with test results"
     key: "junit-annotate"
     depends_on:
-      - step: "run-tests"
+      - step: "compare-openapi"
       - step: "check-scripts"
-      - step: "external-tests"
-        allow_failure: true
     plugins:
       - junit-annotate#v2.7.0:
           artifacts: "build/test-results/**/*.xml"

--- a/.buildkite/scripts/compare-openapi.sh
+++ b/.buildkite/scripts/compare-openapi.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+.buildkite/scripts/install-deps.sh --java --tools --node
+
+echo "--- :openapi: Generate OpenAPI docs to test that server can start up"
+./gradlew generateOpenApiDocs
+
+echo "--- :openapi: Diff OpenAPI docs against staging"
+if curl -f -s https://staging.terraware.io/v3/api-docs.yaml > staging.yaml; then
+  for f in openapi.yaml staging.yaml; do
+    yq -i '
+      .info.version = null |
+      .servers[0].url = null |
+      .components.securitySchemes.openId.openIdConnectUrl = null' "$f"
+  done
+
+  # Indent the diff output so the "---" in the diff header isn't treated as a section header.
+  diff -u staging.yaml openapi.yaml | sed 's/^/ /' || true
+else
+  echo "Unable to fetch OpenAPI schema from staging"
+fi

--- a/.buildkite/scripts/test.sh
+++ b/.buildkite/scripts/test.sh
@@ -3,24 +3,6 @@ set -euo pipefail
 
 .buildkite/scripts/install-deps.sh --java --tools --node
 
-echo "--- :openapi: Generate OpenAPI docs to test that server can start up"
-./gradlew generateOpenApiDocs
-
-echo "--- :openapi: Diff OpenAPI docs against staging"
-if curl -f -s https://staging.terraware.io/v3/api-docs.yaml > staging.yaml; then
-  for f in openapi.yaml staging.yaml; do
-    yq -i '
-      .info.version = null |
-      .servers[0].url = null |
-      .components.securitySchemes.openId.openIdConnectUrl = null' "$f"
-  done
-
-  # Indent the diff output so the "---" in the diff header isn't treated as a section header.
-  diff -u staging.yaml openapi.yaml | sed 's/^/ /' || true
-else
-  echo "Unable to fetch OpenAPI schema from staging"
-fi
-
 echo "--- :junit: Run tests"
 
 # Suppress some debug log messages that add up to megabytes of test output and slow down annotating


### PR DESCRIPTION
Move the "generate OpenAPI schema to test that the server can start up,
and compare the result against staging" part of the CI pipeline to its
own pipeline step and put it after the JUnit test runs, not before.
When a CI run fails, it's usually because of a failing test, so this
will give us faster failures when there's a problem.