### PR TITLE
Fix intermittent ApplicationStoreTest failures

### DIFF
--- a/src/test/kotlin/com/terraformation/backend/accelerator/db/ApplicationStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/db/ApplicationStoreTest.kt
@@ -246,7 +246,7 @@ class ApplicationStoreTest : DatabaseTest(), RunsAsUser {
 
       @Test
       fun `throws exception if application does not exist`() {
-        assertThrows<ApplicationNotFoundException> { store.fetchOneById(ApplicationId(1)) }
+        assertThrows<ApplicationNotFoundException> { store.fetchOneById(ApplicationId(0)) }
       }
 
       @Test
@@ -304,7 +304,7 @@ class ApplicationStoreTest : DatabaseTest(), RunsAsUser {
 
       @Test
       fun `throws exception if application does not exist`() {
-        assertThrows<ApplicationNotFoundException> { store.fetchGeoFeatureById(ApplicationId(1)) }
+        assertThrows<ApplicationNotFoundException> { store.fetchGeoFeatureById(ApplicationId(0)) }
       }
 
       @Test


### PR DESCRIPTION
A couple of tests that check the behavior when a given application ID
doesn't exist were assuming that there was no application with ID 1, but
depending on the order in which tests were run, it was possible for one
of the test-fixture-created applications to have that ID.

Change the tests to use ID 0, which should never exist since the
database allocates IDs starting with 1.