### PR TITLE
SW-8861 Allow adding species to completed plots

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/tracking/db/Exceptions.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/db/Exceptions.kt
@@ -180,9 +180,6 @@ class ShapefilesInvalidException(val problems: List<String>) :
 class SpeciesInWrongOrganizationException(val speciesId: SpeciesId) :
     MismatchedStateException("Species $speciesId is in the wrong organization")
 
-class SpeciesNotInObservationException(val speciesId: SpeciesId?, val speciesName: String?) :
-    EntityNotFoundException("Species ${speciesId ?: speciesName} not found in observation")
-
 class StratumNotFoundException(val stratumId: StratumId) :
     EntityNotFoundException("Stratum $stratumId not found")
 

--- a/src/main/kotlin/com/terraformation/backend/tracking/db/ObservationStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/db/ObservationStore.kt
@@ -6,6 +6,7 @@ import com.terraformation.backend.customer.model.SystemUser
 import com.terraformation.backend.customer.model.TerrawareUser
 import com.terraformation.backend.customer.model.requirePermissions
 import com.terraformation.backend.db.EntityLocker
+import com.terraformation.backend.db.SpeciesNotFoundException
 import com.terraformation.backend.db.asNonNullable
 import com.terraformation.backend.db.default_schema.OrganizationId
 import com.terraformation.backend.db.default_schema.SpeciesId
@@ -1295,8 +1296,16 @@ class ObservationStore(
                 .and(SPECIES_ID.eqOrIsNull(speciesId))
                 .and(SPECIES_NAME.eqOrIsNull(speciesName))
                 .fetchOne { EditableMonitoringSpeciesModel.of(it) }
-                ?: throw SpeciesNotInObservationException(speciesId, speciesName)
           }
+              ?: if (
+                  speciesId == null ||
+                      parentStore.getOrganizationId(speciesId) ==
+                          parentStore.getOrganizationId(observationId)
+              ) {
+                EditableMonitoringSpeciesModel(0, 0, 0)
+              } else {
+                throw SpeciesNotFoundException(speciesId)
+              }
 
       val updated = updateFunc(existing)
 

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/observationStore/ObservationStoreUpdateMonitoringSpeciesTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/observationStore/ObservationStoreUpdateMonitoringSpeciesTest.kt
@@ -144,6 +144,70 @@ class ObservationStoreUpdateMonitoringSpeciesTest : DatabaseTest(), RunsAsDataba
   }
 
   @Test
+  fun `adds new species to observation if needed`() {
+    scenario {
+      siteCreated { stratum(1) { substratum(1) { plot(1) } } }
+
+      val density = 100
+
+      t0DensitySet { plot(1) { species(0, density = density) } }
+
+      observation(1) {
+        plot(1) // No plants recorded
+      }
+
+      val liveCount = 6
+      val deadCount = 7
+      val existingCount = 8
+
+      observationEdited(1) {
+        plot(1) { species(0, live = liveCount, dead = deadCount, existing = existingCount) }
+      }
+
+      expectResults(observation = 1) {
+        survivalRate(percent(liveCount, density))
+        species(
+            0,
+            survivalRate = percent(liveCount, density),
+            totalLive = liveCount,
+            totalDead = deadCount,
+            totalExisting = existingCount,
+        )
+        stratum(1) {
+          survivalRate(percent(liveCount, density))
+          species(
+              0,
+              survivalRate = percent(liveCount, density),
+              totalLive = liveCount,
+              totalDead = deadCount,
+              totalExisting = existingCount,
+          )
+          substratum(1) {
+            survivalRate(percent(liveCount, density))
+            species(
+                0,
+                survivalRate = percent(liveCount, density),
+                totalLive = liveCount,
+                totalDead = deadCount,
+                totalExisting = existingCount,
+            )
+            plot(1) {
+              survivalRate(percent(liveCount, density))
+              species(
+                  0,
+                  survivalRate = percent(liveCount, density),
+                  totalLive = liveCount,
+                  totalDead = deadCount,
+                  totalExisting = existingCount,
+              )
+            }
+          }
+        }
+      }
+    }
+  }
+
+  @Test
   fun `updates plant counts for unknown and Other species`() {
     scenario {
       siteCreated { stratum(1) { substratum(1) { plot(1) } } }


### PR DESCRIPTION
The endpoint for editing the plant counts in completed plots in
monitoring observations included an explicit test to prevent setting
plant counts for a species that wasn't already in the observation.
That turns out to be overly restrictive: there are legitimate cases
where we do need to be able to add a species to a plot's observed
totals. Remove the restriction.