### PR TITLE
SW-8782 Allow adding map to mapless planting site

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/admin/AdminPlantingSitesController.kt
+++ b/src/main/kotlin/com/terraformation/backend/admin/AdminPlantingSitesController.kt
@@ -446,7 +446,7 @@ class AdminPlantingSitesController(
                 existing.name,
                 existing.description,
                 existing.organizationId,
-                requireStableIds = true,
+                requireStableIds = existing.boundary != null,
             )
 
         val calculator = PlantingSiteEditCalculator(existing, desired)

--- a/src/main/kotlin/com/terraformation/backend/tracking/db/PlantingSiteStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/db/PlantingSiteStore.kt
@@ -585,6 +585,7 @@ class PlantingSiteStore(
 
     return entityLocker.withLockedPlantingSite(plantingSiteId) {
       val existing = fetchSiteById(plantingSiteId, PlantingSiteDepth.Plot)
+      val gridOrigin = existing.gridOrigin ?: plantingSiteEdit.desiredModel.gridOrigin
       val now = clock.instant()
       val userId = currentUser().userId
       val replacementResults = mutableListOf<ReplacementResult>()
@@ -605,6 +606,7 @@ class PlantingSiteStore(
             .set(BOUNDARY, plantingSiteEdit.desiredModel.boundary)
             .set(COUNTRY_CODE, countryCode)
             .set(EXCLUSION, plantingSiteEdit.desiredModel.exclusion)
+            .set(GRID_ORIGIN, gridOrigin)
             .set(MODIFIED_BY, userId)
             .set(MODIFIED_TIME, now)
             .where(ID.eq(plantingSiteId))
@@ -620,7 +622,7 @@ class PlantingSiteStore(
                 .set(CREATED_BY, userId)
                 .set(CREATED_TIME, now)
                 .set(EXCLUSION, plantingSiteEdit.desiredModel.exclusion)
-                .set(GRID_ORIGIN, existing.gridOrigin)
+                .set(GRID_ORIGIN, gridOrigin)
                 .set(PLANTING_SITE_ID, plantingSiteId)
                 .returning(ID)
                 .fetchOne(ID)!!

--- a/src/main/resources/templates/admin/plantingSite.html
+++ b/src/main/resources/templates/admin/plantingSite.html
@@ -274,33 +274,40 @@
                 </td>
             </tr>
         </table>
+    </th:block>
+</th:block>
 
-        <h3>Upload New Shapefiles</h3>
+<th:block th:if="${canUpdatePlantingSite}">
+    <h3>Upload New Shapefiles</h3>
 
-        <form method="POST" enctype="multipart/form-data"
-              action="/admin/updatePlantingSiteShapefiles">
-            <input type="hidden" name="plantingSiteId" th:value="${site.id}"/>
-            <label>
-                Zipfile
-                <input type="file" name="zipfile" required/>
-            </label>
-            <br/>
-            <label>
-                Operation
-                <select name="dryRun">
-                    <option value="true" selected>Dry run (no change to site)</option>
-                    <option value="false">Apply changes to site</option>
-                </select>
-            </label>
-            <br/>
+    <form method="POST" enctype="multipart/form-data"
+          action="/admin/updatePlantingSiteShapefiles">
+        <input type="hidden" name="plantingSiteId" th:value="${site.id}"/>
+        <label>
+            Zipfile
+            <input type="file" name="zipfile" required/>
+        </label>
+        <br/>
+        <label>
+            Operation
+            <select name="dryRun">
+                <option value="true" selected>Dry run (no change to site)</option>
+                <option value="false">Apply changes to site</option>
+            </select>
+        </label>
+        <br/>
+        <th:block th:if="!${site.strata.isEmpty()}">
             <label>
                 Substratum IDs to mark incomplete (comma-separated)
                 <input type="text" name="substratumIdsToMarkIncomplete"/>
             </label>
             <br/>
-            <input type="submit" value="Use Updated Shapefiles"/>
-        </form>
-    </th:block>
+        </th:block>
+        <input type="submit" value="Use Updated Shapefiles"/>
+    </form>
+</th:block>
+
+<th:block th:if="!${site.strata.isEmpty()}">
 
     <h3>Site Details</h3>
 

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/plantingSiteStore/PlantingSiteStoreApplyEditTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/plantingSiteStore/PlantingSiteStoreApplyEditTest.kt
@@ -1,5 +1,6 @@
 package com.terraformation.backend.tracking.db.plantingSiteStore
 
+import com.terraformation.backend.assertGeometryEquals
 import com.terraformation.backend.customer.db.ParentStore
 import com.terraformation.backend.db.NumericIdentifierType
 import com.terraformation.backend.db.StableId
@@ -57,6 +58,31 @@ internal class PlantingSiteStoreApplyEditTest : BasePlantingSiteStoreTest() {
 
   @Nested
   inner class ApplyPlantingSiteEdit {
+    @Test
+    fun `adds map to site that has no map yet`() {
+      val desired = newSite()
+      val existing =
+          createSite(
+              desired.copy(
+                  areaHa = null,
+                  boundary = null,
+                  gridOrigin = null,
+                  strata = emptyList(),
+              )
+          )
+
+      val edited = store.applyPlantingSiteEdit(calculateSiteEdit(existing, desired))
+
+      assertEquals(desired.areaHa, edited.areaHa, "Area")
+      assertGeometryEquals(desired.boundary, edited.boundary, "Boundary")
+      assertGeometryEquals(desired.gridOrigin, edited.gridOrigin, "Grid origin")
+      assertEquals(1, edited.strata.single().substrata.size, "Substrata")
+
+      val history = plantingSiteHistoriesDao.fetchByPlantingSiteId(existing.id).single()
+      assertGeometryEquals(edited.boundary, history.boundary, "History boundary")
+      assertGeometryEquals(edited.gridOrigin, history.gridOrigin, "History grid origin")
+    }
+
     @Test
     fun `updates existing boundaries`() {
       val (edited, existing) =


### PR DESCRIPTION
The admin UI doesn't show the shapefile upload form if the planting site
doesn't already have a map. Make it show the form in that case so we can
add maps to old sites that don't have them yet, and relax a validation
rule on map updates that doesn't make sense on initial map upload.