### PR TITLE
Fix intermittent T0StoreTest failures

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/tracking/db/T0Store.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/db/T0Store.kt
@@ -300,7 +300,11 @@ class T0Store(
                     )
             )
 
-    val combined = withdrawnSpecies.unionAll(observedNotWithdrawnSpecies).asTable("combined")
+    val combined =
+        withdrawnSpecies
+            .unionAll(observedNotWithdrawnSpecies)
+            .orderBy(MONITORING_PLOTS.ID, DSL.field("species_id"))
+            .asTable("combined")
 
     val plotIdField = combined.field(MONITORING_PLOTS.ID)
     val speciesIdField = combined.field("species_id")!!


### PR DESCRIPTION
The test was assuming a certain order of query results, but the queries
were unordered.